### PR TITLE
[Core] Batch offline request admission

### DIFF
--- a/tests/entrypoints/unit_tests/test_offline_utils.py
+++ b/tests/entrypoints/unit_tests/test_offline_utils.py
@@ -4,7 +4,10 @@
 import pytest
 
 from vllm import SamplingParams
-from vllm.entrypoints.offline_utils import OfflineInferenceMixin
+from vllm.entrypoints.offline_utils import (
+    OfflineInferenceMixin,
+    _can_batch_engine_requests,
+)
 from vllm.exceptions import VLLMValidationError
 from vllm.lora.request import LoRARequest
 
@@ -55,3 +58,30 @@ def test_matching_lengths_pass_through(mixin: OfflineInferenceMixin):
     ]
     assert mixin._lora_request_to_seq([lora], num_requests=1) == [lora]
     assert mixin._priority_to_seq([3], num_requests=1) == [3]
+
+
+@pytest.mark.parametrize(
+    "prompts, expected",
+    [
+        ([{"prompt_token_ids": [1]}, {"prompt_token_ids": [2]}], True),
+        ([[1], [2]], True),
+        ([{"prompt_token_ids": [1]}], False),
+        (["first", "second"], False),
+        (
+            [
+                {"prompt_token_ids": [1], "multi_modal_data": {"image": object()}},
+                {"prompt_token_ids": [2]},
+            ],
+            False,
+        ),
+        (
+            [
+                {"prompt_token_ids": [1], "prompt_embeds": object()},
+                {"prompt_token_ids": [2]},
+            ],
+            False,
+        ),
+    ],
+)
+def test_can_batch_engine_requests(prompts, expected):
+    assert _can_batch_engine_requests(prompts) is expected

--- a/tests/v1/engine/test_sync_mp_request_batch.py
+++ b/tests/v1/engine/test_sync_mp_request_batch.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock, Mock, call
+
+import pytest
+
+from vllm import SamplingParams
+from vllm.v1.engine import EngineCoreRequest, EngineCoreRequestType
+from vllm.v1.engine.core import EngineCoreProc
+from vllm.v1.engine.core_client import SyncMPClient
+from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
+
+
+def make_client() -> SyncMPClient:
+    client = object.__new__(SyncMPClient)
+    client.is_dp = False
+    client._pending_add_batch = None
+    client._send_input = Mock()
+    return client
+
+
+def make_request(request_id: str) -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id=request_id,
+        prompt_token_ids=[1],
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=None,
+        data_parallel_rank=None,
+    )
+
+
+def test_batches_add_requests():
+    client = make_client()
+    requests = [MagicMock(spec=EngineCoreRequest) for _ in range(2)]
+
+    with client.batch_add_requests():
+        for request in requests:
+            client.add_request(request)
+
+    client._send_input.assert_called_once_with(
+        EngineCoreRequestType.ADD_BATCH, requests
+    )
+
+
+def test_preserves_single_add():
+    client = make_client()
+    request = MagicMock(spec=EngineCoreRequest)
+
+    with client.batch_add_requests():
+        client.add_request(request)
+
+    client._send_input.assert_called_once_with(EngineCoreRequestType.ADD, request)
+
+
+def test_preserves_individual_adds_for_data_parallel():
+    client = make_client()
+    client.is_dp = True
+    requests = [MagicMock(spec=EngineCoreRequest) for _ in range(2)]
+
+    with client.batch_add_requests():
+        for request in requests:
+            client.add_request(request)
+
+    assert client._send_input.call_args_list == [
+        call(EngineCoreRequestType.ADD, requests[0]),
+        call(EngineCoreRequestType.ADD, requests[1]),
+    ]
+    assert client._pending_add_batch is None
+
+
+def test_discards_failed_batch():
+    client = make_client()
+
+    with pytest.raises(RuntimeError), client.batch_add_requests():
+        client.add_request(MagicMock(spec=EngineCoreRequest))
+        raise RuntimeError("frontend preprocessing failed")
+
+    client._send_input.assert_not_called()
+    assert client._pending_add_batch is None
+
+
+def test_request_batch_msgpack_round_trip():
+    requests = [make_request("0"), make_request("1")]
+
+    encoded = MsgpackEncoder().encode(requests)
+    decoded = MsgpackDecoder(list[EngineCoreRequest]).decode(encoded)
+
+    assert [request.request_id for request in decoded] == ["0", "1"]
+    assert all(request.sampling_params.max_tokens == 1 for request in decoded)
+
+
+def test_engine_core_admits_entire_batch():
+    core = object.__new__(EngineCoreProc)
+    core._reject_add_in_shutdown = Mock(return_value=False)
+    core.add_request = Mock()
+    requests = [(MagicMock(), 3), (MagicMock(), 3)]
+
+    core._handle_client_request(EngineCoreRequestType.ADD_BATCH, requests)
+
+    assert core.add_request.call_args_list == [
+        call(requests[0][0], 3),
+        call(requests[1][0], 3),
+    ]

