### PR TITLE
[Feature][Multimodal] Add cross-encoder caching to Mooncake P2P

### DIFF
--- a/docs/features/cross_encoder_cache.md
+++ b/docs/features/cross_encoder_cache.md
@@ -1,0 +1,132 @@
+# Shared Encoder output Store
+
+The shared Encoder output Store reuses embeddings across Encoder instances in
+EPD serving. An Encoder publishes newly computed outputs while delivering them
+to Prefill; another Encoder can load those outputs instead of running the
+vision encoder again. Mooncake Store provides the RAM cache, and
+`ECMooncakeConnector` P2P is the currently supported delivery integration.
+
+## Execution
+
+The scheduler retains its existing local-cache, compute-budget and allocation
+rules. On a local miss, the producer worker attempts a Store read before
+encoding. Loaded items enter the local encoder cache and are submitted to the
+existing P2P reservation. Only unresolved items run the encoder. Newly computed
+outputs are published asynchronously, independently of delivery completion.
+
+Publication is best-effort: serving request completion does not acknowledge
+Store readiness or pin an object against eviction. A request arriving before
+publication completes may encode the input again.
+
+Store reads are synchronous on the worker path. They do not bypass preprocessing
+or refund the scheduler's reserved encoder budget. Concurrent cold requests may
+compute the same image independently.
+
+## Configuration
+
+Start from a working Mooncake EPD deployment. The producer requires Model Runner
+V2, Encoder TP=1, and no dynamic LoRA. Shared lookup currently covers images;
+other modalities retain the normal encoder path. Supported embedding dtypes are
+FP16, BF16 and FP32. Only contiguous outputs are published; non-contiguous
+outputs are skipped without allocating a staging copy.
+
+On each Encoder, enable `cross_encoder_cache` in the normal Mooncake P2P
+configuration. For example:
+
+```json
+{
+  "ec_connector": "ECMooncakeConnector",
+  "ec_role": "ec_producer",
+  "ec_connector_extra_config": {
+    "mooncake_protocol": "tcp",
+    "cross_encoder_cache": true,
+    "embedding_cache_prefix": "my-deployment-v1",
+    "embedding_model_identity": "my-model-snapshot",
+    "store_max_pending_items": 32,
+    "store_max_pending_bytes": 2147483648
+  }
+}
+```
+
+Keep Prefill configured with `ECMooncakeConnector`, `ec_consumer`, and its normal
+P2P addresses and buffer settings. It does not need a Store client. Omitting
+`cross_encoder_cache` (or setting it to false) disables shared reuse and does
+not create a Store client or publisher.
+
+Set `MOONCAKE_CONFIG_PATH` on Encoder workers to a JSON file describing the
+running Store. A client using an independently managed RAM pool can use:
+
+```json
+{
+  "metadata_server": "http://STORE_HOST:2379/metadata",
+  "master_server_address": "STORE_HOST:50051",
+  "protocol": "tcp",
+  "device_name": "",
+  "mode": "standalone-store",
+  "global_segment_size": 0,
+  "local_buffer_size": "4GB"
+}
+```
+
+Replace the addresses with the actual deployment endpoints. This file connects
+to existing Mooncake services; it does not start the master, metadata service
+or storage pool. The bindings must provide `batch_is_exist`,
+`batch_put_from_multi_buffers`, `get_into_ranges`, `register_buffer`, and
+`unregister_buffer`. Use Mooncake 0.3.12 or later, including its `close()` and
+`ObjectDataType.TENSOR` APIs. EC and KV use the same Store configuration parser
+and setup. Non-default `tenant_id` is passed to Mooncake; unsupported tenant
+configuration fails at setup rather than falling back to the default tenant.
+`standalone-store` requires an explicit zero `global_segment_size`. This
+feature uses RAM storage and rejects `enable_offload: true`.
+
+An independent Store process allows embeddings to survive Encoder worker
+restarts. RAM contents do not survive loss of the storage process unless the
+Store deployment provides the necessary replicas. Capacity and eviction belong
+to Mooncake Store.
+
+## Cache identity and memory
+
+Keys contain the deployment prefix, model identity and configured revision,
+encoder configuration hash, dtype, format version, and vLLM
+multimodal identifier. They exclude the request and Encoder instance IDs.
+The current key namespace uses `protocol:v2`.
+
+All Encoders sharing a namespace must use the same immutable model weights and
+compatible preprocessing. `embedding_model_identity` overrides the model path
+in the key, allowing identical snapshots mounted at different paths to share
+outputs; it must not identify different weights as equivalent. Change the
+namespace when replacing weights in place or changing an output-affecting
+setting. Caller-supplied multimodal identifiers must identify the same input
+consistently. Shape validation alone cannot detect semantically different
+outputs with the same dimensions.
+
+The default publisher admits at most 32 pending items and 2 GiB of retained
+tensor storage per Encoder. Both limits require positive integers and are
+validated before native initialization. Views charge their full backing storage;
+aliases may be charged more than once. Each admitted item also needs a 304-byte header.
+Store client buffers and the existing P2P pool are separate allocations.
+Exceeding the publication budget skips that cache write without rejecting the
+request.
+
+## Failure semantics and limitations
+
+A missing object, rejected lookup, completed failed read, or incompatible tensor
+falls back to encoding the affected item. A buffer-registration rejection occurs
+before I/O submission: after undoing any earlier registrations for that operation,
+reads fall back to encoding and publications are skipped. Completed publication
+failures do not change P2P request completion. Unexpected binding exceptions and
+invalid lookup result counts remain errors. If native I/O completion or buffer
+unregistration cannot be established, the worker fails while retaining the
+affected buffers: it cannot safely release memory
+that a transfer may still access. Shared Store is therefore an optional
+optimization, not isolation from every backend failure.
+
+The feature requires compatible model weights and preprocessing across
+Encoders. It does not coordinate concurrent cold computation, change request
+routing, or make the scheduler aware of remote hits. Benefits depend on the
+frequency of reusable local misses and the cost of Store access relative to
+encoding.
+
+Shutdown stops publication admission, waits for queued writes, reaps their results,
+and closes the Store client. Buffers with unconfirmed I/O or unregistration remain
+owned until process exit; shutdown does not reinterpret them as recoverable misses.

--- a/docs/features/cross_encoder_cache.md
+++ b/docs/features/cross_encoder_cache.md
@@ -30,6 +30,11 @@ other modalities retain the normal encoder path. Supported embedding dtypes are
 FP16, BF16 and FP32. Only contiguous outputs are published; non-contiguous
 outputs are skipped without allocating a staging copy.
 
+Keep `--mm-processor-cache-gb` greater than zero when shared reuse is enabled.
+Encoder-only serving disables prefix caching; also disabling processor caching
+replaces content identifiers with process-local request counters that can collide
+across Encoders or restarts. This combination is rejected at startup.
+
 On each Encoder, enable `cross_encoder_cache` in the normal Mooncake P2P
 configuration. For example:
 
@@ -92,10 +97,16 @@ multimodal identifier. They exclude the request and Encoder instance IDs.
 The current key namespace uses `protocol:v2`.
 
 All Encoders sharing a namespace must use the same immutable model weights and
-compatible preprocessing. `embedding_model_identity` overrides the model path
-in the key, allowing identical snapshots mounted at different paths to share
-outputs; it must not identify different weights as equivalent. Change the
-namespace when replacing weights in place or changing an output-affecting
+compatible preprocessing. `embedding_model_identity` overrides only the key's
+model field; reuse also requires identical vLLM multimodal identifiers.
+Automatically generated identifiers include the configured model path.
+Caller-provided UUIDs are also hashed with that path when processor or media
+kwargs are present. Use the same configured model path across Encoders when
+relying on automatic identifiers: an equal `embedding_model_identity` alone
+does not enable reuse across different mount paths.
+
+The model identity must not identify different weights as equivalent. Change
+the namespace when replacing weights in place or changing an output-affecting
 setting. Caller-supplied multimodal identifiers must identify the same input
 consistently. Shape validation alone cannot detect semantically different
 outputs with the same dimensions.

--- a/docs/features/disagg_encoder.md
+++ b/docs/features/disagg_encoder.md
@@ -45,6 +45,9 @@ Below ready-to-run scripts shows the workflow:
 
 ## 3  Test Script
 
+For optional cross-Encoder output reuse while retaining Mooncake P2P delivery,
+see [Cross-encoder output reuse](cross_encoder_cache.md).
+
 Please refer to the directories `tests/v1/ec_connector`
 
 ## 4  Development

--- a/tests/v1/ec_connector/unit/test_cross_encoder_cache.py
+++ b/tests/v1/ec_connector/unit/test_cross_encoder_cache.py
@@ -14,7 +14,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+from tests.v1.ec_connector.unit.utils import create_ec_vllm_config
+from vllm.config import MultiModalConfig
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorRole
+from vllm.distributed.ec_transfer.ec_connector.mooncake.config import MooncakeECConfig
 from vllm.distributed.ec_transfer.ec_connector.mooncake.metadata import (
     ECMooncakeConnectorMetadata,
     ECMooncakePushSpec,
@@ -39,6 +42,18 @@ KEY = EmbeddingKeyMetadata(
     "test", "model", "revision", "encoder", "torch.float32", "v2"
 )
 SPEC = TensorSpec((2, 2), "torch.float32", 16)
+
+
+def test_shared_reuse_requires_content_stable_identifiers():
+    """Encoder-only cache-off rendering uses process-local counter identifiers."""
+    config = create_ec_vllm_config(ec_role="ec_producer")
+    config.ec_transfer_config.ec_connector = "ECMooncakeConnector"
+    config.ec_transfer_config.ec_connector_extra_config["cross_encoder_cache"] = True
+    config.model_config.multimodal_config = MultiModalConfig(mm_processor_cache_gb=0)
+    config.use_v2_model_runner = True
+    config.lora_config = None
+    with pytest.raises(ValueError, match="mm_processor_cache_gb"):
+        MooncakeECConfig.from_vllm_config(config)
 
 
 class MemoryStore:
@@ -137,6 +152,7 @@ def make_worker(backend):
         "hit",
         "partial",
         "get-failure",
+        "lease-expired",
         "registration-failure",
     ],
 )
@@ -154,24 +170,25 @@ def test_reuse_pipeline(backend, mode):
     native = backend.store_client.store
     if mode == "partial":
         hits = {"a", "c"}
-    elif mode in ("hit", "get-failure", "registration-failure"):
+    elif mode in ("hit", "get-failure", "lease-expired", "registration-failure"):
         hits = set("abc")
     else:
         hits = set()
     for key in hits:
         backend.store_client.put_tensor(EmbeddingPoolKey(KEY, key), torch.ones(2, 2))
-    if mode == "get-failure":
+    if mode in ("get-failure", "lease-expired"):
         read = native.get_into_ranges
 
-        def evicted(pointers, keys, dst, src, sizes):
-            return (
-                [[[-704]]]
-                if keys == [[EmbeddingPoolKey(KEY, "b").to_string()]]
-                and src == [[[304]]]
-                else read(pointers, keys, dst, src, sizes)
-            )
+        def failed_read(pointers, keys, dst, src, sizes):
+            if keys == [[EmbeddingPoolKey(KEY, "b").to_string()]] and src == [[[304]]]:
+                if mode == "lease-expired":
+                    # Native ranged GET checks the lease after the transfer.
+                    read(pointers, keys, dst, src, sizes)
+                    return [[[-707]]]
+                return [[[-704]]]
+            return read(pointers, keys, dst, src, sizes)
 
-        native.get_into_ranges = evicted
+        native.get_into_ranges = failed_read
         hits.remove("b")
     if mode == "registration-failure":
         native.register_buffer = MagicMock(return_value=-500)
@@ -308,7 +325,7 @@ def test_native_io_owners(backend, operation):
             native.unregister_buffer = MagicMock(return_value=-500)
         else:
             native.batch_put_from_multi_buffers = MagicMock(
-                return_value=[-200 if rejected else -800]
+                return_value=[-1700 if rejected else -800]
             )
         assert backend._enqueue_save("a", tensor)
         future = backend._pending["a"][0]

