### PR TITLE
[Kernel] Fuse Qwen3.5 gate/up projection with SwiGLU on SM120

### DIFF
--- a/tests/kernels/core/test_fused_swiglu_gemm.py
+++ b/tests/kernels/core/test_fused_swiglu_gemm.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.model_executor.layers.fused_swiglu_gemm import fused_swiglu_gemm
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda()
+    or not current_platform.is_device_capability_family(120),
+    reason="the fused SwiGLU GEMM is only selected on SM120",
+)
+
+
+def _reference(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    gate, up = F.linear(x, weight).chunk(2, dim=-1)
+    return F.silu(gate) * up
+
+
+@pytest.mark.parametrize("num_tokens", [1024, 4096, 8192])
+def test_fused_swiglu_gemm(num_tokens: int) -> None:
+    torch.manual_seed(0)
+    x = torch.randn((num_tokens, 1024), device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn((7168, 1024), device="cuda", dtype=torch.bfloat16)
+
+    output = fused_swiglu_gemm(x, weight)
+
+    torch.testing.assert_close(output, _reference(x, weight), rtol=0.02, atol=0.02)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 128, 2048])
+def test_fused_swiglu_gemm_falls_back_for_other_token_counts(
+    num_tokens: int,
+) -> None:
+    torch.manual_seed(0)
+    x = torch.randn((num_tokens, 1024), device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn((7168, 1024), device="cuda", dtype=torch.bfloat16)
+
+    output = fused_swiglu_gemm(x, weight)
+
+    torch.testing.assert_close(output, _reference(x, weight), rtol=0, atol=0)
+
+
+def test_fused_swiglu_gemm_falls_back_for_noncontiguous_input() -> None:
+    torch.manual_seed(0)
+    x = torch.randn((1024, 2048), device="cuda", dtype=torch.bfloat16)[:, ::2]
+    weight = torch.randn((7168, 1024), device="cuda", dtype=torch.bfloat16)
+    assert not x.is_contiguous()
+
+    output = fused_swiglu_gemm(x, weight)
+
+    torch.testing.assert_close(output, _reference(x, weight), rtol=0, atol=0)

--- a/vllm/model_executor/layers/fused_swiglu_gemm.py
+++ b/vllm/model_executor/layers/fused_swiglu_gemm.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused dense gate/up projection and SwiGLU kernels."""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.config import get_current_vllm_config_or_none
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    UnquantizedLinearMethod,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+_SUPPORTED_TOKEN_COUNTS = frozenset((1024, 4096, 8192))
+_SUPPORTED_INPUT_SIZE = 1024
+_SUPPORTED_INTERMEDIATE_SIZE = 3584
+
+
+@triton.jit
+def _fused_swiglu_gemm_kernel(
+    x_ptr,
+    weight_ptr,
+    output_ptr,
+    M,
+    N,
+    K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+) -> None:
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    accumulator_gate = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    accumulator_up = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k_start in range(0, K, BLOCK_K):
+        k = k_start + offs_k
+        x = tl.load(
+            x_ptr + offs_m[:, None] * K + k[None, :],
+            mask=(offs_m[:, None] < M) & (k[None, :] < K),
+            other=0.0,
+        )
+        gate_weight = tl.load(
+            weight_ptr + offs_n[None, :] * K + k[:, None],
+            mask=(offs_n[None, :] < N) & (k[:, None] < K),
+            other=0.0,
+        )
+        up_weight = tl.load(
+            weight_ptr + (offs_n[None, :] + N) * K + k[:, None],
+            mask=(offs_n[None, :] < N) & (k[:, None] < K),
+            other=0.0,
+        )
+        accumulator_gate += tl.dot(x, gate_weight)
+        accumulator_up += tl.dot(x, up_weight)
+
+    output = accumulator_gate * tl.sigmoid(accumulator_gate) * accumulator_up
+    tl.store(
+        output_ptr + offs_m[:, None] * N + offs_n[None, :],
+        output,
+        mask=(offs_m[:, None] < M) & (offs_n[None, :] < N),
+    )
+
+
+def fused_swiglu_gemm_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    m, k = x.shape
+    n = weight.shape[0] // 2
+    use_kernel = (
+        m in _SUPPORTED_TOKEN_COUNTS
+        and k == _SUPPORTED_INPUT_SIZE
+        and x.dtype == torch.bfloat16
+        and x.is_cuda
+        and x.is_contiguous()
+        and weight.shape == (2 * _SUPPORTED_INTERMEDIATE_SIZE, _SUPPORTED_INPUT_SIZE)
+        and weight.dtype == torch.bfloat16
+        and weight.device == x.device
+        and weight.is_contiguous()
+    )
+    if not use_kernel:
+        gate, up = torch.nn.functional.linear(x, weight).chunk(2, dim=-1)
+        return torch.nn.functional.silu(gate) * up
+    output = torch.empty((m, n), device=x.device, dtype=x.dtype)
+    grid = (triton.cdiv(m, 64), triton.cdiv(n, 32))
+    _fused_swiglu_gemm_kernel[grid](
+        x,
+        weight,
+        output,
+        M=m,
+        N=n,
+        K=k,
+        BLOCK_M=64,
+        BLOCK_N=32,
+        BLOCK_K=64,
+        num_warps=4,
+        num_stages=3,
+    )
+    return output
+
+
+def fused_swiglu_gemm_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    return x.new_empty((x.shape[0], weight.shape[0] // 2))
+
+
+direct_register_custom_op(
+    op_name="fused_swiglu_gemm",
+    op_func=fused_swiglu_gemm_impl,
+    fake_impl=fused_swiglu_gemm_fake,
+)
+
+
+def fused_swiglu_gemm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    return torch.ops.vllm.fused_swiglu_gemm(x, weight)
+
+
+def supports_fused_swiglu_gemm(layer: MergedColumnParallelLinear) -> bool:
+    """Return whether a layer satisfies the static SM120 BF16 contract."""
+    config = get_current_vllm_config_or_none()
+    linear_backend = (
+        config.kernel_config.linear_backend if config is not None else "auto"
+    )
+    weight = getattr(layer, "weight", None)
+    return (
+        current_platform.is_cuda()
+        and current_platform.is_device_capability_family(120)
+        and linear_backend == "auto"
+        and isinstance(layer.quant_method, UnquantizedLinearMethod)
+        and layer.tp_size == 1
+        and layer.bias is None
+        and isinstance(weight, torch.Tensor)
+        and weight.shape == (2 * _SUPPORTED_INTERMEDIATE_SIZE, _SUPPORTED_INPUT_SIZE)
+        and weight.dtype == torch.bfloat16
+        and weight.is_contiguous()
+    )

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -28,6 +28,7 @@ from collections.abc import Iterable
 
 import torch
 from torch import nn
+from torch.nn import functional as F
 
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
@@ -37,6 +38,10 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.utils import (
     is_model_fused_shared_expert_compatible,
+)
+from vllm.model_executor.layers.fused_swiglu_gemm import (
+    fused_swiglu_gemm,
+    supports_fused_swiglu_gemm,
 )
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm as Qwen3_5RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -49,6 +54,7 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateDtypeCalculator,
     MambaStateShapeCalculator,
 )
+from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -73,7 +79,7 @@ from .interfaces import (
     SupportsPP,
     _require_is_multimodal,
 )
-from .qwen2_moe import Qwen2MoeMLP as Qwen3NextMLP
+from .qwen2_moe import Qwen2MoeMLP
 from .qwen3_next import (
     Qwen3NextAttention,
     Qwen3NextDecoderLayer,
@@ -101,6 +107,47 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
+
+
+class Qwen3_5MLP(Qwen2MoeMLP):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
+        expert_gate: torch.nn.Linear | None = None,
+        is_sequence_parallel: bool = False,
+        disable_tp: bool = False,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            hidden_act=hidden_act,
+            quant_config=quant_config,
+            reduce_results=reduce_results,
+            expert_gate=expert_gate,
+            is_sequence_parallel=is_sequence_parallel,
+            disable_tp=disable_tp,
+            prefix=prefix,
+        )
+        # Hardware and linear-backend introspection is intentionally kept out
+        # of the torch.compile region. Unsupported token counts fall back in
+        # the custom-op implementation.
+        self.use_fused_swiglu_gemm = supports_fused_swiglu_gemm(self.gate_up_proj)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.use_fused_swiglu_gemm:
+            out = fused_swiglu_gemm(x, self.gate_up_proj.weight)
+        else:
+            gate_up, _ = self.gate_up_proj(x)
+            out = self.act_fn(gate_up)
+        out, _ = self.down_proj(out)
+        if self.expert_gate is not None:
+            out = F.sigmoid(self.expert_gate(x)[0]) * out
+        return out
 
 
 class Qwen3_5ProcessingInfo(Qwen3VLProcessingInfo):
@@ -169,7 +216,7 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
                 prefix=f"{prefix}.mlp",
             )
         elif config.model_type == "qwen3_5_text":
-            self.mlp = Qwen3NextMLP(
+            self.mlp = Qwen3_5MLP(
                 hidden_size=config.hidden_size,
                 intermediate_size=config.intermediate_size,
                 hidden_act=config.hidden_act,


### PR DESCRIPTION
## Purpose

Fuse the BF16 gate/up projection and SwiGLU epilogue used by Qwen3.5-0.8B prefill on SM120.

Related design context: #52776 proposes a provider-neutral GEMM epilogue contract and names paired gate/up projection plus SiLU-multiply as an initial target. This PR provides a measured SM120 implementation and end-to-end evidence for that composition; it intentionally does not attempt to define the full generic contract. I am opening it as a Draft so maintainers can advise whether this narrow guarded integration should land directly or be adapted to that interface.

An Nsight Systems trace on an RTX 5090 showed that the 24 gate/up GEMMs plus separate SwiGLU materialization accounted for 17.377 ms of an 83.005 ms B=1/T=8192 request. The GEMM was already at 185.6 dense BF16 TFLOP/s (88.6% of device specification peak), leaving little opportunity in GEMM retuning alone. This change computes the gate and up accumulators together and applies SwiGLU before storing the output, removing the intermediate activation materialization and one launch per layer.

The fast path is intentionally fail-closed. It is selected only for CUDA SM120, unquantized BF16, TP1, `linear_backend=auto`, no bias, contiguous Qwen3.5-0.8B weights/input, and M in `{1024, 4096, 8192}`. Every other configuration uses the existing linear-plus-activation path.

## Test Plan

- Run the focused SM120 kernel/fallback tests and existing Qwen3.5 quantization-wiring tests.
- Compare current main and the candidate in fresh processes on official ModelScope `Qwen/Qwen3.5-0.8B` BF16 weights.
- Run both offline `LLM.generate` and the real streaming OpenAI `/v1/completions` server path.
- Use B=1, one generated token, TP1, MRV2, FlashAttention, no prefix caching, and T=1024/4096/8192 weighted 0.2/0.3/0.5.
- Run two paired repeats in opposite arm order, with two warmups and six timed requests per context and arm.
- Require exact output token IDs, reciprocal top-5 token-set agreement, no inference-time Triton JIT warning, every context >=0.98x, and each weighted repeat >=1.02x.

Test command:

```bash
python -m pytest -vv \
  tests/kernels/core/test_fused_swiglu_gemm.py \
  tests/model_executor/test_qwen3_5_quantization.py
```

## Test Result

RTX 5090 (SM120), PyTorch 2.13.0+cu132, Triton 3.7.1:

- Exact latest-main review archive: 9 focused tests passed.
- Online server: 4/4 fresh arms and 96/96 requests passed.
- Online correctness: 36/36 exact output tokens, prompt lengths, and reciprocal top-5 sets.
- Inference-time candidate JIT warnings: 0.

Online client-observed streaming TTFT:

| Pair | T=1024 | T=4096 | T=8192 | Weighted |
|---|---:|---:|---:|---:|
| Repeat 1 | 1.0272x | 1.0290x | 1.0461x | 1.0412x |
| Repeat 2 | 1.0190x | 1.0357x | 1.0325x | 1.0325x |
| Pooled | 1.0210x | 1.0419x | 1.0379x | 1.0378x |

Supporting offline `LLM.generate` latency:

| Pair | T=1024 | T=4096 | T=8192 | Weighted |
|---|---:|---:|---:|---:|
| Repeat 1 | 1.0253x | 1.0278x | 1.0415x | 1.0376x |
| Repeat 2 | 1.0007x | 1.0199x | 1.0313x | 1.0270x |
| Pooled | 1.0130x | 1.0238x | 1.0364x | 1.0323x |

At T=8192, the trace-derived optimistic whole-request ceiling was 1.0453x (3.600 ms removable). The offline pooled result removed 2.881 ms and reached 1.0364x, realizing about 80% of the optimistic removable time.

This result is scoped to Qwen3.5-0.8B BF16 single-request prefill on one SM120 GPU. It does not claim gains for decode, concurrency, prefix-cached traffic, quantization, TP>1, other model sizes, or other GPU architectures.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described.
- [x] The test plan and commands are included.
- [x] Correctness and repeated offline/online performance results are included.
- [x] No documentation update is required because this is a guarded kernel fast path, not a new user-facing feature.
</details>

