### PR TITLE
[Bugfix][Model] Fix DeepSeek-V4.1 microbatch positions and Engram histories

### DIFF
--- a/tests/v1/attention/test_attention_splitting.py
+++ b/tests/v1/attention/test_attention_splitting.py
@@ -107,8 +107,10 @@ def test_make_metadata_with_slice_decode_batch(small_decode_metadata):
     """Test slicing decode batch metadata"""
     # Split first request only
     ubatch_slice = UBatchSlice(slice(0, 1), slice(0, 1))
+    small_decode_metadata.positions = small_decode_metadata.seq_lens - 1
 
     result = _make_metadata_with_slice(ubatch_slice, small_decode_metadata)
+    torch.testing.assert_close(result.positions, small_decode_metadata.positions[:1])
 
     # Check sliced results
     assert result.num_reqs == 1  # slice(0, 1) gives 1 requests
@@ -330,6 +332,9 @@ def test_prefill_split_across_ubatches(
     device = torch.device("cpu")
     batch_spec = BatchSpec(seq_lens=seq_lens, query_lens=query_lens)
     common = create_common_attn_metadata(batch_spec, block_size=16, device=device)
+    common.positions = torch.cat(
+        [torch.arange(seq - query, seq) for seq, query in zip(seq_lens, query_lens)]
+    )
 
     num_scheduled_tokens = np.array(query_lens, dtype=np.int32)
     qsl_np = common.query_start_loc_cpu.numpy()
@@ -347,10 +352,16 @@ def test_prefill_split_across_ubatches(
 
     first_meta = _make_metadata_with_slice(ubatch_slices[0], common)
     second_meta = _make_metadata_with_slice(ubatch_slices[1], common)
+    # Compressor ring slots depend on absolute positions, even inside a request.
+    torch.testing.assert_close(first_meta.positions, common.positions[:split_point])
+    torch.testing.assert_close(second_meta.positions, common.positions[split_point:])
 
     # Token counts match the split
     assert first_meta.num_actual_tokens == split_point
     assert second_meta.num_actual_tokens == num_tokens - split_point
+    # These counts are passed directly to Triton kernels.
+    assert isinstance(first_meta.num_actual_tokens, int)
+    assert isinstance(second_meta.num_actual_tokens, int)
 
     # Number of requests per ubatch
     assert first_meta.num_reqs == expected_first_reqs

--- a/tests/v1/worker/test_ubatch_inputs.py
+++ b/tests/v1/worker/test_ubatch_inputs.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+from vllm.v1.worker.ubatch_inputs import (
+    slice_lookback_token_ids,
+    update_captured_lookback,
+)
+
+
+@pytest.mark.parametrize(
+    "request_slice,token_slice,expected",
+    [
+        (slice(0, 1), slice(0, 2), [[9, 8, 7], [-1, -1, -1]]),
+        (slice(0, 2), slice(2, 5), [[11, 10, 9], [29, 28, 27], [-1, -1, -1]]),
+        (slice(1, 2), slice(3, 5), [[29, 28, 27], [-1, -1, -1]]),
+        (slice(0, 1), slice(1, 3), [[10, 9, 8], [-1, -1, -1]]),
+    ],
+)
+def test_lookbacks_follow_microbatch_chunk_start(request_slice, token_slice, expected):
+    """A split request reads previous batch tokens before its older history."""
+    actual = slice_lookback_token_ids(
+        torch.tensor([[9, 8, 7], [29, 28, 27]], dtype=torch.int32),
+        torch.tensor([10, 11, 12, 30, 31]),
+        torch.tensor([0, 3, 5]),
+        request_slice,
+        token_slice,
+    )
+    assert actual.tolist() == expected
+
+
+def test_lookback_padding_does_not_read_the_last_live_request():
+    actual = slice_lookback_token_ids(
+        torch.tensor([[5, -1, -1]]),
+        torch.tensor([6, 0, 0]),
+        torch.tensor([0, 1]),
+        slice(0, 3),
+        slice(0, 3),
+    )
+    assert actual.tolist() == [[5, -1, -1], [-1, -1, -1], [-1, -1, -1]]
+
+
+def test_replay_refreshes_history_and_clears_unused_request_rows():
+    captured = torch.tensor([[1, 2, 3], [4, 5, 6]])
+    address = captured.data_ptr()
+    current = slice_lookback_token_ids(
+        torch.tensor([[7, 8, 9]]),
+        torch.tensor([10, 11]),
+        torch.tensor([0, 2]),
+        slice(0, 1),
+        slice(0, 2),
+    )
+    update_captured_lookback(captured, current)
+    assert captured.data_ptr() == address
+    assert captured.tolist() == [[7, 8, 9], [-1, -1, -1]]
+
+
+def test_replay_rejects_a_changed_history_signature():
+    with pytest.raises(ValueError, match="graph signature"):
+        update_captured_lookback(torch.empty(2, 3), torch.empty(3, 3))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("capture", [False, True])
+def test_wrapper_preserves_split_request_history_across_replay(capture):
+    """Actual microbatch threads and graph replay must receive refreshed history."""
+    from vllm.config import CUDAGraphMode, ParallelConfig, VllmConfig
+    from vllm.forward_context import (
+        BatchDescriptor,
+        DPMetadata,
+        create_forward_context,
+        override_forward_context,
+    )
+    from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
+    from vllm.v1.worker.ubatch_utils import UBatchSlice
+
+    config = VllmConfig(
+        parallel_config=ParallelConfig(data_parallel_size=2, is_moe_model=True)
+    )
+    # The callable below has no attention or MoE layers to configure.
+    config.parallel_config.ubatch_size = 2
+    config.parallel_config.all2all_backend = "deepep_high_throughput"
+
+    def model(
+        *, input_ids, positions, intermediate_tensors, inputs_embeds, lookback_token_ids
+    ):
+        return lookback_token_ids.clone()
+
+    mode = CUDAGraphMode.FULL if capture else CUDAGraphMode.NONE
+    wrapper = UBatchWrapper(model, config, mode, torch.device("cuda:0"))
+    ids = torch.arange(10, 18, device="cuda")
+    positions = torch.arange(8, device="cuda")
+    history = torch.tensor([[9, 8, 7], [29, 28, 27]], device="cuda")
+    starts = torch.tensor([0, 6, 8], device="cuda", dtype=torch.int32)
+    slices = [
+        UBatchSlice(slice(0, 1), slice(0, 4)),
+        UBatchSlice(slice(0, 2), slice(4, 8)),
+    ]
+    compute_stream = torch.cuda.Stream()
+
+    def run(runtime_mode):
+        context = create_forward_context(
+            None,
+            config,
+            dp_metadata=DPMetadata(torch.tensor([8, 8])),
+            cudagraph_runtime_mode=runtime_mode,
+            batch_descriptor=BatchDescriptor(num_tokens=8),
+            ubatch_slices=slices,
+        )
+        compute_stream.wait_stream(torch.cuda.current_stream())
+        with override_forward_context(context), torch.cuda.stream(compute_stream):
+            output = wrapper(
+                input_ids=ids,
+                positions=positions,
+                intermediate_tensors=None,
+                inputs_embeds=None,
+                lookback_token_ids=history,
+                lookback_query_start_loc=starts,
+            )
+        torch.cuda.current_stream().wait_stream(compute_stream)
+        return output
+
+    # Initialize thread-local CUDA handles before capture.
+    run(CUDAGraphMode.NONE)
+    if capture:
+        run(mode)
+    for change in (0, 100, 200):
+        ids.copy_(torch.arange(10, 18, device="cuda") + change)
+        history.copy_(torch.tensor([[9, 8, 7], [29, 28, 27]], device="cuda") + change)
+        if change == 200:
+            starts.copy_(torch.tensor([0, 8, 8], device="cuda"))
+            slices[1] = UBatchSlice(slice(0, 1), slice(4, 8))
+        actual = run(mode)
+        expected = torch.full((8, 3), -1, device="cuda", dtype=torch.int64)
+        expected[0] = history[0]
+        expected[4] = ids[torch.tensor([3, 2, 1], device="cuda")]
+        if change != 200:
+            expected[5] = history[1]
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    wrapper.clear_graphs()

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -53,6 +53,7 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.triton_utils import tl, triton
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
+from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 logger = init_logger(__name__)
 
@@ -939,14 +940,41 @@ class Engram(nn.Module):
             layout.head_dim,
             dtype=torch.bfloat16,
         )
+        parallel_config = get_current_vllm_config().parallel_config
+        self._init_lookup_staging(
+            parallel_config.num_ubatches if parallel_config.use_ubatching else 1,
+        )
 
-    def prepare_embeddings(self, hash_ids: torch.Tensor) -> None:
-        """Gather this layer's rows on the main stream before decoder layers."""
-        self.embed_tokens.lookup(hash_ids, self.staged_rows[: hash_ids.shape[0]])
+    def _init_lookup_staging(self, num_slots: int) -> None:
+        self._lookup_rows = [self.staged_rows] + [
+            torch.empty_like(self.staged_rows) for _ in range(num_slots - 1)
+        ]
 
-    def embed(self, hash_ids: torch.Tensor) -> torch.Tensor:
+    def _lookup_slot(self) -> int:
+        rows = getattr(self, "_lookup_rows", None)
+        return dbo_current_ubatch_id() if rows is not None and len(rows) > 1 else 0
+
+    def prepare_embeddings(self, hash_ids: torch.Tensor) -> torch.Tensor:
+        """Stage lookup rows in the current microbatch's own buffer."""
+        buffers = getattr(self, "_lookup_rows", None)
+        rows = (
+            buffers[self._lookup_slot()] if buffers is not None else self.staged_rows
+        )[: hash_ids.shape[0]]
+        self.embed_tokens.lookup(hash_ids, rows)
+        return rows
+
+    def embed(
+        self, hash_ids: torch.Tensor, prepared_rows: torch.Tensor | None = None
+    ) -> torch.Tensor:
         """Gather heads, returning only local tokens when SP is enabled."""
-        rows = self.staged_rows[: hash_ids.shape[0]]
+        if prepared_rows is None:
+            buffers = getattr(self, "_lookup_rows", None)
+            prepared_rows = (
+                buffers[self._lookup_slot()]
+                if buffers is not None
+                else self.staged_rows
+            )
+        rows = prepared_rows[: hash_ids.shape[0]]
         if self.embed_tokens.tp_size == 1:
             return rows
         if self.use_sequence_parallel:
@@ -974,11 +1002,12 @@ class Engram(nn.Module):
         hidden_states: torch.Tensor,
         hash_ids: torch.Tensor,
         token_mask: torch.Tensor | None = None,
+        prepared_rows: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """hidden_states: [T, hc_mult, dim]; hash_ids: [T, n_hash_cols] (all
         tokens, pre sequence-parallel shard); token_mask: [T], False shuts
         the gate so those positions pass through untouched."""
-        kv = self.wkv(self.embed(hash_ids).flatten(-2))
+        kv = self.wkv(self.embed(hash_ids, prepared_rows).flatten(-2))
         num_kv_tokens = hash_ids.shape[0]
         assert token_mask is None or token_mask.shape == (num_kv_tokens,)
         if self.use_sequence_parallel:

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -293,6 +293,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         residual: torch.Tensor | None = None,
         engram_hashes: torch.Tensor | None = None,
         engram_mask: torch.Tensor | None = None,
+        engram_rows: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         # The reference collapses each sublayer's input with the *previous*
         # sublayer's pre-mix: attention uses the pre-mix carried in (identity
@@ -343,6 +344,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                     residual,
                     engram_hashes[:, self.engram.layer_hash_index],
                     engram_mask,
+                    prepared_rows=engram_rows,
                 )
             post_mix, res_mix, x, attn_pre = mhc_pre_delayed_tilelang(
                 residual,
@@ -556,6 +558,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # profile runs (KV cache unbound).
         engram_hashes: torch.Tensor | None = None
         engram_mask: torch.Tensor | None = None
+        engram_rows: dict[int, torch.Tensor] = {}
         if (
             self.engram_hash is not None
             and input_ids is not None
@@ -598,8 +601,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 for layer in islice(self.layers, self.start_layer, self.end_layer):
                     engram = getattr(layer, "engram", None)
                     if engram is not None:
-                        engram.prepare_embeddings(
-                            engram_hashes[:, engram.layer_hash_index]
+                        engram_rows[engram.layer_hash_index] = (
+                            engram.prepare_embeddings(
+                                engram_hashes[:, engram.layer_hash_index]
+                            )
                         )
 
         full_num_tokens = positions.shape[0]
@@ -623,6 +628,9 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
         ):
+            prepared_rows = None
+            if layer.engram is not None and engram_hashes is not None:
+                prepared_rows = engram_rows[layer.engram.layer_hash_index]
             hidden_states, residual, post_mix, res_mix, pre_mix = layer(
                 hidden_states,
                 positions,
@@ -633,6 +641,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 residual,
                 engram_hashes,
                 engram_mask,
+                prepared_rows,
             )
             if idx + 1 in self.aux_hidden_state_layers:
                 # Reconstruct the aux hidden state for draft models

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1097,6 +1097,8 @@ class GPUModelRunner(
             model_kwargs["lookback_token_ids"] = self._prepare_lookback_token_ids(
                 num_reqs
             )
+            if self.parallel_config.use_ubatching:
+                model_kwargs["lookback_query_start_loc"] = self.query_start_loc.gpu
 
         if not self.is_pooling_model:
             return model_kwargs

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -22,6 +22,10 @@ from vllm.logger import init_logger
 from vllm.model_executor.offloader.base import get_offloader
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
+from vllm.v1.worker.ubatch_inputs import (
+    slice_lookback_token_ids,
+    update_captured_lookback,
+)
 from vllm.v1.worker.ubatch_utils import create_sm_control_context
 from vllm.v1.worker.ubatching import UBatchContext, make_ubatch_contexts
 
@@ -53,12 +57,18 @@ class UbatchMetadata:
     inputs_embeds: torch.Tensor | None
     intermediate_tensors: IntermediateTensors | None
     num_tokens: int
+    lookback_token_ids: torch.Tensor | None = None
+
+    def model_kwargs(self) -> dict[str, torch.Tensor]:
+        if self.lookback_token_ids is None:
+            return {}
+        return {"lookback_token_ids": self.lookback_token_ids}
 
 
 @dataclass
 class CUDAGraphMetaData:
     cudagraph: torch.cuda.CUDAGraph
-    ubatch_metadata: UbatchMetadata
+    ubatch_metadata: list[UbatchMetadata]
     outputs: Any | None = None
 
 
@@ -155,6 +165,7 @@ class UBatchWrapper:
                     positions=ubatch_metadata.positions,
                     intermediate_tensors=ubatch_metadata.intermediate_tensors,
                     inputs_embeds=ubatch_metadata.inputs_embeds,
+                    **ubatch_metadata.model_kwargs(),
                 )
 
             results.append((ubatch_metadata.context.id, model_output))
@@ -220,6 +231,7 @@ class UBatchWrapper:
                     positions=ubatch_metadata.positions,
                     intermediate_tensors=ubatch_metadata.intermediate_tensors,
                     inputs_embeds=ubatch_metadata.inputs_embeds,
+                    **ubatch_metadata.model_kwargs(),
                 )
             results.append((ubatch_metadata.context.id, model_output))
 
@@ -262,6 +274,7 @@ class UBatchWrapper:
         dp_metadata,
         batch_descriptor,
         cudagraph_runtime_mode,
+        lookback_inputs: list[torch.Tensor | None] | None = None,
     ) -> list[UbatchMetadata]:
         # Create one forward context per ubatch
         forward_contexts = []
