### PR TITLE
[DSv4.1] Integrate Mega-mHC from DeepGEMM

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -29,8 +29,8 @@ if(DEEPGEMM_SRC_DIR)
 else()
   # Keep in sync with tools/install_deepgemm.sh
   set(_DEEPGEMM_UPSTREAM_REPO "https://github.com/deepseek-ai/DeepGEMM.git")
-  # Pinned to the tip of the nv_dev branch (SM120 support).
-  set(_DEEPGEMM_UPSTREAM_TAG "8b1392b978f5a03c828dd1711090d7fb50958b8a")
+  # DeepGEMM 2.8.0 (mega_mhc and DeepJIT runtime).
+  set(_DEEPGEMM_UPSTREAM_TAG "39d8c4cacc2c07c1fa9921c6c29c6a8a2da75359")
 
   set(_deepgemm_fc_root "${FETCHCONTENT_BASE_DIR}")
   if(NOT _deepgemm_fc_root)
@@ -51,16 +51,14 @@ else()
       BINARY_DIR "${_deepgemm_bin}"
       GIT_REPOSITORY "${_DEEPGEMM_UPSTREAM_REPO}"
       GIT_TAG "${_DEEPGEMM_UPSTREAM_TAG}"
-      GIT_SUBMODULES "third-party/cutlass" "third-party/fmt"
+      GIT_SUBMODULES "third-party/cutlass" "third-party/deep_jit"
       GIT_PROGRESS TRUE
     )
   endif()
   message(STATUS "DeepGEMM is available at ${deepgemm_SOURCE_DIR}")
 endif()
 
-# DeepGEMM requires CUDA 12.3+ for SM90, 12.9+ for SM100 (official upstream),
-# and 12.8+ for SM120 / SM12x. CUDA 13+ can use the family-specific SM12x
-# arch; CUDA 12.x builds the arch-specific SM120/SM121 variants.
+# DeepGEMM requires CUDA 12.3+ for SM90 and 12.8+ for SM100.
 set(DEEPGEMM_SUPPORT_ARCHS)
 if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.3)
   list(APPEND DEEPGEMM_SUPPORT_ARCHS "9.0a")
@@ -74,11 +72,12 @@ if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8)
   else()
     list(APPEND DEEPGEMM_SUPPORT_ARCHS "10.0a")
   endif()
-  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
-    list(APPEND DEEPGEMM_SUPPORT_ARCHS "12.0f")
-  else()
-    list(APPEND DEEPGEMM_SUPPORT_ARCHS "12.0a" "12.1a")
-  endif()
+  # SM120 support can be restored when this pin is rebased onto nv_dev.
+  # if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+  #   list(APPEND DEEPGEMM_SUPPORT_ARCHS "12.0f")
+  # else()
+  #   list(APPEND DEEPGEMM_SUPPORT_ARCHS "12.0a" "12.1a")
+  # endif()
 endif()
 
 cuda_archs_loose_intersection(DEEPGEMM_ARCHS
@@ -119,13 +118,15 @@ if(DEEPGEMM_ARCHS)
   message(STATUS "DeepGEMM _C will be built for: ${_dg_pythons}")
 
   # add_custom_command does no implicit header scanning; glob explicitly so
-  # header-only edits in DeepGEMM/cutlass/fmt re-trigger the rebuild.
+  # header-only edits in DeepGEMM/CUTLASS/DeepJIT re-trigger the rebuild.
   file(GLOB_RECURSE _dg_headers
     "${deepgemm_SOURCE_DIR}/csrc/*.h"
     "${deepgemm_SOURCE_DIR}/csrc/*.hpp"
     "${deepgemm_SOURCE_DIR}/deep_gemm/include/*.h"
     "${deepgemm_SOURCE_DIR}/deep_gemm/include/*.hpp"
-    "${deepgemm_SOURCE_DIR}/deep_gemm/include/*.cuh")
+    "${deepgemm_SOURCE_DIR}/deep_gemm/include/*.cuh"
+    "${deepgemm_SOURCE_DIR}/third-party/deep_jit/include/*.h"
+    "${deepgemm_SOURCE_DIR}/third-party/deep_jit/include/*.hpp")
 
   set(_dg_markers)
   set(_dg_seen_soabis)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,6 +132,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
         curl \
         sudo \
         rdma-core-devel \
+        elfutils-devel \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 