--- a/vllm/entrypoints/offline_utils.py
+++ b/vllm/entrypoints/offline_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable, Iterable, Sequence
+from contextlib import nullcontext
 from typing import Any
 
 from tqdm import tqdm
@@ -45,6 +46,20 @@ _O = TypeVar(
     default=RequestOutput | PoolingRequestOutput,
 )
 _R = TypeVar("_R", default=Any)
+
+
+def _can_batch_engine_requests(prompts: Sequence[PromptType]) -> bool:
+    """Whether prompts need no expensive or asynchronous frontend work."""
+    return len(prompts) > 1 and all(
+        isinstance(prompt, list)
+        or (
+            isinstance(prompt, dict)
+            and "prompt_token_ids" in prompt
+            and "multi_modal_data" not in prompt
+            and "prompt_embeds" not in prompt
+        )
+        for prompt in prompts
+    )
 
 
 class OfflineInferenceMixin:
@@ -312,6 +327,7 @@ class OfflineInferenceMixin:
         seq_params = self._params_to_seq(params, len(seq_prompts))
         seq_lora_requests = self._lora_request_to_seq(lora_request, len(seq_prompts))
         seq_priority = self._priority_to_seq(priority, len(seq_prompts))
+        batch_engine_requests = _can_batch_engine_requests(seq_prompts)
 
         return self._render_and_add_requests(
             prompts=(
@@ -329,6 +345,7 @@ class OfflineInferenceMixin:
             params=seq_params,
             lora_requests=seq_lora_requests,
             priorities=seq_priority,
+            batch_engine_requests=batch_engine_requests,
         )
 
     def _run_completion(
@@ -535,21 +552,28 @@ class OfflineInferenceMixin:
         *,
         lora_requests: Sequence[LoRARequest | None] | None = None,
         priorities: Sequence[int] | None = None,
+        batch_engine_requests: bool = False,
     ) -> list[str]:
         added_request_ids: list[str] = []
+        batch_context = (
+            self.llm_engine.engine_core.batch_add_requests()
+            if batch_engine_requests
+            else nullcontext()
+        )
 
         try:
-            for i, prompt in enumerate(prompts):
-                request_id = self._add_request(
-                    prompt,
-                    params[i],
-                    lora_request=self._resolve_mm_lora(
+            with batch_context:
+                for i, prompt in enumerate(prompts):
+                    request_id = self._add_request(
                         prompt,
-                        None if lora_requests is None else lora_requests[i],
-                    ),
-                    priority=0 if priorities is None else priorities[i],
-                )
-                added_request_ids.append(request_id)
+                        params[i],
+                        lora_request=self._resolve_mm_lora(
+                            prompt,
+                            None if lora_requests is None else lora_requests[i],
+                        ),
+                        priority=0 if priorities is None else priorities[i],
+                    )
+                    added_request_ids.append(request_id)
         except Exception as e:
             if added_request_ids:
                 self.llm_engine.abort_request(added_request_ids, internal=True)

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -295,6 +295,8 @@ class EngineCoreRequestType(enum.Enum):
     EXECUTOR_FAILED = b"\x04"
     # Sentinel to wake up input_queue.get() during shutdown.
     WAKEUP = b"\x05"
+    # A frontend-declared request batch that must be admitted atomically.
+    ADD_BATCH = b"\x06"
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1541,6 +1541,9 @@ class EngineCoreProc(EngineCore):
             if self._reject_add_in_shutdown(req):
                 return
             self.add_request(req, request_wave)
+        elif request_type == EngineCoreRequestType.ADD_BATCH:
+            for req in request:
+                self._handle_client_request(EngineCoreRequestType.ADD, req)
         elif request_type == EngineCoreRequestType.ABORT:
             self.abort_requests(request)
         elif request_type == EngineCoreRequestType.UTILITY:
@@ -1696,6 +1699,9 @@ class EngineCoreProc(EngineCore):
         add_request_decoder = MsgpackDecoder(
             EngineCoreRequest, oob_tensor_provider=self.tensor_ipc_receiver
         )
+        add_batch_decoder = MsgpackDecoder(
+            list[EngineCoreRequest], oob_tensor_provider=self.tensor_ipc_receiver
+        )
         generic_decoder = MsgpackDecoder(oob_tensor_provider=self.tensor_ipc_receiver)
 
         with ExitStack() as stack, zmq.Context() as ctx:
@@ -1765,6 +1771,18 @@ class EngineCoreProc(EngineCore):
                         except Exception:
                             self._handle_request_preproc_error(req)
                             continue
+                    elif request_type == EngineCoreRequestType.ADD_BATCH:
+                        request = []
+                        reqs: list[EngineCoreRequest] = add_batch_decoder.decode(
+                            data_frames
+                        )
+                        for req in reqs:
+                            try:
+                                request.append(self.preprocess_add_request(req))
+                            except MultiModalCacheMissError as e:
+                                self._handle_mm_cache_miss(req, e)
+                            except Exception:
+                                self._handle_request_preproc_error(req)
                     elif request_type == EngineCoreRequestType.UTILITY:
                         request = generic_decoder.decode(data_frames)
                         client_idx, call_id, method, args = request

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -177,6 +177,11 @@ class EngineCoreClient(ABC):
     def add_request(self, request: EngineCoreRequest) -> None:
         raise NotImplementedError
 
+    @contextlib.contextmanager
+    def batch_add_requests(self):
+        """Batch synchronous request admission when the client supports it."""
+        yield
+
     def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
         raise NotImplementedError
 
@@ -886,6 +891,7 @@ class SyncMPClient(MPClient):
         )
 
         self.is_dp = self.vllm_config.parallel_config.data_parallel_size > 1
