### PR TITLE
[Model][PP] Relay DeepSeek-V4.1 cache and index state across stages

### DIFF
--- a/tests/distributed/test_deepseek_v41_pipeline_transfer.py
+++ b/tests/distributed/test_deepseek_v41_pipeline_transfer.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exercise eager cache snapshots through multiple actual process boundaries."""
+
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm.models.deepseek_v4_1.common.pipeline_transfer import (
+    restore_cache_blocks,
+    snapshot_cache_blocks,
+)
+
+
+def _relay_worker(rank, rendezvous):
+    dist.init_process_group(
+        "gloo",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=3,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        expected = torch.arange(6 * 3 * 4, dtype=torch.uint8).reshape(6, 3, 4)
+        cache = expected.clone() if rank == 0 else torch.zeros_like(expected)
+        table = torch.tensor([[1, 4, -1]])
+        if rank:
+            ids = torch.empty(2, dtype=torch.int64)
+            blocks = torch.empty(2, 3, 4, dtype=torch.uint8)
+            dist.recv(ids, src=rank - 1)
+            dist.recv(blocks, src=rank - 1)
+            restore_cache_blocks(cache, ids, blocks)
+        torch.testing.assert_close(cache[[1, 4]], expected[[1, 4]], rtol=0, atol=0)
+        if rank < 2:
+            ids, blocks = snapshot_cache_blocks(cache, [table], max_bytes=1024)
+            dist.send(ids, dst=rank + 1)
+            dist.send(blocks, dst=rank + 1)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_cache_blocks_survive_two_pipeline_hops(tmp_path):
+    mp.spawn(_relay_worker, args=((tmp_path / "rendezvous").as_uri(),), nprocs=3)

--- a/tests/models/test_deepseek_v41_pipeline.py
+++ b/tests/models/test_deepseek_v41_pipeline.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.models.deepseek_v4_1.common.pipeline import (
+    get_sharing_dependencies,
+    validate_local_sharing,
+)
+
+
+def _config():
+    return SimpleNamespace(
+        num_hidden_layers=40,
+        compress_ratios=[0, 0] + [2] * 18 + [1] * 20,
+        kv_source_layer_ids=[2, 8, 14, 20],
+        index_source_layer_ids=[2, 8, 14, 20, 24, 28, 32, 36],
+        candidate_source_layer_id=20,
+        candidate_topk_blocks=2048,
+    )
+
+
+@pytest.mark.parametrize(
+    "ranges", [[(0, 40)], [(0, 20), (20, 40)], [(0, 8), (8, 14), (14, 20), (20, 40)]]
+)
+def test_group_aligned_pipeline_cuts_keep_all_sources_local(ranges):
+    validate_local_sharing(get_sharing_dependencies(_config(), ranges))
+
+
+def test_equal_pp4_reports_cross_stage_kv_index_and_candidates():
+    dependencies = get_sharing_dependencies(
+        _config(), [(0, 10), (10, 20), (20, 30), (30, 40)]
+    )
+    cross = {
+        (d.kind, d.source_layer, d.consumer_layer)
+        for d in dependencies
+        if d.source_stage != d.consumer_stage
+    }
+    assert {("kv", 8, 10), ("index", 28, 30), ("candidate", 20, 32)} <= cross
+    with pytest.raises(NotImplementedError, match="source layer 8.*stage 0.*stage 1"):
+        validate_local_sharing(dependencies)
+
+
+@pytest.mark.parametrize("values", [[8, 2], [2, 2], [0, 2], [-1, 2], [2, 40]])
+def test_invalid_source_lists_fail_before_layer_construction(values):
+    config = _config()
+    config.kv_source_layer_ids = values
+    with pytest.raises(ValueError, match="kv_source_layer_ids"):
+        get_sharing_dependencies(config, [(0, 40)])
+
+
+def test_compressed_consumer_requires_an_earlier_source():
+    config = _config()
+    config.kv_source_layer_ids = [8, 14, 20]
+    with pytest.raises(ValueError, match="layer 2 has no preceding kv source"):
+        get_sharing_dependencies(config, [(0, 40)])
+
+
+def test_candidate_source_must_publish_indices():
+    config = _config()
+    config.candidate_source_layer_id = 21
+    with pytest.raises(ValueError, match="candidate source must be an index source"):
+        get_sharing_dependencies(config, [(0, 40)])

--- a/tests/models/test_deepseek_v41_pipeline_transfer.py
+++ b/tests/models/test_deepseek_v41_pipeline_transfer.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+from vllm.models.deepseek_v4_1.common.pipeline import SharingDependency
+from vllm.models.deepseek_v4_1.common.pipeline_transfer import (
+    get_sharing_routes,
+    restore_cache_blocks,
+    snapshot_cache_blocks,
+)
+
+
+def test_sharing_routes_relay_across_idle_stages_without_duplicate_sends():
+    routes = get_sharing_routes(
+        (
+            SharingDependency("kv", 2, 8, 0, 2),
+            SharingDependency("kv", 2, 9, 0, 2),
+            SharingDependency("kv", 2, 10, 0, 3),
+            SharingDependency("index", 2, 3, 0, 0),
+        )
+    )
+    assert [(r.kind, r.source_layer, r.sender, r.receiver) for r in routes] == [
+        ("kv", 2, 0, 1),
+        ("kv", 2, 1, 2),
+        ("kv", 2, 2, 3),
+    ]
+    assert len({r.payload_keys for r in routes}) == 1
+
+
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.bfloat16])
+def test_snapshot_refreshes_prefix_blocks_and_keeps_packed_layout(dtype):
+    # Interleaved cache allocations have gaps between physical blocks.
+    source = torch.arange(6 * 2 * 3 * 4).reshape(6, 2, 3, 4).to(dtype)[:, 0]
+    replica = torch.full((6, 2, 3, 4), 17, dtype=dtype)[:, 0]
+    ids, blocks = snapshot_cache_blocks(
+        source, [torch.tensor([[4, 1, -1], [1, 4, -1]])], max_bytes=1024
+    )
+    assert ids.tolist() == [1, 4]
+    old = source.clone()
+    source.zero_()
+    restore_cache_blocks(replica, ids, blocks)
+    torch.testing.assert_close(replica[ids], old[ids], rtol=0, atol=0)
+    assert torch.all(replica[[0, 2, 3, 5]] == 17)
+
+
+def test_empty_snapshot_preserves_replica():
+    cache = torch.ones(2, 3, 4)
+    ids, blocks = snapshot_cache_blocks(cache, [torch.tensor([[-1]])], max_bytes=0)
+    restore_cache_blocks(cache, ids, blocks)
+    assert torch.all(cache == 1)
+
+
+def test_snapshot_enforces_memory_budget():
+    with pytest.raises(ValueError, match="byte budget"):
+        snapshot_cache_blocks(torch.ones(2, 3, 4), [torch.tensor([[0, 1]])], 1)
+
+
+def test_snapshot_rejects_invalid_physical_blocks():
+    with pytest.raises(ValueError, match="unallocated cache block"):
+        snapshot_cache_blocks(torch.ones(2, 3, 4), [torch.tensor([[2]])], 1024)
+
+
+@pytest.mark.parametrize("blocks", [torch.zeros(1, 4, 3), torch.zeros(1, 3, 4).int()])
+def test_restore_rejects_different_cache_layouts(blocks):
+    with pytest.raises(ValueError, match="different block layout"):
+        restore_cache_blocks(torch.ones(2, 3, 4), torch.tensor([0]), blocks)

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1328,6 +1328,30 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
+def test_pp_empty_uniform_group_does_not_allocate_remote_layers():
+    """An empty projected group retains its type, but must allocate no layers."""
+    spec = new_kv_cache_spec()
+    remote_spec = UniformTypeKVCacheSpecs(
+        block_size=spec.block_size,
+        kv_cache_specs={"remote": spec},
+    )
+    groups = kv_cache_utils._project_kv_cache_groups_to_worker(
+        [
+            KVCacheGroupSpec(["remote"], remote_spec),
+            KVCacheGroupSpec(["local"], spec),
+        ],
+        {"local": spec},
+    )
+    config = VllmConfig()
+    config.cache_config.kv_cache_layout = "BLHNC"
+    cache = kv_cache_utils.get_kv_cache_config_from_groups(
+        config, groups, spec.page_size_bytes * 4
+    )
+    assert cache.num_blocks == 4
+    assert [tensor.layers for tensor in cache.kv_cache_tensors] == [["local"]]
+    assert cache.kv_cache_groups[0].layer_names == []
+
+
 def test_dcp_world_size_for_kv_cache_spec_shards_full_attention_only():
     dcp = 8
     full = FullAttentionSpec(

--- a/vllm/models/deepseek_v4_1/attention.py
+++ b/vllm/models/deepseek_v4_1/attention.py
@@ -147,6 +147,28 @@ def _resolve_dsv4_kv_cache_dtype(
     return kv_cache_dtype, torch.bfloat16
 
 
+def _compressed_cache_spec(
+    vllm_config: VllmConfig,
+    head_dim: int,
+    compress_ratio: int,
+    cache_dtype: str,
+    cache_torch_dtype: torch.dtype,
+) -> MLAAttentionSpec:
+    uses_fp8_ds_mla_layout = cache_dtype == "fp8_ds_mla"
+    return MLAAttentionSpec(
+        block_size=vllm_config.cache_config.block_size,
+        num_kv_heads=1,
+        head_size=head_dim,
+        dtype=torch.uint8 if uses_fp8_ds_mla_layout else cache_torch_dtype,
+        tokens_per_state=compress_ratio,
+        cache_dtype_str=cache_dtype,
+        alignment=576 if uses_fp8_ds_mla_layout else 512,
+        model_version="deepseek_v4",
+        kv_quant_mode=get_kv_quant_mode(cache_dtype),
+        state_content_bytes=584 if uses_fp8_ds_mla_layout else None,
+    )
+
+
 class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
     """DeepseekV4 MLA attention layer.
 