@@ -311,6 +324,9 @@ class UBatchWrapper:
                     intermediate_tensors=sliced_intermediate_tensors,
                     num_tokens=ubatch_slice.token_slice.stop
                     - ubatch_slice.token_slice.start,
+                    lookback_token_ids=(
+                        lookback_inputs[i] if lookback_inputs is not None else None
+                    ),
                 )
             )
 
@@ -348,6 +364,7 @@ class UBatchWrapper:
         )
 
     def __call__(self, *args, **kwargs):
+        lookback_query_start_loc = kwargs.pop("lookback_query_start_loc", None)
         forward_context = get_forward_context()
         batch_descriptor = forward_context.batch_descriptor
         ubatch_slices = forward_context.ubatch_slices
@@ -380,6 +397,24 @@ class UBatchWrapper:
         intermediate_tensors = kwargs["intermediate_tensors"]
         inputs_embeds = kwargs["inputs_embeds"]
         compute_stream = torch.cuda.current_stream()
+        history = kwargs.get("lookback_token_ids")
+        lookback_inputs: list[torch.Tensor | None] = [None] * len(ubatch_slices)
+        if history is not None:
+            if lookback_query_start_loc is None or input_ids is None:
+                raise ValueError(
+                    "Microbatch lookbacks require input_ids and "
+                    "lookback_query_start_loc"
+                )
+            lookback_inputs = [
+                slice_lookback_token_ids(
+                    history,
+                    input_ids,
+                    lookback_query_start_loc,
+                    ubatch_slice.request_slice,
+                    ubatch_slice.token_slice,
+                )
+                for ubatch_slice in ubatch_slices
+            ]
 
         dp_metadata = forward_context.dp_metadata
 