+        self._pending_add_batch: list[EngineCoreRequest] | None = None
         self.outputs_queue = queue.Queue[EngineCoreOutputs | Exception]()
 
         # Ensure that the outputs socket processing thread does not have
@@ -976,7 +982,32 @@ class SyncMPClient(MPClient):
     def add_request(self, request: EngineCoreRequest) -> None:
         if self.is_dp:
             self.engines_running = True
-        self._send_input(EngineCoreRequestType.ADD, request)
+        if self._pending_add_batch is not None:
+            self._pending_add_batch.append(request)
+        else:
+            self._send_input(EngineCoreRequestType.ADD, request)
+
+    @contextlib.contextmanager
+    def batch_add_requests(self):
+        """Send a synchronous offline request cohort as one engine message."""
+        if self.is_dp:
+            yield
+            return
+        assert self._pending_add_batch is None, "Nested request batches are unsupported"
+        self._pending_add_batch = []
+        try:
+            yield
+        except BaseException:
+            self._pending_add_batch = None
+            raise
+        else:
+            requests = self._pending_add_batch
+            self._pending_add_batch = None
+            assert requests is not None
+            if len(requests) == 1:
+                self._send_input(EngineCoreRequestType.ADD, requests[0])
+            elif requests:
+                self._send_input(EngineCoreRequestType.ADD_BATCH, requests)
 
     def abort_requests(self, request_ids: list[str]) -> None:
         if request_ids and not self.resources.engine_dead:


### PR DESCRIPTION
## Summary

Batch eligible synchronous offline requests into one EngineCore message so the
complete caller-owned cohort is visible before the next scheduler decision.

The fast path is deliberately narrow: it only covers batches of pretokenized,
non-multimodal, non-embedding prompts. Single requests, data-parallel clients,
in-process clients, raw-text rendering, multimodal inputs, and prompt embeddings
keep their existing behavior.

Related to #16373, which describes the same split-admission scheduling effect in
the asynchronous parallel-sampling path. This PR only claims the synchronous
offline path described above.

## Design

- Add an `ADD_BATCH` EngineCore message carrying a list of requests.
- Buffer requests in `SyncMPClient` inside a scoped context manager, then send
  one batch message after frontend request construction succeeds.
- Decode and preprocess every member in the input thread, then enqueue the
  cohort as one item so EngineCore admits it before its next scheduling step.
- Fall back to individual `ADD` messages for data parallelism and single-item
  batches.

## Correctness

- Current upstream base: `22f6e4eccb674b534f62810c66838317169b6b98`
- Focused tests: 16 passed
- Ruff lint and format checks: passed
- Real Engine comparison: 108/108 sequence checks passed the frozen exact-or-
  reciprocal-top-5 contract; 76/108 were bit-for-bit token-sequence exact.
- Transport realization was checked: control emitted 72 `ADD` messages per arm;
  candidate emitted 8 `ADD` plus 8 `ADD_BATCH` messages.

## Performance

NVIDIA RTX 5090 (SM120), Qwen3.5-0.8B BF16, Model Runner V2,
multiprocessing EngineCore, synchronous offline `LLM.generate`, pretokenized
text-only input, B=8, 64 generated tokens, two fresh-process paired repeats:

| Repeat | Control elapsed | Candidate elapsed | Speedup | Control TTFT | Candidate TTFT |
|---|---:|---:|---:|---:|---:|
| 0 | 172.931 ms | 168.849 ms | 1.0242x | 16.484 ms | 11.568 ms |
| 1 | 173.005 ms | 168.738 ms | 1.0253x | 16.652 ms | 11.617 ms |

Geometric-mean elapsed speedup: **1.0247x**. The B=1 negative control was
neutral (worst paired ratio: 0.9997x). Decode time remained effectively flat;
the benefit is concentrated before the first token, as expected.

## Claim boundary

These measurements do not establish gains for online serving, asynchronous
clients, raw-text frontend processing, multimodal or embedding inputs, pooling,
in-process EngineCore, data parallelism, other models, or other hardware.
