### PR TITLE
[Model] Add FlashInfer PrimTS QSA backend for Qwen3.8-Flash-Next

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -129,6 +129,7 @@ if TYPE_CHECKING:
     VLLM_USE_HW_AGNOSTIC: bool = False
     VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE: bool = True
     VLLM_GDN_DECODE_KERNEL: Literal["cuda", "triton"] = "cuda"
+    VLLM_QSA_ATTENTION_BACKEND: Literal["auto", "triton", "prims_ts"] = "auto"
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
@@ -1235,6 +1236,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "VLLM_GDN_DECODE_KERNEL",
         "cuda",
         ["cuda", "triton"],
+        case_sensitive=False,
+    ),
+    # Select Qwen sparse attention; auto uses PrimTS when supported and
+    # available, otherwise Triton. Explicit prims_ts fails if unsupported.
+    "VLLM_QSA_ATTENTION_BACKEND": env_with_choices(
+        "VLLM_QSA_ATTENTION_BACKEND",
+        "auto",
+        ["auto", "triton", "prims_ts"],
         case_sensitive=False,
     ),
     # Disable pynccl (using torch.distributed instead)

--- a/vllm/model_executor/layers/attention_layer_base.py
+++ b/vllm/model_executor/layers/attention_layer_base.py
@@ -31,6 +31,15 @@ class AttentionLayerBase(ABC):
         """
         self.kv_cache = kv_cache
 
+    def unbind_kv_cache(self) -> None:
+        """Release cache views installed by :meth:`bind_kv_cache`.
+
+        Subclasses retaining derived views or cache-dependent state should
+        override this hook and release those references before returning.
+        """
+        kv_cache = self.kv_cache
+        self.kv_cache = torch.tensor([]) if isinstance(kv_cache, torch.Tensor) else []
+
     @abstractmethod
     def get_attn_backend(self) -> type[AttentionBackend]:
         """Get the attention backend class for this layer."""

--- a/vllm/model_executor/warmup/qwen4_exp_qsa_warmup.py
+++ b/vllm/model_executor/warmup/qwen4_exp_qsa_warmup.py
@@ -71,6 +71,11 @@ def qwen4_exp_qsa_triton_warmup(worker: "Worker") -> None:
     )
     logger.info("Warmed up Qwen4Exp QSA decode kernels: %s.", profiles)
 
+    if owner.impl.use_q_token_kv_block_sparse_ts:
+        # PrimTS plans compile during graph/eager warmup; only the shared
+        # indexer uses the Triton kernels above on this backend.
+        return
+
     from vllm.models.qwen4_exp.nvidia.ops.qsa import (
         warmup_qsa_sparse_paged_attention,
     )

--- a/vllm/models/qwen4_exp/common/qsa_cache.py
+++ b/vllm/models/qwen4_exp/common/qsa_cache.py
@@ -19,7 +19,7 @@ from typing import ClassVar
 import torch
 from torch import nn
 
-from vllm.config import CacheConfig, VllmConfig
+from vllm.config import CacheConfig, CUDAGraphMode, VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.platforms import current_platform
@@ -571,6 +571,62 @@ build_qsa_metadata = (
     build_qsa_metadata_triton if HAS_TRITON else _build_qsa_metadata_torch
 )
 
+Q_TOKEN_KV_BLOCK_SPARSE_TS_GROUP_SIZES = (1, 2, 4, 5)
+
+
+def _uniform_qsa_decode_query_len(
+    query_start_offsets: tuple[int, ...] | None,
+    *,
+    num_query_tokens: int,
+    max_query_len: int,
+    has_prefill: bool,
+) -> int | None:
+    """Return the proven fixed decode width, or ``None`` if not provable.
+
+    ``num_query_tokens`` may include CUDA-graph token padding and the request
+    offsets may include zero-length padded request rows. Positive request
+    lengths must all agree. Wider groups must equal ``max_query_len``; Q1 is
+    also legal when a varlen graph advertises a larger runtime upper bound.
+    Total divisibility alone is insufficient: request lengths 1 and 3 would
+    otherwise be grouped into one unsafe G=4 route.
+    """
+
+    if (
+        has_prefill
+        or query_start_offsets is None
+        or len(query_start_offsets) < 2
+        or max_query_len <= 0
+        or num_query_tokens <= 0
+        or query_start_offsets[0] != 0
+        or query_start_offsets[-1] > num_query_tokens
+    ):
+        return None
+
+    query_lens = tuple(
+        end - begin
+        for begin, end in zip(
+            query_start_offsets,
+            query_start_offsets[1:],
+            strict=False,
+        )
+    )
+    positive_lens = tuple(length for length in query_lens if length > 0)
+    uniform_query_len = positive_lens[0] if positive_lens else 0
+    if (
+        not positive_lens
+        or any(length < 0 for length in query_lens)
+        or any(length != uniform_query_len for length in positive_lens)
+        # Varlen piecewise graphs are profiled with one dummy token per
+        # request while max_query_len remains the runtime upper bound. Q1 is
+        # request-independent and therefore safe in that special case. Wider
+        # fixed groups still require the exact promised runtime width.
+        or (uniform_query_len != 1 and uniform_query_len != max_query_len)
+        or num_query_tokens % uniform_query_len
+        or query_start_offsets[-1] != uniform_query_len * len(positive_lens)
+    ):
+        return None
+    return uniform_query_len
+
 
 @dataclass
 class QSAForwardMetadata(AttentionMetadata):
@@ -580,6 +636,7 @@ class QSAForwardMetadata(AttentionMetadata):
     slot_mapping: torch.Tensor
     seq_lens: torch.Tensor
     query_start_loc: torch.Tensor
+    query_start_offsets: tuple[int, ...] | None
     token_to_req: torch.Tensor
     logical_positions: torch.Tensor
     visible_blocks: torch.Tensor
@@ -594,6 +651,9 @@ class QSAForwardMetadata(AttentionMetadata):
     max_seq_len: int
     storage_block_size: int
     compress_ratio: int
+    has_prefill: bool
+    uniform_decode_query_len: int | None
+    prepare_cudagraph_plan: bool
 
 
 class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
@@ -620,6 +680,19 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
             self.compress_ratio = compress_ratio
         else:
             self.compress_ratio = 1
+        decode_group_size = vllm_config.uniform_decode_query_len
+        self.decode_group_size = (
+            int(decode_group_size)
+            if decode_group_size in Q_TOKEN_KV_BLOCK_SPARSE_TS_GROUP_SIZES
+            else 1
+        )
+        compilation_config = vllm_config.compilation_config
+        capture_sizes = compilation_config.cudagraph_capture_sizes or []
+        self.full_decode_graph_token_counts = (
+            frozenset(int(size) for size in capture_sizes)
+            if compilation_config.cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+            else frozenset()
+        )
         self.storage_block_size = kv_cache_spec.num_states
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         self.token_to_req_buffer = torch.empty(
@@ -654,7 +727,7 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
         common_attn_metadata: CommonAttentionMetadata,
         fast_build: bool = False,
     ) -> QSAForwardMetadata:
-        del common_prefix_len, fast_build
+        del common_prefix_len
         num_tokens = common_attn_metadata.num_actual_tokens
         decode_threshold = self.reorder_batch_threshold
         assert decode_threshold is not None
@@ -702,11 +775,42 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
                 request_capacity=request_capacity,
             )
         )
+        is_prefilling = getattr(common_attn_metadata, "is_prefilling", None)
+        has_prefill = is_prefilling is None or bool(is_prefilling.any().item())
+        query_start_offsets = (
+            None
+            if fast_build
+            else tuple(
+                int(offset)
+                for offset in common_attn_metadata.query_start_loc_cpu[
+                    : common_attn_metadata.num_reqs + 1
+                ].tolist()
+            )
+        )
+        uniform_decode_query_len = _uniform_qsa_decode_query_len(
+            query_start_offsets,
+            num_query_tokens=num_tokens,
+            max_query_len=getattr(common_attn_metadata, "max_query_len", 0),
+            has_prefill=has_prefill,
+        )
+        decode_group_size = getattr(self, "decode_group_size", 1)
+        uses_fixed_decode = not has_prefill and (
+            query_start_offsets is None
+            or decode_group_size == 1
+            or uniform_decode_query_len == 1
+            or uniform_decode_query_len == decode_group_size
+        )
+        prepare_cudagraph_plan = uses_fixed_decode and num_tokens in getattr(
+            self, "full_decode_graph_token_counts", frozenset()
+        )
         return QSAForwardMetadata(
             block_table=common_attn_metadata.block_table_tensor,
             slot_mapping=slot_mapping,
             seq_lens=common_attn_metadata.seq_lens,
             query_start_loc=common_attn_metadata.query_start_loc,
+            # Fast drafting metadata has no authoritative CPU request
+            # boundaries. Keep that path on the request-independent Q1 route.
+            query_start_offsets=query_start_offsets,
             token_to_req=token_to_req,
             logical_positions=logical_positions,
             visible_blocks=visible_blocks,
@@ -721,7 +825,30 @@ class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
             max_seq_len=common_attn_metadata.max_seq_len,
             storage_block_size=self.storage_block_size,
             compress_ratio=self.compress_ratio,
+            has_prefill=has_prefill,
+            uniform_decode_query_len=uniform_decode_query_len,
+            prepare_cudagraph_plan=prepare_cudagraph_plan,
         )
+
+    def build_for_cudagraph_capture(
+        self, common_attn_metadata: CommonAttentionMetadata
+    ) -> QSAForwardMetadata:
+        """Mark metadata whose warmup and replay belong to a FULL graph.
+
+        vLLM's standalone MTP graph manager deliberately invokes both its
+        warmup and the body recorded by ``torch.cuda.graph`` with forward
+        context mode ``NONE``.  The metadata builder is the only component
+        that still receives the explicit FULL-capture signal in that path.
+        Carry it to the QSA owner so preparation happens during warmup and
+        capture only reuses graph-stable storage.
+        """
+
+        metadata = self.build(
+            common_prefix_len=0,
+            common_attn_metadata=common_attn_metadata,
+        )
+        metadata.prepare_cudagraph_plan = True
+        return metadata
 
 
 class QSAStateBackend(AttentionBackend):
@@ -837,6 +964,11 @@ class QSAKeyStateCache(_QSAStateCache):
             self.rope_position_cache = position_tail.view(torch.int64)
         else:
             self.rope_position_cache = None
+
+    def unbind_kv_cache(self) -> None:
+        self.key_cache = None
+        self.rope_position_cache = None
+        super().unbind_kv_cache()
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         # Hold the open group's committed keys plus every row a speculative

--- a/vllm/models/qwen4_exp/common/qsa_cache.py
+++ b/vllm/models/qwen4_exp/common/qsa_cache.py
@@ -12,7 +12,7 @@ shared by the generic cache-layout planner.
 """
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cache
 from typing import ClassVar
 
