### PR TITLE
[Bugfix][Mooncake] Reject unsupported local SSD settings

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -188,13 +188,13 @@ class MooncakeStoreConfig:
             if config.get(name)
         ]
         if unsupported_ssd_fields:
-            logger.warning(
-                "MooncakeStoreConnector ignores %s in its JSON config; "
-                "these fields do not enable local SSD offload in vLLM workers. "
+            raise ValueError(
+                "MooncakeStoreConnector does not support "
+                f"{', '.join(unsupported_ssd_fields)} in its JSON config. "
+                "These settings do not enable local SSD offload in vLLM workers. "
                 "For SSD offload, use mode='standalone-store' with "
                 "enable_offload=true and configure SSD storage on an external "
-                "mooncake_client.",
-                ", ".join(unsupported_ssd_fields),
+                "mooncake_client."
             )
         return MooncakeStoreConfig(
             metadata_server=config.get("metadata_server", ""),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -182,6 +182,20 @@ class MooncakeStoreConfig:
     def from_file(file_path: str) -> "MooncakeStoreConfig":
         with open(file_path) as file:
             config = json.load(file)
+        unsupported_ssd_fields = [
+            name
+            for name in ("enable_ssd_offload", "ssd_offload_path")
+            if config.get(name)
+        ]
+        if unsupported_ssd_fields:
+            logger.warning(
+                "MooncakeStoreConnector ignores %s in its JSON config; "
+                "these fields do not enable local SSD offload in vLLM workers. "
+                "For SSD offload, use mode='standalone-store' with "
+                "enable_offload=true and configure SSD storage on an external "
+                "mooncake_client.",
+                ", ".join(unsupported_ssd_fields),
+            )
         return MooncakeStoreConfig(
             metadata_server=config.get("metadata_server", ""),
             master_server_address=config.get("master_server_address", ""),


### PR DESCRIPTION
## Purpose

The shared Mooncake Store configuration silently ignores `enable_ssd_offload` and `ssd_offload_path`, which can make users believe local SSD offload is enabled. Reject enabled/non-empty values with `ValueError` during configuration loading. For KV cache SSD offload, point users to `standalone-store` with an external `mooncake_client`.

Disabled/empty settings and the supported KV `enable_offload` flag remain valid. Deployments using these previously ignored SSD settings must remove or disable them before starting vLLM.

The validation lives in `vllm/distributed/mooncake_store.py`, shared by KV and EC clients following #56242. The error's SSD deployment guidance is explicitly scoped to KV caching; cross-Encoder caching retains its existing RAM-only restriction.

## Test Plan

Check that enabled/non-empty SSD settings raise `ValueError`, while valid configurations retain their existing behavior across default, embedded, and standalone-store modes. Exercise the EC client factory with native Store dependencies mocked to check RAM-only configurations and startup rejection before Store creation.

```bash
.venv/bin/pre-commit run --files vllm/distributed/mooncake_store.py
```

## Test Result

- 30 shared config-module scenarios passed: 12 invalid configurations raised `ValueError`, and 18 valid configurations parsed unchanged.
- 30 isolated EC factory scenarios passed with native Store dependencies mocked: 15 valid configurations initialized the mocked Store, and 15 invalid configurations failed before Store creation.
- All applicable file-scoped pre-commit hooks passed, including Ruff, typos, mypy, and repository-local static checks.
- GPU/SSD runtime tests were not run; this change only adds startup configuration validation.
