### PR TITLE
[Model][EDP][Engram] Support DP sharding for Engram tables

### DIFF
--- a/tests/distributed/test_engram_dp_shard.py
+++ b/tests/distributed/test_engram_dp_shard.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Engram tables shared by co-located DP replicas.
+
+Four GPUs on one node split the hash heads four ways, whether as DEP
+(TP1 x DP4, the single-node MoE layout) or TP2 x DP2. A lookup only returns
+the right rows if the ids of every replica are gathered, each rank looks up
+its own heads, and each replica trades those tokens back for the heads its
+peers own.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+from torch import nn
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.config.parallel import ParallelConfig
+from vllm.distributed import cleanup_dist_env_and_memory, parallel_state
+from vllm.distributed.parallel_state import (
+    get_engram_dp_group,
+    get_engram_dp_size,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.forward_context import set_forward_context
+from vllm.models.deepseek_v4_1.common import engram as engram_ops
+from vllm.models.deepseek_v4_1.common.engram import (
+    Engram,
+    ParallelEngramEmbedding,
+    engram_head_shard_rank,
+    gather_engram_hashes,
+)
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import get_open_port
+from vllm.utils.system_utils import update_environment_variables
+
+WORLD_SIZE = 4
+DIM, BLOCK = 64, 32
+# Prime-sized buckets, as the model's layout builds them.
+HEAD_SIZES = (97, 101, 103, 107, 109, 113, 127, 131)
+
+
+def _token_counts(dp_size: int) -> tuple[tuple[int, ...], ...]:
+    """Even loads, then uneven ones with an idle replica to pad around."""
+    return ((8,) * dp_size, (7, 0, 5, 1)[:dp_size], (7,) * dp_size)
+
+
+def _full_table(rows: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """The unsharded table, identical on every rank."""
+    torch.manual_seed(0)
+    weight = (torch.randn(rows, DIM) * 4).to(torch.float8_e4m3fn)
+    scale_inv = torch.randint(120, 134, (rows, DIM // BLOCK), dtype=torch.uint8)
+    return weight, scale_inv
+
+
+def _make_ids(head_sizes: tuple[int, ...], num_tokens: int, seed: int) -> torch.Tensor:
+    """Ids of each head, drawn from that head's own bucket range."""
+    torch.manual_seed(seed)
+    offset = 0
+    columns = []
+    for size in head_sizes:
+        columns.append(torch.randint(offset, offset + size, (num_tokens, 1)))
+        offset += size
+    return torch.cat(columns, dim=1).to(torch.int32).cuda()
+
+
+def _reference(weight, scale_inv, ids) -> torch.Tensor:
+    """Dequantized lookup against the whole table."""
+    valid = ids >= 0
+    safe_ids = ids.clamp_min(0).long()
+    values = torch.nn.functional.embedding(safe_ids, weight).float()
+    scales = torch.nn.functional.embedding(safe_ids, scale_inv)
+    scales = (scales.to(torch.int32) << 23).view(torch.float32)
+    values = values.unflatten(-1, (-1, BLOCK)) * scales.unsqueeze(-1)
+    return values.flatten(-2).to(torch.bfloat16).masked_fill(~valid.unsqueeze(-1), 0)
+
+
+def _worker(
+    rank: int,
+    tp_size: int,
+    dp_size: int,
+    cpu_offload: bool,
+    n_heads: int,
+    sequence_parallel: bool,
+    port: int,
+) -> None:
+    monkeypatch = pytest.MonkeyPatch()
+    with monkeypatch.context() as m:
+        # Any DeepSeek V4.1 config would do; only the answer matters here.
+        m.setattr("vllm.config.engram.model_has_engram_layers", lambda config: True)
+        torch.accelerator.set_device_index(torch.device(f"cuda:{rank}"))
+        update_environment_variables(
+            {
+                "RANK": str(rank),
+                "LOCAL_RANK": str(rank),
+                "WORLD_SIZE": str(WORLD_SIZE),
+                "MASTER_ADDR": "localhost",
+                "MASTER_PORT": str(port),
+            }
+        )
+        dp_rank, tp_rank = divmod(rank, tp_size)
+        vllm_config = VllmConfig(
+            parallel_config=ParallelConfig(
+                tensor_parallel_size=tp_size,
+                data_parallel_size=dp_size,
+                data_parallel_rank=dp_rank,
+            )
+        )
+        init_distributed_environment()
+        with set_current_vllm_config(vllm_config):
+            initialize_model_parallel(tensor_model_parallel_size=tp_size)
+
+            assert get_engram_dp_size() == dp_size
+            # Replicas group per TP rank: {0, 2} and {1, 3} at TP2 x DP2.
+            assert get_engram_dp_group().ranks == [
+                tp_rank + replica * tp_size for replica in range(dp_size)
+            ]
+            # Head shards run TP-major, so the DP gather brings in neighbours.
+            assert engram_head_shard_rank() == tp_rank * dp_size + dp_rank
+
+            head_sizes = HEAD_SIZES[:n_heads]
+            rows = sum(head_sizes)
+            weight, scale_inv = _full_table(rows)
+            with torch.device("cuda"):
+                layer = ParallelEngramEmbedding(
+                    rows, DIM, head_sizes, block_size=BLOCK, cpu_offload=cpu_offload
+                )
+            layer.weight.weight_loader(layer.weight, weight)
+            layer.weight_scale_inv.weight_loader(layer.weight_scale_inv, scale_inv)
+
+            engram = Engram.__new__(Engram)
+            nn.Module.__init__(engram)
+            engram.embed_tokens = layer
+            engram.use_sequence_parallel = sequence_parallel
+            token_counts = _token_counts(dp_size)
+            engram.staged_rows = torch.empty(
+                max(max(counts) for counts in token_counts) * dp_size,
+                layer.part_n_hash_cols,
+                DIM,
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+
+            for batch_idx, counts in enumerate(token_counts):
+                num_tokens = counts[dp_rank]
+                # Ids differ per replica but must agree across its TP ranks.
+                ids = _make_ids(head_sizes, num_tokens, seed=100 + dp_rank)
+                if batch_idx == 2 and dp_rank == 1:
+                    ids.fill_(engram_ops.DEAD_ID)
+                with set_forward_context(
+                    None,
+                    vllm_config,
+                    num_tokens=num_tokens,
+                    num_tokens_across_dp=torch.tensor(counts, dtype=torch.int32),
+                ):
+                    gathered = gather_engram_hashes(ids)
+                    assert gathered.shape[0] == max(counts) * dp_size
+                    engram.prepare_embeddings(gathered)
+                    looked_up = engram.embed(ids)
+                    standalone = layer(ids)
+                expected = _reference(weight.cuda(), scale_inv.cuda(), ids)
+                torch.testing.assert_close(standalone, expected, atol=0, rtol=0)
+                if sequence_parallel:
+                    # SP hands back only this rank's token shard, zero-padded.
+                    chunk = -(-num_tokens // tp_size)
+                    expected = torch.nn.functional.pad(
+                        expected, (0, 0, 0, 0, 0, chunk * tp_size - num_tokens)
+                    )
+                    expected = expected[tp_rank * chunk : (tp_rank + 1) * chunk]
+                torch.testing.assert_close(looked_up, expected, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize("cpu_offload", [False, True])
+# 8 heads split evenly; 7 leave one padded column on the last shard.
+@pytest.mark.parametrize("n_heads", [8, 7])
+# DEP first: expert parallel over the node keeps the dense layers at TP1.
+# Sequence parallelism only exists above TP1, where it replaces the head
+# gather with a token gather.
+@pytest.mark.parametrize(
+    "tp_size,dp_size,sequence_parallel",
+    [(1, 4, False), (2, 2, False), (2, 2, True)],
+)
+def test_engram_table_shared_across_dp_replicas(
+    tp_size: int,
+    dp_size: int,
+    sequence_parallel: bool,
+    cpu_offload: bool,
+    n_heads: int,
+) -> None:
+    if torch.accelerator.device_count() < WORLD_SIZE:
+        pytest.skip(f"Need {WORLD_SIZE} GPUs to run the test.")
+    mp.spawn(
+        _worker,
+        args=(
+            tp_size,
+            dp_size,
+            cpu_offload,
+            n_heads,
+            sequence_parallel,
+            get_open_port(),
+        ),
+        nprocs=WORLD_SIZE,
+    )
+    cleanup_dist_env_and_memory()
+
+
+@pytest.mark.parametrize(
+    "node_ids,dp_size,replica_size,expected",
+    [
+        ([0] * 4, 4, 1, 4),
+        ([0] * 4, 2, 2, 2),
+        ([0] * 8 + [1] * 8, 8, 2, 4),
+        ([0] * 8 + [1] * 8 + [2] * 8, 8, 3, 1),
+        ([0, 1] * 4, 4, 2, 1),
+        ([0] * 3 + [1] * 5, 4, 2, 1),
+    ],
+)
+def test_engram_dp_shard_size_respects_node_boundaries(
+    node_ids, dp_size, replica_size, expected, monkeypatch
+):
+    """Sharing must fall back when replicas or node rank ranges do not align."""
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architecture="DeepseekV41ForCausalLM",
+            hf_text_config=SimpleNamespace(engram_layer_ids=[1, 14]),
+        )
+    )
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(parallel_state, "get_node_count", lambda: len(set(node_ids)))
+    monkeypatch.setattr(
+        parallel_state, "get_world_group", lambda: SimpleNamespace(cpu_group=None)
+    )
+    monkeypatch.setattr(
+        parallel_state,
+        "in_the_same_node_as",
+        lambda group, src: [node == node_ids[src] for node in node_ids],
+    )
+    assert (
+        parallel_state._engram_dp_shard_size(
+            config, len(node_ids), dp_size, replica_size, False
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [0, 2, 4, 5])
+def test_engram_hash_padding_has_no_valid_rows(num_tokens, monkeypatch):
+    """Idle/padded slots must not query row zero; oversized batches are rejected."""
+    monkeypatch.setattr(engram_ops, "engram_gathered_num_tokens", lambda: 4)
+    monkeypatch.setattr(
+        engram_ops,
+        "get_engram_dp_group",
+        lambda: SimpleNamespace(all_gather=lambda ids, dim: torch.cat([ids, ids], dim)),
+    )
+    ids = torch.full((num_tokens, 2, 3), 17, dtype=torch.int32)
+    if num_tokens > 4:
+        with pytest.raises(ValueError, match="exceeds the DP token slot"):
+            gather_engram_hashes(ids)
+        return
+    gathered = gather_engram_hashes(ids).reshape(2, 4, 2, 3)
+    for replica in gathered:
+        torch.testing.assert_close(replica[:num_tokens], ids)
+        assert torch.all(replica[num_tokens:] == engram_ops.DEAD_ID)

--- a/tests/kernels/test_engram.py
+++ b/tests/kernels/test_engram.py
@@ -116,7 +116,7 @@ def test_fused_engram_post_wkv_matches_reference(
     module.use_sequence_parallel = use_sequence_parallel
     module.embed_tokens = torch.nn.Identity()
     # `forward` reads rows staged by `prepare_embeddings`, so inject kv there.
-    module.embed_tokens.tp_size = 1
+    module.embed_tokens.tp_size = module.embed_tokens.dp_size = 1
     module.staged_rows = kv.unsqueeze(1)
     if use_sequence_parallel:
         padded = torch.nn.functional.pad(kv, (0, 0, 0, (-num_kv_tokens) % tp_size))
@@ -149,6 +149,51 @@ def _hash_state(use_slot_cache: bool) -> NgramHashState:
     state.swa_cache_module = torch.nn.Module()
     state.swa_cache_module.kv_cache = torch.empty(0)
     return state
+
+
+@pytest.mark.parametrize("num_tokens", [0, 7])
+def test_engram_dummy_hashes_leave_history_untouched(num_tokens):
+    """Dummy forwards have no valid table IDs and do not alter cached history."""
+    state = _hash_state(use_slot_cache=True)
+    state.multipliers = torch.empty(2, 4, dtype=torch.int64)
+    state.primes = torch.empty(2, 3, 8, dtype=torch.int64)
+    state._cache = torch.arange(16, dtype=torch.int32)
+    history = state._cache.clone()
+
+    hashes, keep = state.dummy_hashes(torch.arange(num_tokens))
+
+    assert hashes.shape == (num_tokens, 2, 24)
+    assert hashes.dtype == torch.int32
+    assert torch.all(hashes == engram_ops.DEAD_ID)
+    assert keep.shape == (num_tokens,) and keep.dtype == torch.bool
+    assert not keep.any()
+    torch.testing.assert_close(state._cache, history)
+
+
+def test_engram_staging_preserves_interleaved_microbatches(monkeypatch):
+    """A second microbatch must not overwrite rows awaiting a later layer."""
+    module = Engram.__new__(Engram)
+    torch.nn.Module.__init__(module)
+    module.embed_tokens = torch.nn.Identity()
+    module.embed_tokens.tp_size = module.embed_tokens.dp_size = 1
+    module.embed_tokens.lookup = lambda ids, out: out.copy_(ids.unsqueeze(-1))
+    module.use_sequence_parallel = False
+    module.staged_rows = torch.empty(3, 2, 1)
+    module._extra_staged_rows = [torch.empty_like(module.staged_rows)]
+    ids = [torch.full((3, 2), 11), torch.full((2, 2), 22)]
+
+    for ubatch_id in range(2):
+        monkeypatch.setattr(
+            engram_ops, "dbo_current_ubatch_id", lambda ubatch_id=ubatch_id: ubatch_id
+        )
+        module.prepare_embeddings(ids[ubatch_id])
+    for ubatch_id in range(2):
+        monkeypatch.setattr(
+            engram_ops, "dbo_current_ubatch_id", lambda ubatch_id=ubatch_id: ubatch_id
+        )
+        torch.testing.assert_close(
+            module.embed(ids[ubatch_id]), ids[ubatch_id].unsqueeze(-1).float()
+        )
 
 
 @pytest.mark.parametrize("num_blocks", [4, 100])
@@ -533,6 +578,7 @@ def _make_embedding(cpu_offload, rows=4096, dim=256, block=32):
     layer = ParallelEngramEmbedding.__new__(ParallelEngramEmbedding)
     torch.nn.Module.__init__(layer)
     layer.dim, layer.block_size, layer.tp_size = dim, block, 1
+    layer.dp_size = 1
     layer.n_hash_cols = layer.part_n_hash_cols = 24
     layer.head_start = 0
     layer.cpu_offload = cpu_offload
@@ -559,12 +605,25 @@ def _make_embedding(cpu_offload, rows=4096, dim=256, block=32):
     return layer
 
 
+@pytest.mark.parametrize(
+    "tp_size,dp_size,n_heads", [(1, 4, 5), (2, 2, 5), (4, 1, 6), (8, 1, 6)]
+)
+def test_engram_rejects_empty_head_shards(tp_size, dp_size, n_heads, monkeypatch):
+    """Reject empty owners before allocating weights or accessing CUDA."""
+    monkeypatch.setattr(
+        engram_ops, "get_tensor_model_parallel_world_size", lambda: tp_size
+    )
+    monkeypatch.setattr(engram_ops, "get_engram_dp_size", lambda: dp_size)
+    with pytest.raises(AssertionError, match="ranks without hash heads"):
+        ParallelEngramEmbedding(n_heads * 17, 64, (17,) * n_heads)
+
+
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
 @pytest.mark.parametrize("cpu_offload", [False, True])
 @pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
 def test_engram_head_shards_reconstruct_checkpoint(cpu_offload, tp_size, monkeypatch):
     """Keep complete buckets and reconstruct head order, including TP padding."""
-    head_sizes = (17, 19, 23, 29, 31, 37)
+    head_sizes = (17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73)
     num_rows, dim = sum(head_sizes), 64
     torch.manual_seed(0)
     weight = torch.randn(num_rows + 7, dim).to(torch.float8_e4m3fn)
@@ -623,7 +682,7 @@ def test_engram_head_shards_reconstruct_checkpoint(cpu_offload, tp_size, monkeyp
     module.staged_rows = torch.empty_like(shards[0])
     module.prepare_embeddings(ids)
     torch.testing.assert_close(module.embed(ids), expected, rtol=0, atol=0)
-    # Slicing before head reordering must preserve padded heads and empty owners.
+    # Slicing before head reordering must preserve padded heads and tokens.
     module.use_sequence_parallel = True
     chunk = (len(ids) + tp_size - 1) // tp_size
     padded = torch.nn.functional.pad(expected, (0, 0, 0, 0, 0, (-len(ids)) % tp_size))

--- a/vllm/config/engram.py
+++ b/vllm/config/engram.py
@@ -34,6 +34,16 @@ def _default_cpu_offload() -> bool:
     return envs.VLLM_PLE_CPU_OFFLOAD
 
 
+def model_has_engram_layers(model_config: "ModelConfig | None") -> bool:
+    """Whether the model carries n-gram embedding layers."""
+    if model_config is None:
+        return False
+    field = _NGRAM_LAYER_FIELDS.get(model_config.architecture)
+    if field is None:
+        return False
+    return bool(getattr(model_config.hf_text_config, field, None))
+
+
 @config
 class EngramConfig:
     """Configuration for Engram embedding storage and sharding."""

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -32,6 +32,7 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from dataclasses import dataclass
 from datetime import timedelta
+from math import gcd
 from multiprocessing import shared_memory
 from typing import TYPE_CHECKING, Any, Protocol
 from unittest.mock import patch
@@ -59,6 +60,7 @@ from vllm.utils.torch_utils import (
 )
 
 if TYPE_CHECKING:
+    from vllm.config import VllmConfig
     from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
 
 
@@ -1560,6 +1562,23 @@ def get_etp_group() -> GroupCoordinator:
     return _ETP
 
 
+_ENGRAM_DP: GroupCoordinator | None = None
+
+
+def get_engram_dp_group() -> GroupCoordinator | None:
+    """Return the DP replicas that share one engram embedding table.
+
+    None when every replica holds a full (TP-sharded) copy, which is the case
+    for models without engram layers and for replicas that span nodes.
+    """
+    return _ENGRAM_DP
+
+
+def get_engram_dp_size() -> int:
+    """Number of DP replicas one engram embedding table is sharded over."""
+    return _ENGRAM_DP.world_size if _ENGRAM_DP is not None else 1
+
+
 _DCP: GroupCoordinator | None = None
 
 
@@ -1917,6 +1936,48 @@ def init_distributed_environment(
             _INNER_DP_WORLD = _WORLD
 
 
+def _engram_dp_shard_size(
+    config: "VllmConfig",
+    world_size: int,
+    data_parallel_size: int,
+    replica_size: int,
+    enable_elastic_ep: bool,
+) -> int:
+    """DP replicas that can share one engram table: those co-located on a node.
+
+    The tables run to ~100GB per layer, so a node holding one copy instead of
+    one per replica is a large win. Replicas on different nodes are left
+    alone: their per-step row exchange would land on the slow link.
+    """
+    from vllm.config.engram import model_has_engram_layers
+    from vllm.platforms import current_platform
+
+    if (
+        data_parallel_size == 1
+        or enable_elastic_ep
+        or not current_platform.is_cuda()
+        or not model_has_engram_layers(config.model_config)
+    ):
+        return 1
+    node_count = get_node_count()
+    if world_size % node_count:
+        return 1
+    ranks_per_node = world_size // node_count
+    if ranks_per_node % replica_size:
+        return 1
+    shard_size = gcd(data_parallel_size, ranks_per_node // replica_size)
+    if shard_size > 1 and node_count > 1:
+        # The arithmetic assumes uniform nodes with contiguous global ranks.
+        for start in range(0, world_size, ranks_per_node):
+            same_node = in_the_same_node_as(get_world_group().cpu_group, start)
+            if any(
+                bool(local) != (start <= rank < start + ranks_per_node)
+                for rank, local in enumerate(same_node)
+            ):
+                return 1
+    return shard_size
+
+
 def initialize_model_parallel(
     tensor_model_parallel_size: int = 1,
     pipeline_model_parallel_size: int = 1,
@@ -2037,6 +2098,37 @@ def initialize_model_parallel(
             get_world_group().local_rank,
             backend,
             group_name="etp",
+        )
+
+    # Build the engram embedding group: the DP replicas that shard one n-gram
+    # table between them. Hash IDs and lookup results are gathered over
+    # it every step, so it never spans nodes.
+    global _ENGRAM_DP
+    assert _ENGRAM_DP is None, "engram data parallel group is already initialized"
+    engram_dp_size = _engram_dp_shard_size(
+        config,
+        world_size,
+        data_parallel_size,
+        tensor_model_parallel_size
+        * pipeline_model_parallel_size
+        * prefill_context_model_parallel_size,
+        enable_elastic_ep,
+    )
+    if engram_dp_size > 1:
+        group_ranks = (
+            all_ranks.permute(0, 2, 3, 4, 1).reshape(-1, engram_dp_size).unbind(0)
+        )
+        _ENGRAM_DP = init_model_parallel_group(
+            [x.tolist() for x in group_ranks],
+            get_world_group().local_rank,
+            backend,
+            group_name="edp",
+        )
+        logger.info_once(
+            "Engram tables are sharded over %d ranks (TP=%d x DP=%d)",
+            engram_dp_size * tensor_model_parallel_size,
+            tensor_model_parallel_size,
+            engram_dp_size,
         )
 
     # Build the DCP model-parallel groups.
@@ -2284,6 +2376,11 @@ def destroy_model_parallel():
     if _TP:
         _TP.destroy()
     _TP = None
+
+    global _ENGRAM_DP
+    if _ENGRAM_DP:
+        _ENGRAM_DP.destroy()
+    _ENGRAM_DP = None
 
     global _DCP
     if _DCP:

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -42,10 +42,13 @@ from torch import nn
 
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
+    get_engram_dp_group,
+    get_engram_dp_size,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
 )
+from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.quantization import QuantizationConfig
@@ -53,6 +56,7 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.triton_utils import tl, triton
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
+from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 logger = init_logger(__name__)
 
@@ -462,6 +466,21 @@ class NgramHashState(nn.Module):
         self._kv_cache_ref = weakref.ref(kv_cache)
         return True
 
+    def dummy_hashes(
+        self, input_ids: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Participate in DP lookups without valid rows or hash-cache updates."""
+        num_tokens = input_ids.shape[0]
+        num_layers, max_ngram = self.multipliers.shape
+        num_heads = self.primes.shape[-1]
+        hashes = input_ids.new_full(
+            (num_tokens, num_layers, (max_ngram - 1) * num_heads),
+            DEAD_ID,
+            dtype=torch.int32,
+        )
+        keep = torch.zeros(num_tokens, dtype=torch.bool, device=input_ids.device)
+        return hashes, keep
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -546,6 +565,46 @@ class NgramHashState(nn.Module):
         return output
 
 
+def engram_head_shard_rank() -> int:
+    """This rank's slot among the hash-head shards of one engram table.
+
+    TP-major, so the shards a DP gather brings in are contiguous heads and
+    the following TP gather completes the head order.
+    """
+    dp_group = get_engram_dp_group()
+    dp_size = dp_group.world_size if dp_group is not None else 1
+    dp_rank = dp_group.rank_in_group if dp_group is not None else 0
+    return get_tensor_model_parallel_rank() * dp_size + dp_rank
+
+
+def engram_gathered_num_tokens() -> int:
+    """Per-replica token slot of the DP-gathered n-gram id stream."""
+    dp_metadata = get_forward_context().dp_metadata
+    if dp_metadata is None:
+        raise RuntimeError("a DP-shared engram table needs DP token metadata")
+    return int(dp_metadata.num_tokens_across_dp_cpu.max())
+
+
+def gather_engram_hashes(hash_ids: torch.Tensor) -> torch.Tensor:
+    """Collect the n-gram ids of every DP replica sharing one table.
+
+    Replicas are padded to a common token slot, so the gathered shape is
+    static under CUDA graph capture (where DP already pads alike).
+    """
+    dp_group = get_engram_dp_group()
+    if dp_group is None:
+        return hash_ids
+    slot = engram_gathered_num_tokens()
+    if hash_ids.shape[0] > slot:
+        raise ValueError("Engram token count exceeds the DP token slot")
+    if hash_ids.shape[0] < slot:
+        pad = hash_ids.new_full(
+            (slot - hash_ids.shape[0], *hash_ids.shape[1:]), DEAD_ID
+        )
+        hash_ids = torch.cat((hash_ids, pad))
+    return dp_group.all_gather(hash_ids, dim=0)
+
+
 def _engram_head_shard_weight_loader(
     param: torch.nn.Parameter, loaded_weight: torch.Tensor
 ) -> None:
@@ -623,8 +682,13 @@ class ParallelEngramEmbedding(nn.Module):
     """The n-gram hash table, sharded by complete hash heads over TP ranks.
     Rows stay fp8 and are dequantized with ue8m0 per-32 scales on lookup.
 
+    DP replicas that sit on the same node split the heads further
+    (`get_engram_dp_size()`), so a node holds one table instead of a copy per
+    replica; the lookup then covers every replica's tokens and `Engram.embed`
+    trades those tokens back for the heads the peers own.
+
     With `cpu_offload` the shard lives in pinned host memory and is read over
-    UVA instead of HBM; the TP sharding is unchanged either way.
+    UVA instead of HBM; the sharding is unchanged either way.
     """
 
     def __init__(
@@ -637,7 +701,7 @@ class ParallelEngramEmbedding(nn.Module):
     ):
         super().__init__()
         tp_size = get_tensor_model_parallel_world_size()
-        tp_rank = get_tensor_model_parallel_rank()
+        dp_size = get_engram_dp_size()
         assert head_sizes and all(size > 0 for size in head_sizes)
         assert sum(head_sizes) <= num_embeddings
         if cpu_offload and not is_uva_available():
@@ -646,13 +710,19 @@ class ParallelEngramEmbedding(nn.Module):
         self.dim = dim
         self.block_size = block_size
         self.n_hash_cols = len(head_sizes)
-        self.part_n_hash_cols = triton.cdiv(self.n_hash_cols, tp_size)
-        self.head_start = tp_rank * self.part_n_hash_cols
+        num_shards = tp_size * dp_size
+        self.part_n_hash_cols = triton.cdiv(self.n_hash_cols, num_shards)
+        assert (num_shards - 1) * self.part_n_hash_cols < self.n_hash_cols, (
+            f"Engram sharding leaves ranks without hash heads: "
+            f"{self.n_hash_cols} heads over TP={tp_size} x DP={dp_size}"
+        )
+        self.head_start = engram_head_shard_rank() * self.part_n_hash_cols
         head_end = self.head_start + self.part_n_hash_cols
         self.vocab_start_idx = sum(head_sizes[: self.head_start])
         self.vocab_end_idx = sum(head_sizes[:head_end])
         self.part_num_embeddings = self.vocab_end_idx - self.vocab_start_idx
         self.tp_size = tp_size
+        self.dp_size = dp_size
         self.cpu_offload = cpu_offload
         self._views: tuple[torch.Tensor, torch.Tensor] | None = None
         self._view_src: tuple[int, int] | None = None
@@ -749,17 +819,21 @@ class ParallelEngramEmbedding(nn.Module):
 
     def forward(self, indices: torch.Tensor) -> torch.Tensor:
         """indices: [num_tokens, n_hash_cols] -> [num_tokens, n_hash_cols, dim]
-        bf16, gathered from all TP shards."""
+        bf16, gathered from all shards for this replica's tokens."""
+        num_tokens = indices.shape[0]
+        if self.dp_size > 1:
+            indices = gather_engram_hashes(indices)
         out = torch.empty(
             (indices.shape[0], self.part_n_hash_cols, self.dim),
             dtype=torch.bfloat16,
             device=indices.device,
         )
         self.lookup(indices, out)
+        if self.dp_size > 1:
+            out = _gather_engram_rows(out, num_tokens)
         if self.tp_size > 1:
             out = tensor_model_parallel_all_gather(out, dim=1)
-            out = out[:, : self.n_hash_cols]
-        return out
+        return out[:, : self.n_hash_cols]
 
 
 @triton.jit(do_not_specialize=["num_kv_tokens"])
@@ -855,7 +929,7 @@ def _fused_engram_post_wkv_kernel(
 
 
 @triton.jit(do_not_specialize=["num_tokens", "token_start", "num_elements"])
-def _engram_sp_rows_kernel(
+def _engram_select_rows_kernel(
     gathered,
     output,
     num_tokens,
@@ -874,6 +948,51 @@ def _engram_sp_rows_kernel(
         gathered + source, (offsets < num_elements) & (tokens < num_tokens), other=0
     )
     tl.store(output + offsets, values, offsets < num_elements)
+
+
+def _engram_select_rows(
+    gathered: torch.Tensor,
+    output: torch.Tensor,
+    source_tokens: int,
+    token_start: int,
+    local_width: int,
+) -> None:
+    """Copy one token window out of a rank-major gathered buffer.
+
+    Both gathers land rank-major ([rank][token][local width]); this walks the
+    window the rank keeps and lays its ranks out side by side as width.
+    """
+    if output.numel() == 0:
+        return
+    _engram_select_rows_kernel[(triton.cdiv(output.numel(), 1024),)](
+        gathered,
+        output,
+        source_tokens,
+        token_start,
+        output.numel(),
+        local_width,
+        output.shape[1] * output.shape[2],
+        BLOCK_SIZE=1024,
+    )
+
+
+def _gather_engram_rows(staged: torch.Tensor, num_tokens: int) -> torch.Tensor:
+    """Exchange DP tokens for heads, retaining only this replica's tokens."""
+    dp_group = get_engram_dp_group()
+    assert dp_group is not None
+    slot, remainder = divmod(staged.shape[0], dp_group.world_size)
+    assert remainder == 0 and 0 <= num_tokens <= slot
+    gathered = dp_group.all_gather(staged, dim=0)
+    local_heads, dim = staged.shape[1:]
+    rows = staged.new_empty((num_tokens, dp_group.world_size * local_heads, dim))
+    _engram_select_rows(
+        gathered,
+        rows,
+        staged.shape[0],
+        dp_group.rank_in_group * slot,
+        local_heads * dim,
+    )
+    return rows
 
 
 class Engram(nn.Module):
@@ -931,41 +1050,75 @@ class Engram(nn.Module):
             requires_grad=False,
         )
 
-        max_tokens = get_current_vllm_config().scheduler_config.max_num_batched_tokens
-        # Keep lookup results alive across breakable graph segments.
+        vllm_config = get_current_vllm_config()
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        # Keep lookup results alive across breakable graph segments. A table
+        # shared by DP replicas stages every replica's tokens at once.
         self.staged_rows = torch.empty(
-            max_tokens,
+            max_tokens * self.embed_tokens.dp_size,
             self.embed_tokens.part_n_hash_cols,
             layout.head_dim,
             dtype=torch.bfloat16,
         )
 
+        self._extra_staged_rows = [
+            torch.empty_like(self.staged_rows)
+            for _ in range(vllm_config.parallel_config.num_ubatches - 1)
+        ]
+
+    def _staged_rows_for_ubatch(self) -> torch.Tensor:
+        ubatch_id = dbo_current_ubatch_id()
+        if ubatch_id == 0:
+            return self.staged_rows
+        return self._extra_staged_rows[ubatch_id - 1]
+
     def prepare_embeddings(self, hash_ids: torch.Tensor) -> None:
-        """Gather this layer's rows on the main stream before decoder layers."""
-        self.embed_tokens.lookup(hash_ids, self.staged_rows[: hash_ids.shape[0]])
+        """Gather this layer's rows on the main stream before decoder layers.
+
+        `hash_ids` covers every DP replica sharing the table (see
+        `gather_engram_hashes`), so only `embed` narrows back to this one.
+        """
+        rows = self._staged_rows_for_ubatch()[: hash_ids.shape[0]]
+        assert rows.shape[0] == hash_ids.shape[0], "engram staging buffer too small"
+        self.embed_tokens.lookup(hash_ids, rows)
+
+    def _trade_dp_tokens_for_heads(self, num_tokens: int) -> torch.Tensor:
+        """Keep this replica's tokens, take the heads its DP peers own.
+
+        An all-to-all would move `dp_size` times less, but the gather stays on
+        vLLM's own collective path and so survives graph capture.
+        """
+        dp_group = get_engram_dp_group()
+        assert dp_group is not None
+        slot = engram_gathered_num_tokens()
+        staged = self._staged_rows_for_ubatch()[: slot * dp_group.world_size]
+        return _gather_engram_rows(staged, num_tokens)
 
     def embed(self, hash_ids: torch.Tensor) -> torch.Tensor:
         """Gather heads, returning only local tokens when SP is enabled."""
-        rows = self.staged_rows[: hash_ids.shape[0]]
-        if self.embed_tokens.tp_size == 1:
-            return rows
+        if self.embed_tokens.dp_size > 1:
+            rows = self._trade_dp_tokens_for_heads(hash_ids.shape[0])
+            if self.embed_tokens.tp_size == 1:
+                # No TP gather follows to drop the padded heads.
+                return rows[:, : self.embed_tokens.n_hash_cols]
+        else:
+            rows = self._staged_rows_for_ubatch()[: hash_ids.shape[0]]
+            if self.embed_tokens.tp_size == 1:
+                return rows
         if self.use_sequence_parallel:
             tp_size = self.embed_tokens.tp_size
             num_tokens, local_heads, dim = rows.shape
             gathered = tensor_model_parallel_all_gather(rows, dim=0)
             chunk = (num_tokens + tp_size - 1) // tp_size
-            rows = rows.new_empty((chunk, self.embed_tokens.n_hash_cols, dim))
-            _engram_sp_rows_kernel[(triton.cdiv(rows.numel(), 1024),)](
+            out = rows.new_empty((chunk, self.embed_tokens.n_hash_cols, dim))
+            _engram_select_rows(
                 gathered,
-                rows,
+                out,
                 num_tokens,
                 get_tensor_model_parallel_rank() * chunk,
-                rows.numel(),
                 local_heads * dim,
-                self.embed_tokens.n_hash_cols * dim,
-                BLOCK_SIZE=1024,
             )
-            return rows
+            return out
         rows = tensor_model_parallel_all_gather(rows, dim=1)
         return rows[:, : self.embed_tokens.n_hash_cols]
 

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -12,6 +12,7 @@ import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.config.kernel import MEGA_MOE_BACKENDS
 from vllm.distributed import (
+    get_engram_dp_size,
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -74,7 +75,12 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
-from ..common.engram import Engram, EngramLayout, NgramHashState
+from ..common.engram import (
+    Engram,
+    EngramLayout,
+    NgramHashState,
+    gather_engram_hashes,
+)
 from ..common.mm_preprocess import IMAGE_SENTINEL_BASE_ID, image_sentinel_mask
 
 if typing.TYPE_CHECKING:
@@ -594,12 +600,19 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                     swa_metadata.slot_mapping,
                     swa_metadata.block_table,
                 )
+            elif get_engram_dp_size() > 1:
+                # The lookup is collective once DP replicas share a table, so
+                # a replica skipping the hash still has to reach it.
+                engram_hashes, engram_mask = self.engram_hash.dummy_hashes(input_ids)
+            if engram_hashes is not None:
                 # Gather all Engram rows before entering the decoder layers.
+                # One gather feeds every layer sharing the DP-split table.
+                gathered_hashes = gather_engram_hashes(engram_hashes)
                 for layer in islice(self.layers, self.start_layer, self.end_layer):
                     engram = getattr(layer, "engram", None)
                     if engram is not None:
                         engram.prepare_embeddings(
-                            engram_hashes[:, engram.layer_hash_index]
+                            gathered_hashes[:, engram.layer_hash_index]
                         )
 
         full_num_tokens = positions.shape[0]


### PR DESCRIPTION
## Purpose

Support DP head-wise sharding for engram tables: DP replicas shard a
single engram embedding table instead of each holding a full copy.

## Test Plan
- New `tests/distributed/test_engram_dp_shard.py`: 4-GPU single-node test
  covering DEP (TP1×DP4) and TP2×DP2 layouts, even/uneven/idle-replica token
  loads, verifying gathered lookups reconstruct the full-table reference.
- Extended `tests/kernels/test_engram.py`: dummy-hash behavior,
  interleaved-microbatch staging, empty-head-shard rejection, and larger
  head-shard checkpoint reconstruction.
- Run GSM8K evaluation to validate end-to-end model quality and verify that
  the expected accuracy is maintained with Engram enabled.

## Test Result
- `.venv/bin/python -m pytest tests/kernels/test_engram.py -q` → **All passed**
- `.venv/bin/python -m pytest tests/distributed/test_engram_dp_shard.py -q`
  on a 4× GB200 single node → **All passed**, covering DEP (TP1×DP4)
  and TP2×DP2 layouts with even/uneven/idle-replica token loads.
- GSM8K evaluation completed successfully, achieving the expected accuracy
  and confirming no regression in end-to-end model quality.