--- a/tests/kernels/quantization/test_block_fp8.py
+++ b/tests/kernels/quantization/test_block_fp8.py
@@ -27,6 +27,7 @@ from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
     fp8_gemm_nt,
     get_tma_aligned_size,
+    is_deep_gemm_e8m0_used,
     per_block_cast_to_fp8,
     should_use_deepgemm_for_fp8_linear,
 )
@@ -291,7 +292,11 @@ def test_w8a8_block_fp8_deep_gemm_matmul(M, N, K, block_size, out_dtype, seed):
     A_fp8, As_fp8 = per_token_group_quant_fp8(
         A_fp32, block_size[1], column_major_scales=True, tma_aligned_scales=True
     )
-    B_fp8, Bs_fp8 = per_block_cast_to_fp8(B_fp32, block_size=block_size)
+    B_fp8, Bs_fp8 = per_block_cast_to_fp8(
+        B_fp32,
+        block_size=block_size,
+        use_ue8m0=is_deep_gemm_e8m0_used(),
+    )
 
     As = As_fp8.to(torch.float32)
     Bs = Bs_fp8.to(torch.float32)

--- a/tests/kernels/test_mhc_kernels.py
+++ b/tests/kernels/test_mhc_kernels.py
@@ -9,9 +9,11 @@ import torch.nn.functional as F
 
 import vllm.model_executor.kernels.mhc  # noqa: F401
 import vllm.model_executor.layers.mhc as mhc_layers
+import vllm.models.deepseek_v4_1.nvidia.ops.mega_mhc as mega_mhc_ops
 from vllm.model_executor.kernels.mhc.tilelang import (
     _tilelang_hc_prenorm_gemm,
     _torch_hc_prenorm_gemm,
+    mhc_post_tilelang,
     mhc_pre_delayed_tilelang,
 )
 from vllm.model_executor.kernels.mhc.torch import mhc_pre_delayed_torch
@@ -31,6 +33,10 @@ from vllm.models.deepseek_v4.nvidia.model import (
 )
 from vllm.models.deepseek_v4_1.nvidia.model import (
     DeepseekV4DecoderLayer as DeepseekV41DecoderLayer,
+)
+from vllm.models.deepseek_v4_1.nvidia.ops.mega_mhc import (
+    is_mega_mhc_supported,
+    mhc_shifted_post_pre_deep_gemm,
 )
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
@@ -289,6 +295,12 @@ def test_deepseek_v41_decoder_mixes_match_torch(
         "vllm.models.deepseek_v4_1.nvidia.model.mhc_pre_delayed_tilelang",
         reference,
     )
+    monkeypatch.setattr(mega_mhc_ops, "mhc_pre_delayed_tilelang", reference)
+    monkeypatch.setattr(
+        mega_mhc_ops,
+        "is_mega_mhc_supported",
+        lambda hidden_size, hc_mult: False,
+    )
     expected = decoder(x, positions, None, **kwargs)
     for result, ref in zip(actual, expected, strict=True):
         torch.testing.assert_close(result, ref, atol=2e-2, rtol=1e-2)
