### PR TITLE
[Bugfix][MLA] Preserve flattened indexer context-length rows

### DIFF
--- a/tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
+++ b/tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
@@ -157,3 +157,95 @@ def test_indexer_builder_deepseek_v4_compressed_slot_mapping_uses_num_states():
         device=device,
     )
     torch.testing.assert_close(valid_slots, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_compressed_flattened_seq_lens_reuses_cudagraph_buffer():
+    """Flattened context lengths must keep one address across decode layouts."""
+    device = torch.device("cuda")
+    max_tokens = 32
+    compress_ratio = 4
+    speculative_config = SimpleNamespace(
+        num_speculative_tokens=3,
+        enable_adaptive_verification=False,
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=speculative_config,
+        num_speculative_tokens=3,
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=max_tokens,
+            max_num_seqs=max_tokens,
+        ),
+        model_config=SimpleNamespace(max_model_len=1024),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+            cp_kv_cache_interleave_size=1,
+        ),
+        attention_config=SimpleNamespace(
+            resolve_indexer_kv_dtype=lambda default: default
+        ),
+    )
+    builder = DeepseekV32IndexerMetadataBuilder(
+        kv_cache_spec=MLAAttentionSpec(
+            block_size=256,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            tokens_per_state=compress_ratio,
+        ),
+        layer_names=["dummy"],
+        vllm_config=vllm_config,
+        device=device,
+        block_table_width=1,
+    )
+    assert builder.use_flattening
+
+    def make_metadata(query_lens: list[int], context_lens: list[int]):
+        query_start_loc_cpu = torch.zeros(len(query_lens) + 1, dtype=torch.int32)
+        query_start_loc_cpu[1:] = torch.tensor(query_lens, dtype=torch.int32).cumsum(0)
+        query_start_loc = query_start_loc_cpu.to(device)
+        seq_lens = torch.tensor(
+            [
+                context_len + query_len
+                for context_len, query_len in zip(context_lens, query_lens)
+            ],
+            dtype=torch.int32,
+            device=device,
+        )
+        return CommonAttentionMetadata(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc_cpu,
+            seq_lens=seq_lens,
+            seq_lens_cpu_upper_bound=seq_lens.cpu(),
+            num_reqs=len(query_lens),
+            num_actual_tokens=sum(query_lens),
+            max_query_len=max(query_lens),
+            max_seq_len=int(seq_lens.max().item()),
+            block_table_tensor=torch.arange(
+                len(query_lens), dtype=torch.int32, device=device
+            ).unsqueeze(1),
+            slot_mapping=torch.zeros(sum(query_lens), dtype=torch.int64, device=device),
+            causal=True,
+        )
+
+    # Both layouts use the same four-token graph size. The first build takes
+    # the max_decode_len > 1 path; the second takes max_decode_len == 1.
+    first = builder.build(0, make_metadata([2, 2], [100, 200]))
+    assert first.decode is not None
+    first_seq_lens = first.decode.seq_lens
+    torch.testing.assert_close(
+        first_seq_lens,
+        torch.tensor([[25], [25], [50], [50]], dtype=torch.int32, device=device),
+    )
+    first_ptr = first_seq_lens.data_ptr()
+
+    second = builder.build(0, make_metadata([1, 1, 1, 1], [400, 500, 600, 700]))
+    assert second.decode is not None
+    second_seq_lens = second.decode.seq_lens
+    torch.testing.assert_close(
+        second_seq_lens,
+        torch.tensor([[100], [125], [150], [175]], dtype=torch.int32, device=device),
+    )
+
+    assert second_seq_lens.data_ptr() == first_ptr

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -1239,9 +1239,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     )
                     block_table = self.indexer_decode_block_table_buffer[:rows, :cols]
 
-            seq_lens_is_buffer_view = (use_native and next_n > 1) or (
-                not use_native and max_decode_len > 1
-            )
+            seq_lens_is_buffer_view = not use_native or next_n > 1
 
             # DCP: localize the now-expanded per-token global bounds to this
             # rank's owned KV. Done here (after expansion) so each token's global


