### PR TITLE
[Bugfix][Metrics] Anchor queue time at the first QUEUED event

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from vllm.v1.core.sched.output import ScheduledEncoderInputStats, SchedulerOutput
-from vllm.v1.engine import EngineCoreOutputs, FinishReason
+from vllm.v1.engine import (
+    EngineCoreEvent,
+    EngineCoreEventType,
+    EngineCoreOutputs,
+    FinishReason,
+)
 from vllm.v1.metrics.stats import (
     IterationStats,
+    LoRARequestStates,
     PrefillStats,
     PromptTokenStats,
     RequestStateStats,
@@ -288,3 +294,68 @@ def test_prompt_token_stats_full_external_transfer_recompute():
     assert stats.external_kv_transfer == 999
     assert stats.cached_tokens == 999
     assert stats.total == 1000
+
+
+def _apply_events(
+    stats: IterationStats, req_stats: RequestStateStats, *event_pairs: tuple
+):
+    stats.update_from_events(
+        "request-1",
+        [EngineCoreEvent(type=t, timestamp=ts) for t, ts in event_pairs],
+        is_prefilling=True,
+        req_stats=req_stats,
+        lora_states=LoRARequestStates(),
+        lora_name=None,
+    )
+
+
+def _finish_request(stats: IterationStats, req_stats: RequestStateStats):
+    req_stats.first_token_ts = 3.0
+    req_stats.last_token_ts = 60.0
+    req_stats.num_generation_tokens = 10
+    stats.iteration_timestamp = 60.0
+    stats.update_from_finished_request(
+        FinishReason.STOP, "request-1", 100, 128, req_stats
+    )
+
+
+def test_queued_time_anchors_at_first_queued_event():
+    """Streaming-input sessions re-emit QUEUED for each prompt chunk after
+    the first SCHEDULED event; queue time must stay anchored at the first
+    QUEUED event instead of going negative."""
+    stats = IterationStats()
+    req_stats = RequestStateStats(arrival_time=0.0)
+
+    _apply_events(
+        stats,
+        req_stats,
+        (EngineCoreEventType.QUEUED, 1.0),
+        (EngineCoreEventType.SCHEDULED, 2.0),
+    )
+    # Next streaming chunk re-queues the request long after it first ran.
+    _apply_events(stats, req_stats, (EngineCoreEventType.QUEUED, 50.0))
+
+    _finish_request(stats, req_stats)
+
+    assert stats.finished_requests[-1].queued_time == 1.0
+
+
+def test_queued_time_survives_preemption_cycle():
+    """Positive control: preemption (PREEMPTED -> SCHEDULED again) keeps the
+    first QUEUED/SCHEDULED pair as the queue-interval anchors."""
+    stats = IterationStats()
+    req_stats = RequestStateStats(arrival_time=0.0)
+
+    _apply_events(
+        stats,
+        req_stats,
+        (EngineCoreEventType.QUEUED, 1.0),
+        (EngineCoreEventType.SCHEDULED, 2.0),
+        (EngineCoreEventType.PREEMPTED, 5.0),
+        (EngineCoreEventType.SCHEDULED, 7.0),
+    )
+
+    _finish_request(stats, req_stats)
+
+    assert stats.finished_requests[-1].queued_time == 1.0
+    assert req_stats.num_preemptions == 1

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -517,7 +517,11 @@ class IterationStats:
 
         for event in events:
             if event.type == EngineCoreEventType.QUEUED:
-                req_stats.queued_ts = event.timestamp
+                # Streaming-input sessions re-queue the request for each
+                # prompt chunk; keep the queue interval anchored at the
+                # first QUEUED event (mirrors the SCHEDULED guard below).
+                if req_stats.queued_ts == 0.0:
+                    req_stats.queued_ts = event.timestamp
                 lora_states.request_waiting(req_id, lora_name)
             elif event.type == EngineCoreEventType.SCHEDULED:
                 if req_stats.scheduled_ts == 0.0:  # ignore preemptions


### PR DESCRIPTION
## Purpose
`IterationStats.update_from_events` overwrites `queued_ts` on **every** `QUEUED` event, but `update_from_finished_request` computes

```python
# Queued interval is from first QUEUED event to first SCHEDULED
queued_time = req_stats.scheduled_ts - req_stats.queued_ts
```

Streaming-input sessions re-emit `QUEUED` for every prompt chunk: `scheduler._update_request_as_session` moves a session that has already run back to `WAITING` and records `EngineCoreEventType.QUEUED` again. The last `QUEUED` timestamp therefore lands **after** the first `SCHEDULED` event and the reported queue time goes **negative**:

- first chunk: `QUEUED` at t=1, `SCHEDULED` at t=2
- session decodes, then the next prompt chunk re-queues: `QUEUED` at t=50
- reported `queued_time = 2 − 50 = −48 s`

Negative queue time is surfaced through the OpenTelemetry span attribute `GEN_AI_LATENCY_TIME_IN_QUEUE` (`output_processor.do_tracing`) and the finished-request queue-time metrics, corrupting latency breakdowns for streaming-input sessions.

## Approach
Mirror the guard that already exists for `SCHEDULED` two lines below (`if req_stats.scheduled_ts == 0.0:  # ignore preemptions`):

```python
if event.type == EngineCoreEventType.QUEUED:
    if req_stats.queued_ts == 0.0:
        req_stats.queued_ts = event.timestamp
    lora_states.request_waiting(req_id, lora_name)
```

This makes the code match its own documented contract (`first QUEUED → first SCHEDULED`). LoRA waiting/running bookkeeping still updates on every event, and preemption handling is untouched (preemption emits `PREEMPTED`, not `QUEUED`).

## Test Plan
Added to `tests/v1/metrics/test_stats.py`:

- `test_queued_time_anchors_at_first_queued_event`: QUEUED@1 → SCHEDULED@2 → re-QUEUED@50 (streaming chunk) → finish; asserts `queued_time == 1.0`. Fails on `main` with `queued_time == -48.0`.
- `test_queued_time_survives_preemption_cycle`: positive control with a PREEMPTED → SCHEDULED cycle; asserts the first-pair anchors are kept and preemption counting still works.

```
$ pytest tests/v1/metrics/test_stats.py -q
14 passed
```