--- a/tests/v1/ec_connector/unit/test_cross_encoder_cache.py
+++ b/tests/v1/ec_connector/unit/test_cross_encoder_cache.py
@@ -1,0 +1,424 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ctypes
+import gc
+import struct
+import threading
+import weakref
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorRole
+from vllm.distributed.ec_transfer.ec_connector.mooncake.metadata import (
+    ECMooncakeConnectorMetadata,
+    ECMooncakePushSpec,
+)
+from vllm.distributed.ec_transfer.ec_connector.mooncake_ec_connector import (
+    ECMooncakeConnector,
+)
+from vllm.distributed.ec_transfer.ec_connector.mooncake_store_embedding import (
+    backend as store_backend,
+)
+from vllm.distributed.ec_transfer.ec_connector.mooncake_store_embedding import (
+    store_client,
+)
+from vllm.distributed.ec_transfer.ec_connector.mooncake_store_embedding.data import (
+    EmbeddingKeyMetadata,
+    EmbeddingPoolKey,
+    TensorSpec,
+)
+
+pytestmark = pytest.mark.cpu_test
+KEY = EmbeddingKeyMetadata(
+    "test", "model", "revision", "encoder", "torch.float32", "v2"
+)
+SPEC = TensorSpec((2, 2), "torch.float32", 16)
+
+
+class MemoryStore:
+    """Only the native boundary is faked; codec, resolver and publisher are real."""
+
+    def __init__(self):
+        self.objects: dict[str, bytes] = {}
+        self.registered: dict[int, int] = {}
+
+    def close(self):
+        return 0
+
+    def batch_is_exist(self, keys):
+        return [int(k in self.objects) for k in keys]
+
+    def register_buffer(self, addr, size):
+        self.registered[addr] = size
+        return 0
+
+    def unregister_buffer(self, addr):
+        del self.registered[addr]
+        return 0
+
+    def batch_put_from_multi_buffers(self, keys, pointers, sizes, config):
+        [key], [ptrs], [lengths] = keys, pointers, sizes
+        self.objects[key] = b"".join(
+            ctypes.string_at(p, n) for p, n in zip(ptrs, lengths, strict=True)
+        )
+        return [0]
+
+    def get_into_ranges(self, pointers, keys, dst_offsets, src_offsets, sizes):
+        [ptr], [[key]], [[[dst]]], [[[src]]], [[[size]]] = (
+            pointers,
+            keys,
+            dst_offsets,
+            src_offsets,
+            sizes,
+        )
+        obj = self.objects.get(key)
+        if obj is None:
+            return [[[-704]]]
+        ctypes.memmove(ptr + dst, obj[src : src + size], size)
+        return [[[size]]]
+
+
+@pytest.fixture
+def backend():
+    instance = store_backend.MooncakeEmbeddingStoreBackend(
+        store_client.MooncakeEmbeddingStoreClient(MemoryStore()),
+        KEY,
+        max_pending_items=32,
+        max_pending_bytes=2 * 1024**3,
+    )
+    yield instance
+    # Some tests deliberately poison I/O; always stop the Python executor.
+    instance._executor.shutdown(wait=True)
+
+
+def make_worker(backend):
+    from vllm.distributed.ec_transfer.ec_connector.mooncake.worker import (
+        ECMooncakeWorker,
+    )
+
+    worker = object.__new__(ECMooncakeWorker)
+    worker.is_producer = True
+    worker.is_consumer = False
+    worker._output_store = backend
+    worker._buffer_device = "cpu"
+    worker._producer_pushes = MagicMock()
+    worker._producer_pushes.reserve.return_value = (MagicMock(), True)
+    worker._producer_pushes.poll.return_value = []
+    worker._producer_pushes.cancel_requests.return_value = []
+    worker._producer_pushes.pending = False
+    worker._control_executor = MagicMock()
+    worker._consumer_memory = MagicMock()
+    worker._consumer_memory.drain_reclaimed.return_value = set()
+    worker._completed_loads = set()
+    worker._failed_loads = set()
+    worker._failed_saves = set()
+    worker._push_ready = threading.Event()
+    worker._flush_pending_pushes = MagicMock()
+    worker._bind_push_source = MagicMock()
+    connector = object.__new__(ECMooncakeConnector)
+    connector._worker = worker
+    connector._role = ECConnectorRole.WORKER
+    connector._is_producer = True
+    connector._is_consumer = False
+    connector._connector_metadata = None
+    return connector
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "miss",
+        "hit",
+        "partial",
+        "get-failure",
+        "registration-failure",
+    ],
+)
+def test_reuse_pipeline(backend, mode):
+    from vllm.multimodal.inputs import (
+        MultiModalFeatureSpec,
+        MultiModalKwargsItem,
+        PlaceholderRange,
+    )
+    from vllm.v1.worker.gpu.ec_connector import ActiveECConnector
+    from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+    from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
+    from vllm.v1.worker.gpu.model_states.interface import ModelState
+
+    native = backend.store_client.store
+    if mode == "partial":
+        hits = {"a", "c"}
+    elif mode in ("hit", "get-failure", "registration-failure"):
+        hits = set("abc")
+    else:
+        hits = set()
+    for key in hits:
+        backend.store_client.put_tensor(EmbeddingPoolKey(KEY, key), torch.ones(2, 2))
+    if mode == "get-failure":
+        read = native.get_into_ranges
+
+        def evicted(pointers, keys, dst, src, sizes):
+            return (
+                [[[-704]]]
+                if keys == [[EmbeddingPoolKey(KEY, "b").to_string()]]
+                and src == [[[304]]]
+                else read(pointers, keys, dst, src, sizes)
+            )
+
+        native.get_into_ranges = evicted
+        hits.remove("b")
+    if mode == "registration-failure":
+        native.register_buffer = MagicMock(return_value=-500)
+        hits.clear()
+    connector = make_worker(backend)
+    metadata = ECMooncakeConnectorMetadata(
+        store_candidates=dict.fromkeys("abc", SPEC),
+        pushes=[
+            ECMooncakePushSpec(
+                mm_hash=k,
+                shape=(2, 2),
+                dtype="float32",
+                nbytes=16,
+                consumer_zmq="ipc:///tmp/test",
+                transfer_id=k,
+                request_id="req",
+            )
+            for k in "abc"
+        ],
+    )
+    cache = EncoderCache()
+    cache.mm_features["req"] = [
+        MultiModalFeatureSpec(
+            data=MultiModalKwargsItem({}),
+            modality="image",
+            identifier=k,
+            mm_position=PlaceholderRange(offset=i * 2, length=2),
+        )
+        for i, k in enumerate("abc")
+    ]
+    runner = EncoderRunner(
+        model=None,
+        max_num_tokens=8,
+        hidden_size=2,
+        encoder_cache=cache,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+    runner.enable_timing = False
+    missing = [k for k in "abc" if k not in hits]
+    runner.execute_mm_encoder = MagicMock(
+        return_value=[torch.full((2, 2), 7.0) for _ in missing]
+    )
+    state = SimpleNamespace(encoder_runner=runner, encoder_cache=cache)
+    with patch(
+        "vllm.v1.worker.gpu.ec_connector.get_ec_transfer", return_value=connector
+    ):
+        adapter = ActiveECConnector(SimpleNamespace(), cache.encoder_outputs)
+    with adapter.maybe_get_output(
+        SimpleNamespace(ec_connector_metadata=metadata, finished_req_ids=set())
+    ) as output:
+        assert runner.prepare_mm_inputs({"req": [0, 1, 2]})[0] == missing
+        ModelState.execute_mm_encoder(state, {"req": [0, 1, 2]})
+    assert runner.execute_mm_encoder.call_count == bool(missing)
+    assert output.ec_connector_worker_meta.pending_saves is False
+    assert all(
+        torch.equal(
+            cache.encoder_outputs[k], torch.full((2, 2), 1.0 if k in hits else 7.0)
+        )
+        for k in "abc"
+    )
+    assert {
+        c.args[1] for c in connector._worker._bind_push_source.call_args_list
+    } == set("abc")
+    backend.shutdown()
+    assert not native.registered
+    if mode == "miss":
+        other = store_backend.MooncakeEmbeddingStoreBackend(
+            store_client.MooncakeEmbeddingStoreClient(native),
+            KEY,
+            max_pending_items=32,
+            max_pending_bytes=2 * 1024**3,
+        )
+        try:
+            loaded: dict[str, torch.Tensor] = {}
+            assert other.resolve_inputs(
+                dict.fromkeys("abc", SPEC),
+                loaded,
+                "cpu",
+            ) == set("abc")
+            assert all(torch.equal(loaded[k], cache.encoder_outputs[k]) for k in "abc")
+        finally:
+            other.shutdown()
+
+
+@pytest.mark.parametrize("mismatch", ["revision", "shape"])
+def test_incompatible_output_is_a_miss(backend, mismatch):
+    backend.store_client.put_tensor(EmbeddingPoolKey(KEY, "a"), torch.ones(2, 2))
+    if mismatch == "revision":
+        backend.key_metadata = replace(KEY, model_revision="other")
+    expected = replace(SPEC, shape=(4, 1)) if mismatch == "shape" else SPEC
+    outputs: dict[str, torch.Tensor] = {}
+    assert not backend.resolve_inputs({"a": expected}, outputs, "cpu")
+    assert not outputs and not backend.store_client.store.registered
+
+
+def test_partial_registration_rejection_releases_publication(backend):
+    """Rejecting the header must undo the prior tensor registration."""
+    native = backend.store_client.store
+    register = native.register_buffer
+    native.register_buffer = lambda addr, size: (
+        -500 if size == 304 else register(addr, size)
+    )
+    native.batch_put_from_multi_buffers = MagicMock()
+    tensor = torch.ones(2, 2)
+    owner = weakref.ref(tensor)
+    assert backend._enqueue_save("a", tensor)
+    future = backend._pending["a"][0]
+    with pytest.raises(store_client.EmbeddingStoreOperationError, match="register"):
+        future.result(timeout=5)
+    del tensor
+    gc.collect()
+    assert owner() is None and not native.registered
+    native.batch_put_from_multi_buffers.assert_not_called()
+    backend.reap()
+    assert backend._pending_bytes == 0
+
+
+@pytest.mark.parametrize("operation", ["get", "put", "rejected-put", "unregister"])
+def test_native_io_owners(backend, operation):
+    """Uncertain I/O retains owners; completed rejection frees them even via Future."""
+    native, client = backend.store_client.store, backend.store_client
+    tensor = torch.ones(2, 2)
+    owner = weakref.ref(tensor)
+    rejected = operation == "rejected-put"
+    if operation == "get":
+        native.get_into_ranges = MagicMock(return_value=[[[-800]]])
+        with pytest.raises(store_client.EmbeddingStoreError, match="unconfirmed"):
+            client.get_tensor_payload(
+                EmbeddingPoolKey(KEY, "a"), tensor.data_ptr(), 16, 304, owner=tensor
+            )
+    else:
+        if operation == "unregister":
+            native.unregister_buffer = MagicMock(return_value=-500)
+        else:
+            native.batch_put_from_multi_buffers = MagicMock(
+                return_value=[-200 if rejected else -800]
+            )
+        assert backend._enqueue_save("a", tensor)
+        future = backend._pending["a"][0]
+        with pytest.raises(store_client.EmbeddingStoreError):
+            future.result(timeout=5)
+    del tensor
+    gc.collect()
+    if rejected:
+        assert owner() is None  # A live Future must not retain the tensor.
+        backend.reap()
+        assert backend._pending_bytes == 0 and not native.registered
+    else:
+        assert owner() is not None and native.registered
+        with pytest.raises(store_client.EmbeddingStoreError, match="unconfirmed"):
+            client.close()
+
+
+def test_publication_budget_charges_and_releases_backing_storage(backend):
+    tensor = torch.arange(16, dtype=torch.float32)[:4]
+    owner = weakref.ref(tensor)
+    future: Future[None] = Future()
+    backend.max_pending_items = 1
+    backend.max_pending_bytes = tensor.nbytes
+    with patch.object(backend._executor, "submit", return_value=future):
+        assert not backend._enqueue_save("a", tensor)
+        backend.max_pending_bytes = 64
+        assert backend._enqueue_save("a", tensor)
+        backend.max_pending_bytes = 128
+        assert not backend._enqueue_save("b", tensor)
+    del tensor
+    gc.collect()
+    assert owner() is not None
+    future.set_result(None)
+    backend.reap()
+    gc.collect()
+    assert owner() is None and backend._pending_bytes == 0
+
+
+def test_completion_race_preserves_failure_and_reclaims_other_items(backend):
+    class RacingFuture(Future[None]):
+        def done(self):
+            observed = super().done()
+            if not observed:
+                self.set_exception(store_client.EmbeddingStoreError("uncertain"))
+            return observed
+
+    racing = RacingFuture()
+    other: Future[None] = Future()
+    with patch.object(backend._executor, "submit", side_effect=[racing, other]):
+        assert backend._enqueue_save("race", torch.ones(2, 2))
+        assert backend._enqueue_save("other", torch.ones(2, 2))
+    assert not backend._drain_completed()
+    assert backend._pending_bytes == 32
+    other.set_result(None)
+    with pytest.raises(store_client.EmbeddingStoreError):
+        backend.reap()
+    assert backend._pending_bytes == 16
+    with pytest.raises(store_client.EmbeddingStoreError):
+        backend._enqueue_save("later", torch.ones(2, 2))
+
+
+def test_readiness_and_shutdown_do_not_block_p2p_completion(backend):
+    ready, waiting, entered = [threading.Event() for _ in range(3)]
+
+    class ReadyEvent:
+        def synchronize(self):
+            waiting.set()
+            assert ready.wait(5)
+
+    original = backend._executor.shutdown
+
+    def closing(*args, **kwargs):
+        entered.set()
+        return original(*args, **kwargs)
+
+    native = backend.store_client.store
+
+    def close_store():
+        assert ready.is_set() and not native.registered
+        assert backend._pending_bytes == 0
+        return 0
+
+    native.close = MagicMock(side_effect=close_store)
+    connector = make_worker(backend)
+    connector.bind_connector_metadata(
+        ECMooncakeConnectorMetadata(store_candidates={"a": SPEC})
+    )
+    cache: dict[str, torch.Tensor] = {}
+    with (
+        patch.object(
+            store_backend, "_record_tensor_ready_event", return_value=ReadyEvent()
+        ),
+        patch.object(backend._executor, "shutdown", side_effect=closing),
+        ThreadPoolExecutor(max_workers=1) as closer,
+    ):
+        connector.start_save_caches(encoder_cache=cache)
+        cache["a"] = torch.arange(4, dtype=torch.float32).view(2, 2)
+        connector.save_caches(cache, "a")
+        assert connector.build_connector_worker_meta().pending_saves is False
+        assert waiting.wait(5) and not backend.store_client.store.objects
+        close = closer.submit(backend.shutdown)
+        try:
+            assert entered.wait(5) and not close.done()
+            assert not backend._enqueue_save("late", torch.ones(2, 2))
+        finally:
+            ready.set()
+        close.result(timeout=5)
+    native.close.assert_called_once_with()
+    assert not backend.store_client.store.registered and backend._pending_bytes == 0
+
+    assert backend.store_client.store.objects[EmbeddingPoolKey(KEY, "a").to_string()][
+        304:
+    ] == struct.pack("<4f", 0, 1, 2, 3)

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 
 from tests.v1.attention.utils import dense_kv_cache_views
+from vllm.distributed import mooncake_store
 from vllm.distributed.kv_events import KVEventAggregator
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import (
     rdma_utils,
@@ -356,6 +357,7 @@ def _install_fake_mooncake(monkeypatch, store_instance: MagicMock):
     fake_store_module = types.ModuleType("mooncake.store")
     fake_store_module.MooncakeDistributedStore = lambda: store_instance  # type: ignore[attr-defined]
     fake_store_module.ReplicateConfig = FakeReplicateConfig  # type: ignore[attr-defined]
+    fake_store_module.ObjectDataType = SimpleNamespace(TENSOR=1)  # type: ignore[attr-defined]
     fake_mooncake_module = types.ModuleType("mooncake")
     fake_mooncake_module.store = fake_store_module  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "mooncake", fake_mooncake_module)
@@ -544,7 +546,7 @@ def test_pool_key_cache_prefix_namespaces_and_disambiguates():
 def test_default_local_buffer_size_matches_pr40900():
     """PR-40900 shipped a 4 GiB default for local_buffer_size; the dual-mode
     patch preserves it (and the JSON key) so unchanged PR-40900 configs work."""
-    assert worker.DEFAULT_LOCAL_BUFFER_SIZE == 4 * 1024**3
+    assert mooncake_store.DEFAULT_LOCAL_BUFFER_SIZE == 4 * 1024**3
 
 
 def test_get_requester_local_hostname_prefers_override(monkeypatch):
@@ -2811,6 +2813,7 @@ def test_requester_worker_group_semantics_string_true_enables(
     fake_store_module = types.ModuleType("mooncake.store")
     fake_store_module.MooncakeDistributedStore = lambda: store  # type: ignore[attr-defined]
     fake_store_module.ReplicateConfig = FakeReplicateConfig  # type: ignore[attr-defined]
+    fake_store_module.ObjectDataType = SimpleNamespace(TENSOR=1)  # type: ignore[attr-defined]
     fake_mooncake_module = types.ModuleType("mooncake")
     fake_mooncake_module.store = fake_store_module  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "mooncake", fake_mooncake_module)
@@ -4120,10 +4123,10 @@ def test_config_defaults_to_embedded():
     """A JSON without explicit mode parses as embedded with 4 GiB segment."""
     cfg = _make_config()
     assert cfg.mode == "embedded"
-    assert cfg.global_segment_size == worker.DEFAULT_GLOBAL_SEGMENT_SIZE
-    assert cfg.local_buffer_size == worker.DEFAULT_LOCAL_BUFFER_SIZE
+    assert cfg.global_segment_size == mooncake_store.DEFAULT_GLOBAL_SEGMENT_SIZE
+    assert cfg.local_buffer_size == mooncake_store.DEFAULT_LOCAL_BUFFER_SIZE
     assert cfg.enable_offload is False
-    assert cfg.tenant_id == worker.DEFAULT_TENANT_ID
+    assert cfg.tenant_id == mooncake_store.DEFAULT_TENANT_ID
 
 
 def test_config_pr40900_unchanged(tmp_path):
@@ -4145,7 +4148,7 @@ def test_config_pr40900_unchanged(tmp_path):
     assert cfg.global_segment_size == 4 * 1024**3
     assert cfg.local_buffer_size == 4 * 1024**3
     assert cfg.enable_offload is False
-    assert cfg.tenant_id == worker.DEFAULT_TENANT_ID
+    assert cfg.tenant_id == mooncake_store.DEFAULT_TENANT_ID
 
 
 def test_config_from_file_normalizes_tenant_id(tmp_path):
@@ -4175,7 +4178,7 @@ def test_config_from_file_normalizes_empty_tenant_id_to_default(tmp_path):
 
     cfg = worker.MooncakeStoreConfig.from_file(config_path)
 
-    assert cfg.tenant_id == worker.DEFAULT_TENANT_ID
+    assert cfg.tenant_id == mooncake_store.DEFAULT_TENANT_ID
 
 
 def test_config_from_file_rejects_non_string_tenant_id(tmp_path):
@@ -4327,7 +4330,20 @@ def test_topology_embedded_cpu_only(tmp_path, monkeypatch):
     assert w.disk_offload_buffer_budget_bytes is None
 
 
-def test_topology_forwards_non_default_tenant_id(tmp_path, monkeypatch):
+def _create_store_client_for_tenant_test(consumer):
+    if consumer == "ec":
+        from vllm.distributed.ec_transfer.ec_connector.mooncake_store_embedding.store_client import (  # noqa: E501
+            create_mooncake_embedding_store_client,
+        )
+
+        return create_mooncake_embedding_store_client()
+    return worker.MooncakeStoreWorker(
+        _make_vllm_config(rank=1), _make_kv_cache_config()
+    )
+
+
+@pytest.mark.parametrize("consumer", ["kv", "ec"])
+def test_topology_forwards_non_default_tenant_id(tmp_path, monkeypatch, consumer):
     store = MagicMock()
     store.setup.return_value = 0
     _install_fake_mooncake(monkeypatch, store)
@@ -4348,12 +4364,13 @@ def test_topology_forwards_non_default_tenant_id(tmp_path, monkeypatch):
         ),
     )
 