@@ -654,6 +654,10 @@ class QSAForwardMetadata(AttentionMetadata):
     has_prefill: bool
     uniform_decode_query_len: int | None
     prepare_cudagraph_plan: bool
+    # Immutable CPU/device query routes shared by layers in this forward pass.
+    q_token_kv_block_sparse_qo_indptr: dict[
+        tuple[object, ...], tuple[torch.Tensor, torch.Tensor]
+    ] = field(default_factory=dict)
 
 
 class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):

--- a/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
@@ -195,6 +195,10 @@ class QSAIndexer(nn.Module):
         """
         return self.output_width + 1
 
+    @property
+    def block_topk(self) -> int:
+        return self.token_topk // self.compress_ratio
+
     def _metadata(
         self,
     ) -> tuple[QSAForwardMetadata, QSAForwardMetadata] | None:
@@ -236,14 +240,14 @@ class QSAIndexer(nn.Module):
         projected_qk: torch.Tensor,
         positions: torch.Tensor,
         out: torch.Tensor | None = None,
+        *,
+        compact_blocks: bool = False,
     ) -> torch.Tensor:
         """Update side caches and select token indices from pre-projected Q/K.
 
-        Returns the packed buffer of shape [num_tokens, output_width + 1]:
-        the leading ``output_width`` columns are ``-1``-padded
-        request-relative token indices, and the trailing column is the row's
-        valid-entry count (the attention kernel's loop bound, never a token
-        index).
+        Compact mode returns [num_tokens, block_topk] logical block IDs for
+        PrimTS. Otherwise return [num_tokens, output_width + 1], with a
+        trailing valid-entry count after the padded token-index columns.
         """
 
         metadata = self._metadata()
@@ -251,14 +255,18 @@ class QSAIndexer(nn.Module):
             # Preserve step-0 indices when later MTP steps reuse the buffer.
             if self.skip_topk and out is not None:
                 return out
+            selection_width = (
+                self.block_topk if compact_blocks else self.packed_output_width
+            )
             result = torch.full(
-                (projected_qk.shape[0], self.packed_output_width),
+                (projected_qk.shape[0], selection_width),
                 -1,
                 dtype=torch.int32,
                 device=projected_qk.device,
             )
-            # Inert rows carry a zero valid count (empty loop bound), not -1.
-            result[:, -1] = 0
+            if not compact_blocks:
+                # Inert expanded rows carry an empty tile-loop bound.
+                result[:, -1] = 0
             if out is not None:
                 out.copy_(result)
                 return out
@@ -389,24 +397,31 @@ class QSAIndexer(nn.Module):
                 raise RuntimeError("QSA top-k reuse requires an output buffer")
             return out
 
+        selection_width = (
+            self.block_topk if compact_blocks else self.packed_output_width
+        )
         if out is None:
             out = torch.empty(
                 num_tokens,
-                self.packed_output_width,
+                selection_width,
                 dtype=torch.int32,
                 device=q.device,
             )
-        elif out.shape != (num_tokens, self.packed_output_width):
+        elif out.shape != (num_tokens, selection_width):
             raise ValueError("QSA selection output has an invalid shape")
 
         num_decode_tokens = compressed_metadata.num_decode_tokens
         decode_query_len = compressed_metadata.decode_query_len
         visible_blocks = compressed_metadata.visible_blocks[:num_tokens]
-        block_indices = torch.empty(
-            num_tokens,
-            self.token_topk // self.compress_ratio,
-            dtype=torch.int32,
-            device=q.device,
+        block_indices = (
+            out
+            if compact_blocks
+            else torch.empty(
+                num_tokens,
+                self.block_topk,
+                dtype=torch.int32,
+                device=q.device,
+            )
         )
 
         # Decode requests occupy the leading rows and share one query length.
@@ -442,14 +457,15 @@ class QSAIndexer(nn.Module):
                 block_indices[prefill_slice],
                 compressed_metadata.max_seq_len,
             )
-        expand_qsa_block_indices(
-            block_indices,
-            compressed_metadata.logical_positions[:num_tokens],
-            visible_blocks,
-            self.compress_ratio,
-            self.token_topk,
-            out,
-        )
+        if not compact_blocks:
+            expand_qsa_block_indices(
+                block_indices,
+                compressed_metadata.logical_positions[:num_tokens],
+                visible_blocks,
+                self.compress_ratio,
+                self.token_topk,
+                out,
+            )
         return out
 
 

--- a/vllm/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp.py
@@ -223,6 +223,16 @@ class Qwen4ExpMultiTokenPredictor(nn.Module):
             Qwen4ExpSparseMoeBlock,
             "mlp",
         )
+        for attention in self._iter_qsa_attentions():
+            if attention.qsa_indices_are_blocks:
+                # Expanded Triton rows already freeze the step-0 tail. Compact
+                # selections need its position to reconstruct the same tail.
+                attention.topk_query_positions_buffer = torch.full(
+                    (attention.topk_indices_buffer.shape[0],),
+                    -1,
+                    dtype=torch.int64,
+                    device=attention.topk_indices_buffer.device,
+                )
 
         self.pre_fc_norm_embedding = GemmaRMSNorm(
             self.hidden_size, eps=config.rms_norm_eps
@@ -273,6 +283,9 @@ class Qwen4ExpMultiTokenPredictor(nn.Module):
             buffer = attention.topk_indices_buffer
             selected = buffer.index_select(0, row_indices)
             buffer[:num_rows].copy_(selected)
+            positions = attention.topk_query_positions_buffer
+            if positions is not None:
+                positions[:num_rows].copy_(positions.index_select(0, row_indices))
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Triton kernels for Qwen4Exp QSA sparse attention and cache updates."""
+"""Qwen4Exp weight-free QSA kernels and optional FlashInfer bridge."""
 
 from __future__ import annotations
+
+from collections.abc import Callable
+from functools import lru_cache
+from typing import Protocol, cast
 
 import torch
 
@@ -11,6 +15,32 @@ from vllm.model_executor.warmup.jit_warmup_triton_helper import (
     triton_scalar_specialization_rep,
 )
 from vllm.triton_utils import HAS_TRITON, tl, triton
+
+_QTokenKvBlockSparseTSAPIs = tuple[
+    Callable[..., int],
+    Callable[..., int],
+    Callable[..., torch.Tensor],
+    Callable[..., "_QTokenKvBlockSparseTSPlan"],
+]
+
+
+class _QTokenKvBlockSparseTSPlan(Protocol):
+    def plan(self, *args: object, **kwargs: object) -> None: ...
+
+    def run(
+        self,
+        q: torch.Tensor,
+        paged_kv_cache: tuple[torch.Tensor, torch.Tensor],
+        block_table: torch.Tensor,
+        indexer_block_ids: torch.Tensor,
+        token_to_request: torch.Tensor,
+        query_positions: torch.Tensor,
+        *,
+        qo_indptr: torch.Tensor | None = None,
+        sm_scale: float | None = None,
+        v_scale: float | None = None,
+        out: torch.Tensor,
+    ) -> torch.Tensor: ...
 
 
 @triton.jit(do_not_specialize=["num_rows", "num_requests"])
@@ -39,6 +69,8 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     num_rows,
     num_cache_blocks,
     num_requests,
+    bmm1_scale,
+    bmm2_scale,
     TOPK: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
     PAGE_TABLE_WIDTH: tl.constexpr,
@@ -78,7 +110,7 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
     max_value = tl.full((BLOCK_M,), -1.0e20, dtype=tl.float32)
     normalizer = tl.zeros((BLOCK_M,), dtype=tl.float32)
     accumulator = tl.zeros((BLOCK_M, HEAD_DIM), dtype=tl.float32)
-    softmax_scale_log2: tl.constexpr = (HEAD_DIM**-0.5) * 1.4426950408889634
+    softmax_scale_log2 = bmm1_scale * 1.4426950408889634
 
     tile_end = tl.minimum(NUM_TILES, tl.cdiv(tl.minimum(valid_count, TOPK), BLOCK_N))
 
@@ -149,6 +181,7 @@ def _qsa_sparse_paged_gqa_splitk_kernel(
         accumulator / tl.maximum(normalizer[:, None], 1.0e-20),
         0.0,
     )