@@ -306,6 +318,82 @@ def test_mhc_pre_delayed_custom_op_supports_compile(carried):
     torch.library.opcheck(
         torch.ops.vllm.mhc_pre_delayed_tilelang.default,
         (x, fn, scale, base, 1e-20, 1e-6, 1e-6, 2.0, 20, pre_mix),
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(100),
+    reason="DeepGEMM Mega mHC requires SM100-family CUDA",
+)
+def test_deep_gemm_mega_mhc_correctness():
+    num_tokens, hidden_size, hc_mult = 17, 7168, 4
+    if not is_mega_mhc_supported(hidden_size, 4):
+        pytest.skip("DeepGEMM Mega mHC is not available")
+
+    x = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device=DEVICE)
+    residual = torch.randn(
+        num_tokens, hc_mult, hidden_size, dtype=torch.bfloat16, device=DEVICE
+    )
+    previous_mix = torch.rand(num_tokens, hc_mult, device=DEVICE)
+    post_mix = torch.rand(num_tokens, hc_mult, 1, device=DEVICE)
+    res_mix = torch.rand(num_tokens, hc_mult, hc_mult, device=DEVICE)
+    fn = torch.randn(24, hc_mult * hidden_size, device=DEVICE) * 0.01
+    scale = torch.randn(3, device=DEVICE) * 0.1
+    base = torch.randn(24, device=DEVICE) * 0.1
+    norm_weight = torch.empty(
+        hidden_size, dtype=torch.bfloat16, device=DEVICE
+    ).uniform_(0.9, 1.1)
+
+    expected_residual = mhc_post_tilelang(x, residual, post_mix, res_mix)
+    (
+        expected_post_mix,
+        expected_res_mix,
+        expected_y_bf16,
+        expected_previous_mix,
+    ) = mhc_pre_delayed_tilelang(
+        expected_residual,
+        fn,
+        scale,
+        base,
+        2e-5,
+        3e-4,
+        2e-6,
+        1.25,
+        10,
+        pre_mix=previous_mix,
+        norm_weight=norm_weight,
+        norm_eps=7e-6,
+    )
+    (
+        actual_residual,
+        actual_post_mix,
+        actual_res_mix,
+        actual_y_bf16,
+        actual_previous_mix,
+    ) = mhc_shifted_post_pre_deep_gemm(
+        x,
+        residual,
+        previous_mix,
+        post_mix,
+        res_mix,
+        fn,
+        scale,
+        base,
+        2e-5,
+        3e-4,
+        1.25,
+        2e-6,
+        10,
+        norm_weight,
+        7e-6,
+    )
+    torch.accelerator.synchronize()
+    torch.testing.assert_close(actual_residual, expected_residual, atol=1e-5, rtol=1e-2)
+    torch.testing.assert_close(actual_post_mix, expected_post_mix, atol=1e-6, rtol=1e-3)
+    torch.testing.assert_close(actual_res_mix, expected_res_mix, atol=1e-6, rtol=1e-3)
+    torch.testing.assert_close(actual_y_bf16, expected_y_bf16, atol=1e-5, rtol=1e-2)
+    torch.testing.assert_close(
+        actual_previous_mix, expected_previous_mix, atol=1e-6, rtol=1e-3
     )
 
 

--- a/tools/build_deepgemm_C.py
+++ b/tools/build_deepgemm_C.py
@@ -50,7 +50,7 @@ includes = [
     str(src / "deep_gemm/include"),
     str(src / "third-party/cutlass/include"),
     str(src / "third-party/cutlass/tools/util/include"),
-    str(src / "third-party/fmt/include"),
+    str(src / "third-party/deep_jit/include"),
     *cpp_extension.include_paths(device_type="cuda"),
 ]
 
@@ -77,7 +77,6 @@ cmd = [
     "-lc10",
     "-lc10_cuda",
     "-lcudart",
-    "-lnvrtc",
     "-o",
     str(out / f"_C{info['EXT_SUFFIX']}"),
 ]

--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -7,8 +7,7 @@ set -e
 # Default values
 # Keep DEEPGEMM_GIT_REF in sync with cmake/external_projects/deepgemm.cmake
 DEEPGEMM_GIT_REPO="https://github.com/deepseek-ai/DeepGEMM.git"
-# NOTE: This is currently targeting the nv_dev branch tip due to sm120 support
-DEEPGEMM_GIT_REF="8b1392b978f5a03c828dd1711090d7fb50958b8a"
+DEEPGEMM_GIT_REF="39d8c4cacc2c07c1fa9921c6c29c6a8a2da75359"
 WHEEL_DIR=""
 
 # Parse command line arguments
@@ -91,6 +90,7 @@ pushd "$INSTALL_DIR/deepgemm"
 
 # Checkout the specific reference
 git checkout "$DEEPGEMM_GIT_REF"
+git submodule update --init --recursive
 
 # Clean previous build artifacts
 # (Based on https://github.com/deepseek-ai/DeepGEMM/blob/main/install.sh)

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -76,6 +76,7 @@ from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 from ..common.engram import Engram, EngramLayout, NgramHashState
 from ..common.mm_preprocess import IMAGE_SENTINEL_BASE_ID, image_sentinel_mask
+from .ops.mega_mhc import mhc_shifted_post_pre
 
 if typing.TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
@@ -334,30 +335,48 @@ class DeepseekV4DecoderLayer(nn.Module):
                     norm_eps=self.attn_norm.variance_epsilon,
                 )
         else:
-            residual = mhc_post_tilelang(x, residual, post_mix, res_mix)
             if self.engram is not None and engram_hashes is not None:
                 # Engram injection happens between the previous sublayer's
                 # post and this block's pre, on the full hc stream, so the
                 # mix coefficients see the injected stream.
+                residual = mhc_post_tilelang(x, residual, post_mix, res_mix)
                 residual = self.engram(
                     residual,
                     engram_hashes[:, self.engram.layer_hash_index],
                     engram_mask,
                 )
-            post_mix, res_mix, x, attn_pre = mhc_pre_delayed_tilelang(
-                residual,
-                self.hc_attn_fn,
-                self.hc_attn_scale,
-                self.hc_attn_base,
-                self.rms_norm_eps,
-                self.hc_eps,
-                self.hc_eps,
-                self.hc_post_alpha,
-                self.hc_sinkhorn_iters,
-                pre_mix=pre_mix,
-                norm_weight=self.attn_norm.weight,
-                norm_eps=self.attn_norm.variance_epsilon,
-            )
+                post_mix, res_mix, x, attn_pre = mhc_pre_delayed_tilelang(
+                    residual,
+                    self.hc_attn_fn,
+                    self.hc_attn_scale,
+                    self.hc_attn_base,
+                    self.rms_norm_eps,
+                    self.hc_eps,
+                    self.hc_eps,
+                    self.hc_post_alpha,
+                    self.hc_sinkhorn_iters,
+                    pre_mix=pre_mix,
+                    norm_weight=self.attn_norm.weight,
+                    norm_eps=self.attn_norm.variance_epsilon,
+                )
+            else:
+                assert pre_mix is not None
+                residual, post_mix, res_mix, x, attn_pre = mhc_shifted_post_pre(
+                    x,
+                    residual,
+                    pre_mix,
+                    post_mix,
+                    res_mix,
+                    self.hc_attn_fn,
+                    self.hc_attn_scale,
+                    self.hc_attn_base,
+                    self.rms_norm_eps,
+                    self.hc_eps,
+                    self.hc_post_alpha,
+                    self.hc_sinkhorn_iters,
+                    self.attn_norm.weight,
+                    self.attn_norm.variance_epsilon,
+                )
 
         if self.use_sequence_parallel:
             x = sp_all_gather(x)[: positions.shape[0]]
@@ -366,20 +385,21 @@ class DeepseekV4DecoderLayer(nn.Module):
         if self.use_sequence_parallel:
             x = sp_reduce_scatter(x)
 