-    worker.MooncakeStoreWorker(_make_vllm_config(rank=1), _make_kv_cache_config())
+    _create_store_client_for_tenant_test(consumer)
 
     assert store.setup.call_args.kwargs == {"tenant_id": "tenant-a"}
 
 
-def test_non_default_tenant_preserves_setup_type_error(tmp_path, monkeypatch):
+@pytest.mark.parametrize("consumer", ["kv", "ec"])
+def test_non_default_tenant_preserves_setup_type_error(tmp_path, monkeypatch, consumer):
     store = MagicMock()
     setup_error = TypeError(
         "setup(): incompatible function arguments; "
@@ -4379,7 +4396,7 @@ def test_non_default_tenant_preserves_setup_type_error(tmp_path, monkeypatch):
     )
 
     with pytest.raises(TypeError) as exc_info:
-        worker.MooncakeStoreWorker(_make_vllm_config(rank=1), _make_kv_cache_config())
+        _create_store_client_for_tenant_test(consumer)
 
     assert exc_info.value is setup_error
 

--- a/vllm/config/ec_transfer.py
+++ b/vllm/config/ec_transfer.py
@@ -23,6 +23,8 @@ class ECTransferConfig:
     safetensors) and ``ECMooncakeConnector`` (Mooncake TransferEngine RDMA;
     requires ``mooncake-transfer-engine`` and matching producer/consumer
     ``ec_connector_extra_config``; see ``mooncake_ec_connector`` module docstring).
