### PR TITLE
[CI][XPU] Add Rust Frontend CI coverage for Intel GPU

### DIFF
--- a/.buildkite/intel_jobs/rust_frontend_intel.yaml
+++ b/.buildkite/intel_jobs/rust_frontend_intel.yaml
@@ -38,7 +38,7 @@ steps:
     'export VLLM_USE_RUST_FRONTEND=1 &&
     export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
     cd tests &&
-    pytest -v -s benchmarks/test_serve_cli.py -k "not insecure and not (test_bench_serve and not test_bench_serve_chat)" &&
+    pytest -v -s benchmarks/test_serve_cli.py::test_bench_serve_chat &&
     pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex and not test_kv_transfer_prompt_token_ids_round_trip and not test_kv_transfer_prompt_token_ids_streaming" &&
     pytest -v -s entrypoints/openai/chat_completion/test_include_reasoning.py &&
     pytest -v -s entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py -k "not multiple" &&

--- a/.buildkite/intel_jobs/rust_frontend_intel.yaml
+++ b/.buildkite/intel_jobs/rust_frontend_intel.yaml
@@ -68,6 +68,7 @@ steps:
   - vllm/entrypoints/serve/
   - vllm/v1/engine/
   - tests/utils.py
+  - tests/entrypoints/serve/dev/rpc/test_collective_rpc.py
   - tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py
   - tests/entrypoints/serve/instrumentator/test_basic.py
   - tests/entrypoints/serve/instrumentator/test_metrics.py
@@ -78,6 +79,7 @@ steps:
     'export VLLM_USE_RUST_FRONTEND=1 &&
     export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
     cd tests &&
+    PYTHONPATH=/workspace/vllm pytest -v -s entrypoints/serve/dev/rpc/test_collective_rpc.py &&
     pytest -v -s entrypoints/serve/instrumentator/test_basic.py -k "not server_load" &&
     pytest -v -s entrypoints/scale_out/token_in_token_out/test_serving_tokens.py -k "not stream and not lora and not test_generate_logprobs and not stop_string_workflow" &&
     pytest -v -s entrypoints/serve/instrumentator/test_metrics.py -k "text and not show and not run_batch and not test_metrics_counts and not test_metrics_exist" &&

