### PR TITLE
[Bugfix][DCP] Preserve interleave for per-slot KV connectors

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -211,6 +211,47 @@ def test_kv_offloading_does_not_skip_dcp_interleave_validation():
         VllmConfig.validate_block_size(config)
 
 
+def test_connector_can_preserve_dcp_interleave_size(caplog):
+    class PerSlotConnector:
+        @classmethod
+        def preserves_dcp_kv_cache_interleave_size(cls, extra_config):
+            del extra_config
+            return True
+
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=2,
+            dcp_kv_cache_interleave_size=1,
+            cp_kv_cache_interleave_size=1,
+        ),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="NixlConnector",
+            kv_role="kv_both",
+        ),
+    )
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[
+            SimpleNamespace(kv_cache_spec=SimpleNamespace(block_size=5760))
+        ]
+    )
+
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.factory."
+            "KVConnectorFactory.get_connector_class",
+            return_value=PerSlotConnector,
+        ),
+        caplog.at_level(logging.INFO),
+    ):
+        VllmConfig.adjust_dcp_kv_cache_interleave_size(config, kv_cache_config)
+
+    assert config.parallel_config.cp_kv_cache_interleave_size == 1
+    assert (
+        "KV connector PerSlotConnector preserves cp_kv_cache_interleave_size=1 for DCP"
+        in caplog.text
+    )
+
+
 def test_compile_config_repr_succeeds():
     # setup: VllmBackend mutates the config object
     config = VllmConfig()

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2883,6 +2883,27 @@ class VllmConfig:
                 "deprecated when PCP is fully supported."
             )
 
+        if (
+            self.kv_transfer_config is not None
+            and self.kv_transfer_config.kv_connector is not None
+        ):
+            from vllm.distributed.kv_transfer.kv_connector.factory import (
+                KVConnectorFactory,
+            )
+
+            connector_cls = KVConnectorFactory.get_connector_class(
+                self.kv_transfer_config
+            )
+            if connector_cls.preserves_dcp_kv_cache_interleave_size(
+                self.kv_transfer_config.kv_connector_extra_config
+            ):
+                logger.info_once(
+                    "KV connector %s preserves cp_kv_cache_interleave_size=%d for DCP.",
+                    connector_cls.__name__,
+                    self.parallel_config.cp_kv_cache_interleave_size,
+                )
+                return
+
         if self.kv_transfer_config is None or not self.kv_transfer_config.has_connector(
             "NixlConnector"
         ):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -173,6 +173,24 @@ class KVConnectorBase_V1(ABC):
     Base class for KV connectors.
     """
 
+    @classmethod
+    def preserves_dcp_kv_cache_interleave_size(
+        cls, extra_config: dict[str, Any]
+    ) -> bool:
+        """Whether vLLM must preserve the configured DCP cache interleave.
+
+        By default a KV connector is treated as a PD transport, whose external
+        transfer unit is one whole local vLLM cache block.  vLLM therefore
+        normalizes ``cp_kv_cache_interleave_size`` to that block size.  A
+        connector that transfers cache rows using its own per-slot geometry
+        may override this method so that its configured interleave reaches the
+        attention backend unchanged.
+
+        ``extra_config`` is supplied to allow a connector to make this
+        capability conditional without constructing a worker-side instance.
+        """
+        return False
+
     @property
     def supports_divergent_local_hybrid_hits(self) -> bool:
         """Whether external hits can complete divergent local hybrid hits.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -141,6 +141,24 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
     """
 
     @classmethod
+    def preserves_dcp_kv_cache_interleave_size(
+        cls, extra_config: dict[str, Any]
+    ) -> bool:
+        """Preserve DCP interleave only when every child can use it."""
+        connectors_config = extra_config.get("connectors", [])
+        if not connectors_config:
+            return False
+        for conn_config in connectors_config:
+            temp_ktc = KVTransferConfig(**conn_config)
+            connector_cls = KVConnectorFactory.get_connector_class(temp_ktc)
+            child_extra_config = conn_config.get("kv_connector_extra_config", {})
+            if not connector_cls.preserves_dcp_kv_cache_interleave_size(
+                child_extra_config
+            ):
+                return False
+        return True
+
+    @classmethod
     def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
         """
         MultiConnector requires PIECEWISE CUDA graph mode if any of its


### PR DESCRIPTION
## Purpose

Fix DCP KV-cache interleave handling for KV connectors that transfer cache rows
using their own per-slot geometry.

Currently, DCP interleave normalization assumes that the external transfer unit
is a complete local vLLM KV-cache block. This is correct for the existing Nixl
P/D path, but is incorrect for connectors whose transfer layout is based on
individual cache rows or slots.

This PR:

- Adds a connector capability for preserving the configured
  `cp_kv_cache_interleave_size`.
- Keeps the existing default behavior for connectors that do not opt in.
- Propagates the capability through `MultiConnector`.
- Preserves the existing Nixl block-level alignment behavior.
- Only preserves the configured interleave when all child connectors in a
  `MultiConnector` support it.

No existing issue is linked. This is a focused extension of the current DCP
connector behavior and does not replace the existing Nixl-specific normalization
logic.

## Test Plan

Added a configuration unit test covering a KV connector that preserves the
configured DCP interleave size.

Commands run:

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest \
  tests/test_config.py -k 'dcp_interleave' -q

.venv/bin/python -m py_compile \
  vllm/config/vllm.py \
  vllm/distributed/kv_transfer/kv_connector/v1/base.py \
  vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py \
  tests/test_config.py

.venv/bin/python -m ruff check \
  vllm/config/vllm.py \
  vllm/distributed/kv_transfer/kv_connector/v1/base.py \
  vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py \
  tests/test_config.py

.venv/bin/python -m ruff format --check \
  vllm/config/vllm.py \
  vllm/distributed/kv_transfer/kv_connector/v1/base.py \
  vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py \
  tests/test_config.py

git diff --check

Repository pre-commit hooks were also run during commit.
### Test Result
The targeted unit tests passed:
```bash
5 passed, 284 deselected, 15 warnings in 1.75s
```
Ruff, formatting, Python syntax compilation, git diff --check, and all
pre-commit hooks passed.

The test was run with VLLM_TARGET_DEVICE=cpu because the local environment
does not expose a supported GPU platform. Without this override, pytest reached
the teardown phase but the local PyTorch accelerator cleanup triggered a
platform-related segmentation fault. No test assertion failed.

No documentation update is required.

AI assistance was used during implementation, testing, and preparation of this
PR description. The patch has been reviewed by the submitting author.