+    Set ``cross_encoder_cache`` in Mooncake extra config to reuse shared
+    Encoder outputs from Store before encoding, retaining P2P delivery.
     """
 
     engine_id: str | None = None

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake/config.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake/config.py
@@ -107,6 +107,12 @@ class MooncakeECConfig:
                 raise ValueError("cross_encoder_cache requires Model Runner V2")
             if vllm_config.lora_config is not None:
                 raise ValueError("cross_encoder_cache does not support dynamic LoRA")
+            mm_config = vllm_config.model_config.multimodal_config
+            if mm_config is not None and mm_config.mm_processor_cache_gb == 0:
+                raise ValueError(
+                    "cross_encoder_cache requires mm_processor_cache_gb > 0 "
+                    "to preserve content identifiers across Encoders and restarts"
+                )
         control_port = int(ec_config.ec_port) + (
             parallel_config.data_parallel_index * parallel_config.tensor_parallel_size
         )

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake/config.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake/config.py
@@ -69,6 +69,9 @@ class MooncakeECConfig:
     control_timeout_ms: int
     push_wait_timeout_s: float
     pool_size: int
+    cross_encoder_cache: bool = False
+    store_max_pending_items: int = 32
+    store_max_pending_bytes: int = 2 * 1024**3
 
     @classmethod
     def from_vllm_config(cls, vllm_config: VllmConfig) -> MooncakeECConfig:
@@ -94,6 +97,16 @@ class MooncakeECConfig:
             "ec_buffer_size", ec_config.ec_buffer_size
         )
         get = ec_config.get_from_extra_config
+        shared_reuse = get("cross_encoder_cache", False)
+        if not isinstance(shared_reuse, bool):
+            raise ValueError("cross_encoder_cache must be a boolean")
+        if shared_reuse:
+            if not ec_config.is_ec_producer or ec_config.is_ec_consumer:
+                raise ValueError("cross_encoder_cache requires an Encoder producer")
+            if not vllm_config.use_v2_model_runner:
+                raise ValueError("cross_encoder_cache requires Model Runner V2")
+            if vllm_config.lora_config is not None:
+                raise ValueError("cross_encoder_cache does not support dynamic LoRA")
         control_port = int(ec_config.ec_port) + (
             parallel_config.data_parallel_index * parallel_config.tensor_parallel_size
         )
@@ -120,4 +133,11 @@ class MooncakeECConfig:
                 "push_wait_timeout_s", get("push_wait_timeout_s", 60)
             ),
             pool_size=registered_buffer_size,
+            cross_encoder_cache=shared_reuse,
+            store_max_pending_items=_positive_int(
+                "store_max_pending_items", get("store_max_pending_items", 32)
+            ),
+            store_max_pending_bytes=_positive_int(
+                "store_max_pending_bytes", get("store_max_pending_bytes", 2 * 1024**3)
+            ),
         )

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake/metadata.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake/metadata.py
@@ -10,6 +10,9 @@ from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorMetadata,
     ECConnectorWorkerMetadata,
 )
+from vllm.distributed.ec_transfer.ec_connector.mooncake_store_embedding.data import (
+    TensorSpec,
+)
 
 
 @dataclass
@@ -46,6 +49,7 @@ class ECMooncakeConnectorMetadata(ECConnectorMetadata):
     loads: list[ECMooncakeLoadSpec] = field(default_factory=list)
     pushes: list[ECMooncakePushSpec] = field(default_factory=list)
     freed: list[str] | None = None
+    store_candidates: dict[str, TensorSpec] = field(default_factory=dict)
 
 
 @dataclass

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake/scheduler.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake/scheduler.py
@@ -45,6 +45,9 @@ from vllm.distributed.ec_transfer.ec_connector.mooncake.state import (
 from vllm.distributed.ec_transfer.ec_connector.mooncake.transfer import (
     ensure_mooncake_available,
 )
+from vllm.distributed.ec_transfer.ec_connector.mooncake_store_embedding.data import (
+    TensorSpec,
+)
 from vllm.distributed.ec_transfer.ec_connector.utils import (
     PlaceholderMetadataResolver,
     collect_ec_item_metadata,
@@ -76,6 +79,8 @@ class ECMooncakeScheduler:
         ensure_mooncake_available()
         config = MooncakeECConfig.from_vllm_config(vllm_config)
 
+        self._store_candidates: list[tuple[str, str, TensorSpec]] = []
+        self._cross_encoder_cache = config.cross_encoder_cache
         self._is_producer = config.is_producer
         self._is_consumer = config.is_consumer
         self._control_addr = config.control_addr
@@ -427,28 +432,40 @@ class ECMooncakeScheduler:
             transfer_id = f"{request.request_id}:{index}"
         if not consumer_zmq or transfer_id in self._prepared_push_transfer_ids:
             return
-        num_tokens = request.get_num_encoder_embeds(index)
-        dtype = self._model_config.dtype
-        assert isinstance(dtype, torch.dtype)
-        assert self._encoder_cache_hidden_dim is not None
-        dtype_name = str(dtype).split(".")[-1]
-        shape = (num_tokens, self._encoder_cache_hidden_dim)
-        nbytes = math.prod(shape) * dtype.itemsize
+        output = self._encoder_output_spec(request, index)
         self._pushes_to_prepare[transfer_id] = ECMooncakePushSpec(
             mm_hash=mm_hash,
-            nbytes=nbytes,
-            shape=shape,
-            dtype=dtype_name,
+            nbytes=output.nbytes,
+            shape=output.shape,
+            dtype=output.dtype.removeprefix("torch."),
             consumer_zmq=str(consumer_zmq),
             transfer_id=transfer_id,
             request_id=request.request_id,
         )
         self._prepared_push_transfer_ids.add(transfer_id)
 
+    def _encoder_output_spec(self, request: Any, index: int) -> TensorSpec:
+        dtype = self._model_config.dtype
+        assert isinstance(dtype, torch.dtype)
+        assert self._encoder_cache_hidden_dim is not None
+        shape = (request.get_num_encoder_embeds(index), self._encoder_cache_hidden_dim)
+        return TensorSpec(shape, str(dtype), math.prod(shape) * dtype.itemsize)
+
     def update_state_after_alloc(self, request: Any, index: int) -> None:
         self._local_cache.add(request.mm_features[index].identifier)
         if self._is_producer:
             self._prepare_push_spec(request, index)
+            if (
+                self._cross_encoder_cache
+                and request.mm_features[index].modality == "image"
+            ):
+                self._store_candidates.append(
+                    (
+                        request.request_id,
+                        request.mm_features[index].identifier,
+                        self._encoder_output_spec(request, index),
+                    )
+                )
 
     def update_state_after_free(self, request: Any, index: int) -> None:
         if not self._is_consumer:
@@ -474,6 +491,13 @@ class ECMooncakeScheduler:
         meta = ECMooncakeConnectorMetadata(
             freed=scheduler_output.free_encoder_mm_hashes
         )
+        preempted = scheduler_output.preempted_req_ids or set()
+        meta.store_candidates = {
+            identifier: output
+            for request_id, identifier, output in self._store_candidates
+            if request_id not in preempted
+        }
+        self._store_candidates.clear()
         for push_spec in self._pushes_to_prepare.values():
             meta.pushes.append(push_spec)
         self._pushes_to_prepare.clear()

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake/worker.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake/worker.py
@@ -49,6 +49,9 @@ from vllm.distributed.ec_transfer.ec_connector.mooncake.transfer import (
     MooncakeTransfer,
     ensure_mooncake_available,
 )
+from vllm.distributed.ec_transfer.ec_connector.mooncake_store_embedding.data import (
+    build_embedding_key_metadata,
+)
 from vllm.logger import init_logger
 from vllm.utils.network_utils import get_ip
 
@@ -58,6 +61,10 @@ _T = TypeVar("_T")
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+
+    from ..mooncake_store_embedding.backend import (
+        MooncakeEmbeddingStoreBackend,
+    )
 
 _RESERVATION_REFRESH_SECONDS = _RESERVATION_TTL_SECONDS / 2
 _MAX_CANCELLED_TRANSFER_IDS = 1 << 16
@@ -87,6 +94,16 @@ class ECMooncakeWorker:
     def __init__(self, vllm_config: VllmConfig) -> None:
         ensure_mooncake_available()
         config = MooncakeECConfig.from_vllm_config(vllm_config)
+        self._store_config = (
+            (
+                build_embedding_key_metadata(vllm_config),
+                config.store_max_pending_items,
+                config.store_max_pending_bytes,
+            )
+            if config.cross_encoder_cache
+            else None
+        )
+        self._output_store: MooncakeEmbeddingStoreBackend | None = None
         self.is_producer = config.is_producer
         self.is_consumer = config.is_consumer
         self._buffer_device = config.buffer_device
@@ -173,6 +190,21 @@ class ECMooncakeWorker:
             self._is_receiving_rank = True
 
     def start_services(self) -> None:
+        if self._store_config is not None and self._output_store is None:
+            from ..mooncake_store_embedding.backend import (
+                MooncakeEmbeddingStoreBackend,
+            )
+            from ..mooncake_store_embedding.store_client import (
+                create_mooncake_embedding_store_client,
+            )
+
+            key_metadata, max_items, max_bytes = self._store_config
+            self._output_store = MooncakeEmbeddingStoreBackend(
+                create_mooncake_embedding_store_client(),
+                key_metadata,
+                max_pending_items=max_items,
+                max_pending_bytes=max_bytes,
+            )
         if not self.is_consumer or self._control_server is not None:
             return
         self._resolve_consumer_rank()
@@ -470,6 +502,14 @@ class ECMooncakeWorker:
             tensor = encoder_cache.get(mm_hash)
             if tensor is not None:
                 self._bind_push_source(tensor, mm_hash)
+        if self._output_store is not None:
+            loaded = self._output_store.resolve_inputs(
+                metadata.store_candidates, encoder_cache, self._buffer_device
+            )
+            # Loaded entries precede the runner's new-output snapshot, so they
+            # need explicit P2P source binding here.
+            for mm_hash in loaded:
+                self._bind_push_source(encoder_cache[mm_hash], mm_hash)
 
     def _reserve_batch(self, records: list[ProducerPushRecord]) -> None:
         """Resolve independent item futures with one reserve RPC per shard."""
@@ -851,6 +891,8 @@ class ECMooncakeWorker:
         if not self.is_producer:
             return None, None
 
+        if self._output_store is not None:
+            self._output_store.reap()
         for record in self._producer_pushes.cancel_requests(finished_req_ids):
             self._producer_pushes.submit_cancel(
                 record,
@@ -866,6 +908,8 @@ class ECMooncakeWorker:
             return
         tensor = encoder_cache[mm_hash]
         self._bind_push_source(tensor, mm_hash)
+        if self._output_store is not None:
+            self._output_store.record_output(mm_hash, tensor)
 
     def build_connector_worker_meta(self) -> ECMooncakeWorkerMetadata | None:
         if self.is_consumer and not self._is_receiving_rank:
@@ -894,6 +938,8 @@ class ECMooncakeWorker:
         self._failed_saves = set()
         self._completed_loads = set()
         self._failed_loads = set()
+        if self._output_store is not None:
+            self._output_store.publish_outputs()
         return meta
 
     def close(self) -> None:
@@ -938,3 +984,6 @@ class ECMooncakeWorker:
             )
         self._producer_memory.close()
         self._transfer.close()
+        if self._output_store is not None:
+            self._output_store.shutdown()
+            self._output_store = None

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/__init__.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Mooncake Store support for cross-Encoder output reuse."""

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/backend.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/backend.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Encoder-side Mooncake Store resolver and publisher."""
+
+from __future__ import annotations
+
+import threading
+import traceback
+from collections.abc import Mapping
+from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
+from dataclasses import dataclass
+
+import torch
+
+from vllm.logger import init_logger
+
+from .data import (
+    MOONCAKE_TENSOR_METADATA_NBYTES,
+    EmbeddingKeyMetadata,
+    EmbeddingPoolKey,
+    TensorSpec,
+)
+from .store_client import (
+    EmbeddingStoreError,
+    EmbeddingStoreOperationError,
+    MooncakeEmbeddingStoreClient,
+)
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class _StoreSave:
+    tensor: torch.Tensor | None
+    ready_event: torch.Event | None
+    budget_bytes: int
+
+    def release(self) -> None:
+        self.tensor = None
+        self.ready_event = None
+
+
+class MooncakeEmbeddingStoreBackend:
+    """Resolve immutable encoder outputs and publish misses asynchronously."""
+
+    def __init__(
+        self,
+        store_client: MooncakeEmbeddingStoreClient,
+        key_metadata: EmbeddingKeyMetadata,
+        *,
+        max_pending_items: int,
+        max_pending_bytes: int,
+    ) -> None:
+        self.store_client = store_client
+        self.key_metadata = key_metadata
+        self.max_pending_items = max_pending_items
+        self.max_pending_bytes = max_pending_bytes
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="ec-mooncake-store",
+        )
+        self._pending: dict[str, tuple[Future[None], _StoreSave]] = {}
+        self._pending_lock = threading.Lock()
+        self._pending_bytes = 0
+        self._step_candidates: set[str] = set()
+        self._step_outputs: dict[str, torch.Tensor] = {}
+        self._closed = False
+        self._fatal_error: BaseException | None = None
+
+    def record_output(self, identifier: str, tensor: torch.Tensor) -> None:
+        if identifier in self._step_candidates:
+            self._step_outputs.setdefault(identifier, tensor)
+
+    def publish_outputs(self) -> None:
+        """Publish outputs recorded in this Encoder step."""
+        outputs, self._step_outputs = self._step_outputs, {}
+        self._step_candidates.clear()
+        for identifier, tensor in outputs.items():
+            self._enqueue_save(identifier, tensor)
+
+    def reap(self) -> None:
+        for identifier, reason in self._drain_completed().items():
+            logger.warning("Store PUT failed for %s: %s", identifier, reason)
+
+    def resolve_inputs(
+        self,
+        expected_tensors: Mapping[str, TensorSpec],
+        encoder_cache: dict[str, torch.Tensor],
+        device: torch.device | str,
+    ) -> set[str]:
+        """Load outputs before encoding; unresolved items retain normal computation."""
+        self._step_candidates = set(expected_tensors)
+        self._step_outputs.clear()
+        candidates = [key for key in expected_tensors if key not in encoder_cache]
+        if not candidates:
+            return set()
+
+        pool_keys = [
+            EmbeddingPoolKey(self.key_metadata, identifier) for identifier in candidates
+        ]
+        try:
+            exists = self.store_client.batch_exists(pool_keys)
+        except (EmbeddingStoreOperationError, OSError):
+            logger.warning(
+                "Mooncake embedding Store lookup failed; falling back to encoder",
+                exc_info=True,
+            )
+            return set()
+
+        loaded: set[str] = set()
+        for identifier, pool_key, hit in zip(
+            candidates, pool_keys, exists, strict=True
+        ):
+            if not hit:
+                continue
+            try:
+                tensor_meta = self.store_client.get_tensor_meta(pool_key)
+                expected = expected_tensors[identifier]
+                if tensor_meta != expected:
+                    raise ValueError(
+                        f"Store tensor {tensor_meta} does not match {expected}"
+                    )
+                target = torch.empty(
+                    expected.shape,
+                    dtype=_resolve_torch_dtype(expected.dtype),
+                    device=device,
+                )
+                self.store_client.get_tensor_payload(
+                    pool_key,
+                    target.data_ptr(),
+                    tensor_meta.nbytes,
+                    MOONCAKE_TENSOR_METADATA_NBYTES,
+                    owner=target,
+                )
+            except (EmbeddingStoreOperationError, ValueError, OSError):
+                logger.warning(
+                    "Mooncake embedding Store GET failed for identifier=%s; "
+                    "falling back to encoder",
+                    identifier,
+                    exc_info=True,
+                )
+                continue
+            encoder_cache[identifier] = target
+            loaded.add(identifier)
+        return loaded
+
+    def _enqueue_save(self, identifier: str, tensor: torch.Tensor) -> bool:
+        """Admit contiguous outputs using their full retained storage size."""
+        if not tensor.is_contiguous():
+            return False
+        budget_bytes = tensor.untyped_storage().nbytes()
+        with self._pending_lock:
+            if self._fatal_error is not None:
+                raise EmbeddingStoreError(
+                    "Store publisher has failed"
+                ) from self._fatal_error
+            if self._closed or identifier in self._pending:
+                return False
+            if (
+                len(self._pending) >= self.max_pending_items
+                or self._pending_bytes + budget_bytes > self.max_pending_bytes
+            ):
+                return False
+            # Only admitted work creates an event. Runtime errors propagate.
+            save = _StoreSave(
+                tensor,
+                _record_tensor_ready_event(tensor),
+                budget_bytes,
+            )
+            try:
+                future = self._executor.submit(
+                    self._save, EmbeddingPoolKey(self.key_metadata, identifier), save
+                )
+            except RuntimeError:
+                save.release()
+                logger.warning("Failed to enqueue Mooncake Store PUT", exc_info=True)
+                return False
+            self._pending[identifier] = (future, save)
+            self._pending_bytes += budget_bytes
+        return True
+
+    def _save(self, pool_key: EmbeddingPoolKey, save: _StoreSave) -> None:
+        tensor = None
+        try:
+            if self.store_client.exists(pool_key):
+                return
+            tensor = save.tensor
+            assert tensor is not None
+            _wait_tensor_ready_event(save.ready_event)
+            self.store_client.put_tensor(pool_key, tensor)
+        except BaseException as error:
+            # Returned client frames can otherwise keep tensors via a Future's
+            # traceback. Uncertain I/O owners remain retained by the client.
+            traceback.clear_frames(error.__traceback__)
+            raise
+        finally:
+            tensor = None
+            save.release()
+
+    def _drain_completed(self) -> dict[str, str]:
+        failures: dict[str, str] = {}
+        with self._pending_lock:
+            for identifier, (future, save) in list(self._pending.items()):
+                # Observe once; a racing completion is handled on the next poll.
+                if not future.done():
+                    continue
+                try:
+                    future.result()  # Already done: never waits on Store I/O.
+                except CancelledError:
+                    failures[identifier] = "Store publication cancelled"
+                except (EmbeddingStoreOperationError, OSError) as error:
+                    failures[identifier] = str(error)
+                except BaseException as error:
+                    # The client may still own unsafe native-I/O buffers. Keep
+                    # their charge and fatal result until worker termination.
+                    if self._fatal_error is None:
+                        self._fatal_error = error
+                    continue
+                del self._pending[identifier]
+                save.release()  # Also clears owners of cancelled queued work.
+                self._pending_bytes -= save.budget_bytes
+            fatal = self._fatal_error
+        if fatal is not None:
+            raise fatal
+        return failures
+
+    def shutdown(self) -> None:
+        with self._pending_lock:
+            if self._closed:
+                return
+            self._closed = True
+        self._executor.shutdown(wait=True, cancel_futures=False)
+        self.reap()
+        self.store_client.close()
+
+
+def _resolve_torch_dtype(dtype: str) -> torch.dtype:
+    if dtype == "torch.float16":
+        return torch.float16
+    if dtype == "torch.bfloat16":
+        return torch.bfloat16
+    if dtype == "torch.float32":
+        return torch.float32
+    raise ValueError(f"unsupported embedding tensor dtype: {dtype}")
+
+
+def _record_tensor_ready_event(tensor: torch.Tensor) -> torch.Event | None:
+    if tensor.device.type != "cuda":
+        return None
+    event = torch.Event()
+    event.record(torch.accelerator.current_stream(tensor.device))
+    return event
+
+
+def _wait_tensor_ready_event(event: torch.Event | None) -> None:
+    if event is not None:
+        event.synchronize()

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/data.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/data.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Content identities and output contracts for the shared Encoder Store."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+EMBEDDING_PROTOCOL_VERSION = "v2"
+MOONCAKE_TENSOR_METADATA_NBYTES = 304
+
+
+def _escape_key_part(value: str) -> str:
+    return quote(value, safe="-_.~")
+
+
+@dataclass(frozen=True)
+class EmbeddingKeyMetadata:
+    """Metadata that defines the semantic namespace for embedding reuse."""
+
+    cache_prefix: str
+    model_name: str
+    model_revision: str
+    encoder: str
+    dtype: str
+    protocol_version: str
+
+
+@dataclass(frozen=True)
+class EmbeddingPoolKey:
+    """Key for addressing one embedding tensor in the distributed store."""
+
+    key_metadata: EmbeddingKeyMetadata
+    identifier: str
+
+    def to_string(self) -> str:
+        meta = self.key_metadata
+        prefix = f"{_escape_key_part(meta.cache_prefix)}@" if meta.cache_prefix else ""
+        return (
+            f"{prefix}embedding"
+            f"@model:{_escape_key_part(meta.model_name)}"
+            f"@revision:{_escape_key_part(meta.model_revision)}"
+            f"@encoder:{_escape_key_part(meta.encoder)}"
+            f"@dtype:{_escape_key_part(meta.dtype)}"
+            f"@protocol:{_escape_key_part(meta.protocol_version)}"
+            f"@id:{_escape_key_part(self.identifier)}"
+        )
+
+
+@dataclass(frozen=True)
+class TensorSpec:
+    """Contiguous output contract used by the Encoder and Store codec."""
+
+    shape: tuple[int, ...]
+    dtype: str
+    nbytes: int
+
+
+def build_embedding_key_metadata(vllm_config: VllmConfig) -> EmbeddingKeyMetadata:
+    model_config = vllm_config.model_config
+    ec_config = vllm_config.ec_transfer_config
+    assert ec_config is not None
+    extra_config = ec_config.ec_connector_extra_config
+
+    multimodal_config = model_config.multimodal_config
+    encoder_hash = (
+        multimodal_config.compute_hash()
+        if multimodal_config is not None
+        else "encoder:default"
+    )
+    return EmbeddingKeyMetadata(
+        cache_prefix=str(extra_config.get("embedding_cache_prefix", "")),
+        model_name=str(
+            extra_config.get("embedding_model_identity", model_config.model)
+        ),
+        model_revision=str(model_config.revision or "default"),
+        encoder=str(encoder_hash),
+        dtype=str(model_config.dtype),
+        protocol_version=EMBEDDING_PROTOCOL_VERSION,
+    )

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/store_client.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/store_client.py
@@ -40,14 +40,29 @@ class _MooncakeErrorCode(IntEnum):
     REPLICA_IS_NOT_READY = -703
     OBJECT_NOT_FOUND = -704
     OBJECT_ALREADY_EXISTS = -705
+    LEASE_EXPIRED = -707
     RPC_FAIL = -900
     RPC_TIMEOUT = -901
+    TENANT_QUOTA_EXCEEDED = -1700
 
 
 # For partial RAM reads and single-replica writes, these rejections occur
 # before submission or after completed I/O. Transfer timeouts can leave I/O
 # in flight; all other failures retain registered buffers and poison the client.
-_SAFE_IO_REJECTIONS = frozenset(_MooncakeErrorCode)
+_SAFE_IO_REJECTIONS = frozenset(
+    {
+        _MooncakeErrorCode.NO_AVAILABLE_HANDLE,
+        _MooncakeErrorCode.REPLICA_IS_NOT_READY,
+        _MooncakeErrorCode.OBJECT_NOT_FOUND,
+        _MooncakeErrorCode.OBJECT_ALREADY_EXISTS,
+        _MooncakeErrorCode.RPC_FAIL,
+        _MooncakeErrorCode.RPC_TIMEOUT,
+    }
+)
+# Ranged GET checks the lease after transfer completion; PUT rejects tenant
+# quotas before allocating replicas or submitting transfers.
+_SAFE_GET_REJECTIONS = _SAFE_IO_REJECTIONS | {_MooncakeErrorCode.LEASE_EXPIRED}
+_SAFE_PUT_REJECTIONS = _SAFE_IO_REJECTIONS | {_MooncakeErrorCode.TENANT_QUOTA_EXCEEDED}
 
 
 _MOONCAKE_TENSOR_OBJECT_MAGIC = 0x4D4F4F4E
@@ -133,7 +148,10 @@ class MooncakeEmbeddingStoreClient:
 
     @contextmanager
     def _registered_io(
-        self, buffers: list[tuple[Any, int, int]]
+        self,
+        buffers: list[tuple[Any, int, int]],
+        *,
+        safe_rejections: frozenset[_MooncakeErrorCode],
     ) -> Iterator[Callable[[Any], None]]:
         self._check_healthy()
         registered = []
@@ -146,9 +164,7 @@ class MooncakeEmbeddingStoreClient:
             def terminal(value: Any) -> bool:
                 if isinstance(value, (list, tuple)):
                     return bool(value) and all(terminal(x) for x in value)
-                return type(value) is int and (
-                    value >= 0 or value in _SAFE_IO_REJECTIONS
-                )
+                return type(value) is int and (value >= 0 or value in safe_rejections)
 
             if not terminal(results):
                 raise EmbeddingStoreError(
@@ -241,7 +257,9 @@ class MooncakeEmbeddingStoreClient:
             (tensor, tensor.data_ptr(), data_size),
             (header, header_ptr, len(metadata)),
         ]
-        with self._registered_io(buffers) as confirm:
+        with self._registered_io(
+            buffers, safe_rejections=_SAFE_PUT_REJECTIONS
+        ) as confirm:
             results = self.store.batch_put_from_multi_buffers(
                 [pool_key.to_string()],
                 [[header_ptr, tensor.data_ptr()]],
@@ -279,7 +297,9 @@ class MooncakeEmbeddingStoreClient:
         *,
         owner: Any,
     ) -> int:
-        with self._registered_io([(owner, addr, size)]) as confirm:
+        with self._registered_io(
+            [(owner, addr, size)], safe_rejections=_SAFE_GET_REJECTIONS
+        ) as confirm:
             key = pool_key.to_string()
             results = self.store.get_into_ranges(
                 [addr],

--- a/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/store_client.py
+++ b/vllm/distributed/ec_transfer/ec_connector/mooncake_store_embedding/store_client.py
@@ -1,0 +1,421 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Thin Mooncake Store client for embedding objects.
+
+Tensor codec adapted from vLLM PR #47302 (0d1f71f5d36c).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import math
+import struct
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from enum import IntEnum
+from typing import Any
+
+from vllm.distributed.ec_transfer.ec_connector.mooncake_store_embedding.data import (
+    MOONCAKE_TENSOR_METADATA_NBYTES,
+    EmbeddingPoolKey,
+    TensorSpec,
+)
+from vllm.distributed.mooncake_store import MooncakeStoreConfig, setup_mooncake_store
+from vllm.logger import init_logger
+from vllm.utils.network_utils import get_ip
+
+logger = init_logger(__name__)
+
+# A failed transfer can still use registered memory after the binding returns.
+# Poisoned clients retain their owners until process exit, including if normal
+# worker teardown drops the connector. New operations are rejected.
+_UNSAFE_CLIENTS: list[Any] = []
+
+
+# Values from Mooncake v0.3.12 / v0.3.12.post1 types.h (ErrorCode).
+# Python exposes integer returns, not this enum.
+class _MooncakeErrorCode(IntEnum):
+    NO_AVAILABLE_HANDLE = -200
+    REPLICA_IS_NOT_READY = -703
+    OBJECT_NOT_FOUND = -704
+    OBJECT_ALREADY_EXISTS = -705
+    RPC_FAIL = -900
+    RPC_TIMEOUT = -901
+
+
+# For partial RAM reads and single-replica writes, these rejections occur
+# before submission or after completed I/O. Transfer timeouts can leave I/O
+# in flight; all other failures retain registered buffers and poison the client.
+_SAFE_IO_REJECTIONS = frozenset(_MooncakeErrorCode)
+
+
+_MOONCAKE_TENSOR_OBJECT_MAGIC = 0x4D4F4F4E
+_MOONCAKE_TENSOR_OBJECT_VERSION = 1
+_MOONCAKE_TENSOR_HEADER_FORMAT = "<IHHiiIIQQ"
+_MOONCAKE_TENSOR_HEADER_NBYTES = struct.calcsize(_MOONCAKE_TENSOR_HEADER_FORMAT)
+_MOONCAKE_TENSOR_GLOBAL_SHAPE_OFFSET = _MOONCAKE_TENSOR_HEADER_NBYTES
+_MOONCAKE_TENSOR_LOCAL_SHAPE_OFFSET = _MOONCAKE_TENSOR_GLOBAL_SHAPE_OFFSET + 64
+_MOONCAKE_DTYPE_TO_TORCH_DTYPE = {
+    0: "torch.float32",
+    11: "torch.float16",
+    12: "torch.bfloat16",
+}
+_TORCH_DTYPE_TO_MOONCAKE_DTYPE = {
+    value: key for key, value in _MOONCAKE_DTYPE_TO_TORCH_DTYPE.items()
+}
+_SUPPORTED_EMBEDDING_DTYPE_NBYTES = {
+    "torch.float16": 2,
+    "torch.bfloat16": 2,
+    "torch.float32": 4,
+}
+
+
+def create_mooncake_embedding_store_client() -> MooncakeEmbeddingStoreClient:
+    try:
+        from mooncake.store import (  # type: ignore
+            MooncakeDistributedStore,
+            ObjectDataType,
+            ReplicateConfig,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "Install mooncake with Store support to enable cross_encoder_cache."
+        ) from e
+
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake import rdma_utils
+
+    config = MooncakeStoreConfig.load_from_config()
+    if config.enable_offload:
+        raise ValueError(
+            "cross_encoder_cache supports a RAM Store; disable enable_offload"
+        )
+    store = MooncakeDistributedStore()
+    local_ip = get_ip()
+    local_hostname = rdma_utils.get_requester_local_hostname(local_ip)
+    setup_mooncake_store(store, config, local_hostname)
+
+    logger.info(
+        "Initialized embedding Mooncake store mode=%s global_segment_size=%d "
+        "local_buffer_size=%d",
+        config.mode,
+        config.global_segment_size,
+        config.local_buffer_size,
+    )
+    replicate_config = ReplicateConfig()
+    replicate_config.data_type = ObjectDataType.TENSOR
+    return MooncakeEmbeddingStoreClient(store, replicate_config=replicate_config)
+
+
+class EmbeddingStoreError(RuntimeError):
+    """A Store failure that must propagate to the worker."""
+
+
+class EmbeddingStoreOperationError(EmbeddingStoreError):
+    """A rejected or completed operation that permits normal Encoder fallback."""
+
+
+class MooncakeEmbeddingStoreClient:
+    """Wraps Mooncake object and buffer APIs used by embedding transfer."""
+
+    def __init__(self, store: Any, replicate_config: Any | None = None):
+        self._lifetime_lock = threading.Lock()
+        self._unsafe_owners: list[Any] = []
+        self._poisoned = False
+        self.store = store
+        self.replicate_config = replicate_config
+
+    def _check_healthy(self) -> None:
+        if self._poisoned:
+            raise EmbeddingStoreError(
+                "Mooncake I/O completion is unconfirmed; worker must exit"
+            )
+
+    @contextmanager
+    def _registered_io(
+        self, buffers: list[tuple[Any, int, int]]
+    ) -> Iterator[Callable[[Any], None]]:
+        self._check_healthy()
+        registered = []
+        submitted = False
+        confirmed = False
+
+        def confirm(results: Any) -> None:
+            nonlocal confirmed
+
+            def terminal(value: Any) -> bool:
+                if isinstance(value, (list, tuple)):
+                    return bool(value) and all(terminal(x) for x in value)
+                return type(value) is int and (
+                    value >= 0 or value in _SAFE_IO_REJECTIONS
+                )
+
+            if not terminal(results):
+                raise EmbeddingStoreError(
+                    "Mooncake I/O completion is unconfirmed; retaining buffers"
+                )
+            confirmed = True
+
+        try:
+            for owner, addr, size in buffers:
+                if owner is None:
+                    raise ValueError("registered I/O requires a buffer owner")
+                if addr not in registered:
+                    ret = self.store.register_buffer(addr, size)
+                    if ret != 0:
+                        raise EmbeddingStoreOperationError(
+                            f"Failed to register embedding buffer: {ret}"
+                        )
+                    registered.append(addr)
+            submitted = True
+            yield confirm
+        except BaseException as error:
+            if submitted and not confirmed:
+                with self._lifetime_lock:
+                    self._unsafe_owners.extend(owner for owner, _, _ in buffers)
+                    if not self._poisoned:
+                        self._poisoned = True
+                        _UNSAFE_CLIENTS.append(self)
+                raise EmbeddingStoreError(
+                    "Mooncake I/O completion is unconfirmed; retaining buffers"
+                ) from error
+            raise
+        finally:
+            if not submitted or confirmed:
+                try:
+                    for addr in reversed(registered):
+                        self.unregister_tensor(addr)
+                except BaseException:
+                    with self._lifetime_lock:
+                        self._unsafe_owners.extend(owner for owner, _, _ in buffers)
+                        if not self._poisoned:
+                            self._poisoned = True
+                            _UNSAFE_CLIENTS.append(self)
+                    raise
+
+    def close(self) -> None:
+        """Close the supported Mooncake binding after all I/O is drained."""
+        self._check_healthy()
+        ret = self.store.close()
+        if ret != 0:
+            raise EmbeddingStoreError(
+                f"failed to close embedding Mooncake Store: {ret}"
+            )
+
+    def exists(self, pool_key: EmbeddingPoolKey) -> bool:
+        return self.batch_exists([pool_key])[0]
+
+    def batch_exists(self, pool_keys: list[EmbeddingPoolKey]) -> list[bool]:
+        self._check_healthy()
+        if not pool_keys:
+            return []
+
+        keys = [pool_key.to_string() for pool_key in pool_keys]
+        states = self.store.batch_is_exist(keys)
+        if len(states) != len(keys):
+            raise RuntimeError(
+                "Mooncake Store returned an unexpected number of lookup results"
+            )
+        return [state == 1 for state in states]
+
+    def get_tensor_meta(self, pool_key: EmbeddingPoolKey) -> TensorSpec:
+        buffer = (ctypes.c_ubyte * MOONCAKE_TENSOR_METADATA_NBYTES)()
+        self.get_tensor_payload(
+            pool_key,
+            ctypes.addressof(buffer),
+            MOONCAKE_TENSOR_METADATA_NBYTES,
+            0,
+            owner=buffer,
+        )
+        return _decode_mooncake_tensor_metadata(pool_key, bytes(buffer))
+
+    def put_tensor(self, pool_key: EmbeddingPoolKey, tensor: Any) -> None:
+        self._check_healthy()
+        if not tensor.is_contiguous():
+            raise EmbeddingStoreOperationError("embedding tensor must be contiguous")
+        metadata = _encode_mooncake_tensor_metadata(tensor)
+        header = (ctypes.c_ubyte * len(metadata)).from_buffer_copy(metadata)
+        header_ptr = ctypes.addressof(header)
+        data_size = tensor.numel() * tensor.element_size()
+        buffers = [
+            (tensor, tensor.data_ptr(), data_size),
+            (header, header_ptr, len(metadata)),
+        ]
+        with self._registered_io(buffers) as confirm:
+            results = self.store.batch_put_from_multi_buffers(
+                [pool_key.to_string()],
+                [[header_ptr, tensor.data_ptr()]],
+                [[len(metadata), data_size]],
+                self.replicate_config,
+            )
+            if len(results) != 1:
+                raise EmbeddingStoreOperationError(
+                    "Mooncake put returned an unexpected number of results"
+                )
+            confirm(results)
+            if results[0] < 0:
+                raise EmbeddingStoreOperationError(
+                    f"failed to put embedding tensor for {pool_key.to_string()}"
+                )
+
+    def unregister_tensor(self, addr: int) -> None:
+        try:
+            ret = self.store.unregister_buffer(addr)
+        except Exception as error:
+            raise EmbeddingStoreError(
+                f"could not confirm buffer unregistration addr={addr:#x}"
+            ) from error
+        if ret != 0:
+            raise EmbeddingStoreError(
+                f"failed to unregister embedding buffer addr={addr:#x}: {ret}"
+            )
+
+    def get_tensor_payload(
+        self,
+        pool_key: EmbeddingPoolKey,
+        addr: int,
+        size: int,
+        src_offset: int,
+        *,
+        owner: Any,
+    ) -> int:
+        with self._registered_io([(owner, addr, size)]) as confirm:
+            key = pool_key.to_string()
+            results = self.store.get_into_ranges(
+                [addr],
+                [[key]],
+                [[[0]]],
+                [[[src_offset]]],
+                [[[size]]],
+            )
+            confirm(results)
+            result = _single_range_result(results)
+            if result != size:
+                raise EmbeddingStoreOperationError(
+                    "failed to get embedding tensor payload for "
+                    f"{pool_key.to_string()}: {result}"
+                )
+            return result
+
+
+def _single_range_result(results: Any) -> int:
+    try:
+        return int(results[0][0][0])
+    except (IndexError, TypeError, ValueError):
+        return -1
+
+
+def _decode_mooncake_tensor_metadata(
+    pool_key: EmbeddingPoolKey,
+    metadata: bytes,
+) -> TensorSpec:
+    if len(metadata) < MOONCAKE_TENSOR_METADATA_NBYTES:
+        raise EmbeddingStoreOperationError(
+            f"embedding tensor metadata is too small: {len(metadata)}"
+        )
+    (
+        magic,
+        version,
+        header_size,
+        dtype,
+        ndim,
+        layout_kind,
+        _reserved_flags,
+        data_offset,
+        data_bytes,
+    ) = struct.unpack_from(_MOONCAKE_TENSOR_HEADER_FORMAT, metadata, 0)
+    if (
+        magic != _MOONCAKE_TENSOR_OBJECT_MAGIC
+        or version != _MOONCAKE_TENSOR_OBJECT_VERSION
+        or header_size != MOONCAKE_TENSOR_METADATA_NBYTES
+    ):
+        raise EmbeddingStoreOperationError(
+            f"invalid Mooncake tensor metadata header for {pool_key.to_string()}"
+        )
+    if ndim <= 0 or ndim > 8:
+        raise EmbeddingStoreOperationError(
+            f"invalid embedding tensor ndim for {pool_key.to_string()}: {ndim}"
+        )
+    if dtype not in _MOONCAKE_DTYPE_TO_TORCH_DTYPE:
+        raise EmbeddingStoreOperationError(
+            f"unsupported Mooncake tensor dtype for {pool_key.to_string()}: {dtype}"
+        )
+    dtype_name = _MOONCAKE_DTYPE_TO_TORCH_DTYPE[dtype]
+    if layout_kind != 0:
+        raise EmbeddingStoreOperationError(
+            "unsupported embedding tensor layout for "
+            f"{pool_key.to_string()}: {layout_kind}"
+        )
+    if data_offset != MOONCAKE_TENSOR_METADATA_NBYTES:
+        raise EmbeddingStoreOperationError(
+            "invalid embedding tensor data offset for "
+            f"{pool_key.to_string()}: {data_offset}"
+        )
+    global_shape = struct.unpack_from(
+        "<8q",
+        metadata,
+        _MOONCAKE_TENSOR_GLOBAL_SHAPE_OFFSET,
+    )
+    local_shape = struct.unpack_from(
+        "<8q",
+        metadata,
+        _MOONCAKE_TENSOR_LOCAL_SHAPE_OFFSET,
+    )
+    if global_shape != local_shape:
+        raise EmbeddingStoreOperationError(
+            f"embedding tensor global/local shape mismatch for {pool_key.to_string()}"
+        )
+    shape = tuple(int(dim) for dim in local_shape[:ndim])
+    if any(dim <= 0 for dim in shape):
+        raise EmbeddingStoreOperationError(
+            f"invalid embedding tensor shape for {pool_key.to_string()}: {shape}"
+        )
+    expected_data_bytes = (
+        math.prod(shape) * _SUPPORTED_EMBEDDING_DTYPE_NBYTES[dtype_name]
+    )
+    if data_bytes <= 0 or data_bytes != expected_data_bytes:
+        raise EmbeddingStoreOperationError(
+            "embedding tensor shape/dtype do not match payload size for "
+            f"{pool_key.to_string()}: expected={expected_data_bytes} "
+            f"actual={data_bytes}"
+        )
+    return TensorSpec(
+        shape=shape,
+        dtype=dtype_name,
+        nbytes=int(data_bytes),
+    )
+
+
+def _encode_mooncake_tensor_metadata(tensor: Any) -> bytes:
+    dtype = str(tensor.dtype)
+    if dtype not in _TORCH_DTYPE_TO_MOONCAKE_DTYPE:
+        raise EmbeddingStoreOperationError(
+            f"unsupported embedding tensor dtype: {dtype}"
+        )
+    shape = tuple(int(dim) for dim in tensor.shape)
+    if len(shape) > 8:
+        raise EmbeddingStoreOperationError(
+            f"embedding tensor has too many dimensions: {len(shape)}"
+        )
+    nbytes = tensor.numel() * tensor.element_size()
+    header = struct.pack(
+        _MOONCAKE_TENSOR_HEADER_FORMAT,
+        _MOONCAKE_TENSOR_OBJECT_MAGIC,
+        _MOONCAKE_TENSOR_OBJECT_VERSION,
+        MOONCAKE_TENSOR_METADATA_NBYTES,
+        _TORCH_DTYPE_TO_MOONCAKE_DTYPE[dtype],
+        len(shape),
+        0,
+        0,
+        MOONCAKE_TENSOR_METADATA_NBYTES,
+        nbytes,
+    )
+    dims = shape + (-1,) * (8 - len(shape))
+    tensor_shape = struct.pack("<8q", *dims)
+    axes = b"\0" * (32 * 4)
+    metadata = header + tensor_shape + tensor_shape + struct.pack("<II", 0, 0) + axes
+    if len(metadata) != MOONCAKE_TENSOR_METADATA_NBYTES:
+        raise EmbeddingStoreOperationError(
+            f"invalid Mooncake tensor metadata size: {len(metadata)}"
+        )
+    return metadata

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -11,7 +11,6 @@ and MooncakeDistributedStore integration.
 """
 
 import dataclasses