--- a/.buildkite/intel_jobs/rust_frontend_intel.yaml
+++ b/.buildkite/intel_jobs/rust_frontend_intel.yaml
@@ -1,0 +1,178 @@
+group: Rust Frontend
+depends_on:
+  - image-build-xpu
+steps:
+- label: ":intel: (BMG) Rust Frontend OpenAI Coverage"
+  key: rust-frontend-openai-coverage-intel
+  timeout_in_minutes: 40
+  device: intel_gpu
+  agent_tags:
+    label: production
+    gpu: 1+
+    mem: 16+
+  no_plugin: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+  - rust/
+  - vllm/benchmarks/
+  - vllm/entrypoints/openai/
+  - vllm/entrypoints/serve/
+  - vllm/v1/sample/
+  - tests/utils.py
+  - tests/benchmarks/test_serve_cli.py
+  - tests/entrypoints/openai/chat_completion/test_chat_completion.py
+  - tests/entrypoints/openai/chat_completion/test_include_reasoning.py
+  - tests/entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py
+  - tests/entrypoints/openai/chat_completion/test_serving_chat.py
+  - tests/entrypoints/launchers/test_shutdown.py
+  - tests/entrypoints/openai/test_return_token_ids.py
+  - tests/entrypoints/serve/instrumentator/test_uds.py
+  - tests/v1/sample/test_logprobs_e2e.py
+  commands:
+  - >-
+    bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+    'export VLLM_USE_RUST_FRONTEND=1 &&
+    export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
+    cd tests &&
+    pytest -v -s benchmarks/test_serve_cli.py -k "not insecure and not (test_bench_serve and not test_bench_serve_chat)" &&
+    pytest -v -s entrypoints/openai/chat_completion/test_chat_completion.py -k "not test_invalid_json_schema and not test_invalid_regex and not test_kv_transfer_prompt_token_ids_round_trip and not test_kv_transfer_prompt_token_ids_streaming" &&
+    pytest -v -s entrypoints/openai/chat_completion/test_include_reasoning.py &&
+    pytest -v -s entrypoints/openai/chat_completion/test_chat_logit_bias_validation.py -k "not multiple" &&
+    pytest -v -s entrypoints/openai/chat_completion/test_serving_chat.py -k "test_chat_per_request_metrics_follow_server_flag or test_streaming_reasoning_usage_counts_across_deltas or test_completion_tokens_details" &&
+    pytest -v -s entrypoints/launchers/test_shutdown.py -k "not engine_failure and not test_abort_timeout_exits_quickly" &&
+    pytest -v -s entrypoints/openai/test_return_token_ids.py -k "not test_comparison" &&
+    pytest -v -s entrypoints/serve/instrumentator/test_uds.py &&
+    pytest -v -s v1/sample/test_logprobs_e2e.py -k test_prompt_logprobs_e2e_server'
+
+- label: ":intel: (BMG) Rust Frontend Serve/Admin Coverage"
+  key: rust-frontend-serve-admin-coverage-intel
+  timeout_in_minutes: 35
+  device: intel_gpu
+  agent_tags:
+    label: production
+    gpu: 1+
+    mem: 16+
+  no_plugin: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+  - rust/
+  - vllm/entrypoints/openai/
+  - vllm/entrypoints/serve/
+  - vllm/v1/engine/
+  - tests/utils.py
+  - tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py
+  - tests/entrypoints/serve/instrumentator/test_basic.py
+  - tests/entrypoints/serve/instrumentator/test_metrics.py
+  - tests/entrypoints/serve/tokenize/test_tokenization.py
+  commands:
+  - >-
+    bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+    'export VLLM_USE_RUST_FRONTEND=1 &&
+    export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
+    cd tests &&
+    pytest -v -s entrypoints/serve/instrumentator/test_basic.py -k "not server_load" &&
+    pytest -v -s entrypoints/scale_out/token_in_token_out/test_serving_tokens.py -k "not stream and not lora and not test_generate_logprobs and not stop_string_workflow" &&
+    pytest -v -s entrypoints/serve/instrumentator/test_metrics.py -k "text and not show and not run_batch and not test_metrics_counts and not test_metrics_exist" &&
+    pytest -v -s entrypoints/serve/tokenize/test_tokenization.py -k "not tokenizer_info"'
+
+- label: ":intel: (BMG) Rust Frontend Core Correctness"
+  key: rust-frontend-core-correctness-intel
+  timeout_in_minutes: 30
+  device: intel_gpu
+  agent_tags:
+    label: production
+    gpu: 1+
+    mem: 24+
+  no_plugin: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+  - rust/
+  - vllm/entrypoints/openai/
+  - tests/utils.py
+  - tests/entrypoints/openai/correctness/test_lmeval.py
+  commands:
+  - >-
+    bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+    'export VLLM_USE_RUST_FRONTEND=1 &&
+    export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
+    cd tests &&
+    pytest -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine'
+
+- label: ":intel: (BMG) Rust Frontend Tool Use"
+  key: rust-frontend-tool-use-intel
+  timeout_in_minutes: 30
+  device: intel_gpu
+  agent_tags:
+    label: production
+    gpu: 1+
+    mem: 24+
+  no_plugin: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+  - rust/
+  - vllm/entrypoints/openai/
+  - vllm/tool_parsers/
+  - tests/utils.py
+  - tests/tool_use/
+  commands:
+  - >-
+    bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+    'export VLLM_USE_RUST_FRONTEND=1 &&
+    export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
+    cd tests &&
+    pytest -v -s tool_use --ignore=tool_use/mistral --models llama3.2 -k not "test_response_format_with_tool_choice_required and not test_parallel_tool_calls_false and not test_tool_call_and_choice"'
+
+- label: ":intel: (BMG) Rust Frontend Distributed"
+  key: rust-frontend-distributed-intel
+  timeout_in_minutes: 30
+  device: intel_gpu
+  agent_tags:
+    label: production
+    gpu: 4+
+    mem: 16+
+  no_plugin: true
+  optional: true
+  working_dir: "."
+  env:
+    REGISTRY: "public.ecr.aws/q9t5s3a7"
+    REPO: "vllm-ci-test-repo"
+    VLLM_TEST_DEVICE: "xpu"
+  source_file_dependencies:
+  - rust/
+  - vllm/distributed/
+  - "!vllm/distributed/kv_transfer/"
+  - vllm/engine/
+  - vllm/executor/
+  - vllm/v1/engine/
+  - vllm/v1/worker/
+  - tests/utils.py
+  - tests/v1/distributed/test_dense_dp_world_size.py
+  - tests/v1/distributed/test_external_lb_dp.py
+  - tests/v1/distributed/test_hybrid_lb_dp.py
+  - tests/v1/distributed/test_internal_lb_dp.py
+  commands:
+  - >-
+    bash .buildkite/scripts/hardware_ci/run-intel-test.sh
+    'export VLLM_USE_RUST_FRONTEND=1 &&
+    export VLLM_WORKER_MULTIPROC_METHOD=spawn &&
+    cd tests &&
+    TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_dense_dp_world_size.py &&
+    TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_internal_lb_dp.py -k "not 4 and not server_info" &&
+    TP_SIZE=1 DP_SIZE=2 pytest -v -s v1/distributed/test_external_lb_dp.py -k "not 4 and not server_info and not test_external_lb_completion_streaming" &&
+    TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_hybrid_lb_dp.py -k "not 4 and not server_info"'


### PR DESCRIPTION
### Purpose
Port the Rust frontend (`VLLM_USE_RUST_FRONTEND=1`) CI coverage from
`.buildkite/test_areas/rust_frontend.yaml` (CUDA/AMD) to Intel XPU (BMG)
agents.

### Jobs added
- Rust Frontend OpenAI Coverage
- Rust Frontend Serve/Admin Coverage
- Rust Frontend Core Correctness
- Rust Frontend Tool Use
- Rust Frontend Distributed 