+    normalized_output *= bmm2_scale
     output_mask = head_offsets[:, None] < GROUP_SIZE
     if NUM_SPLITS == 1:
         tl.store(
@@ -446,6 +479,206 @@ def _select_config(
     return BLOCK_N, num_warps, num_tiles, num_splits
 
 
+@lru_cache
+def _q_token_kv_block_sparse_ts_apis() -> _QTokenKvBlockSparseTSAPIs | None:
+    """Resolve QToken-KvBlock-Sparse-Attention without a hard dependency.
+
+    The validator is a compatibility sentinel for the caller-owned grouping
+    contract. Workspace sizing and plan preparation perform the validation,
+    so the bridge deliberately does not add another hot-path call.
+    """
+
+    try:
+        from flashinfer.decode import (
+            QTokenKvBlockSparsePagedTSWrapper,
+            get_q_token_kv_block_sparse_workspace_size,
+            make_q_token_kv_block_sparse_qo_indptr,
+            validate_q_token_kv_block_sparse_group_size,
+        )
+    except (AttributeError, ImportError):
+        return None
+    return (
+        validate_q_token_kv_block_sparse_group_size,
+        get_q_token_kv_block_sparse_workspace_size,
+        make_q_token_kv_block_sparse_qo_indptr,
+        QTokenKvBlockSparsePagedTSWrapper,
+    )
+
+
+def has_q_token_kv_block_sparse_ts_attention() -> bool:
+    """Return whether FlashInfer exposes QToken-KvBlock-Sparse-Attention."""
+
+    return _q_token_kv_block_sparse_ts_apis() is not None
+
+
+def q_token_kv_block_sparse_ts_combined_workspace_size(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    block_topk: int,
+    *,
+    max_seq_len_kv: int,
+    o_data_type: torch.dtype | None = None,
+    qo_indptr: torch.Tensor | None = None,
+    seq_len_q: int | None = None,
+    kv_block_size: int = 4,
+) -> int:
+    """Return bytes required for a fixed or packed causal QSA launch."""
+
+    apis = _q_token_kv_block_sparse_ts_apis()
+    if apis is None:
+        raise RuntimeError(
+            "FlashInfer does not provide QToken-KvBlock-Sparse-Attention"
+        )
+    _, get_workspace_size, _, _ = apis
+    return int(
+        get_workspace_size(
+            q,
+            k_cache,
+            block_table,
+            block_topk=block_topk,
+            max_seq_len_kv=max_seq_len_kv,
+            o_data_type=o_data_type,
+            qo_indptr=qo_indptr,
+            seq_len_q=seq_len_q,
+            kv_block_size=kv_block_size,
+        )
+    )
+
+
+@lru_cache(maxsize=1)
+def _q_token_kv_block_sparse_ts_qo_indptr_cached(
+    query_starts: tuple[int, ...],
+    num_query_tokens: int,
+    group_size: int,
+) -> torch.Tensor:
+    """Build one immutable CPU route tensor shared by all QSA layers."""
+
+    apis = _q_token_kv_block_sparse_ts_apis()
+    if apis is None:
+        raise RuntimeError(
+            "FlashInfer does not provide QToken-KvBlock-Sparse-Attention"
+        )
+    _, _, make_qo_indptr, _ = apis
+    return make_qo_indptr(
+        torch.tensor(query_starts, dtype=torch.int32),
+        num_query_tokens,
+        group_size=group_size,
+        device="cpu",
+    )
+
+
+def q_token_kv_block_sparse_ts_qo_indptr(
+    query_start_offsets: tuple[int, ...] | torch.Tensor | None,
+    num_query_tokens: int,
+    group_size: int,
+) -> torch.Tensor:
+    """Return CPU packed-route offsets for a fixed maximum group size.
+
+    Prefill uses this packed-Q representation so request tails remain
+    explicit. Decode omits ``qo_indptr`` and uses the fixed five-dimensional
+    QSA layout; a runtime shape that cannot prove the configured complete MTP
+    group falls back to request-independent fixed Q1.
+    """
+
+    if query_start_offsets is None:
+        raise ValueError("packed QSA requires CPU query boundaries")
+    if isinstance(query_start_offsets, torch.Tensor):
+        query_starts = tuple(int(value) for value in query_start_offsets.tolist())
+    else:
+        query_starts = query_start_offsets
+    return _q_token_kv_block_sparse_ts_qo_indptr_cached(
+        query_starts,
+        num_query_tokens,
+        group_size,
+    )
+
+
+def q_token_kv_block_sparse_ts_prepare_attention(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    indexer_block_ids: torch.Tensor,
+    workspace_buffer: torch.Tensor,
+    out: torch.Tensor,
+    *,
+    max_seq_len_kv: int,
+    qo_indptr: torch.Tensor | None = None,
+    seq_len_q: int | None = None,
+    kv_block_size: int = 4,
+) -> object:
+    """Plan one framework-owned QToken-KvBlock-Sparse-Attention wrapper."""
+
+    apis = _q_token_kv_block_sparse_ts_apis()
+    if apis is None:
+        raise RuntimeError(
+            "FlashInfer does not provide QToken-KvBlock-Sparse-Attention"
+        )
+    _, _, _, wrapper_type = apis
+    use_packed_q = qo_indptr is not None
+    if qo_indptr is not None:
+        if seq_len_q is None:
+            raise ValueError("packed QToken attention requires seq_len_q")
+        batch_size = int(qo_indptr.numel()) - 1
+    else:
+        if q.ndim != 5:
+            raise ValueError("fixed QToken attention requires [B,Nq,G,Hq,D] q")
+        batch_size = int(q.shape[0] * q.shape[1])
+        fixed_seq_len_q = int(q.shape[2])
+        if seq_len_q is not None and seq_len_q != fixed_seq_len_q:
+            raise ValueError("fixed seq_len_q must match q.shape[2]")
+        seq_len_q = fixed_seq_len_q
+    plan = wrapper_type()
+    plan.plan(
+        batch_size,
+        seq_len_q,
+        int(q.shape[-2]),
+        int(k_cache.shape[1]),
+        int(q.shape[-1]),
+        kv_block_size,
+        int(k_cache.shape[2]),
+        int(indexer_block_ids.shape[1]),
+        max_seq_len_kv,
+        device=q.device,
+        workspace_buffer=workspace_buffer,
+        use_packed_q=use_packed_q,
+        q_data_type=q.dtype,
+        kv_data_type=k_cache.dtype,
+        o_data_type=out.dtype,
+    )
+    return plan
+
+
+def q_token_kv_block_sparse_ts_run_prepared(
+    plan: object,
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    indexer_block_ids: torch.Tensor,
+    token_to_request: torch.Tensor,
+    query_positions: torch.Tensor,
+    out: torch.Tensor,
+    *,
+    qo_indptr: torch.Tensor | None = None,
+    sm_scale: float | None = None,
+    v_scale: float | None = None,
+) -> torch.Tensor:
+    """Launch a prepared framework-owned metadata-plus-attention plan."""
+
+    return cast(_QTokenKvBlockSparseTSPlan, plan).run(
+        q,
+        (k_cache, v_cache),
+        block_table,
+        indexer_block_ids,
+        token_to_request,
+        query_positions,
+        qo_indptr=qo_indptr,
+        sm_scale=sm_scale,
+        v_scale=v_scale,
+        out=out,
+    )
+
+
 def qsa_sparse_paged_attention(
     q: torch.Tensor,
     k_cache: torch.Tensor,
@@ -455,8 +688,11 @@ def qsa_sparse_paged_attention(
     token_to_req: torch.Tensor,
     use_prefill_config: bool,
     out: torch.Tensor | None = None,
+    *,
+    bmm1_scale: float | None = None,
+    bmm2_scale: float = 1.0,
 ) -> torch.Tensor:
-    """Run sparse GQA directly over paged BF16 K/V caches.
+    """Run sparse GQA directly over paged BF16 or FP8-E4M3 K/V caches.
 
     logical_indices is the PACKED selection buffer: [rows, selection_width + 1]
     with the trailing column holding each row's valid-entry count (written by
@@ -480,7 +716,10 @@ def qsa_sparse_paged_attention(
         raise ValueError("QSA sparse attention requires valid grouped-query heads")
     head_dim = q.shape[2]
     assert head_dim >= 16 and (head_dim & (head_dim - 1)) == 0
-    assert q.dtype == k_cache.dtype == v_cache.dtype == torch.bfloat16
+    if q.dtype != k_cache.dtype or q.dtype != v_cache.dtype:
+        raise ValueError("QSA sparse attention requires matching Q/K/V dtypes")
+    if q.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+        raise ValueError("QSA sparse attention supports BF16 and FP8-E4M3 Q/K/V")
     assert logical_indices.dtype == block_table.dtype == torch.int32
     assert token_to_req.dtype == torch.int32
     assert q.device == k_cache.device == v_cache.device
@@ -494,10 +733,19 @@ def qsa_sparse_paged_attention(
         out = torch.empty_like(q)
     if out.shape != q.shape:
         raise ValueError("QSA sparse output must match its query")
-    assert out.dtype == q.dtype and out.device == q.device
+    output_dtype_supported = out.dtype == q.dtype or (
+        q.dtype == torch.float8_e4m3fn and out.dtype in (torch.float16, torch.bfloat16)
+    )
+    if not output_dtype_supported or out.device != q.device:
+        raise ValueError(
+            "QSA sparse output must use the query dtype, or FP16/BF16 for FP8 "
+            "inputs, and reside on the query device"
+        )
     assert out.stride(2) == 1
     if not q.shape[0]:
         return out
+    if bmm1_scale is None:
+        bmm1_scale = head_dim**-0.5
 
     group_size = q.shape[1] // k_cache.shape[2]
     block_m = triton.next_power_of_2(group_size)
@@ -548,6 +796,8 @@ def qsa_sparse_paged_attention(
         q.shape[0],
         k_cache.shape[0],
         block_table.shape[0],
+        bmm1_scale,
+        bmm2_scale,
         TOPK=selection_width,
         PAGE_SIZE=k_cache.shape[1],
         PAGE_TABLE_WIDTH=block_table.shape[1],
@@ -590,6 +840,10 @@ def warmup_qsa_sparse_paged_attention(
 ) -> tuple[tuple[int, int, int], ...]:
     """Compile every production-reachable split-K/merge specialization."""
 
+    if kv_cache.dtype == torch.uint8:
+        # The framework stores FP8 cache bytes; runtime attention views them
+        # as E4M3 before launching, so warmup must use that same pointer type.
+        kv_cache = kv_cache.view(torch.float8_e4m3fn)
     head_dim = kv_cache.shape[-1] // 2
     key_cache, value_cache = kv_cache.transpose(1, 2).split(head_dim, dim=-1)
     num_kv_heads = key_cache.shape[2]
@@ -609,7 +863,7 @@ def warmup_qsa_sparse_paged_attention(
     num_rows = 16
     num_requests = 16
     q_ptr = TritonWarmupTensor(
-        torch.bfloat16, shape=(num_rows, num_query_heads, head_dim)
+        key_cache.dtype, shape=(num_rows, num_query_heads, head_dim)
     )
     k_cache_ptr = TritonWarmupTensor(
         key_cache.dtype,
@@ -674,6 +928,8 @@ def warmup_qsa_sparse_paged_attention(
             num_rows,
             num_cache_blocks,
             num_requests,
+            head_dim**-0.5,
+            1.0,
             TOPK=selection_width,
             PAGE_SIZE=key_cache.shape[1],
             PAGE_TABLE_WIDTH=block_table.shape[1],
@@ -863,6 +1119,10 @@ def qsa_compress_groups_with_ratio(
 
 __all__ = [
     "qsa_compress_groups_with_ratio",
+    "q_token_kv_block_sparse_ts_combined_workspace_size",
+    "q_token_kv_block_sparse_ts_qo_indptr",
+    "q_token_kv_block_sparse_ts_prepare_attention",
+    "q_token_kv_block_sparse_ts_run_prepared",
     "qsa_sparse_paged_attention",
     "qsa_store_cache_rows",
     "warmup_qsa_sparse_paged_attention",

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -1,16 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""NVIDIA QSA owner with Triton kernels."""
+"""NVIDIA QSA attention owner."""
 
 from __future__ import annotations
 
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import ClassVar, cast
+from weakref import WeakValueDictionary
 
 import torch
 from torch import nn
 
+from vllm import _custom_ops as custom_ops
+from vllm import envs
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
-from vllm.config import VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
@@ -28,6 +34,8 @@ from vllm.transformers_utils.configs.qwen4_exp import (
     Qwen4ExpTextConfig,
 )
 from vllm.utils.torch_utils import (
+    canonicalize_singleton_dim_strides,
+    is_quantized_kv_cache,
     kv_cache_dtype_str_to_dtype,
 )
 from vllm.v1.attention.backend import (
@@ -49,9 +57,110 @@ from vllm.v1.kv_cache_interface import (
     get_kv_quant_mode,
 )
 
-from ..common.qsa_cache import QSAForwardMetadata
+from ..common.qsa_cache import (
+    Q_TOKEN_KV_BLOCK_SPARSE_TS_GROUP_SIZES,
+    QSAForwardMetadata,
+)
 from . import model
 from .indexer_qsa import QSAIndexer
+
+_Q_TOKEN_KV_BLOCK_SPARSE_PREFILL_GROUP_SIZE = 4
+_Q_TOKEN_KV_BLOCK_SPARSE_TS_HEAD_SIZE = 256
+_Q_TOKEN_KV_BLOCK_SPARSE_TS_SPARSE_BLOCK_SIZE = 4
+_Q_TOKEN_KV_BLOCK_SPARSE_TS_TILE_Q = 64
+_Q_TOKEN_KV_BLOCK_SPARSE_TS_DEVICE_CAPABILITIES = (100, 103)
+_Q_TOKEN_KV_BLOCK_SPARSE_TS_EAGER_PLAN_CACHE_CAPACITY = 4
+
+
+@dataclass(frozen=True)
+class _QTokenKvBlockSparseTSPreparedState:
+    key: tuple[object, ...]
+    workspace: torch.Tensor
+    plan: object
+    qo_indptr: torch.Tensor | None
+
+
+class _QTokenKvBlockSparseTSWorkspaces:
+    """Share scratch across ordered layers without owning captured storage.
+
+    One instance belongs to a model's static forward context, including MTP.
+    The PrimTS owner rejects DBO and microbatching. Graph geometries stay
+    disjoint so their split-KV counter layouts cannot overwrite each other.
+    Weak entries release storage after its last layer drops its plans.
+    """
+
+    def __init__(self) -> None:
+        self._buffers: WeakValueDictionary[tuple[object, ...], torch.Tensor] = (
+            WeakValueDictionary()
+        )
+
+    def get(
+        self, key: tuple[object, ...], num_bytes: int, device: torch.device
+    ) -> torch.Tensor:
+        key = (device, num_bytes, *key)
+        workspace = self._buffers.get(key)
+        if workspace is None:
+            workspace = torch.empty(num_bytes, dtype=torch.uint8, device=device)
+            self._buffers[key] = workspace
+        return workspace
+
+
+def _supports_q_token_kv_block_sparse_ts_geometry(
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    sparse_block_size: int,
+    max_group_size: int,
+) -> bool:
+    """Return whether every configured QSA route fits the PrimTS kernel."""
+
+    return (
+        head_size == _Q_TOKEN_KV_BLOCK_SPARSE_TS_HEAD_SIZE
+        and sparse_block_size == _Q_TOKEN_KV_BLOCK_SPARSE_TS_SPARSE_BLOCK_SIZE
+        and num_kv_heads > 0
+        and num_heads % num_kv_heads == 0
+        and max_group_size in Q_TOKEN_KV_BLOCK_SPARSE_TS_GROUP_SIZES
+        and max_group_size * (num_heads // num_kv_heads)
+        <= _Q_TOKEN_KV_BLOCK_SPARSE_TS_TILE_Q
+    )
+
+
+def _supports_q_token_kv_block_sparse_ts_device() -> bool:
+    """Match the exact architectures implemented by the FlashInfer runtime."""
+
+    return any(
+        current_platform.is_device_capability(capability)
+        for capability in _Q_TOKEN_KV_BLOCK_SPARSE_TS_DEVICE_CAPABILITIES
+    )
+
+
+def _has_q_token_kv_block_sparse_ts_attention() -> bool:
+    """Probe the optional FlashInfer API only when backend resolution needs it."""
+
+    from .ops.qsa import has_q_token_kv_block_sparse_ts_attention
+
+    return has_q_token_kv_block_sparse_ts_attention()
+
+
+def _resolve_q_token_kv_block_sparse_ts_backend(
+    *, capable: bool, availability_probe: Callable[[], bool]
+) -> bool:
+    """Select PrimTS when supported, or preserve the Triton fallback."""
+
+    backend = envs.VLLM_QSA_ATTENTION_BACKEND
+    if backend == "triton":
+        return False
+    available = availability_probe() if capable else False
+    supported = capable and available
+    if backend == "prims_ts" and not supported:
+        raise RuntimeError(
+            "VLLM_QSA_ATTENTION_BACKEND=prims_ts requires an SM100 or SM103 GPU, "
+            "FlashInfer QToken-KvBlock-Sparse-Attention, and a supported QSA "
+            "geometry (head size 256, sparse block size 4, and grouped heads "
+            "within TileQ64)"
+        )
+    return supported
 
 
 class Qwen4ExpQSAMetadataBuilder(FlashAttentionMetadataBuilder):
@@ -64,11 +173,16 @@ class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
     """FullAttentionSpec backend used by the merged QSA owner."""
 
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
-    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "bfloat16",
+        "fp8",
+        "fp8_e4m3",
+    ]
 
     @staticmethod
     def get_name() -> str:
-        return "QWEN4_EXP_QSA_TRITON"
+        return "QWEN4_EXP_QSA"
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
@@ -93,22 +207,234 @@ class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
 
 
 class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
-    """Run paged sparse GQA with the QSA Triton kernel."""
+    """Run paged sparse GQA with Triton or FlashInfer PrimTS."""
 
     supports_dcp: bool = False
     supports_pcp: bool = False
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None,
+        sliding_window: int | None,
+        kv_cache_dtype: str,
+        logits_soft_cap: float | None = None,
+        attn_type: AttentionType = AttentionType.DECODER,
+        kv_sharing_target_layer_name: str | None = None,
+        sinks: torch.Tensor | None = None,
+        *,
+        qsa_sparse_block_size: int = _Q_TOKEN_KV_BLOCK_SPARSE_TS_SPARSE_BLOCK_SIZE,
+        qsa_max_group_size: int = _Q_TOKEN_KV_BLOCK_SPARSE_PREFILL_GROUP_SIZE,
+    ) -> None:
+        # Reuse FlashAttention's metadata/DCP initialization, but do not apply
+        # its dense-kernel FP8 capability gate. QSA never calls the inherited
+        # dense attention kernel: it owns FP8 query quantization, cache update,
+        # descales, and sparse attention end to end below.
+        base_kv_cache_dtype = (
+            "auto" if is_quantized_kv_cache(kv_cache_dtype) else kv_cache_dtype
+        )
+        super().__init__(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            alibi_slopes=alibi_slopes,
+            sliding_window=sliding_window,
+            kv_cache_dtype=base_kv_cache_dtype,
+            logits_soft_cap=logits_soft_cap,
+            attn_type=attn_type,
+            kv_sharing_target_layer_name=kv_sharing_target_layer_name,
+            sinks=sinks,
+        )
+        self.kv_cache_dtype = kv_cache_dtype
         if not is_flash_attn_varlen_func_available():
             raise NotImplementedError("Qwen4Exp QSA requires FlashAttention")
         if self.dcp_world_size != 1:
             raise NotImplementedError(
                 "Qwen4Exp QSA does not support decode context parallelism"
             )
-        if self.kv_cache_dtype not in ("auto", "bfloat16"):
-            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        if self.kv_cache_dtype not in ("auto", "bfloat16", "fp8", "fp8_e4m3"):
+            raise NotImplementedError(
+                "Qwen4Exp QSA supports BF16 and FP8-E4M3 KV caches"
+            )
         self.supports_quant_query_input = False
+        geometry_supported = _supports_q_token_kv_block_sparse_ts_geometry(
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            sparse_block_size=qsa_sparse_block_size,
+            max_group_size=qsa_max_group_size,
+        )
+        self.use_q_token_kv_block_sparse_ts = (
+            _resolve_q_token_kv_block_sparse_ts_backend(
+                capable=_supports_q_token_kv_block_sparse_ts_device()
+                and geometry_supported,
+                availability_probe=_has_q_token_kv_block_sparse_ts_attention,
+            )
+        )
+
+    def _get_q_token_kv_block_sparse_ts_prepared_state(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        block_indices: torch.Tensor,
+        block_table: torch.Tensor,
+        token_to_req: torch.Tensor,
+        logical_positions: torch.Tensor,
+        out: torch.Tensor,
+        qo_indptr_cpu: torch.Tensor | None,
+        qo_topology: tuple[int, ...] | None,
+        group_size: int,
+        sparse_block_size: int,
+        max_seq_len_kv: int,
+        *,
+        persistent: bool = False,
+    ) -> _QTokenKvBlockSparseTSPreparedState:
+        """Return workspace and plan for one graph-stable QSA geometry."""
+
+        from .ops.qsa import (
+            q_token_kv_block_sparse_ts_combined_workspace_size,
+            q_token_kv_block_sparse_ts_prepare_attention,
+        )
+
+        state_key = (
+            query.device,
+            tuple(query.shape),
+            query.stride(),
+            query.dtype,
+            tuple(out.shape),
+            out.stride(),
+            out.dtype,
+            tuple(key_cache.shape),
+            key_cache.stride(),
+            key_cache.dtype,
+            key_cache.data_ptr(),
+            tuple(value_cache.shape),
+            value_cache.stride(),
+            value_cache.dtype,
+            value_cache.data_ptr(),
+            tuple(block_indices.shape),
+            block_indices.stride(),
+            block_indices.dtype,
+            tuple(block_table.shape),
+            block_table.stride(),
+            block_table.dtype,
+            tuple(token_to_req.shape),
+            token_to_req.stride(),
+            token_to_req.dtype,
+            tuple(logical_positions.shape),
+            logical_positions.stride(),
+            logical_positions.dtype,
+            group_size,
+            sparse_block_size,
+            max_seq_len_kv,
+            qo_topology,
+        )
+        if persistent:
+            state = layer._q_token_kv_block_sparse_ts_graph_states.get(state_key)
+            if state is not None:
+                return state
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "QToken-KvBlock-Sparse-Attention PrimTS plans must be "
+                    "prepared during CUDA-graph warmup"
+                )
+        else:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "eager QToken-KvBlock-Sparse-Attention PrimTS state cannot "
+                    "be used during CUDA-graph capture"
+                )
+            state = layer._q_token_kv_block_sparse_ts_eager_states.get(state_key)
+            if state is not None:
+                layer._q_token_kv_block_sparse_ts_eager_states.move_to_end(state_key)
+                return state
+
+        qo_indptr = (
+            None
+            if qo_indptr_cpu is None
+            else qo_indptr_cpu.to(query.device, non_blocking=True)
+        )
+        required_bytes = q_token_kv_block_sparse_ts_combined_workspace_size(
+            query,
+            key_cache,
+            block_table,
+            block_indices.shape[1],
+            max_seq_len_kv=max_seq_len_kv,
+            o_data_type=out.dtype,
+            qo_indptr=qo_indptr_cpu,
+            seq_len_q=group_size if qo_indptr_cpu is not None else None,
+            kv_block_size=sparse_block_size,
+        )
+        if persistent:
+            # Share only equal workspace layouts, not layer-specific K/V maps.
+            # Query strides and cache pointers do not affect scratch sizing.
+            workspace_key = (
+                "graph",
+                tuple(query.shape),
+                query.dtype,
+                out.dtype,
+                tuple(key_cache.shape[1:]),
+                key_cache.dtype,
+                block_indices.shape[1],
+                group_size,
+                sparse_block_size,
+                max_seq_len_kv,
+                None if qo_indptr_cpu is None else qo_indptr_cpu.numel() - 1,
+            )
+            workspace = layer._q_token_kv_block_sparse_ts_workspaces.get(
+                workspace_key, required_bytes, query.device
+            )
+        else:
+            eager_workspace = layer._q_token_kv_block_sparse_ts_eager_workspace
+            if (
+                eager_workspace is None
+                or eager_workspace.device != query.device
+                or eager_workspace.numel() < required_bytes
+            ):
+                # Every eager plan binds typed views into this arena. Drop those
+                # plans and the old arena before growing so none retain stale
+                # workspace storage. PrimTS rejects DBO/microbatching, and
+                # ordinary eager launches are sequential on the current stream.
+                layer._q_token_kv_block_sparse_ts_eager_states.clear()
+                layer._q_token_kv_block_sparse_ts_eager_workspace = None
+                del eager_workspace
+                eager_workspace = layer._q_token_kv_block_sparse_ts_workspaces.get(
+                    ("eager",), required_bytes, query.device
+                )
+                layer._q_token_kv_block_sparse_ts_eager_workspace = eager_workspace
+            workspace = eager_workspace
+        plan = q_token_kv_block_sparse_ts_prepare_attention(
+            query,
+            key_cache,
+            block_indices,
+            workspace,
+            out,
+            max_seq_len_kv=max_seq_len_kv,
+            qo_indptr=qo_indptr,
+            seq_len_q=group_size if qo_indptr is not None else None,
+            kv_block_size=sparse_block_size,
+        )
+        state = _QTokenKvBlockSparseTSPreparedState(
+            state_key, workspace, plan, qo_indptr
+        )
+        if persistent:
+            layer._q_token_kv_block_sparse_ts_graph_states[state_key] = state
+        else:
+            eager_states = layer._q_token_kv_block_sparse_ts_eager_states
+            eager_states[state_key] = state
+            eager_states.move_to_end(state_key)
+            while (
+                len(eager_states)
+                > _Q_TOKEN_KV_BLOCK_SPARSE_TS_EAGER_PLAN_CACHE_CAPACITY
+            ):
+                eager_states.popitem(last=False)
+        return state
 
     def forward_qsa(
         self,
@@ -120,7 +446,12 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
         attn_metadata: FlashAttentionMetadata,
         output: torch.Tensor,
         token_to_req: torch.Tensor,
-        use_prefill_config: bool,
+        logical_positions: torch.Tensor,
+        use_prefill_config: bool = False,
+        query_start_offsets: tuple[int, ...] | None = None,
+        has_prefill: bool = True,
+        uniform_decode_query_len: int | None = None,
+        persistent_plan: bool = False,
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
@@ -141,15 +472,183 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
         if topk_buffer is None:
             raise RuntimeError("QSA owner did not provide its top-k buffer")
         logical_indices = topk_buffer[:num_tokens]
+        indices_are_blocks = bool(getattr(layer, "qsa_indices_are_blocks", False))
         token_to_req = token_to_req[:num_tokens]
+        logical_positions = logical_positions[:num_tokens]
+        if query.dtype != torch.bfloat16 or output.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 Q/output")
+
+        query_for_attention = query[:num_tokens]
+        bmm1_scale = self.scale
+        bmm2_scale = 1.0
+        fp8_query_buffer: torch.Tensor | None = None
+        if is_quantized_kv_cache(self.kv_cache_dtype):
+            if kv_cache.dtype != torch.uint8:
+                raise ValueError("FP8 QSA cache storage must use encoded uint8 bytes")
+            kv_cache = kv_cache.view(current_platform.fp8_dtype())
+            fp8_query_buffer = getattr(layer, "_qsa_fp8_query_buffer", None)
+            if fp8_query_buffer is None or fp8_query_buffer.shape[0] < num_tokens:
+                raise RuntimeError("QSA owner did not provide its FP8 query buffer")
+            query_for_attention = fp8_query_buffer[:num_tokens]
+            custom_ops.scaled_fp8_quant(
+                query[:num_tokens].view(num_tokens, -1),
+                scale=layer._q_scale,
+                output=query_for_attention.view(num_tokens, -1),
+            )
+            bmm1_scale *= layer._q_scale_float * layer._k_scale_float
+            bmm2_scale = layer._v_scale_float
+        elif kv_cache.dtype != torch.bfloat16:
+            raise ValueError("BF16 QSA cache storage must use BF16")
+
         key_cache, value_cache = kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
-        if key_cache.dtype != torch.bfloat16 or query.dtype != torch.bfloat16:
-            raise NotImplementedError("Qwen4Exp QSA requires BF16 Q/K/V")
+        key_cache = canonicalize_singleton_dim_strides(key_cache)
+        value_cache = canonicalize_singleton_dim_strides(value_cache)
+
+        if self.use_q_token_kv_block_sparse_ts:
+            from .ops.qsa import (
+                q_token_kv_block_sparse_ts_qo_indptr,
+                q_token_kv_block_sparse_ts_run_prepared,
+            )
+
+            if not indices_are_blocks:
+                raise RuntimeError(
+                    "PrimTS QSA requires compact sparse-block indexer output"
+                )
+
+            # The owner stores the combined cache as [P,Hkv,N,2D]. The common
+            # transpose/split above gives Triton's [P,N,Hkv,D] views; PrimTS
+            # consumes HND pages, so recover [P,Hkv,N,D] without a copy.
+            prims_key_cache = canonicalize_singleton_dim_strides(
+                key_cache.transpose(1, 2)
+            )
+            prims_value_cache = canonicalize_singleton_dim_strides(
+                value_cache.transpose(1, 2)
+            )
+            prims_output = output[:num_tokens]
+            route_query_start_offsets = query_start_offsets
+            if has_prefill:
+                # Prefill always uses packed Q. Fast drafting metadata may omit
+                # CPU request boundaries, in which case Q1 is the only
+                # request-independent grouping.
+                if route_query_start_offsets is None:
+                    group_size = 1
+                    route_query_start_offsets = (0, num_tokens)
+                else:
+                    group_size = _Q_TOKEN_KV_BLOCK_SPARSE_PREFILL_GROUP_SIZE
+                use_fixed_layout = False
+            elif query_start_offsets is None:
+                # Missing CPU boundaries cannot prove multi-token request
+                # ownership. Keep those launches request-independent.
+                group_size = 1
+                use_fixed_layout = True
+            elif layer.q_token_kv_block_sparse_ts_decode_group_size == 1:
+                group_size = 1
+                use_fixed_layout = True
+            elif uniform_decode_query_len == 1:
+                # Standalone MTP recurrence invokes the layer once per draft
+                # position, even when the configured target-verification
+                # width is MTP + 1. Q1 is request-independent and can keep the
+                # fixed layout without pretending those separate invocations
+                # are one wider group.
+                group_size = 1
+                use_fixed_layout = True
+            elif (
+                uniform_decode_query_len
+                == layer.q_token_kv_block_sparse_ts_decode_group_size
+            ):
+                # Uniform target verification contributes MTP + 1 adjacent
+                # rows per live request. Fixed routing is legal only after the
+                # shared metadata builder proves those exact CPU boundaries.
+                assert uniform_decode_query_len is not None
+                group_size = uniform_decode_query_len
+                use_fixed_layout = True
+            else:
+                # Decode always uses the fixed layout. A runtime query width
+                # that does not prove the configured MTP+1 group falls back
+                # to request-independent Q1 instead of introducing a packed
+                # decode route and a second graph-facing layout.
+                group_size = 1
+                use_fixed_layout = True
+
+            route_qo_indptr_cpu: torch.Tensor | None = None
+            if use_fixed_layout:
+                if num_tokens % group_size:
+                    raise RuntimeError(
+                        "fixed QSA decode rows must be divisible by the query "
+                        f"group size ({num_tokens=} {group_size=})"
+                    )
+                num_query_groups = num_tokens // group_size
+                route_query = query_for_attention.view(
+                    num_query_groups,
+                    1,
+                    group_size,
+                    query_for_attention.shape[1],
+                    query_for_attention.shape[2],
+                )
+                route_output = prims_output.view_as(route_query)
+            else:
+                assert route_query_start_offsets is not None
+                route_qo_indptr_cpu = q_token_kv_block_sparse_ts_qo_indptr(
+                    route_query_start_offsets,
+                    num_tokens,
+                    group_size,
+                )
+                route_query = query_for_attention
+                route_output = prims_output
+
+            # max_seq_len_kv is the model's per-request logical context bound,
+            # not the number of physical pages allocated across all requests.
+            # The dense table only proves that each request row can address
+            # that model-length bound.
+            metadata_block_table = attn_metadata.block_table
+            sparse_block_size = int(layer.indexer.compress_ratio)
+            dense_row_capacity = (
+                metadata_block_table.shape[1] * prims_key_cache.shape[2]
+            )
+            max_seq_len_kv = int(layer.q_token_kv_block_sparse_ts_max_seq_len_kv)
+            if max_seq_len_kv > dense_row_capacity:
+                raise RuntimeError(
+                    "QSA model length exceeds the per-request dense block-table "
+                    f"capacity ({max_seq_len_kv=} {dense_row_capacity=})"
+                )
+            state = self._get_q_token_kv_block_sparse_ts_prepared_state(
+                layer,
+                route_query,
+                prims_key_cache,
+                prims_value_cache,
+                logical_indices,
+                metadata_block_table,
+                token_to_req,
+                logical_positions,
+                route_output,
+                route_qo_indptr_cpu,
+                route_query_start_offsets if route_qo_indptr_cpu is not None else None,
+                group_size,
+                sparse_block_size,
+                max_seq_len_kv,
+                persistent=persistent_plan,
+            )
+
+            q_token_kv_block_sparse_ts_run_prepared(
+                state.plan,
+                route_query,
+                prims_key_cache,
+                prims_value_cache,
+                metadata_block_table,
+                logical_indices,
+                token_to_req,
+                logical_positions,
+                route_output,
+                qo_indptr=state.qo_indptr,
+                sm_scale=bmm1_scale,
+                v_scale=bmm2_scale,
+            )
+            return output
 
         from .ops.qsa import qsa_sparse_paged_attention
 
         qsa_sparse_paged_attention(
-            query[:num_tokens],
+            query_for_attention,
             key_cache,
             value_cache,
             logical_indices,
@@ -157,6 +656,8 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
             token_to_req,
             use_prefill_config,
             output[:num_tokens],
+            bmm1_scale=bmm1_scale,
+            bmm2_scale=bmm2_scale,
         )
         return output
 
@@ -165,6 +666,38 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
     """Merged Qwen full-attention owner with a QSA index side branch."""
 
     supports_dcp = False
+    _q_token_kv_block_sparse_ts_graph_states: dict[
+        tuple[object, ...], _QTokenKvBlockSparseTSPreparedState
+    ]
+    _q_token_kv_block_sparse_ts_eager_states: OrderedDict[
+        tuple[object, ...], _QTokenKvBlockSparseTSPreparedState
+    ]
+    _q_token_kv_block_sparse_ts_eager_workspace: torch.Tensor | None
+    _q_token_kv_block_sparse_ts_workspaces: _QTokenKvBlockSparseTSWorkspaces
+    q_token_kv_block_sparse_ts_max_seq_len_kv: int
+
+    def _clear_q_token_kv_block_sparse_ts_prepared_storage(self) -> None:
+        self._q_token_kv_block_sparse_ts_graph_states.clear()
+        self._q_token_kv_block_sparse_ts_eager_states.clear()
+        self._q_token_kv_block_sparse_ts_eager_workspace = None
+
+    def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
+        """Bind one cache generation and discard plans bound to its predecessor.
+
+        vLLM first binds a minimal cache while profiling CUDA-graph memory,
+        tears it down, and later binds the real cache. Prepared PrimTS plans
+        retain K/V tensor maps, and workspaces allocated during the profiling
+        capture belong to a throwaway graph pool. Neither may cross this
+        rebinding boundary.
+        """
+
+        self._clear_q_token_kv_block_sparse_ts_prepared_storage()
+        self.kv_cache = kv_cache
+
+    def unbind_kv_cache(self) -> None:
+        """Release the KV cache and every prepared object that refers to it."""
+        self._clear_q_token_kv_block_sparse_ts_prepared_storage()
+        self.kv_cache = torch.tensor([])
 
     def __init__(
         self,
@@ -183,8 +716,15 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             raise ValueError("Qwen4Exp QSA requires a paged KV cache")
         if model_config.dtype != torch.bfloat16:
             raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
-        if cache_config.cache_dtype not in ("auto", "bfloat16"):
-            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        if cache_config.cache_dtype not in (
+            "auto",
+            "bfloat16",
+            "fp8",
+            "fp8_e4m3",
+        ):
+            raise NotImplementedError(
+                "Qwen4Exp QSA supports BF16 and FP8-E4M3 KV caches"
+            )
         if getattr(quant_config, "kv_cache_scheme", None) is not None:
             raise NotImplementedError("Qwen4Exp QSA does not support KV quantization")
         parallel_config = vllm_config.parallel_config
@@ -283,11 +823,22 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
         self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, model_config
         )
-        if self.kv_cache_torch_dtype != torch.bfloat16:
-            raise NotImplementedError("Qwen4Exp QSA requires BF16 cache storage")
+        if self.kv_cache_torch_dtype not in (torch.bfloat16, torch.uint8):
+            raise NotImplementedError(
+                "Qwen4Exp QSA requires BF16 or encoded FP8 cache storage"
+            )
         self.kv_sharing_target_layer_name = None
         self.kv_cache = torch.tensor([])
         set_default_quant_scales(self, register_buffer=True)
+
+        decode_group_size = vllm_config.uniform_decode_query_len
+        # TODO: add a Q3 kernel configuration instead of falling back to Q1
+        # when a framework configures MTP=2.
+        if decode_group_size not in Q_TOKEN_KV_BLOCK_SPARSE_TS_GROUP_SIZES:
+            decode_group_size = 1
+        self.q_token_kv_block_sparse_ts_decode_group_size = int(decode_group_size)
+        self.q_token_kv_block_sparse_ts_max_seq_len_kv = int(model_config.max_model_len)
+        sparse_block_size = int(config.indexer_compress_ratio)
 
         self.attn_backend = Qwen4ExpQSAFlashAttentionBackend
         self.impl = Qwen4ExpQSAFlashAttentionImpl(
@@ -301,7 +852,17 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             None,
             AttentionType.DECODER,
             None,
+            qsa_sparse_block_size=sparse_block_size,
+            qsa_max_group_size=max(
+                _Q_TOKEN_KV_BLOCK_SPARSE_PREFILL_GROUP_SIZE,
+                self.q_token_kv_block_sparse_ts_decode_group_size,
+            ),
         )
+        if self.impl.use_q_token_kv_block_sparse_ts and parallel_config.use_ubatching:
+            raise NotImplementedError(
+                "PrimTS QToken-KvBlock-Sparse-Attention workspace sharing "
+                "does not support DBO or microbatching"
+            )
         self.indexer = QSAIndexer(
             vllm_config=vllm_config,
             config=config,
@@ -311,28 +872,66 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             prefix=f"{prefix}.indexer",
         )
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        # PACKED selection buffer: the trailing column holds each row's
-        # valid-entry count (written by the expand kernel) — never a token
-        # index; the sparse attention kernel reads it as its loop bound.
-        # MTP skip_topk steps reuse rows frozen from step 0; the count is
-        # a row column, so compaction/reuse keep it paired with the content.
+        # Expanded Triton rows retain the trailing valid-count column during
+        # MTP reuse; PrimTS rows contain only compact logical block IDs.
+        self.qsa_indices_are_blocks = self.impl.use_q_token_kv_block_sparse_ts
+        selection_width = (
+            self.indexer.block_topk
+            if self.qsa_indices_are_blocks
+            else self.indexer.packed_output_width
+        )
         self.register_buffer(
             "topk_indices_buffer",
             torch.empty(
                 max_tokens,
-                self.indexer.packed_output_width,
+                selection_width,
                 dtype=torch.int32,
             ),
             persistent=False,
         )
+        # Only the MTP owner enables this buffer. Target attention uses the
+        # current positions directly, without an extra copy per layer.
+        self.register_buffer("topk_query_positions_buffer", None, persistent=False)
+        if is_quantized_kv_cache(self.kv_cache_dtype):
+            self.register_buffer(
+                "_qsa_fp8_query_buffer",
+                torch.zeros(
+                    max_tokens,
+                    self.num_heads,
+                    self.head_dim,
+                    dtype=current_platform.fp8_dtype(),
+                ),
+                persistent=False,
+            )
+        self._q_token_kv_block_sparse_ts_graph_states = {}
+        self._q_token_kv_block_sparse_ts_eager_states = OrderedDict()
+        self._q_token_kv_block_sparse_ts_eager_workspace = None
 
         static_context = vllm_config.compilation_config.static_forward_context
         if self.layer_name in static_context:
             raise ValueError(f"Duplicate layer name: {self.layer_name}")
+        self._q_token_kv_block_sparse_ts_workspaces = next(
+            (
+                layer._q_token_kv_block_sparse_ts_workspaces
+                for layer in static_context.values()
+                if isinstance(layer, Qwen4ExpQSAAttention)
+            ),
+            _QTokenKvBlockSparseTSWorkspaces(),
+        )
         static_context[self.layer_name] = self
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return self.attn_backend
+
+    def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:
+        """Finalize host descales used by the model-facing FP8 QSA path."""
+
+        self.impl.process_weights_after_loading(act_dtype)
+        for name in ("q", "k", "v"):
+            scale = float(getattr(self, f"_{name}_scale").item())
+            setattr(self, f"_{name}_scale_float", scale)
+        self._k_scale_cpu.fill_(self._k_scale_float)
+        self._v_scale_cpu.fill_(self._v_scale_float)
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         return FullAttentionSpec(
@@ -354,7 +953,8 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
         value: torch.Tensor,
         output: torch.Tensor,
     ) -> None:
-        metadata = get_forward_context().attn_metadata
+        forward_context = get_forward_context()
+        metadata = forward_context.attn_metadata
         if isinstance(metadata, list):
             metadata = metadata[0]
         if not isinstance(metadata, dict):
@@ -375,9 +975,20 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             projected_qk,
             positions,
             self.topk_indices_buffer[:num_tokens],
+            compact_blocks=self.qsa_indices_are_blocks,
         )
-        if selected.shape != (num_tokens, self.indexer.packed_output_width):
+        if selected.shape != (
+            num_tokens,
+            self.topk_indices_buffer.shape[1],
+        ):
             raise RuntimeError("QSA indexer returned an invalid selection shape")
+        selected_positions = side_metadata.logical_positions
+        if self.topk_query_positions_buffer is not None:
+            if not self.indexer.skip_topk:
+                self.topk_query_positions_buffer[:num_tokens].copy_(
+                    selected_positions[:num_tokens]
+                )
+            selected_positions = self.topk_query_positions_buffer[:num_tokens]
         impl = cast(Qwen4ExpQSAFlashAttentionImpl, self.impl)
         impl.do_kv_cache_update(
             self,
@@ -396,6 +1007,14 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             output,
             token_to_req=side_metadata.token_to_req,
             use_prefill_config=main_metadata.max_query_len > self._max_decode_query_len,
+            logical_positions=selected_positions,
+            query_start_offsets=side_metadata.query_start_offsets,
+            has_prefill=side_metadata.has_prefill,
+            uniform_decode_query_len=side_metadata.uniform_decode_query_len,
+            persistent_plan=(
+                forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+                or side_metadata.prepare_cudagraph_plan
+            ),
         )
 
     def forward(

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -77,16 +77,15 @@ class _QTokenKvBlockSparseTSPreparedState:
     key: tuple[object, ...]
     workspace: torch.Tensor
     plan: object
-    qo_indptr: torch.Tensor | None
 
 
 class _QTokenKvBlockSparseTSWorkspaces:
-    """Share scratch across ordered layers without owning captured storage.
+    """Share scratch and immutable query routes across ordered layers.
 
     One instance belongs to a model's static forward context, including MTP.
     The PrimTS owner rejects DBO and microbatching. Graph geometries stay
     disjoint so their split-KV counter layouts cannot overwrite each other.
-    Weak entries release storage after its last layer drops its plans.
+    Weak entries do not outlive the plans or forward metadata owning storage.
     """
 
     def __init__(self) -> None:
@@ -103,6 +102,20 @@ class _QTokenKvBlockSparseTSWorkspaces:
             workspace = torch.empty(num_bytes, dtype=torch.uint8, device=device)
             self._buffers[key] = workspace
         return workspace
+
+    def get_qo_indptr(
+        self,
+        key: tuple[object, ...],
+        offsets_cpu: torch.Tensor,
+        device: torch.device,
+    ) -> torch.Tensor:
+        # Keep the address stable while FlashInfer plans still bind these routes.
+        key = ("qo_indptr", device, *key)
+        offsets = self._buffers.get(key)
+        if offsets is None:
+            offsets = offsets_cpu.to(device, non_blocking=True)
+            self._buffers[key] = offsets
+        return offsets
 
 
 def _supports_q_token_kv_block_sparse_ts_geometry(
@@ -355,11 +368,6 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
                 layer._q_token_kv_block_sparse_ts_eager_states.move_to_end(state_key)
                 return state
 
-        qo_indptr = (
-            None
-            if qo_indptr_cpu is None
-            else qo_indptr_cpu.to(query.device, non_blocking=True)
-        )
         required_bytes = q_token_kv_block_sparse_ts_combined_workspace_size(
             query,
             key_cache,
@@ -416,13 +424,11 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
             workspace,
             out,
             max_seq_len_kv=max_seq_len_kv,
-            qo_indptr=qo_indptr,
-            seq_len_q=group_size if qo_indptr is not None else None,
+            qo_indptr=qo_indptr_cpu,
+            seq_len_q=group_size if qo_indptr_cpu is not None else None,
             kv_block_size=sparse_block_size,
         )
-        state = _QTokenKvBlockSparseTSPreparedState(
-            state_key, workspace, plan, qo_indptr
-        )
+        state = _QTokenKvBlockSparseTSPreparedState(state_key, workspace, plan)
         if persistent:
             layer._q_token_kv_block_sparse_ts_graph_states[state_key] = state
         else:
@@ -454,6 +460,8 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
         persistent_plan: bool = False,
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
+        qo_indptr_cache: dict[tuple[object, ...], tuple[torch.Tensor, torch.Tensor]]
+        | None = None,
     ) -> torch.Tensor:
         del key, value
         if output_scale is not None or output_block_scale is not None:
@@ -571,6 +579,7 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
                 use_fixed_layout = True
 
             route_qo_indptr_cpu: torch.Tensor | None = None
+            route_qo_indptr: torch.Tensor | None = None
             if use_fixed_layout:
                 if num_tokens % group_size:
                     raise RuntimeError(
@@ -588,11 +597,30 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
                 route_output = prims_output.view_as(route_query)
             else:
                 assert route_query_start_offsets is not None
-                route_qo_indptr_cpu = q_token_kv_block_sparse_ts_qo_indptr(
+                route_key = (
                     route_query_start_offsets,
                     num_tokens,
                     group_size,
+                    query.device,
                 )
+                routes = (
+                    None if qo_indptr_cache is None else qo_indptr_cache.get(route_key)
+                )
+                if routes is None:
+                    route_qo_indptr_cpu = q_token_kv_block_sparse_ts_qo_indptr(
+                        route_query_start_offsets,
+                        num_tokens,
+                        group_size,
+                    )
+                    routes = (
+                        route_qo_indptr_cpu,
+                        layer._q_token_kv_block_sparse_ts_workspaces.get_qo_indptr(
+                            route_key, route_qo_indptr_cpu, query.device
+                        ),
+                    )
+                    if qo_indptr_cache is not None:
+                        qo_indptr_cache[route_key] = routes
+                route_qo_indptr_cpu, route_qo_indptr = routes
                 route_query = query_for_attention
                 route_output = prims_output
 
@@ -639,7 +667,7 @@ class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
                 token_to_req,
                 logical_positions,
                 route_output,
-                qo_indptr=state.qo_indptr,
+                qo_indptr=route_qo_indptr,
                 sm_scale=bmm1_scale,
                 v_scale=bmm2_scale,
             )
@@ -1009,6 +1037,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
             use_prefill_config=main_metadata.max_query_len > self._max_decode_query_len,
             logical_positions=selected_positions,
             query_start_offsets=side_metadata.query_start_offsets,
+            qo_indptr_cache=side_metadata.q_token_kv_block_sparse_qo_indptr,
             has_prefill=side_metadata.has_prefill,
             uniform_decode_query_len=side_metadata.uniform_decode_query_len,
             persistent_plan=(

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1166,6 +1166,7 @@ class SpecDecodeBaseProposer:
             slot_mapping=common_attn_metadata.slot_mapping[:total_num_tokens],
             causal=True,
             dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
+            is_prefilling=common_attn_metadata.is_prefilling,
         )
 
         return (
@@ -1277,6 +1278,7 @@ class SpecDecodeBaseProposer:
             slot_mapping=common_attn_metadata.slot_mapping[token_indices],
             causal=True,
             dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
+            is_prefilling=common_attn_metadata.is_prefilling,
         )
 
         return spec_common_attn_metadata, token_indices

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -246,6 +246,7 @@ from .utils import (
     add_kv_sharing_layers_to_kv_cache_groups,
     allocate_kv_cache,
     bind_kv_cache,
+    clear_layer_kv_caches,
     copy_kv_cache_blocks_inplace,
     prepare_kernel_block_sizes,
     sanity_check_mm_encoder_outputs,
@@ -6677,19 +6678,7 @@ class GPUModelRunner(
             delattr(self, "kv_cache_config")
         self.cache_config.num_gpu_blocks = None
 
-        for layer in self.compilation_config.static_forward_context.values():
-            if hasattr(layer, "kv_cache"):
-                kv_cache = layer.kv_cache
-                layer.kv_cache = (
-                    torch.tensor([]) if isinstance(kv_cache, torch.Tensor) else []
-                )
-            # Clean up quantized KV cache scale views
-            # (int8_per_token_head, fp8_per_token_head)
-            if hasattr(layer, "impl"):
-                if hasattr(layer.impl, "_k_scale_cache"):
-                    layer.impl._k_scale_cache = None
-                if hasattr(layer.impl, "_v_scale_cache"):
-                    layer.impl._v_scale_cache = None
+        clear_layer_kv_caches(self.compilation_config.static_forward_context.values())
 
         gc.collect()
         torch.accelerator.empty_cache()

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -657,8 +657,14 @@ def clear_layer_kv_caches(layers: Iterable[Any]) -> None:
     for layer in layers:
         if not hasattr(layer, "kv_cache"):
             continue
-        kv_cache = layer.kv_cache
-        layer.kv_cache = torch.tensor([]) if isinstance(kv_cache, torch.Tensor) else []
+        unbind_kv_cache = getattr(layer, "unbind_kv_cache", None)
+        if unbind_kv_cache is not None:
+            unbind_kv_cache()
+        else:
+            kv_cache = layer.kv_cache
+            layer.kv_cache = (
+                torch.tensor([]) if isinstance(kv_cache, torch.Tensor) else []
+            )
         # Clean up quantized KV cache scale views
         # (int8_per_token_head, fp8_per_token_head)
         if hasattr(layer, "impl"):


### PR DESCRIPTION
## Purpose

Integrate FlashInfer's QToken-KvBlock-Sparse-Attention backend for Qwen3.8-Flash-Next (Qwen4Exp). Depends on https://github.com/flashinfer-ai/flashinfer/pull/4996 and a compatible CUTLASS DSL 4.7 installation.

- Support SM100/SM103 with BF16 or FP8-E4M3 KV caches, dense page tables, and compact indexer block IDs.
- Use request-safe packed prefill groups and fixed MTP decode groups, preserving each query's causal selection and reused MTP tail positions.
- Share workspace and query offsets across layers; keep K/V plans layer-specific and release cache-dependent state on unbind.
- Add `VLLM_QSA_ATTENTION_BACKEND=auto|triton|prims_ts`. `auto` selects PrimTS when supported and available, otherwise Triton. Fixed decode supports CUDA graphs.

Related work checked: #55430 targets Triton SM121 prefill, #55065 targets dense SM120 prefill, and #55557/#54846 target KV quantization. This PR adds the FlashInfer SM100/SM103 sparse prefill-and-MTP backend rather than duplicating those implementations.

## Test Plan

```bash
.venv/bin/python -m pytest tests/models/qwen4_exp/{test_qsa_reference,test_qsa_pre_indexer,test_config,test_ple}.py -q
```

Additional local integration, hook, and sanitizer gate: `bash qsa_bench/shared_qo_indptr_20260910/run_final.sh`. This harness is retained outside the public source diff.

## Test Result

SM103: 143 upstream tests, 19 focused route/ownership/CUDA checks, 95 preserved QSA cases, and 10 ownership/MTP checks passed (overlapping suites). BF16/FP8 reference and decode-graph checks passed. Five prefill cases passed each of memcheck and initcheck with zero errors; changed-file hooks passed.

Prior frozen-revision model evaluation, TP2 / FP8 KV / MTP3:

| Task | Triton | PrimTS |
| --- | --- | --- |
| GSM8K | 1290/1319 | 1286/1319 |
| GPQA-Diamond, two repetitions | 365/396 | 361/396 |
| LongBench v2, 48-question cohort | 32/48 | 33/48 |

GPQA includes two unfinished PrimTS answers and remains an accuracy follow-up, not an equivalence pass. These model evaluations were not rerun after the latest offset-sharing change. SM100 runtime validation remains pending.

### E2E performance: all-layer GPU time

Prior matched Nsight measurements on GB300/SM103, TP2, at the frozen revisions in the linked report; not rerun after the latest offset-sharing change. Prefill measures request four after three warmups, with prefix caching disabled. Decode uses full CUDA graphs and 64 resident requests with MTP3 (256 target-query tokens), averaged over 33 scheduler iterations including draft work.

| Stage | KV | Context | Resident BS | Triton (ms) | PrimTS (ms) | All-layer speedup | Sparse-path speedup |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Prefill | BF16 | 8K | 1 | 137.374 | 126.808 | 1.083x | 2.473x |
| Prefill | BF16 | 16K | 1 | 253.880 | 233.289 | 1.088x | 2.172x |
| Prefill | FP8 | 8K | 1 | 135.457 | 126.978 | 1.067x | 2.211x |
| Prefill | FP8 | 16K | 1 | 249.392 | 233.744 | 1.067x | 1.915x |
| Decode MTP3 | BF16 | 8K | 64 | 25.045 | 24.509 | 1.022x | 1.657x |
| Decode MTP3 | BF16 | 16K | 64 | 25.131 | 24.628 | 1.020x | 1.565x |
| Decode MTP3 | FP8 | 8K | 64 | 24.826 | 24.478 | 1.014x | 1.284x |
| Decode MTP3 | FP8 | 16K | 64 | 24.800 | 24.453 | 1.014x | 1.178x |

Speedup = Triton / PrimTS. These are warm, pure-stage GPU wall times across all layers, not API TTFT, queue latency, cold-L2 standalone timing, or time per accepted token. Sparse-path speedups include metadata/index expansion, attention, and reduction, with PDL overlap counted once. These are single matched captures, not confidence intervals. Both BF16 prefill backends use the same documented image-MoE padding fix; resident BS256 did not fit this TP2 cache configuration.

[Detailed prior accuracy and pure-stage performance results](https://github.com/PerkzZheng/vllm/blob/b10972e13c51d0ba61906e64e9b01b87bd6a0549/benchmarks/qsa/VALIDATION_20260910.md). [Standalone kernel benchmark suites](https://github.com/PerkzZheng/flashinfer-prims-ts-validation/blob/main/docs/sparse_attention.md).

AI assistance: OpenAI Codex assisted with implementation, validation, and this description. Kept as a draft for human review and dependency/validation follow-up.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose and related work described.
- [x] Test commands provided.
- [x] Test and model-evaluation results included with limitations.
- [x] Existing model support; no supported-model-list update required.
</details>