@@ -937,20 +959,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         # fp8_ds_mla is a UE8M0 block-scaled uint8 layout and needs 576B
         # alignment; plain bf16 / per-tensor fp8 rows use natural element-size
         # pages.
-        uses_fp8_ds_mla_layout = self.kv_cache_dtype == "fp8_ds_mla"
-        return MLAAttentionSpec(
-            block_size=vllm_config.cache_config.block_size,
-            num_kv_heads=1,
-            head_size=self.head_dim,
-            dtype=torch.uint8 if uses_fp8_ds_mla_layout else self.kv_cache_torch_dtype,
-            tokens_per_state=self.compress_ratio,
-            cache_dtype_str=self.kv_cache_dtype,
-            alignment=576 if uses_fp8_ds_mla_layout else 512,
-            model_version="deepseek_v4",
-            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
-            # DeepseekV4: 448B NoPE + 128B RoPE + 8B fp8 scale = 584B per token;
-            # head_size stays semantic (512).
-            state_content_bytes=584 if uses_fp8_ds_mla_layout else None,
+        return _compressed_cache_spec(
+            vllm_config,
+            self.head_dim,
+            self.compress_ratio,
+            self.kv_cache_dtype,
+            self.kv_cache_torch_dtype,
         )
 
     def _compressed_kv_cache(self) -> torch.Tensor:
@@ -1006,6 +1020,76 @@ class DeepseekV4IndexerCache(torch.nn.Module, AttentionLayerBase):
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return DeepseekV4IndexerBackend
+
+
+class DeepseekV4PipelineCache(nn.Module, AttentionLayerBase):
+    """Weight-free replica registered under the original KV source's layer name."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str,
+        source_layer: int,
+        attn_cls: type[DeepseekV4Attention],
+    ) -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        cache_config = vllm_config.cache_config
+        self.head_dim = config.head_dim
+        self.compress_ratio = config.compress_ratios[source_layer]
+        self.kv_cache_dtype, self.kv_cache_torch_dtype = _resolve_dsv4_kv_cache_dtype(
+            attn_cls.use_fp8_ds_mla_layout, cache_config.cache_dtype, cache_config
+        )
+        self.backend_cls = attn_cls.backend_cls
+        self.prefix = prefix
+        self.kv_cache = torch.tensor([])
+        context = vllm_config.compilation_config.static_forward_context
+        if prefix in context:
+            raise ValueError(f"Duplicate pipeline cache name: {prefix}")
+        context[prefix] = self
+
+    def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
+        self.kv_cache = kv_cache.squeeze(1)
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return self.backend_cls
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        return _compressed_cache_spec(
+            vllm_config,
+            self.head_dim,
+            self.compress_ratio,
+            self.kv_cache_dtype,
+            self.kv_cache_torch_dtype,
+        )
+
+    def forward(self):
+        raise RuntimeError("Pipeline cache replicas do not execute attention")
+
+
+def make_pipeline_cache_replica(
+    vllm_config: VllmConfig,
+    source_prefix: str,
+    source_layer: int,
+    kind: str,
+    attn_cls: type[DeepseekV4Attention],
+) -> DeepseekV4PipelineCache | DeepseekV4IndexerCache:
+    if kind == "kv":
+        return DeepseekV4PipelineCache(
+            vllm_config, source_prefix, source_layer, attn_cls
+        )
+    if kind != "index_k":
+        raise ValueError(f"Unsupported pipeline cache kind: {kind}")
+    config = vllm_config.model_config.hf_config
+    return DeepseekV4IndexerCache(
+        head_dim=_indexer_k_cache_head_dim(
+            config.index_head_dim, dsa_indexer_uses_fp4(vllm_config)
+        ),
+        dtype=torch.uint8,
+        prefix=f"{source_prefix}.indexer.k_cache",
+        cache_config=vllm_config.cache_config,
+        compress_ratio=config.compress_ratios[source_layer],
+    )
 
 
 class DeepseekV4Indexer(nn.Module):

--- a/vllm/models/deepseek_v4_1/common/pipeline.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layer-sharing dependencies of a DeepSeek V4.1 pipeline partition."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SharingDependency:
+    kind: str
+    source_layer: int
+    consumer_layer: int
+    source_stage: int
+    consumer_stage: int
+
+
+def get_sharing_dependencies(
+    config: Any, stage_ranges: list[tuple[int, int]]
+) -> tuple[SharingDependency, ...]:
+    """Resolve KV, index and candidate sources before constructing any layers."""
+    num_layers = config.num_hidden_layers
+    if (
+        not stage_ranges
+        or stage_ranges[0][0] != 0
+        or stage_ranges[-1][1] != num_layers
+        or any(start >= end for start, end in stage_ranges)
+        or any(a[1] != b[0] for a, b in zip(stage_ranges, stage_ranges[1:]))
+    ):
+        raise ValueError("DeepSeek V4.1 pipeline stages must partition all layers")
+    owners = {
+        layer: stage
+        for stage, (start, end) in enumerate(stage_ranges)
+        for layer in range(start, end)
+    }
+    ratios = config.compress_ratios
+    if len(ratios) < num_layers:
+        raise ValueError(
+            "DeepSeek V4.1 compress_ratios must cover every backbone layer"
+        )
+
+    sources = {}
+    for kind, field in (
+        ("kv", "kv_source_layer_ids"),
+        ("index", "index_source_layer_ids"),
+    ):
+        values = tuple(getattr(config, field, None) or ())
+        if (
+            any(
+                type(layer) is not int or not 0 <= layer < num_layers
+                for layer in values
+            )
+            or values != tuple(sorted(set(values)))
+            or any(ratios[layer] == 0 for layer in values)
+        ):
+            raise ValueError(
+                f"DeepSeek V4.1 {field} must contain sorted, unique compressed layers"
+            )
+        sources[kind] = values
+
+    if not set(sources["kv"]).issubset(sources["index"]):
+        raise ValueError("DeepSeek V4.1 KV sources must also publish index keys")
+
+    dependencies = []
+
+    def append(kind: str, source: int, consumer: int) -> None:
+        if source != consumer:
+            dependencies.append(
+                SharingDependency(
+                    kind, source, consumer, owners[source], owners[consumer]
+                )
+            )
+
+    for layer in range(num_layers):
+        if ratios[layer] == 0:
+            continue
+        for kind, values in sources.items():
+            preceding = [source for source in values if source <= layer]
+            if not preceding:
+                raise ValueError(
+                    f"DeepSeek V4.1 layer {layer} has no preceding {kind} source"
+                )
+            append(kind, preceding[-1], layer)
+            if kind == "kv" and layer in sources["index"]:
+                append("index_k", preceding[-1], layer)
+
+    candidate = getattr(config, "candidate_source_layer_id", -1)
+    if candidate >= 0 and getattr(config, "candidate_topk_blocks", 0) > 0:
+        if candidate not in sources["index"]:
+            raise ValueError("DeepSeek V4.1 candidate source must be an index source")
+        for layer in sources["index"]:
+            if layer > candidate:
+                append("candidate", candidate, layer)
+    return tuple(dependencies)
+
+
+def validate_local_sharing(dependencies: tuple[SharingDependency, ...]) -> None:
+    """Reject stage cuts that require sharing tensors between pipeline ranks."""
+    cross_stage = [d for d in dependencies if d.source_stage != d.consumer_stage]
+    if cross_stage:
+        detail = "; ".join(
+            f"{d.kind} source layer {d.source_layer} (stage {d.source_stage}) -> "
+            f"layer {d.consumer_layer} (stage {d.consumer_stage})"
+            for d in cross_stage[:4]
+        )
+        raise NotImplementedError(
+            "DeepSeek V4.1 pipeline partition crosses layer-sharing dependencies: "
+            f"{detail}. Keep each sharing group on one stage or explicitly enable "
+            "the experimental deepseek_v41_pp_sharing eager path."
+        )

--- a/vllm/models/deepseek_v4_1/common/pipeline_sharing.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline_sharing.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Experimental eager relay of KV, index keys, indices and candidate blocks."""
+
+from typing import Any
+
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig
+from vllm.models.deepseek_v4_1.attention import (
+    DeepseekV4Attention,
+    make_pipeline_cache_replica,
+)
+
+from .pipeline import SharingDependency
+from .pipeline_transfer import (
+    SharingRoute,
+    get_sharing_routes,
+    restore_cache_blocks,
+    snapshot_cache_blocks,
+)
+
+
+class PipelineSharing(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str,
+        stage: int,
+        dependencies: tuple[SharingDependency, ...],
+        attn_cls: type[DeepseekV4Attention],
+        max_bytes: int,
+    ) -> None:
+        super().__init__()
+        parallel = vllm_config.parallel_config
+        if (
+            not vllm_config.model_config.enforce_eager
+            or vllm_config.use_v2_model_runner
+            or parallel.use_ubatching
+            or parallel.decode_context_parallel_size != 1
+            or parallel.prefill_context_parallel_size != 1
+            or vllm_config.speculative_config is not None
+            or vllm_config.kv_transfer_config is not None
+            or parallel.distributed_executor_backend == "external_launcher"
+        ):
+            raise ValueError(
+                "deepseek_v41_pp_sharing requires eager V1 execution without "
+                "microbatching, context parallelism, speculative decoding, KV transfer "
+                "or external_launcher"
+            )
+        if type(max_bytes) is not int or max_bytes <= 0:
+            raise ValueError(
+                "deepseek_v41_pp_share_max_bytes must be a positive integer"
+            )
+        self.max_bytes = max_bytes
+        routes = get_sharing_routes(dependencies)
+        self.inbound = tuple(r for r in routes if r.receiver == stage)
+        self.outbound = tuple(r for r in routes if r.sender == stage)
+        self.payload_keys = frozenset(k for r in routes for k in r.payload_keys)
+        self._context = vllm_config.compilation_config.static_forward_context
+        self._prefix = prefix
+        self.replicas = nn.ModuleList()
+        # Resolve the main cache dtype before constructing index-K replicas.
+        for kind in ("kv", "index_k"):
+            for route in self.inbound:
+                if route.kind == kind:
+                    self.replicas.append(
+                        make_pipeline_cache_replica(
+                            vllm_config,
+                            self._source_prefix(route),
+                            route.source_layer,
+                            kind,
+                            attn_cls,
+                        )
+                    )
+
+    def _source_prefix(self, route: SharingRoute) -> str:
+        return f"{self._prefix}.layers.{route.source_layer}.attn"
+
+    def _cache_prefix(self, route: SharingRoute) -> str:
+        prefix = self._source_prefix(route)
+        return f"{prefix}.indexer.k_cache" if route.kind == "index_k" else prefix
+
+    def receive(
+        self,
+        tensors: dict[str, torch.Tensor],
+        topk: torch.Tensor,
+        candidates: torch.Tensor | None,
+        num_tokens: int,
+    ) -> None:
+        for route in self.inbound:
+            if any(key not in tensors for key in route.payload_keys):
+                raise ValueError(f"Missing pipeline sharing payload: {route.key}")
+            if route.kind in ("kv", "index_k"):
+                cache = self._context[self._cache_prefix(route)].kv_cache
+                restore_cache_blocks(
+                    cache, tensors[f"{route.key}.ids"], tensors[f"{route.key}.blocks"]
+                )
+            else:
+                target = topk if route.kind == "index" else candidates
+                assert target is not None
+                values = tensors[route.key]
+                if values.shape != target[:num_tokens].shape:
+                    raise ValueError(
+                        f"Pipeline sharing token shape mismatch: {route.key}"
+                    )
+                target[:num_tokens].copy_(values)
+
+    def send(
+        self,
+        metadata: dict[str, Any],
+        topk: torch.Tensor,
+        candidates: torch.Tensor | None,
+        num_tokens: int,
+    ) -> dict[str, torch.Tensor]:
+        payload = {}
+        remaining = self.max_bytes
+        for route in self.outbound:
+            if route.kind in ("kv", "index_k"):
+                prefix = self._cache_prefix(route)
+                layer = self._context[prefix]
+                meta = metadata[prefix]
+                if route.kind == "kv":
+                    tables = [meta.block_table[: meta.num_reqs]]
+                else:
+                    tables = []
+                    if meta.decode is not None:
+                        tables.append(meta.decode.block_table)
+                    if meta.prefill is not None:
+                        tables.extend(
+                            chunk.block_table for chunk in meta.prefill.chunks
+                        )
+                ids, blocks = snapshot_cache_blocks(layer.kv_cache, tables, remaining)
+                values = {f"{route.key}.ids": ids, f"{route.key}.blocks": blocks}
+            else:
+                source = topk if route.kind == "index" else candidates
+                assert source is not None
+                values = {route.key: source[:num_tokens].clone()}
+            remaining -= sum(t.numel() * t.element_size() for t in values.values())
+            if remaining < 0:
+                raise ValueError("Pipeline sharing snapshot exceeds its byte budget")
+            payload.update(values)
+        return payload

--- a/vllm/models/deepseek_v4_1/common/pipeline_transfer.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline_transfer.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Eager pipeline snapshots for DeepSeek V4.1 shared state."""
+
+from dataclasses import dataclass
+
+import torch
+
+from .pipeline import SharingDependency
+
+
+@dataclass(frozen=True, order=True)
+class SharingRoute:
+    kind: str
+    source_layer: int
+    sender: int
+    receiver: int
+
+    @property
+    def key(self) -> str:
+        return f"__dsv41_pp__{self.kind}.{self.source_layer}"
+
+    @property
+    def payload_keys(self) -> tuple[str, ...]:
+        if self.kind in ("kv", "index_k"):
+            return (f"{self.key}.ids", f"{self.key}.blocks")
+        return (self.key,)
+
+
+def get_sharing_routes(
+    dependencies: tuple[SharingDependency, ...],
+) -> tuple[SharingRoute, ...]:
+    """Deduplicate consumers and relay state through every intervening stage."""
+    return tuple(
+        sorted(
+            {
+                SharingRoute(d.kind, d.source_layer, stage, stage + 1)
+                for d in dependencies
+                for stage in range(d.source_stage, d.consumer_stage)
+            }
+        )
+    )
+
+
+def snapshot_cache_blocks(
+    cache: torch.Tensor,
+    block_tables: list[torch.Tensor],
+    max_bytes: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Snapshot all referenced blocks, including prefix hits and quantization data.
+
+    This deliberately uses dynamic tensors and GPU-to-CPU synchronization. It is
+    an eager correctness path; a delta protocol and graph capture are separate work.
+    """
+    if block_tables:
+        ids = torch.cat([table.reshape(-1) for table in block_tables]).to(torch.int64)
+        ids = torch.unique(ids[ids >= 0])
+    else:
+        ids = torch.empty(0, dtype=torch.int64, device=cache.device)
+    if ids.numel() and int(ids[-1]) >= cache.shape[0]:
+        raise ValueError("Pipeline snapshot refers to an unallocated cache block")
+    block_bytes = cache[0].numel() * cache.element_size() if cache.shape[0] else 0
+    if ids.numel() * (block_bytes + ids.element_size()) > max_bytes:
+        raise ValueError("Pipeline sharing snapshot exceeds its configured byte budget")
+    return ids, cache.index_select(0, ids)
+
+
+def restore_cache_blocks(
+    cache: torch.Tensor, ids: torch.Tensor, blocks: torch.Tensor
+) -> None:
+    """Refresh a local replica using the global scheduler's physical block ids."""
+    if blocks.shape != (ids.numel(), *cache.shape[1:]) or blocks.dtype != cache.dtype:
+        raise ValueError("Pipeline cache replica has a different block layout")
+    if ids.ndim != 1 or ids.dtype != torch.int64:
+        raise ValueError("Pipeline cache block ids must be an int64 vector")
+    if ids.numel() and (int(ids.min()) < 0 or int(ids.max()) >= cache.shape[0]):
+        raise ValueError("Pipeline snapshot refers to an unallocated replica block")
+    cache.index_copy_(0, ids, blocks)

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -76,6 +76,8 @@ from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 from ..common.engram import Engram, EngramLayout, NgramHashState
 from ..common.mm_preprocess import IMAGE_SENTINEL_BASE_ID, image_sentinel_mask
+from ..common.pipeline import get_sharing_dependencies, validate_local_sharing
+from ..common.pipeline_sharing import PipelineSharing
 
 if typing.TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
@@ -391,6 +393,33 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
 
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
+        from vllm.distributed.utils import get_pp_indices
+
+        pp_size = get_pp_group().world_size
+        stage_ranges = [
+            get_pp_indices(config.num_hidden_layers, rank, pp_size)
+            for rank in range(pp_size)
+        ]
+        self.sharing_dependencies = get_sharing_dependencies(config, stage_ranges)
+        additional_config = vllm_config.additional_config
+        sharing_enabled = isinstance(additional_config, dict) and additional_config.get(
+            "deepseek_v41_pp_sharing", False
+        )
+        self.pipeline_sharing: PipelineSharing | None = None
+        self.pipeline_payload_keys: frozenset[str] = frozenset()
+        if sharing_enabled:
+            assert isinstance(additional_config, dict)
+            self.pipeline_sharing = PipelineSharing(
+                vllm_config,
+                prefix,
+                get_pp_group().rank_in_group,
+                self.sharing_dependencies,
+                _select_dsv4_attn_cls(vllm_config),
+                additional_config.get("deepseek_v41_pp_share_max_bytes", 512 * 1024**2),
+            )
+            self.pipeline_payload_keys = self.pipeline_sharing.payload_keys
+        else:
+            validate_local_sharing(self.sharing_dependencies)
         self.config = config
         self.quant_config = quant_config
         self.parallel_config = vllm_config.parallel_config
@@ -547,6 +576,26 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
 
+        pipeline_metadata = None
+        if self.pipeline_sharing is not None and is_forward_context_available():
+            context = get_forward_context()
+            if context.attn_metadata is not None and not context.additional_kwargs.get(
+                "is_dummy_run", False
+            ):
+                if not isinstance(context.attn_metadata, dict):
+                    raise ValueError(
+                        "Pipeline sharing requires unsliced attention metadata"
+                    )
+                pipeline_metadata = context.attn_metadata
+                if not get_pp_group().is_first_rank:
+                    assert intermediate_tensors is not None
+                    self.pipeline_sharing.receive(
+                        intermediate_tensors.tensors,
+                        self.topk_indices_buffer,
+                        self.candidate_block_buffer,
+                        positions.shape[0],
+                    )
+
         if self.use_mega_moe:
             input_ids = input_ids.to(torch.int64)
 
@@ -654,9 +703,17 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 )
 
         if not get_pp_group().is_last_rank:
-            return IntermediateTensors(
-                {"hidden_states": hidden_states, "pre_mix": pre_mix}
-            )
+            tensors = {"hidden_states": hidden_states, "pre_mix": pre_mix}
+            if self.pipeline_sharing is not None and pipeline_metadata is not None:
+                tensors.update(
+                    self.pipeline_sharing.send(
+                        pipeline_metadata,
+                        self.topk_indices_buffer,
+                        self.candidate_block_buffer,
+                        full_num_tokens,
+                    )
+                )
+            return IntermediateTensors(tensors)
 
         # MTP needs full HC states; otherwise collapse and normalize locally
         # before gathering to reduce communication.
@@ -1023,6 +1080,7 @@ class DeepseekV41LLMForCausalLM(
         self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
             self.model.make_empty_intermediate_tensors
         )
+        self.pipeline_payload_keys = self.model.pipeline_payload_keys
 
         self.set_moe_parameters()
 

--- a/vllm/models/deepseek_v4_1/nvidia/vl_model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/vl_model.py
@@ -178,6 +178,7 @@ class DeepseekV41ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, Supports
         self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
             self.language_model.make_empty_intermediate_tensors
         )
+        self.pipeline_payload_keys = self.language_model.pipeline_payload_keys
 
         expert_dtype = getattr(config, "expert_dtype", "fp4")
         self.hf_to_vllm_mapper = _make_deepseek_v4_vl_weights_mapper(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1725,13 +1725,9 @@ def get_kv_cache_config_from_groups(
 
     kv_cache_tensors = []
     for group in kv_cache_groups:
-        group_spec = group.kv_cache_spec
         layers_by_spec: defaultdict[KVCacheSpec, list[str]] = defaultdict(list)
-        if isinstance(group_spec, UniformTypeKVCacheSpecs):
-            for layer_name, spec in group_spec.kv_cache_specs.items():
-                layers_by_spec[spec].append(layer_name)
-        elif group.layer_names:
-            layers_by_spec[group_spec].extend(group.layer_names)
+        for layer_name in group.layer_names:
+            layers_by_spec[_get_per_layer_spec(group, layer_name)].append(layer_name)
 
         byte_offset = 0
         for spec, layer_names in layers_by_spec.items():

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -55,6 +55,7 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.forward_context import (
     BatchDescriptor,
+    get_forward_context,
     set_forward_context,
 )
 from vllm.logger import init_logger
@@ -3382,6 +3383,10 @@ class GPUModelRunner(
 
         return tuple(tasks)
 
+    @property
+    def pipeline_payload_keys(self) -> frozenset[str]:
+        return getattr(self.get_model(), "pipeline_payload_keys", frozenset())
+
     def sync_and_gather_intermediate_tensors(
         self,
         num_tokens: int,
@@ -3392,6 +3397,8 @@ class GPUModelRunner(
 
         tp = self.vllm_config.parallel_config.tensor_parallel_size
         is_rs = is_residual_scattered_for_sp(self.vllm_config, num_tokens)
+        payload_keys = self.pipeline_payload_keys
+        payloads = {}
 
         # When sequence parallelism is enabled, the "residual" tensor is
         # sharded across TP ranks. All-gather it here because downstream
@@ -3399,6 +3406,10 @@ class GPUModelRunner(
         if sync_self:
             assert intermediate_tensors is not None
             for k, v in intermediate_tensors.items():
+                if k in payload_keys:
+                    # Eager model-owned state may have a block axis, not tokens.
+                    payloads[k] = v
+                    continue
                 is_scattered = k == "residual" and is_rs
                 if is_scattered:
                     local_len = num_tokens // tp
@@ -3409,7 +3420,7 @@ class GPUModelRunner(
                 )
 
         return IntermediateTensors(
-            {k: v[:num_tokens] for k, v in self.intermediate_tensors.items()}
+            {k: v[:num_tokens] for k, v in self.intermediate_tensors.items()} | payloads
         )
 
     def eplb_step(self, is_dummy: bool = False, is_profile: bool = False) -> None:
@@ -6171,6 +6182,7 @@ class GPUModelRunner(
                     slot_mapping=slot_mappings,
                 ),
             ):
+                get_forward_context().additional_kwargs["is_dummy_run"] = True
                 outputs = self.model(
                     input_ids=input_ids,
                     positions=positions,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1165,6 +1165,12 @@ class Worker(WorkerBase):
                 )
             }
 
+        all_gather_tensors.update(
+            {
+                key: False
+                for key in getattr(self.model_runner, "pipeline_payload_keys", ())
+            }
+        )
         if forward_pass and not get_pp_group().is_first_rank:
             tensor_dict, comm_handles, comm_postprocess = (
                 get_pp_group().irecv_tensor_dict(


### PR DESCRIPTION
## Purpose

Add the default-off `--additional-config '{"deepseek_v41_pp_sharing":true}'` eager V1 path. Register cache replicas and relay active KV/index-K blocks, top-k indices and candidate blocks across pipeline stages, including intermediate relay stages. Preserve cache layout and model-owned payload axes instead of treating every intermediate tensor as token-indexed. Bound each outgoing snapshot with `deepseek_v41_pp_share_max_bytes` (default 512 MiB).

This includes the dependency discovery and local-cache allocation prerequisite from #56221. #56222 supplies the independent PP+SP stage-boundary changes. The implementation rejects microbatching, context parallelism, speculative decoding, KV transfer and external-launcher execution. The duplicate check found no other open V4.1 PR implementing this complete dependency-aware relay; the validation-only #56221 does not transfer state.

Based on #56214 (`dsv41-feat`, `c9d909e802a39292f54101bff8a36096761ea605`). The PR targets that feature branch so the model implementation is not repeated in this diff.

Rebased on 2026-09-11 after the feature branch was rewritten. Changed-file Python parsing and all applicable pre-commit hooks passed. The pipeline suites passed (20 CPU tests, including the real three-process Gloo relay). GPU/full-model measurements below belong to the prior revision based on `e47aa780bccf59f59dfa2cbb18e17a10b4fe69ba`; they were not rerun on this rebased head.

AI assistance: OpenAI Codex assisted with implementation, review, test execution and preparation of this PR. This draft does not claim that a human has completed a line-by-line review.

## Test Plan

Fresh split: **20 CPU tests passed**, including the actual three-process Gloo/two-hop relay, packed/strided cache snapshots, route deduplication, empty snapshots, budget failures and layout checks. The dependency-light loader runs the actual modules and tensor/collective operations without CUDA model-registry imports:

```text
.venv/bin/python run_cpu_checks.py tests/models/test_deepseek_v41_pipeline.py \
  tests/models/test_deepseek_v41_pipeline_transfer.py \
  tests/distributed/test_deepseek_v41_pipeline_transfer.py
```

All applicable pre-commit hooks and changed-file Python parsing passed.

## Test Result

Recorded full-model runs used `deepseek-ai/DeepSeek-V4.1-Flash`, revision `df42c109f1defefcbfcedbe7d905718a12266e40`, on 4×SXM H100 80 GiB. Each positive matrix case checked six short questions, cold/cached long input with chunked prefill, and four unequal-length concurrent requests. “Text equal” means short-answer text equality to the TP4 reference, not logits/token-probability parity or a standard accuracy benchmark.

**Evidence scope:** GPU results below come from the earlier combined integration based on #56214, including companion changes. The isolated PR has not had a new full-model GPU run. Fresh split checks are listed separately; passing the integrated run does not establish isolated-branch equivalence.

| Integrated configuration | QA answers correct | QA text equal to TP4 | Long / chunked + prefix | Concurrent requests | Strict result |
| --- | --- | --- | --- | --- | --- |
| PP4×TP1 sharing eager, 10/10/10/10 | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| PP2×TP2 + SP (#56222) + sharing eager, 19/21 | 6/6 | 6/6 | 2/2 correct; cache reuse checked | 4/4 correct | PASS |
| PP2×TP2 + SP + sharing + overlap (#56220), 19/21 | 6/6 | 5/6 | 2/2 correct; cache reuse checked | 4/4 correct | Text mismatch; strict check not passed |

The overlap combination has a sequence-answer wording difference and is not counted as strict equivalence.

**Short-request serving — one run per configuration**

| Integrated configuration | Layer partition | Input → output | Successful requests / concurrency | Output tokens/s | Median TTFT ms | Median TPOT ms | Median request latency ms |
| --- | --- | --- | --- | --- | --- | --- | --- |
| PP4×TP1 sharing | 10/10/10/10 | 512 → 128 | 16/16; 4 | 5.920 | 20934.75 | 513.89 | 86517.38 |
| PP2×TP2+SP sharing | 19/21 | 512 → 128 | 16/16; 4 | 11.458 | 8235.85 | 294.05 | 44472.22 |

Eager, CPU weight offload 8 GiB, Engram CPU offload, prefix cache off, four warmup requests, fixed input seed 42, and 128 output tokens. These are absolute supported-configuration results: sharing-off rejects both partitions, so no same-partition A/B speedup can be inferred. One run cannot quantify run-to-run variance. No memory-saving figure is established for sharing or PP+SP.

| Fresh split validation | Result | Coverage |
| --- | --- | --- |
| Standalone CPU tests | 20/20 PASS | Dependency routes, packed/strided snapshots, deduplication, empty payloads, budgets and layouts |
| Real distributed transfer, included in the 20 tests | PASS | 3 Gloo processes, 2-hop relay; actual tensor/collective operations |
| Applicable pre-commit hooks and changed Python parsing | PASS; 13 changed files | Isolated PR source |

---
<details>
<summary>PR description checklist</summary>

- [x] Purpose and related work described.
- [x] Test plan and actual results stated.
- [x] Model evaluation limitations stated.
- [x] AI assistance disclosed.

</details>

<details>
<summary>Standalone CPU validation loader</summary>

Saved as `run_cpu_checks.py`; set `DSV41_SPLIT_REPO` to the checked-out branch and pass the test paths listed above. This avoids CUDA model-registry imports on macOS while executing the actual leaf-module implementation, tests and tensor/collective operations. It is not a CUDA or full-model test.

```python
"""Run unchanged CPU test functions against split source without CUDA imports.

Preload only dependency-light leaf modules, as in the integration validation
driver. CUDA-only tests keep their own skip conditions. No tensor operations or
collectives are mocked by this loader.
"""
import importlib.util
import os
from pathlib import Path
import sys

import pytest

ROOT = Path(os.environ["DSV41_SPLIT_REPO"])
for name in (
    "vllm.models.deepseek_v4_1.common.pipeline",
    "vllm.models.deepseek_v4_1.common.pipeline_transfer",
    "vllm.v1.worker.ubatch_inputs",
):
    path = ROOT / (name.replace(".", "/") + ".py")
    if not path.is_file():
        continue
    spec = importlib.util.spec_from_file_location(name, path)
    module = importlib.util.module_from_spec(spec)
    sys.modules[name] = module
    spec.loader.exec_module(module)

if __name__ == "__main__":
    raise SystemExit(pytest.main(["-q", "--noconftest", "-o", "addopts=", *sys.argv[1:]]))
```

</details>
