### PR TITLE
[Bugfix][Core] Avoid initializing CUDA while resolving AllReduce+RMSNorm fusion config

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -100,33 +100,6 @@ if hasattr(torch.ops._C, "scaled_fp4_quant"):
     STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.out
 
 # Max size of the input tensor per world size per device capability
-# to use flashinfer fused allreduce
-FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
-    90: {
-        2: 64,  # 64MB
-        4: 2,  # 2MB
-        8: 0.5,  # 0.5MB
-    },
-    100: {
-        2: 64,  # 64MB
-        4: 32,  # 32MB
-        8: 1,  # 1MB
-        16: 64,  # 64MB (mnnvl multi-node)
-    },
-    103: {
-        2: 64,  # 64MB
-        4: 64,  # 64MB
-        8: 4,  # 4MB
-        16: 64,  # 64MB (mnnvl multi-node)
-    },
-    107: {
-        2: 64,  # 64MB
-        4: 64,  # 64MB
-        8: 2,  # 2MB
-    },
-}
-
-# Max size of the input tensor per world size per device capability
 # to use flashinfer one shot fused allreduce
 # OneShot max size is at most 64MB / world size (FlashInfer restriction)
 _FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB: dict[int, dict[int, float]] = {

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -103,6 +103,38 @@ class CUDAGraphMode(enum.Enum):
         return self != CUDAGraphMode.NONE
 
 
+# Max size of the input tensor per world size per device capability
+# to use flashinfer fused allreduce.  Kept here rather than in
+# allreduce_rms_fusion.py (which never reads it back) so that config
+# resolution can look up the table without importing the fusion pass
+# module — importing it eagerly drags in flashinfer, whose import
+# initializes CUDA as a side effect.
+FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
+    90: {
+        2: 64,  # 64MB
+        4: 2,  # 2MB
+        8: 0.5,  # 0.5MB
+    },
+    100: {
+        2: 64,  # 64MB
+        4: 32,  # 32MB
+        8: 1,  # 1MB
+        16: 64,  # 64MB (mnnvl multi-node)
+    },
+    103: {
+        2: 64,  # 64MB
+        4: 64,  # 64MB
+        8: 4,  # 4MB
+        16: 64,  # 64MB (mnnvl multi-node)
+    },
+    107: {
+        2: 64,  # 64MB
+        4: 64,  # 64MB
+        8: 2,  # 2MB
+    },
+}
+
+
 @config
 class PassConfig:
     """Configuration for custom Inductor passes.
@@ -164,18 +196,8 @@ class PassConfig:
     float in MB.
     Unspecified will fallback to default values
     which are compute capability and world size dependent.
-        FI_ALLREDUCE_FUSION_MAX_SIZE_MB = {
-            90: {
-                2: 64,  # 64MB
-                4: 2,  # 2MB
-                8: 1,  # 1MB
-            },
-            100: {
-                2: 64,  # 64MB
-                4: 32,  # 32MB
-                8: 1,  # 1MB
-            },
-        }, where key is the device capability"""
+    See :data:`FI_ALLREDUCE_FUSION_MAX_SIZE_MB`, keyed by device
+    capability."""
     sp_min_token_num: int | None = None
     """The minimum number of tokens above which vllm should use
     sequence parallelism. Specified as an integer token count.
@@ -203,9 +225,6 @@ class PassConfig:
 
     @staticmethod
     def default_fi_allreduce_fusion_max_size_mb() -> dict[int, float]:
-        from vllm.compilation.passes.fusion.allreduce_rms_fusion import (
-            FI_ALLREDUCE_FUSION_MAX_SIZE_MB,
-        )
         from vllm.platforms import current_platform
 
         if not current_platform.is_cuda():


### PR DESCRIPTION

## Purpose

On Hopper/Blackwell with `tensor_parallel_size > 1` and `flashinfer` installed,
`create_engine_config()` initializes CUDA in the calling process before any engine
exists. This silently overrides `VLLM_WORKER_MULTIPROC_METHOD` from the documented
default (`fork`) to `spawn`, breaking `tests/v1/shutdown/` and causing a warning on
every `LLM()` library call.

Reproduce the warning (Hopper/Blackwell, 2 GPUs):

```bash
python3 -c "
from vllm import LLM
LLM('hmellor/tiny-random-LlamaForCausalLM', tensor_parallel_size=2, enforce_eager=True)
" 2>&1 | grep 'must use the .spawn.'
```

```
WARNING ... We must use the `spawn` multiprocessing start method. Overriding
VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. ... Reasons: CUDA is initialized
```

Reproduce the test failures (Hopper/Blackwell, 2 GPUs):