@@ -415,6 +450,7 @@ class UBatchWrapper:
                 dp_metadata=ubatch_dp_metadata,
                 batch_descriptor=batch_descriptor,
                 cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                lookback_inputs=lookback_inputs,
             )
             with self.sm_control:
                 return self._capture_ubatches(ubatch_metadata, self.runnable)
@@ -423,6 +459,10 @@ class UBatchWrapper:
             and cudagraph_runtime_mode is CUDAGraphMode.FULL
         ):
             cudagraph_metadata = self.cudagraphs[num_tokens]
+            for metadata, lookback in zip(
+                cudagraph_metadata.ubatch_metadata, lookback_inputs, strict=True
+            ):
+                update_captured_lookback(metadata.lookback_token_ids, lookback)
             # Sync offloader before replay - ensures any external dependencies
             # from pre-capture prefetches are satisfied.
             get_offloader().sync_prev_onload()
@@ -441,6 +481,7 @@ class UBatchWrapper:
                 dp_metadata=ubatch_dp_metadata,
                 batch_descriptor=batch_descriptor,
                 cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                lookback_inputs=lookback_inputs,
             )
             with self.sm_control:
                 return self._run_ubatches(ubatch_metadata, self.runnable)

--- a/vllm/v1/worker/ubatch_inputs.py
+++ b/vllm/v1/worker/ubatch_inputs.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Request history inputs at microbatch boundaries."""
+
+import torch
+
+
+def slice_lookback_token_ids(
+    history: torch.Tensor,
+    input_ids: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    request_slice: slice,
+    token_slice: slice,
+) -> torch.Tensor:
+    """Rebase request lookbacks to the first token executed by this microbatch.
+
+    Rows are padded to the token count so graph replay can change request
+    lengths without changing the captured history buffer's address or shape.
+    """
+    num_tokens = token_slice.stop - token_slice.start
+    num_reqs = request_slice.stop - request_slice.start
+    depth = history.shape[1]
+    output = history.new_full((num_tokens, depth), -1)
+    if not num_tokens or not num_reqs:
+        return output
+    if num_reqs > num_tokens:
+        raise ValueError("A microbatch cannot have more request rows than token rows")
+    if history.shape[0] == 0 or query_start_loc.numel() < 2:
+        return output
+    req_ids = torch.arange(
+        request_slice.start, request_slice.stop, device=history.device
+    )
+    num_rows = min(history.shape[0], query_start_loc.numel() - 1)
+    safe_req_ids = req_ids.clamp(0, num_rows - 1)
+    starts = query_start_loc[safe_req_ids].to(torch.int64)
+    ends = query_start_loc[safe_req_ids + 1]
+    active = (
+        (req_ids < num_rows) & (starts < token_slice.stop) & (ends > token_slice.start)
+    )
+    chunk_starts = starts.clamp_min(token_slice.start)
+    positions = chunk_starts[:, None] - 1 - torch.arange(depth, device=history.device)
+    from_batch = positions >= starts[:, None]
+    batch_ids = input_ids[positions.clamp(0, input_ids.numel() - 1)].to(history.dtype)
+    history_cols = starts[:, None] - 1 - positions
+    previous_ids = history[safe_req_ids[:, None], history_cols.clamp(0, depth - 1)]
+    valid = active[:, None] & (from_batch | (history_cols < depth))
+    output[:num_reqs] = torch.where(
+        valid, torch.where(from_batch, batch_ids, previous_ids), -1
+    )
+    return output
+
+
+def update_captured_lookback(
+    captured: torch.Tensor | None, current: torch.Tensor | None
+) -> None:
+    """Refresh graph inputs without replacing their captured storage."""
+    if captured is None and current is None:
+        return
+    if captured is None or current is None or captured.shape != current.shape:
+        raise ValueError(
+            "Microbatch lookback inputs changed their CUDA graph signature"
+        )
+    captured.copy_(current)

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -169,7 +169,7 @@ def maybe_create_ubatch_slices(
     num_tokens_padded: int,
     num_reqs_padded: int,
     num_ubatches: int,
-    split_point: list[int] | int | None = None,
+    split_point: int | None = None,
 ) -> tuple[UBatchSlices | None, UBatchSlices | None]:
     if not should_ubatch:
         return None, None
@@ -188,7 +188,7 @@ def maybe_create_ubatch_slices(
     start_token = 0
 
     # Add the end point to the split points to make iteration easier
-    all_points = token_split_points + [cu_num_tokens[-1]]
+    all_points = token_split_points + [int(cu_num_tokens[-1])]
 
     for end_token in all_points:
         token_slice = slice(start_token, end_token)
@@ -345,6 +345,11 @@ def _make_metadata_with_slice(
         max_seq_len=max_seq_len,
         block_table_tensor=block_table_tensor,
         slot_mapping=slot_mapping,
+        positions=(
+            attn_metadata.positions[token_slice]
+            if attn_metadata.positions is not None
+            else None
+        ),
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=num_computed_tokens_cpu,


### PR DESCRIPTION
## Purpose

Fix DeepSeek-V4.1's inputs when a batch is divided into microbatches. A request can start before the current microbatch, so slicing request rows alone does not provide the history preceding that microbatch's first token. Reconstruct that history, pass it through UBatchWrapper, preserve absolute positions when splitting attention metadata, and normalize the final token boundary to a Python `int`.

Graph replay refreshes the captured lookback tensor in place and clears padding; each microbatch receives its own synchronous Engram staging buffer, passed explicitly to the decoder. The contribution is microbatch input and history correctness. Full-model DBO support and performance optimization are outside this PR's delivered scope.

Searching open Engram/lookback/microbatch PRs found no duplicate of this request-boundary reconstruction and graph-input refresh. #56220 covers asynchronous lookup scheduling, while #56219 covers SP exchange; neither supplies the input corrections here.

Based on #56214 (`dsv41-feat`, `c9d909e802a39292f54101bff8a36096761ea605`). The PR targets that feature branch so the model implementation is not repeated in this diff.

Rebased on 2026-09-11 after the feature branch was rewritten. Changed-file Python parsing and all applicable pre-commit hooks passed. The microbatch history suite passed (7 CPU tests; 2 CUDA cases skipped). GPU/full-model measurements below belong to the prior revision based on `e47aa780bccf59f59dfa2cbb18e17a10b4fe69ba`; they were not rerun on this rebased head.

AI assistance: OpenAI Codex assisted with implementation, review, test execution and preparation of this PR. This draft does not claim that a human has completed a line-by-line review.

## Test Plan

Fresh isolated-source check, using the standalone loader below to avoid CUDA registry imports on macOS:

```text
DSV41_SPLIT_REPO="$PWD" .venv/bin/python run_cpu_checks.py tests/v1/worker/test_ubatch_inputs.py
```

Result: **7 CPU tests passed; 2 CUDA cases skipped**. All applicable pre-commit hooks and changed-file Python parsing passed. Earlier H100 integration separately ran the attention-metadata and actual UBatchWrapper thread/graph regressions. CUDA/full-model execution was not repeated after isolating this PR.

## Test Result

**Corrections implemented and checked**

| Case | Corrected behavior | Evidence |
| --- | --- | --- |
| A request crosses a microbatch boundary | Rebuild history immediately before the microbatch's first actual token, including tokens already present in this batch | Boundary tests and independent reconstruction in real model workers |
| Attention metadata is split | Preserve the corresponding absolute `positions` slice | Attention-metadata regression suite |
| Final token boundary originates from NumPy | Convert the boundary to Python `int` before downstream indexing/kernel use | The two added type-regression cases failed before the fix and passed after it |
| Captured graph receives new request lengths/history | Refresh the captured lookback storage in place and clear padded rows | Actual UBatchWrapper graph replay tests and four-worker refresh probes |
| Two microbatches prepare Engram inputs | Keep synchronous staging storage separate and pass each prepared tensor to its decoder call | Per-microbatch input implementation exercised by the integrated wrapper path |

**Validation results**

| Validation | Result | Scope |
| --- | --- | --- |
| Fresh lookback CPU tests | 7 PASS; 2 CUDA cases skipped | This isolated PR, actual leaf-module code |
| Attention metadata and real UBatchWrapper thread/graph regressions | 32 PASS | Earlier H100 integration after the positions and integer-boundary corrections |
| Independent lookback comparison in real model workers | 4 workers × 182 checked slices; all matched | Covered a request crossing a microbatch boundary, decode and graph input refresh |
| Decode and captured-input refresh coverage | 180 decode slices and 180 replay refreshes per worker | Earlier full-model diagnostic; establishes exercised paths, not full-model correctness |
| Applicable pre-commit hooks and changed Python parsing | PASS; 8 changed files | Fresh isolated PR source |

The full-model probe used official `deepseek-ai/DeepSeek-V4.1-Flash`, revision `df42c109f1defefcbfcedbe7d905718a12266e40`, on 4×SXM H100 80 GiB. It ran the earlier combined integration based on #56214, including companion changes. These are input-correctness and serving diagnostics, not a standard model-accuracy benchmark or isolated-branch full-model proof. No throughput or GPU-memory saving is attributed to this fix.

<details>
<summary>Full-model integration limitation</summary>

The broader DeepEP LL diagnostic used DP2×TP2+EP+SP, CPU offload 32 GiB, fixed KV cache 1 GiB, `NVSHMEM_QP_DEPTH=2048`, graph sizes `[2,4,8]`, and DBO decode/prefill thresholds `1/16`.

| Integration diagnostic | Short questions | Continuous generations | Result |
| --- | --- | --- | --- |
| Non-DBO control | 6/6 expected answers | 8/8 completed, no HTTP errors | PASS, including long/prefix and concurrent checks |
| DBO enabled | 6/6 expected answers | 5/8 completed; 3/8 HTTP 400 | FAIL: runtime NaN; full-model support is not established |

The error was `Out of range float values are not JSON compliant: nan`. A separate probe observed other microbatches overwriting a shared top-k buffer between source layer 2 and consumer layer 3 on all four workers. This PR does not repair that buffer, and its causal relationship to the NaN remains unproven. HT startup profiling also encountered illegal memory access. These failures remain unresolved; passing input/regression checks must not be read as full-model DBO support.

</details>

---
<details>
<summary>PR description checklist</summary>

- [x] Purpose and related work described.
- [x] Test plan and actual results stated.
- [x] Model evaluation limitations stated.
- [x] AI assistance disclosed.

</details>

<details>
<summary>Standalone CPU validation loader</summary>

Saved as `run_cpu_checks.py`; set `DSV41_SPLIT_REPO` to the checked-out branch and pass the test paths listed above. This avoids CUDA model-registry imports on macOS while executing the actual leaf-module implementation, tests and tensor/collective operations. It is not a CUDA or full-model test.

```python
"""Run unchanged CPU test functions against split source without CUDA imports.

Preload only dependency-light leaf modules, as in the integration validation
driver. CUDA-only tests keep their own skip conditions. No tensor operations or
collectives are mocked by this loader.
"""
import importlib.util
import os
from pathlib import Path
import sys

import pytest

ROOT = Path(os.environ["DSV41_SPLIT_REPO"])
for name in (
    "vllm.models.deepseek_v4_1.common.pipeline",
    "vllm.models.deepseek_v4_1.common.pipeline_transfer",
    "vllm.v1.worker.ubatch_inputs",
):
    path = ROOT / (name.replace(".", "/") + ".py")
    if not path.is_file():
        continue
    spec = importlib.util.spec_from_file_location(name, path)
    module = importlib.util.module_from_spec(spec)
    sys.modules[name] = module
    spec.loader.exec_module(module)

if __name__ == "__main__":
    raise SystemExit(pytest.main(["-q", "--noconftest", "-o", "addopts=", *sys.argv[1:]]))
```

</details>