### PR DESCRIPTION
## Purpose

Keep compressed sparse-indexer context lengths at a stable address across flattened speculative-decode layouts.

`DeepseekV32IndexerMetadataBuilder._prepare_decode_tensors()` returns `decode_seq_lens_buffer` for every flattened (`not use_native`) decode. PR #53906 changed the subsequent buffer-view test to require `max_decode_len > 1` for that path:

```python
seq_lens_is_buffer_view = (use_native and next_n > 1) or (
    not use_native and max_decode_len > 1
)
```

Before PR #53906, the condition was the one restored by this PR. The two expressions differ only for flattened decode with `max_decode_len == 1`:

| Decode path | Current condition | Restored condition |
|---|---:|---:|
| Native plain decode (`next_n == 1`) | false | false |
| Native speculative decode (`next_n > 1`) | true | true |
| Flattened decode (`max_decode_len > 1`) | true | true |
| Flattened decode (`max_decode_len == 1`) | false | true |

The distinction must follow buffer ownership rather than decode depth. Both the uniform and variable flattened branches return `decode_seq_lens_buffer`, including when `max_decode_len == 1`. Native plain decode is the only case here that retains the shared input `seq_lens` and therefore requires a separate destination before compression.

For `compress_ratio > 1`, the false branch copies compressed lengths into `expanded_seq_lens_buffer`. Consequently, two ordinary flattened decode layouts with the same total graph token count can return different allocations: for example, two requests with two query tokens each followed by four requests with one query token each.

A full graph retains the address used during capture. If a later build switches allocations, `_prepare_decode_tensors()` updates the captured `decode_seq_lens_buffer` with uncompressed lengths while eager metadata points to the other compressed buffer. Replay then consumes uncompressed context lengths.

Restore the actual ownership invariant:

```python
seq_lens_is_buffer_view = not use_native or next_n > 1
```

This compresses every flattened result in place and keeps its graph address stable. Native decode and flattened `max_decode_len > 1` behavior are unchanged.

AI assistance was used for this PR. No duplicate standalone PR was found for this regression.

## Test Plan

```bash
python3 -m pytest -q \
  tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py \
  tests/v1/attention/test_indexer_native_next_n.py \
  tests/v1/attention/test_sparse_indexer_decode_seq_lens.py \
  tests/v1/attention/test_indexer_dcp_localize.py \
  tests/v1/attention/test_rocm_glm5next_sparse.py
pre-commit run --files \
  vllm/v1/attention/backends/mla/indexer.py \
  tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
```

## Test Result

On `vllm/vllm-openai-rocm:nightly-2a02f6efe319c885e3ccbcecde402e0028f9ec1e`, a standalone MI355X reproducer used speculative decoding. It captured compressed context lengths for query layout `[2, 2]`, rebuilt metadata for layout `[1, 1, 1, 1]` with the same four-token graph size, and replayed the graph.

| Source | Buffer address | Expected replay | Actual replay |
|---|---|---|---|
| Stock nightly | Changed | `[100, 125, 150, 175]` | `[401, 501, 601, 701]` |
| One-line fix | Stable | `[100, 125, 150, 175]` | `[100, 125, 150, 175]` |

The focused regression test fails on the pointer mismatch with the old condition and passes with this change.

- Related sparse-indexer tests: `50 passed, 22 skipped, 1 deselected`
- Changed-file pre-commit: passed

As additional end-to-end validation with draft adaptive verification [PR #52362](https://github.com/vllm-project/vllm/pull/52362), a 1,319-sample adaptive DeepSeek-V4 GSM8K evaluation improved from `0.3723` flexible / `0.2767` strict exact match to `0.9507` for both metrics with the same one-line fix. Fixed-K and no-speculation controls were `0.9477`–`0.9553`.