```bash
cd tests && python3 -m pytest -v -s --tb=long --import-mode=append \
    'v1/shutdown/test_forward_error.py::test_async_llm_model_error[hmellor/tiny-random-LlamaForCausalLM-2]' \
    'v1/shutdown/test_forward_error.py::test_async_llm_model_error[hmellor/tiny-random-LlamaForCausalLM-1]' \
    'v1/shutdown/test_forward_error.py::test_llm_model_error[hmellor/tiny-random-LlamaForCausalLM-2-True]'
```

All three fail: the monkeypatch-based fault injection silently no-ops under the forced
`spawn` (monkeypatch does not survive across `spawn`), so the tests get `DID NOT RAISE`
instead of `EngineDeadError`. The `[...-1]` variant fails as a cascade: the `[...-2]`
engine leaks because the assertion fails before `shutdown()`, starving the next test's
GPU memory.

`docs/design/multiprocessing.md` (#11074) scopes the force-spawn fallback to callers
that initialize CUDA themselves before invoking vLLM — not to vLLM doing it internally.
(`vllm serve` is not affected — it sets `spawn` unconditionally before config resolution
via `api_utils.py:164-166`.)

## Root Cause

```
vllm/config/vllm.py:2233        if pass_config.fuse_allreduce_rms: → flashinfer_max_size(tp_size)
vllm/config/compilation.py:206    → import FI_ALLREDUCE_FUSION_MAX_SIZE_MB from allreduce_rms_fusion
allreduce_rms_fusion.py:87-90       module-level: if find_spec("flashinfer"): import flashinfer.comm
flashinfer/jit/env.py:161             module-level: torch.cuda.get_device_capability() → CUDA init
```

`default_fi_allreduce_fusion_max_size_mb()` reads a pure constant table but imports the
entire `allreduce_rms_fusion` pass module to get it — that module eagerly imports
`flashinfer.comm`, whose import initializes CUDA. The table is defined but never read
back within `allreduce_rms_fusion.py` (`grep` confirms one hit: the definition only).
Wrong import direction. `vllm/utils/flashinfer.py`'s `has_flashinfer()` already
documents the pattern to avoid this ("Use find_spec ... to avoid potential CUDA
initialization side effects").

Bisected to `addac0e653` (#34299, 2026-02-11) which flipped `fuse_allreduce_rms` from
`False` to `enable_allreduce_rms_fusion` under default `-O2`. ~7 month exposure window.

CI stays green because `tests/v1/shutdown/` runs on `device: l4` (below the
Hopper/Blackwell gate), while the 23+ Hopper/Blackwell TP>1 lanes that do trigger the
defect only produce a warning, not a failure.

## Fix

Move `FI_ALLREDUCE_FUSION_MAX_SIZE_MB` into `vllm/config/compilation.py`, reversing the
import direction so config resolution never imports the fusion pass. The table is
defined but never read back in `allreduce_rms_fusion.py`, so removing it is safe.
Docstring copy in `compilation.py` was already stale (missing `103`/`107` Blackwell
entries) — replaced with a pointer to the single definition.

Two files, pure relocation + one import removal + docstring sync, no runtime logic
change.

## Test Plan

The reproduction commands in Purpose above, on Hopper/Blackwell with 2 GPUs.

## Test Result

Verified on Blackwell (GB300, capability 10.3).

**Before:** spawn warning on every TP>1 `LLM()` start; three subtests FAILED.

**After:** spawn warning gone; all three PASSED.

| Subtest | Before | After |
|---------|--------|-------|
| `test_async_llm_model_error[hmellor/tiny-random-LlamaForCausalLM-2]` | FAILED (monkeypatch lost under forced spawn) | **PASSED** |
| `test_async_llm_model_error[hmellor/tiny-random-LlamaForCausalLM-1]` | FAILED (OOM cascade from leaked engine above) | **PASSED** |
| `test_llm_model_error[hmellor/tiny-random-LlamaForCausalLM-2-True]` | FAILED (same, sync variant) | **PASSED** |

## Duplicate-work check

```bash
gh issue list --repo vllm-project/vllm --state all --search "create_engine_config CUDA initialized"
gh pr    list --repo vllm-project/vllm --state all --search "lazy import flashinfer"
gh pr    list --repo vllm-project/vllm --state all --search "flashinfer_max_size"
```
Clean as of 2026-09-10. Precedent: #47446 → #47539, a mechanically identical
"eager import initializes CUDA before fork" regression, merged in 4 days.

## AI assistance

Prepared with AI assistance (Claude Code); human submitter reviewed every changed
line and independently verified the reproduction on real hardware before submission.