-import json
 import math
 import os
 import queue
@@ -20,10 +19,8 @@ import threading
 import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass
-from typing import Any, Literal, TypeVar
+from typing import Any, TypeVar
 
-import regex as re
 import torch
 import zmq
 
@@ -64,6 +61,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.protocol import
     decode_lookup_response,
     encode_lookup_response,
 )
+from vllm.distributed.mooncake_store import MooncakeStoreConfig, setup_mooncake_store
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import get_ip, make_zmq_socket
@@ -89,10 +87,6 @@ from vllm.v1.kv_cache_layout import KVCacheLayout
 from .metrics import MooncakeStoreConnectorStats
 
 logger = init_logger(__name__)
-
-DEFAULT_GLOBAL_SEGMENT_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
-DEFAULT_LOCAL_BUFFER_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
-DEFAULT_TENANT_ID = "default"
 
 MOONCAKE_NO_AVAILABLE_HANDLE = -200
 _T = TypeVar("_T")
@@ -143,115 +137,6 @@ DEFAULT_MOONCAKE_DISK_STAGING_BUFFER_BYTES = 1280 * 1024 * 1024
 # Mirrors DirectIO alignment in Mooncake's AllocateBatch.
 _DIRECT_IO_ALIGNMENT = 4096
 _DIRECT_IO_PADDING_BYTES = 2 * _DIRECT_IO_ALIGNMENT