-        residual = mhc_post_tilelang(x, residual, post_mix, res_mix)
-        post_mix, res_mix, x, ffn_pre = mhc_pre_delayed_tilelang(
+        residual, post_mix, res_mix, x, ffn_pre = mhc_shifted_post_pre(
+            x,
             residual,
+            attn_pre,
+            post_mix,
+            res_mix,
             self.hc_ffn_fn,
             self.hc_ffn_scale,
             self.hc_ffn_base,
             self.rms_norm_eps,
             self.hc_eps,
-            self.hc_eps,
             self.hc_post_alpha,
             self.hc_sinkhorn_iters,
-            pre_mix=attn_pre,
-            norm_weight=self.ffn_norm.weight,
-            norm_eps=self.ffn_norm.variance_epsilon,
+            self.ffn_norm.weight,
+            self.ffn_norm.variance_epsilon,
         )
         x = self.ffn(x, input_ids)
         return x, residual, post_mix, res_mix, ffn_pre

--- a/vllm/models/deepseek_v4_1/nvidia/ops/__init__.py
+++ b/vllm/models/deepseek_v4_1/nvidia/ops/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/models/deepseek_v4_1/nvidia/ops/mega_mhc.py
+++ b/vllm/models/deepseek_v4_1/nvidia/ops/mega_mhc.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import functools
+
+import torch
+
+from vllm.model_executor.kernels.mhc.tilelang import (
+    mhc_post_tilelang,
+    mhc_pre_delayed_tilelang,
+)
+from vllm.platforms import current_platform
+from vllm.utils.deep_gemm import (
+    _import_deep_gemm,
+    is_deep_gemm_supported,
+    mega_mhc,
+)
+
+
+@functools.cache
+def is_mega_mhc_supported(hidden_size: int, hc_mult: int) -> bool:
+    """Return whether DeepGEMM can run the DSV4.1 shifted mHC kernel."""
+    if not (
+        is_deep_gemm_supported()
+        and current_platform.is_device_capability_family(100)
+        and hidden_size > 0
+        and hidden_size % 1024 == 0
+        and hc_mult == 4
+    ):
+        return False
+    deep_gemm = _import_deep_gemm()
+    return deep_gemm is not None and callable(getattr(deep_gemm, "mega_mhc", None))
+
+
+def mhc_shifted_post_pre_deep_gemm(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    shifted_prev_mix: torch.Tensor,
+    post_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    mix_scales: torch.Tensor,
+    mix_bases: torch.Tensor,
+    hc_norm_eps: float,
+    hc_pre_eps: float,
+    hc_post_scale: float,
+    sinkhorn_eps: float,
+    num_sinkhorn_iters: int,
+    rmsnorm_weight: torch.Tensor,
+    rmsnorm_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run DSV4.1 shifted post, next pre, and BF16 RMSNorm with Mega mHC."""
+    num_tokens, hidden_size = x.shape
+    hc_mult = residual.shape[1]
+    new_residual = torch.empty_like(residual)
+    new_prev_mix = x.new_empty(num_tokens, hc_mult, 1, dtype=torch.float32)
+    new_post_mix = torch.empty_like(post_mix)
+    new_comb_res_mix = torch.empty_like(comb_res_mix)
+    y_bf16 = x.new_empty(num_tokens, hidden_size, dtype=torch.bfloat16)
+    mega_mhc(
+        x=x,
+        residual=residual,
+        shifted_prev_mix=shifted_prev_mix.unsqueeze(-1),
+        post_mix=post_mix,
+        comb_res_mix=comb_res_mix,
+        fn=fn,
+        mix_scales=mix_scales,
+        mix_bases=mix_bases,
+        hc_mult=hc_mult,
+        hc_norm_eps=hc_norm_eps,
+        hc_pre_eps=hc_pre_eps,
+        hc_post_scale=hc_post_scale,
+        sinkhorn_eps=sinkhorn_eps,
+        num_sinkhorn_iters=num_sinkhorn_iters,
+        rmsnorm_weight=rmsnorm_weight,
+        rmsnorm_eps=rmsnorm_eps,
+        rmsnorm_scale=1.0,
+        new_residual=new_residual,
+        new_prev_mix=new_prev_mix,
+        new_post_mix=new_post_mix,
+        new_comb_res_mix=new_comb_res_mix,
+        y_bf16=y_bf16,
+    )
+    return (
+        new_residual,
+        new_post_mix,
+        new_comb_res_mix,
+        y_bf16,
+        new_prev_mix.squeeze(-1),
+    )
+
+
+def mhc_shifted_post_pre(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    previous_mix: torch.Tensor,
+    post_mix: torch.Tensor,
+    res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    hc_post_alpha: float,
+    sinkhorn_iters: int,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Dispatch the DSV4.1 shifted mHC transition."""
+    if is_mega_mhc_supported(x.shape[1], residual.shape[1]):
+        return mhc_shifted_post_pre_deep_gemm(
+            x,
+            residual,
+            previous_mix,
+            post_mix,
+            res_mix,
+            fn,
+            scale,
+            base,
+            rms_eps,
+            hc_eps,
+            hc_post_alpha,
+            hc_eps,
+            sinkhorn_iters,
+            norm_weight,
+            norm_eps,
+        )
+
+    residual = mhc_post_tilelang(x, residual, post_mix, res_mix)
+    post_mix, res_mix, x, next_mix = mhc_pre_delayed_tilelang(
+        residual,
+        fn,
+        scale,
+        base,
+        rms_eps,
+        hc_eps,
+        hc_eps,
+        hc_post_alpha,
+        sinkhorn_iters,
+        pre_mix=previous_mix,
+        norm_weight=norm_weight,
+        norm_eps=norm_eps,
+    )
+    return residual, post_mix, res_mix, x, next_mix

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -705,9 +705,8 @@ class CudaPlatformBase(Platform):
     def support_deep_gemm(cls) -> bool:
         """Currently, only Hopper and Blackwell GPUs are supported."""
         return (
-            cls.is_device_capability(90)
-            or cls.is_device_capability_family(100)
-            or cls.is_device_capability_family(120)
+            cls.is_device_capability(90) or cls.is_device_capability_family(100)
+            # or cls.is_device_capability_family(120)
         )
 
     @classmethod

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -159,6 +159,7 @@ _fp8_fp4_mqa_logits_impl: Callable[..., Any] | None = None
 _fp8_fp4_paged_mqa_logits_impl: Callable[..., Any] | None = None
 _get_paged_mqa_logits_metadata_impl: Callable[..., Any] | None = None
 _tf32_hc_prenorm_gemm_impl: Callable[..., Any] | None = None
+_mega_mhc_impl: Callable[..., Any] | None = None
 _get_mn_major_tma_aligned_tensor_impl: Callable[..., Any] | None = None
 _get_mk_alignment_for_contiguous_layout_impl: Callable[..., Any] | None = None
 _get_theoretical_mk_alignment_for_contiguous_layout_impl: Callable[..., Any] | None = (
@@ -231,7 +232,7 @@ def _lazy_init() -> None:
     global _grouped_impl, _grouped_masked_impl, _grouped_fp4_impl
     global _fp8_fp4_mqa_logits_impl, _fp8_fp4_paged_mqa_logits_impl
     global _get_paged_mqa_logits_metadata_impl
-    global _tf32_hc_prenorm_gemm_impl
+    global _tf32_hc_prenorm_gemm_impl, _mega_mhc_impl
     global _get_mn_major_tma_aligned_tensor_impl
     global _get_mk_alignment_for_contiguous_layout_impl
     global _get_theoretical_mk_alignment_for_contiguous_layout_impl
@@ -251,6 +252,7 @@ def _lazy_init() -> None:
         or _fp8_fp4_paged_mqa_logits_impl is not None
         or _get_paged_mqa_logits_metadata_impl is not None
         or _tf32_hc_prenorm_gemm_impl is not None
+        or _mega_mhc_impl is not None
         or _get_mk_alignment_for_contiguous_layout_impl is not None
         or _transform_sf_into_required_layout_impl is not None
         or _pack_ue8m0_to_int_impl is not None
@@ -290,6 +292,7 @@ def _lazy_init() -> None:
         _dg, "get_paged_mqa_logits_metadata", None
     )
     _tf32_hc_prenorm_gemm_impl = getattr(_dg, "tf32_hc_prenorm_gemm", None)
+    _mega_mhc_impl = getattr(_dg, "mega_mhc", None)
     _get_mn_major_tma_aligned_tensor_impl = getattr(
         _dg, "get_mn_major_tma_aligned_tensor", None
     )
@@ -700,6 +703,15 @@ def tf32_hc_prenorm_gemm(
     )
 
 
+def mega_mhc(*args: Any, **kwargs: Any) -> None:
+    """Run DeepGEMM Mega mHC with caller-owned output tensors."""
+    _lazy_init()
+    if _mega_mhc_impl is None:
+        _missing()
+        return
+    _mega_mhc_impl(*args, **kwargs)
+
+
 def _ceil_to_ue8m0(x: torch.Tensor):
     return torch.pow(2.0, torch.ceil(torch.log2(x.abs())))
 
@@ -793,6 +805,7 @@ __all__ = [
     "per_block_cast_to_fp8",
     "is_deep_gemm_e8m0_used",
     "is_deep_gemm_supported",
+    "mega_mhc",
     "get_num_sms",
     "set_num_sms",
     "should_use_deepgemm_for_fp8_linear",


### PR DESCRIPTION
## Purpose

Integrate Mega-mHC from DeepGEMM (https://github.com/deepseek-ai/DeepGEMM/pull/432)
- Temporarily change DeepGEMM commit to main branch. This removes sm120 support. We will add back sm120 support once `nv_dev` branch has rebased onto latest main.
- Add `elfutils-devel` to Dockerfile since DeepJIT depends on it
- New DeepGEMM no longer allows FP32 scales on SM100, hence the change in `tests/kernels/quantization/test_block_fp8.py` is necessary
- The Mega-mHC doesn't support engram. Hence, when there is engram, it uses the existing 2 tilelang kernels.
- Technically Mega-mHC supports DSv4 and GLM5-Next as well (non-shift mode), but this PR only hooks it up to DSv4.1

## Test Plan

Updated unit tests in `tests/kernels/test_mhc_kernels.py`

GSM8K on GB300 TP4, 1 epoch

```
    "exact_match/flexible-extract": 0.9295,
    "exact_match/strict-match": 0.9303
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