-
-
-MooncakeMode = Literal["embedded", "standalone-store"]
-
-
-@dataclass
-class MooncakeStoreConfig:
-    """Configuration for MooncakeDistributedStore.
-
-    ``mode`` selects the topology: ``embedded`` (each rank contributes
-    ``global_segment_size`` in-process) or ``standalone-store`` (rank
-    contributes 0; an external ``mooncake_client`` process owns the pool
-    and the SSD tier).
-    """
-
-    metadata_server: str
-    master_server_address: str
-    protocol: str
-    device_name: str
-    mode: MooncakeMode = "embedded"
-    global_segment_size: int = DEFAULT_GLOBAL_SEGMENT_SIZE
-    local_buffer_size: int = DEFAULT_LOCAL_BUFFER_SIZE
-    enable_offload: bool = False
-    tenant_id: str = DEFAULT_TENANT_ID
-
-    def __post_init__(self) -> None:
-        if self.mode not in ("embedded", "standalone-store"):
-            raise ValueError(f"unknown Mooncake mode: {self.mode!r}")
-        if self.local_buffer_size <= 0:
-            raise ValueError("local_buffer_size must be > 0")
-        if self.mode == "embedded" and self.global_segment_size == 0:
-            raise ValueError("embedded mode requires global_segment_size > 0")
-        if self.mode == "standalone-store" and self.global_segment_size != 0:
-            raise ValueError("standalone-store mode requires global_segment_size == 0")
-
-    @staticmethod
-    def from_file(file_path: str) -> "MooncakeStoreConfig":
-        with open(file_path) as file:
-            config = json.load(file)
-        return MooncakeStoreConfig(
-            metadata_server=config.get("metadata_server", ""),
-            master_server_address=config.get("master_server_address", ""),
-            protocol=config.get("protocol", "rdma"),
-            device_name=config.get("device_name", ""),
-            mode=config.get("mode", "embedded"),
-            global_segment_size=_parse_size(
-                config.get("global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE)
-            ),
-            local_buffer_size=_parse_size(
-                config.get("local_buffer_size", DEFAULT_LOCAL_BUFFER_SIZE)
-            ),
-            enable_offload=bool(config.get("enable_offload", False)),
-            tenant_id=_normalize_tenant_id(config.get("tenant_id", DEFAULT_TENANT_ID)),
-        )
-
-    @staticmethod
-    def load_from_config() -> "MooncakeStoreConfig":
-        config_path = os.getenv("MOONCAKE_CONFIG_PATH")
-        if not config_path:
-            raise ValueError(
-                "The environment variable 'MOONCAKE_CONFIG_PATH' is not set."
-            )
-        return MooncakeStoreConfig.from_file(config_path)
-
-
-def _normalize_tenant_id(value: Any) -> str:
-    if value is None:
-        return DEFAULT_TENANT_ID
-    if not isinstance(value, str):
-        raise TypeError(
-            f"tenant_id must be a string or null, got {type(value).__name__}: {value!r}"
-        )
-    tenant_id = value.strip()
-    return tenant_id if tenant_id else DEFAULT_TENANT_ID
-
-
-def _parse_size(value: Any) -> int:
-    """Parse storage size strings with units: GB, MB, KB, B."""
-    if isinstance(value, int):
-        return value
-    if not isinstance(value, str):
-        try:
-            return int(value)
-        except (TypeError, ValueError) as e:
-            raise TypeError(f"Unsupported type for size: {type(value)}") from e
-
-    cleaned = value.strip().lower()
-    if not cleaned:
-        raise ValueError("Size cannot be empty.")
-
-    unit_multipliers = {
-        "gb": 1024**3,
-        "mb": 1024**2,
-        "kb": 1024,
-        "b": 1,
-    }
-    match = re.match(r"^\s*([\d.]+)\s*(gb|mb|kb|b)?\s*$", cleaned)
-    if not match:
-        raise ValueError(f"Invalid format: '{value}'")
-
-    number_str = match.group(1)
-    unit = match.group(2) or "b"
-    multiplier = unit_multipliers[unit]
-
-    try:
-        numeric_value = float(number_str)
-    except ValueError as exc:
-        raise ValueError(f"Invalid numeric value '{number_str}' in: '{value}'") from exc
-    return int(numeric_value * multiplier)
 
 
 def _align_up(value: int, alignment: int) -> int:
@@ -1562,23 +1447,7 @@ class MooncakeStoreWorker:
         self.store = MooncakeDistributedStore()
         local_ip = get_ip()
         local_hostname = rdma_utils.get_requester_local_hostname(local_ip)
-        setup_kwargs: dict[str, str] = {}
-        if store_config.tenant_id != DEFAULT_TENANT_ID:
-            setup_kwargs["tenant_id"] = store_config.tenant_id
-        ret = self.store.setup(
-            local_hostname,
-            store_config.metadata_server,
-            store_config.global_segment_size,
-            store_config.local_buffer_size,
-            store_config.protocol,
-            store_config.device_name,
-            store_config.master_server_address,
-            **setup_kwargs,
-        )
-        if ret != 0:
-            msg = "Initialize MooncakeDistributedStore failed."
-            logger.error(msg)
-            raise RuntimeError(msg)
+        setup_mooncake_store(self.store, store_config, local_hostname)
 
         preferred_segment = rdma_utils.get_configured_preferred_segment(extra_config)
         self.preferred_segment = preferred_segment

--- a/vllm/distributed/mooncake_store.py
+++ b/vllm/distributed/mooncake_store.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared configuration and setup for EC and KV Mooncake Store clients."""
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import regex as re
+
+DEFAULT_GLOBAL_SEGMENT_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
+DEFAULT_LOCAL_BUFFER_SIZE = 4 * 1024 * 1024 * 1024  # 4 GiB
+DEFAULT_TENANT_ID = "default"
+
+
+MooncakeMode = Literal["embedded", "standalone-store"]
+
+
+@dataclass
+class MooncakeStoreConfig:
+    """Configuration for MooncakeDistributedStore.
+
+    ``mode`` selects the topology: ``embedded`` (each rank contributes
+    ``global_segment_size`` in-process) or ``standalone-store`` (rank
+    contributes 0; an external ``mooncake_client`` process owns the pool
+    and the SSD tier).
+    """
+
+    metadata_server: str
+    master_server_address: str
+    protocol: str
+    device_name: str
+    mode: MooncakeMode = "embedded"
+    global_segment_size: int = DEFAULT_GLOBAL_SEGMENT_SIZE
+    local_buffer_size: int = DEFAULT_LOCAL_BUFFER_SIZE
+    enable_offload: bool = False
+    tenant_id: str = DEFAULT_TENANT_ID
+
+    def __post_init__(self) -> None:
+        if self.mode not in ("embedded", "standalone-store"):
+            raise ValueError(f"unknown Mooncake mode: {self.mode!r}")
+        if self.local_buffer_size <= 0:
+            raise ValueError("local_buffer_size must be > 0")
+        if self.mode == "embedded" and self.global_segment_size == 0:
+            raise ValueError("embedded mode requires global_segment_size > 0")
+        if self.mode == "standalone-store" and self.global_segment_size != 0:
+            raise ValueError("standalone-store mode requires global_segment_size == 0")
+
+    @staticmethod
+    def from_file(file_path: str) -> "MooncakeStoreConfig":
+        with open(file_path) as file:
+            config = json.load(file)
+        return MooncakeStoreConfig(
+            metadata_server=config.get("metadata_server", ""),
+            master_server_address=config.get("master_server_address", ""),
+            protocol=config.get("protocol", "rdma"),
+            device_name=config.get("device_name", ""),
+            mode=config.get("mode", "embedded"),
+            global_segment_size=_parse_size(
+                config.get("global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE)
+            ),
+            local_buffer_size=_parse_size(
+                config.get("local_buffer_size", DEFAULT_LOCAL_BUFFER_SIZE)
+            ),
+            enable_offload=bool(config.get("enable_offload", False)),
+            tenant_id=_normalize_tenant_id(config.get("tenant_id", DEFAULT_TENANT_ID)),
+        )
+
+    @staticmethod
+    def load_from_config() -> "MooncakeStoreConfig":
+        config_path = os.getenv("MOONCAKE_CONFIG_PATH")
+        if not config_path:
+            raise ValueError(
+                "The environment variable 'MOONCAKE_CONFIG_PATH' is not set."
+            )
+        return MooncakeStoreConfig.from_file(config_path)
+
+
+def _normalize_tenant_id(value: Any) -> str:
+    if value is None:
+        return DEFAULT_TENANT_ID
+    if not isinstance(value, str):
+        raise TypeError(
+            f"tenant_id must be a string or null, got {type(value).__name__}: {value!r}"
+        )
+    tenant_id = value.strip()
+    return tenant_id if tenant_id else DEFAULT_TENANT_ID
+
+
+def _parse_size(value: Any) -> int:
+    """Parse storage size strings with units: GB, MB, KB, B."""
+    if isinstance(value, int):
+        return value
+    if not isinstance(value, str):
+        try:
+            return int(value)
+        except (TypeError, ValueError) as e:
+            raise TypeError(f"Unsupported type for size: {type(value)}") from e
+
+    cleaned = value.strip().lower()
+    if not cleaned:
+        raise ValueError("Size cannot be empty.")
+
+    unit_multipliers = {
+        "gb": 1024**3,
+        "mb": 1024**2,
+        "kb": 1024,
+        "b": 1,
+    }
+    match = re.match(r"^\s*([\d.]+)\s*(gb|mb|kb|b)?\s*$", cleaned)
+    if not match:
+        raise ValueError(f"Invalid format: '{value}'")
+
+    number_str = match.group(1)
+    unit = match.group(2) or "b"
+    multiplier = unit_multipliers[unit]
+
+    try:
+        numeric_value = float(number_str)
+    except ValueError as exc:
+        raise ValueError(f"Invalid numeric value '{number_str}' in: '{value}'") from exc
+    return int(numeric_value * multiplier)
+
+
+def setup_mooncake_store(
+    store: Any, config: MooncakeStoreConfig, local_hostname: str
+) -> None:
+    """Initialize a native Store, preserving explicit tenant configuration."""
+    setup_kwargs: dict[str, str] = {}
+    if config.tenant_id != DEFAULT_TENANT_ID:
+        setup_kwargs["tenant_id"] = config.tenant_id
+    ret = store.setup(
+        local_hostname,
+        config.metadata_server,
+        config.global_segment_size,
+        config.local_buffer_size,
+        config.protocol,
+        config.device_name,
+        config.master_server_address,
+        **setup_kwargs,
+    )
+    if ret != 0:
+        raise RuntimeError("Initialize MooncakeDistributedStore failed.")


### PR DESCRIPTION
## Motivation and design

When an image reaches an Encoder that lacks its output locally, a shared Store
can reuse an embedding already computed by another Encoder. This change adds
cross-Encoder output reuse in normal EPD serving, with Mooncake Store as the
cache backend and the existing `ECMooncakeConnector` for P2P delivery. Normal
serving requests populate the Store as they compute outputs.

The Store resolves content identifiers against Encoder-derived tensor contracts
before encoding. Hits skip the Encoder; misses retain normal computation. Both
sources enter the local cache; serving requests then use the configured EC
transport. Store policy accepts tensors and output contracts, without P2P
reservations or destinations.
Only the Mooncake integration is enabled in this PR.

Serving requests arrive with their Prefill destination already selected.

```text
                      Encoder scheduler
                local miss → normal allocation
                              │
                              ▼
               Encoder worker: Store lookup/load
                  (shared Mooncake Store, RAM)
                              │
                ┌─────────────┴─────────────┐
                ▼                           ▼
            Store hit              Miss / recoverable failure
         reuse embedding              Encoder forward
                │                           ├── async PUT → shared Store
                └─────────────┬─────────────┘
                              ▼
                  Local Encoder output cache
                              │
                              ▼
                   Configured EC transport
                              │
                              ▼
                           Prefill
```

Current serving integration: `Configured EC transport = ECMooncakeConnector P2P`.
Store resolution and publication are invoked by the Mooncake Encoder worker.

PUT lazily registers one reusable CPU header per client; payload registration
remains per embedding. The publisher drains before header unregistration.

Publication is bounded, asynchronous and best-effort; request completion does
not acknowledge Store readiness. Concurrent cold requests may still duplicate
computation. Hits are read with native `batch_get_into` through one reusable
registered buffer, pinned for CUDA outputs. The synchronous resolver chunks
reads by byte capacity, validates full objects and copies into independent
tensors before reusing staging. A rejected registration unwinds before falling
back. Batch GET rejections with `INVALID_PARAMS` (-600), `INVALID_REPLICA`
(-702), and completed GETs with
`LEASE_EXPIRED` (-707) fall back to encoding; a PUT rejected for
`TENANT_QUOTA_EXCEEDED` (-1700) skips publication. Unconfirmed native I/O or
unregistration retains buffer owners and fails explicitly.

## Usage

Set `cross_encoder_cache: true` in the producer's `ec_connector_extra_config`
and configure a RAM Store through `MOONCAKE_CONFIG_PATH`. Initial support is
images, MRv2, Encoder TP1, contiguous 2D FP16/BF16/FP32 outputs and no dynamic LoRA.
Shared reuse requires `--mm-processor-cache-gb` greater than zero to preserve
content identifiers; the processor-cache-off combination is rejected at startup.
`store_read_buffer_bytes` controls read staging separately from the publication
budget (default 128 MiB). It is allocated on the first Store hit; full misses
allocate none. Objects larger than the buffer fall back to encoding.
Prefill keeps its P2P configuration. EC and KV share Store configuration/setup.
`embedding_model_identity` overrides only the Store key's model field; matching
vLLM multimodal identifiers are still required, so this override alone does not
enable reuse across different configured model paths.
See `docs/features/cross_encoder_cache.md` for configuration and failure semantics.

## Validation

Self-contained CPU tests, with native Store I/O faked:

```bash
.venv/bin/python -m pytest --confcutdir=tests/v1/ec_connector/unit -q \
  tests/v1/ec_connector/unit/test_cross_encoder_cache.py \
  tests/v1/ec_connector/unit/test_worker_ec_connector.py
```

51 cases passed (45 focused Store cases and 6 existing wrapper cases), covering
MRv2 miss/hit/partial-hit serving, cross-Encoder reuse, registration reuse,
byte-capacity chunking, explicit CPU staging under non-CPU default devices,
independent output storage, mixed batch results and over-capacity returns,
malformed-object isolation, mid-copy/event-record/completion failures,
shared-storage publication budgets,
consumed failure release, completed-publication reaping before the next load
(including empty inputs), and native I/O/shutdown ownership. The tests use their
own fixtures and omit the repository's global accelerator teardown.

71 affected proxy/shared-Store configuration and setup tests passed (27 proxy
and 44 shared-Store cases). Changed-file pre-commit, including mypy 3.10, passed.

Real Mooncake 0.3.12.post1 tests on H20 TCP passed 19 checks, including one
registration over interior slots, bounded chunk reuse, bit-exact FP16/BF16/FP32
GPU outputs, missing/short/oversized/malformed-object isolation and final buffer
unregistration. Full-object reads return actual short lengths; oversized reads
return `INVALID_PARAMS` (-600).

Seven alternating serial/batch resolver measurements per warm condition used
one or four objects of 16 KiB, 1 MiB and 30 MiB, with full hits, partial hits and
misses. Four-object full-hit p50 changed from 3.05 → 0.41 ms, 4.51 → 1.14 ms and
29.44 → 20.59 ms respectively. Four hits changed eight read calls/registrations
per request into one batch read with no registrations after initial allocation.
Full misses perform no reads or staging allocation. These small same-node
measurements cover lookup, I/O and completed copies, not serving throughput.

Serving validation with Qwen3.5-4B BF16, MRv2 and TP1 passed 45 assertions:
full hits skipped Encoder work, partial hits recomputed only the missing image,
and actual P2P-delivered tensors were bit-exact against cold computation.
All 32 generated token IDs matched. Full and partial hits each used one native
batch read and reused the same pinned staging buffer. The completed cold
request from job 3020 was preserved; job 3027 restored those exact tensors into
the Store and completed the serial/batch comparisons and partial-hit phase.
SLURM job 3027 completed with verified task process/port/GPU/IPC cleanup.

Three warm serving requests per implementation had Encoder-request medians of
21.62 ms (serial) and 18.21 ms (batch); approximate E→PD TTFT medians were
97.94 ms and 96.43 ms. The first batch request was slower (623.71 vs 596.08 ms
approximate E→PD TTFT). These are small supplementary samples; TTFT here sums
Encoder HTTP duration and PD time to first nonempty content.

GPU validation reused the `6e1d051fc` PR-base wheel with the candidate's 10
EC/config/shared Store Python modules, without a native rebuild. The tested
batch-read diff is unchanged after rebasing onto the independently published
consumed-traceback fix.
Follow-ups enforce each GET destination capacity, explicitly allocate staging
on CPU, and reap completed publications before the next Store resolution or
Encoder computation. The current 52 CPU cases and changed-file pre-commit
passed; duplicate tests were consolidated. GPU measurements above cover the
preceding batch-read implementation.

PUT header-only follow-up: on H20 / Mooncake 0.3.12.post1 / same-node TCP,
a no-eviction rerun with a 16 GiB Store used three alternating rounds
(30 warm samples per case/path). Median PUT processing time fell from 1.466 to
1.183 ms for 1 × 1 MiB and from 5.088 to 4.118 ms for 4 × 1 MiB (about 19%).
Small-object gains held across all three rounds. For 30 MiB objects the medians
were 15.678 to 15.378 ms (one object) and 61.846 to 61.600 ms (four objects);
the four-object result was noisy and does not establish a stable improvement.
All 780 PUT payloads and headers were verified outside timing. Each candidate
client registered its header once and unregistered it after draining; payload
registration was unchanged. Final Store usage was 11.81/16 GiB, with zero
eviction attempts and zero allocation failures. This supersedes the earlier
6 GiB run, which encountered eviction. These are asynchronous publication
processing measurements, not TTFT.

## Controlled performance result

### Setup and comparison

We evaluated InternVL3_5-38B-HF BF16 on six H20 GPUs on one node, using common
CPU single-tile preprocessing. Each measured request contained four images,
approximately 400 text tokens and 32 output tokens. All instances used TP1;
EPD delivery used Mooncake P2P over TCP.

| Configuration | Six-GPU deployment | Encoder output caching |
|---|---|---|
| M6 (non-EPD) | Six monolithic instances, each running Encoder, Prefill and Decode | Existing instance-local cache |
| EL (local-only EPD) | Two Encoders + four Prefill/Decode instances (2E4PD) | Existing Encoder-local cache |
| ES (shared-cache EPD) | Same 2E4PD topology as EL | Existing Encoder-local cache + shared RAM Store |

**EL → ES is the primary comparison:** topology, inputs, arrival times and
forced E/PD routes are identical; ES adds shared output reuse. M6 provides an
equal-GPU system reference, showing how the EPD configurations compare with
monolithic serving. M6 → EL/ES also changes resource partitioning and delivery,
so it does not isolate the cache's effect.

Each configuration replayed the same fixed, open-loop Poisson arrival trace
at nominal 2 requests/s: 128 measured requests and 512 distinct images. The
client did not wait for one response before sending the next request. All
128 requests completed successfully in each configuration.

### Reassignment workload

We use `seed → ownership swap → measurement`. During seeding, EL and ES process
the same images, and ES publishes the outputs to the shared Store. E0 and E1
then exchange image ownership so each target Encoder has a local-cache miss.
EL recomputes the embedding, while ES reuses the shared output and skips
Encoder execution. Each of the 512 images is measured once after reassignment
to avoid subsequent local-cache hits.

### Results

Encoder GPU time is cumulative CUDA-event time during measurement; it excludes
Store access and does not represent reclaimable whole-GPU time.

| Metric | M6 (non-EPD) | EL (local-only EPD) | ES (shared-cache EPD) |
|---|---:|---:|---:|
| Completed requests | 128/128 | 128/128 | 128/128 |
| Re-encoded images | 512 | 512 | 0 |
| Encoder GPU time | 53.661 s | 55.484 s | 0 s |
| TTFT p50 | 1.173 s | 1.209 s | 0.819 s |
| TTFT p90 | 1.197 s | 1.656 s | 0.891 s |
| TPOT p50 | 19.17 ms | 19.33 ms | 19.33 ms |
| TPOT p90 | 54.53 ms | 41.54 ms | 41.39 ms |

Relative to EL, ES eliminates the 512 repeated Encoder executions and reduces
TTFT p50/p90 by **32.3%/46.2%**, with essentially unchanged TPOT. The E fan-out
completion span falls from 364.40/823.80 ms to 48.39/69.84 ms at p50/p90.
TTFT is measured from scheduled arrival to the first nonempty generated SSE;
client dispatch lag p90 was below 1.7 ms in all three configurations.

### Cold-miss publication overhead

During the closed-loop seeding phase, EL and ES compute the same 512 Encoder
outputs; ES additionally publishes 1.25 GiB of embeddings asynchronously.

| Seeding metric | EL | ES | Observed change |
|---|---:|---:|---:|
| Wall-clock time | 129.71 s | 130.01 s | +0.23% |
| Encoder GPU time | 56.821 s | 57.131 s | +0.55% |
| Store data published | 0 | 1.25 GiB | — |

All 512 publications completed successfully, with no pending writes at phase
completion. Per-request cold-miss TTFT was not measured separately.

### Reduced Encoder work

The 2E4PD topology concentrates vision-encoder work on two E workers, while
M6 distributes it across six monolithic instances. Cross-Encoder reuse
eliminates repeated forwards and reduces demand on the Encoder tier,
shortening the embedding-preparation path in this experiment. This can ease
Encoder capacity pressure when reusable outputs are available.

**Scope.** These results use one run per configuration in a controlled 100%
Encoder-reassignment workload on one model over same-node TCP. They quantify
the benefit when cross-Encoder reuse opportunities exist; production reuse
frequency is not evaluated here.

**Cost.** Shared reuse requires additional Store RAM and I/O: ES writes
1.25 GiB during population and reads 1.25 GiB during reuse. Asynchronous
population showed a +0.23% aggregate wall-clock increase in this experiment.
The prototype performance experiment was not repeated after the final refactor.

## Related work and assistance

Related to the [EPD tracker #52409](https://github.com/vllm-project/vllm/issues/52409).

This builds on [Mooncake P2P #41567](https://github.com/vllm-project/vllm/pull/41567).
Store client operations were originally adapted from
[Store EC #47302](https://github.com/vllm-project/vllm/pull/47302). The current
v3 namespace uses its own 24-byte header for complete 2D embeddings.
#47302 focuses on Encoder → Prefill transfer through Mooncake Store, while this PR focuses on
cross-Encoder output reuse to avoid redundant Encoder computation. Store is
used as a shared computation cache here, while the existing
`ECMooncakeConnector` remains the E→P delivery path.

Overlapping Store helpers require coordination during upstream integration.

[Processor cache #53809](https://github.com/vllm-project/vllm/pull/53809) caches
multimodal preprocessing results. This PR caches Encoder outputs after model
execution and does not replace that preprocessing cache.

AI assistance was used for implementation, testing, and documentation.
