### PR TITLE
[Bugfix][Reasoning] Honor prompt-closed Qwen3 reasoning blocks

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_batched_chat_completions.py
+++ b/tests/entrypoints/openai/chat_completion/test_batched_chat_completions.py
@@ -3,6 +3,7 @@
 
 import json
 from collections.abc import AsyncGenerator
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -322,3 +323,30 @@ async def test_batched_echo_prepends_matching_assistant_prefix() -> None:
     )
 
     assert response.choices[0].message.content == "PREFIX ASSISTANT ANSWER"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_global_cleanup
+async def test_batched_parser_receives_prompt_token_ids() -> None:
+    serving = OpenAIServingChatBatch.__new__(OpenAIServingChatBatch)
+    serving.response_role = "assistant"
+    serving.system_fingerprint = None
+    parser = MagicMock()
+    parser.parse_with_prompt.return_value = (None, "ASSISTANT ANSWER", None)
+    request = BatchChatCompletionRequest(
+        model="test-model",
+        messages=[[{"role": "user", "content": "USER PROMPT"}]],
+    )
+
+    await serving.chat_completion_full_generator_batch(
+        request=request,
+        generators=[_generator(0, "ASSISTANT ANSWER")],
+        request_id="req-parser-prompt",
+        model_name="test-model",
+        all_conversations=[[{"role": "user", "content": "USER PROMPT"}]],
+        tokenizer=None,
+        request_metadata=RequestResponseMetadata(request_id="req-parser-prompt"),
+        parser=parser,
+    )
+
+    assert parser.parse_with_prompt.call_args.kwargs["prompt_token_ids"] == [1, 2, 3]

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -756,6 +756,34 @@ async def test_chat_per_request_metrics_follow_server_flag():
 
 
 @pytest.mark.asyncio
+async def test_nonstreaming_parser_receives_prompt_token_ids():
+    serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=False)
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Test prompt"}],
+        max_tokens=10,
+        stream=False,
+    )
+    request_output = _make_metrics_request_output()
+    parser = MagicMock()
+    parser.parse_with_prompt.return_value = (None, "Hello", None)
+    parser.count_reasoning_tokens.return_value = 0
+
+    await serving.chat_completion_full_generator(
+        request,
+        _single_request_output(request_output),
+        "chatcmpl-test-id",
+        "test-model",
+        conversation=[{"role": "user", "content": "Test"}],
+        tokenizer=MagicMock(),
+        request_metadata=RequestResponseMetadata(request_id="chatcmpl-test-id"),
+        parser=parser,
+    )
+
+    assert parser.parse_with_prompt.call_args.kwargs["prompt_token_ids"] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
 async def test_chat_per_request_metrics_suppressed_for_n_greater_than_one():
     serving = _build_minimal_metrics_serving_chat(enable_per_request_metrics=True)
     response = await serving.chat_completion_full_generator(

--- a/tests/entrypoints/openai/responses/test_parsable_context_unit.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context_unit.py
@@ -220,6 +220,18 @@ def test_process_text_with_parser():
     assert msg.content[0].text == "Hello!"
 
 
+def test_process_passes_prompt_token_ids_to_parser():
+    parser = MagicMock()
+    parser.parse_with_prompt.return_value = (None, "Hello!", None)
+    ctx = _make_context(None, response_parser=parser)
+    output = _make_request_output(text="Hello!")
+    output.prompt_token_ids = [7, 8]
+
+    ctx.append_output(output)
+
+    assert parser.parse_with_prompt.call_args.kwargs["prompt_token_ids"] == [7, 8]
+
+
 def test_process_text_without_parser():
     """parser_cls=None falls back to plain text wrapping."""
     ctx = _make_context(None)

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -1211,6 +1211,31 @@ def _make_serving_instance_with_reasoning():
     return serving
 
 
+def test_nonstreaming_parser_receives_prompt_token_ids():
+    serving = _make_serving_instance_with_reasoning()
+    parser = MagicMock()
+    parser.parse_with_prompt.return_value = (None, "Hello!", None)
+    completion = CompletionOutput(
+        index=0,
+        text="Hello!",
+        token_ids=[1],
+        cumulative_logprob=0.0,
+        logprobs=None,
+        finish_reason="stop",
+        stop_reason=None,
+    )
+
+    serving._make_response_output_items(
+        ResponsesRequest(input="hi", tools=[], stream=False),
+        completion,
+        MagicMock(),
+        parser=parser,
+        prompt_token_ids=[7, 8],
+    )
+
+    assert parser.parse_with_prompt.call_args.kwargs["prompt_token_ids"] == [7, 8]
+
+
 def _identity_increment(event):
     """Simple identity callable for _increment_sequence_number_and_return."""
     seq = getattr(_identity_increment, "_counter", 0)

--- a/tests/parser/engine/test_qwen3_reasoning.py
+++ b/tests/parser/engine/test_qwen3_reasoning.py
@@ -31,6 +31,12 @@ _IM_START_ID = 70
 _IM_END_ID = 71
 _TEXT_ID = 100
 
+_CLOSED_THINK_PROMPT_IDS = [
+    _IM_START_ID,
+    _THINK_START_ID,
+    _THINK_END_ID,
+]
+
 _QWEN3_VOCAB = {
     "<think>": _THINK_START_ID,
     "</think>": _THINK_END_ID,
@@ -57,6 +63,43 @@ def parser(mock_tokenizer):
 
 
 class TestNonStreaming:
+    def test_closed_think_in_prompt_routes_output_to_content(
+        self, parser, mock_request
+    ):
+        reasoning, content, tool_calls = parser.parse_with_prompt(
+            "The answer is 42.",
+            mock_request,
+            model_output_token_ids=[_TEXT_ID],
+            prompt_token_ids=_CLOSED_THINK_PROMPT_IDS,
+        )
+
+        assert reasoning is None
+        assert content == "The answer is 42."
+        assert tool_calls is None
+        assert parser.count_reasoning_tokens([_TEXT_ID]) == 0
+
+    @pytest.mark.parametrize(
+        "prompt_token_ids",
+        [
+            [_IM_START_ID, _THINK_END_ID, _IM_END_ID, _IM_START_ID],
+            [_IM_START_ID, _TOOL_CALL_ID],
+        ],
+    )
+    def test_prompt_without_current_think_end_keeps_output_as_reasoning(
+        self, parser, mock_request, prompt_token_ids
+    ):
+        reasoning, content, tool_calls = parser.parse_with_prompt(
+            "Still thinking.",
+            mock_request,
+            model_output_token_ids=[_TEXT_ID],
+            prompt_token_ids=prompt_token_ids,
+        )
+
+        assert reasoning == "Still thinking."
+        assert content is None
+        assert tool_calls is None
+        assert parser.count_reasoning_tokens([_TEXT_ID]) == 1
+
     def test_reasoning_then_content(self, parser):
         text = "<think>Let me analyze.</think>The answer is 42."
         reasoning, content = parser.extract_reasoning(text, None)
@@ -276,6 +319,23 @@ class TestIsReasoningEndTurnBoundaries:
 
 
 class TestDelegatingPromptDetection:
+    def test_closed_think_in_prompt_routes_non_streaming_output_to_content(
+        self, mock_tokenizer, mock_request
+    ):
+        parser = _Qwen3DelegatingParser(mock_tokenizer)
+
+        reasoning, content, tool_calls = parser.parse_with_prompt(
+            "The answer is 42.",
+            mock_request,
+            model_output_token_ids=[_TEXT_ID],
+            prompt_token_ids=_CLOSED_THINK_PROMPT_IDS,
+        )
+
+        assert reasoning is None
+        assert content == "The answer is 42."
+        assert tool_calls == []
+        assert parser.count_reasoning_tokens([_TEXT_ID]) == 0
+
     def test_prompt_tool_example_does_not_skip_streaming_reasoning(
         self, mock_tokenizer, mock_request
     ):
@@ -343,9 +403,35 @@ class TestDelegatingPromptDetection:
         assert delta is not None
         assert delta.reasoning is None
         assert delta.content == "answer"
+        assert parser.count_reasoning_tokens([_TEXT_ID]) == 0
+
+        parser.parse_delta(
+            "",
+            [_IM_END_ID],
+            mock_request,
+            prompt_token_ids=prompt_ids,
+            finished=True,
+        )
+        assert parser.count_reasoning_tokens([_TEXT_ID, _IM_END_ID]) == 0
 
 
 class TestStreaming:
+    def test_closed_think_in_prompt_routes_output_to_content(
+        self, parser, mock_request
+    ):
+        delta = parser.parse_delta(
+            "The answer is 42.",
+            [_TEXT_ID],
+            mock_request,
+            prompt_token_ids=_CLOSED_THINK_PROMPT_IDS,
+            finished=False,
+        )
+
+        assert delta is not None
+        assert delta.reasoning is None
+        assert delta.content == "The answer is 42."
+        assert parser.count_reasoning_tokens([_TEXT_ID]) == 0
+
     def test_basic_streaming(self, parser):
         reasoning, content = simulate_reasoning_streaming(
             parser,

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -265,10 +265,11 @@ class OpenAIServingChatBatch(OpenAIServingChat):
                     logprobs = None
 
                 if parser is not None:
-                    reasoning, content, _ = parser.parse(
+                    reasoning, content, _ = parser.parse_with_prompt(
                         output.text,
                         request=request,  # type: ignore[arg-type]
                         model_output_token_ids=output.token_ids,
+                        prompt_token_ids=final_res.prompt_token_ids,
                     )
                     if not request.include_reasoning:
                         reasoning = None

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -967,11 +967,12 @@ class OpenAIServingChat(GenerateBaseServing):
                 logprobs = None
 
             if parser is not None:
-                reasoning, content, tool_calls = parser.parse(
+                reasoning, content, tool_calls = parser.parse_with_prompt(
                     output.text,
                     request,
                     enable_auto_tools=self.enable_auto_tools,
                     model_output_token_ids=token_ids,
+                    prompt_token_ids=final_res.prompt_token_ids,
                 )
                 suppress_metadata = not request.include_reasoning and parser is not None
                 if not request.include_reasoning:

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -345,11 +345,12 @@ class ParsableContext(ConversationContext):
         self.finish_reason = completion.finish_reason
 
         if self.response_parser is not None:
-            reasoning, content, tool_calls = self.response_parser.parse(
+            reasoning, content, tool_calls = self.response_parser.parse_with_prompt(
                 completion.text,
                 self.request,
                 enable_auto_tools=self.enable_auto_tools,
                 model_output_token_ids=completion.token_ids,
+                prompt_token_ids=output.prompt_token_ids,
             )
             if not self.request.include_reasoning:
                 reasoning = None

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -803,6 +803,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 final_output,
                 tokenizer,
                 parser=context.response_parser,
+                prompt_token_ids=final_res.prompt_token_ids,
             )
 
             if request.enable_response_messages:
@@ -974,6 +975,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         final_output: CompletionOutput,
         tokenizer: TokenizerLike,
         parser: Parser | None = None,
+        prompt_token_ids: Sequence[int] | None = None,
     ) -> list[ResponseOutputItem]:
         # Log complete response if output logging is enabled
         if self.enable_log_outputs and self.request_logger:
@@ -998,11 +1000,12 @@ class OpenAIServingResponses(GenerateBaseServing):
 
         # Use parser to extract reasoning, content, and tool calls
         if parser:
-            reasoning, content, tool_calls = parser.parse(
+            reasoning, content, tool_calls = parser.parse_with_prompt(
                 final_output.text,
                 request,
                 enable_auto_tools=self.enable_auto_tools,
                 model_output_token_ids=final_output.token_ids,
+                prompt_token_ids=prompt_token_ids,
             )
             if not request.include_reasoning:
                 reasoning = None

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -379,6 +379,22 @@ class Parser:
             A tuple of (reasoning, content, tool_calls).
         """
 
+    def parse_with_prompt(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        enable_auto_tools: bool = False,
+        model_output_token_ids: Sequence[int] = (),
+        prompt_token_ids: Sequence[int] | None = None,
+    ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
+        """Parse a complete output with its rendered prompt token IDs."""
+        return self.parse(
+            model_output,
+            request,
+            enable_auto_tools=enable_auto_tools,
+            model_output_token_ids=model_output_token_ids,
+        )
+
     @abstractmethod
     def parse_delta(
         self,
@@ -836,6 +852,35 @@ class DelegatingParser(Parser):
         )
         return reasoning, content, tool_calls
 
+    def parse_with_prompt(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        enable_auto_tools: bool = False,
+        model_output_token_ids: Sequence[int] = (),
+        prompt_token_ids: Sequence[int] | None = None,
+    ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
+        reasoning_ended_in_prompt = (
+            self._reasoning_parser is not None
+            and prompt_token_ids is not None
+            and self._reasoning_parser.reasoning_ended_in_prompt(prompt_token_ids)
+        )
+        if not reasoning_ended_in_prompt:
+            return self.parse(
+                model_output,
+                request,
+                enable_auto_tools=enable_auto_tools,
+                model_output_token_ids=model_output_token_ids,
+            )
+
+        self._initialize_history_tool_call_cnt(request)
+        tool_calls, content = self._extract_tool_calls(
+            content=model_output,
+            request=request,
+            enable_auto_tools=enable_auto_tools,
+        )
+        return None, content, tool_calls
+
     def parse_delta(
         self,
         delta_text: str,
@@ -850,17 +895,18 @@ class DelegatingParser(Parser):
 
         if not state.prompt_reasoning_checked and prompt_token_ids is not None:
             state.prompt_reasoning_checked = True
-            if self._reasoning_parser is None or self.is_reasoning_end(
-                prompt_token_ids
+            reasoning_parser = self._reasoning_parser
+            if (
+                reasoning_parser is None
+                or reasoning_parser.reasoning_ended_in_prompt(prompt_token_ids)
+                or self.is_reasoning_end(prompt_token_ids)
             ):
                 state.reasoning_ended = True
             else:
                 # Reasoning is still open at the end of the prompt; let the
                 # reasoning parser adjust its initial parsing state so the
                 # first generated tokens are classified correctly.
-                self._reasoning_parser.adjust_initial_state_from_prompt(
-                    prompt_token_ids
-                )
+                reasoning_parser.adjust_initial_state_from_prompt(prompt_token_ids)
 
         current_text, current_token_ids = state.advance(delta_text, delta_token_ids)
         delta_message: DeltaMessage | None = None

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -49,6 +49,7 @@ class ParserEngineReasoningAdapter(ReasoningParser):
         self._parser_engine = self._parser_engine_cls(tokenizer, **kwargs)  # type: ignore[call-arg]
         self._parser_engine_kwargs = kwargs
         self._counting_parser_engine: ParserEngine | None = None
+        self._counting_initial_state: ParserState | None = None
         # TODO: Remove once Responses finalization reuses accumulated streaming
         # parser results instead of reparsing the complete output.
         self._streaming_count_valid = False
@@ -71,6 +72,13 @@ class ParserEngineReasoningAdapter(ReasoningParser):
     def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
         self._parser_engine.adjust_initial_state_from_prompt(prompt_token_ids)
 
+    def reasoning_ended_in_prompt(self, prompt_token_ids: Sequence[int]) -> bool:
+        self._streaming_count_valid = False
+        self._counting_initial_state = self._parser_engine._initial_state_from_prompt(
+            prompt_token_ids
+        )
+        return self._counting_initial_state == ParserState.CONTENT
+
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         return self._parser_engine.extract_content_ids(input_ids)
 
@@ -80,6 +88,7 @@ class ParserEngineReasoningAdapter(ReasoningParser):
         request: ChatCompletionRequest | ResponsesRequest,
     ) -> tuple[str | None, str | None]:
         self._streaming_count_valid = False
+        self._counting_initial_state = None
         with self._skip_tool_parsing():
             return self._parser_engine.extract_reasoning(model_output, request)
 
@@ -145,7 +154,9 @@ class ParserEngineReasoningAdapter(ReasoningParser):
                 self.model_tokenizer, **self._parser_engine_kwargs
             )  # type: ignore[call-arg]
         self._counting_parser_engine._single_pass_parse(
-            self.model_tokenizer.decode(token_ids), token_ids
+            self.model_tokenizer.decode(token_ids),
+            token_ids,
+            initial_state=self._counting_initial_state,
         )
         return self._counting_parser_engine.count_reasoning_tokens(token_ids)
 

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -202,6 +202,11 @@ class ParserEngine(Parser):
         """See :meth:`ReasoningParser.adjust_initial_state_from_prompt`."""
         return
 
+    def _initial_state_from_prompt(
+        self, prompt_token_ids: Sequence[int]
+    ) -> ParserState | None:
+        return None
+
     def finish_streaming(self) -> DeltaMessage | None:
         events = self._engine.finish()
         if events or self._deferred_content:
@@ -454,10 +459,14 @@ class ParserEngine(Parser):
     ) -> DeltaMessage | None:
         self._initialize_history_tool_call_cnt(request)
         if not self._prompt_streaming_prepared and prompt_token_ids is not None:
-            # NOTE: call the hook BEFORE setting the flag, because the hook
-            # may invoke ``_reset`` (e.g. via ``initialize_streaming``) which
-            # clears ``_prompt_streaming_prepared``.
-            self.adjust_initial_state_from_prompt(prompt_token_ids)
+            initial_state = self._initial_state_from_prompt(prompt_token_ids)
+            if initial_state is None:
+                # NOTE: call the hook BEFORE setting the flag, because the hook
+                # may invoke ``_reset`` (e.g. via ``initialize_streaming``) which
+                # clears ``_prompt_streaming_prepared``.
+                self.adjust_initial_state_from_prompt(prompt_token_ids)
+            else:
+                self.initialize_streaming(initial_state=initial_state)
             self._prompt_streaming_prepared = True
         self._check_skip_tool_parsing(request)
         events = self._feed(delta_text, delta_token_ids)
@@ -727,11 +736,45 @@ class ParserEngine(Parser):
         enable_auto_tools: bool = False,
         model_output_token_ids: Sequence[int] = (),
     ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
+        return self._parse_complete_output(
+            model_output,
+            request,
+            model_output_token_ids,
+        )
+
+    def parse_with_prompt(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        enable_auto_tools: bool = False,
+        model_output_token_ids: Sequence[int] = (),
+        prompt_token_ids: Sequence[int] | None = None,
+    ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
+        initial_state = (
+            self._initial_state_from_prompt(prompt_token_ids)
+            if prompt_token_ids is not None
+            else None
+        )
+        return self._parse_complete_output(
+            model_output,
+            request,
+            model_output_token_ids,
+            initial_state=initial_state,
+        )
+
+    def _parse_complete_output(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        model_output_token_ids: Sequence[int],
+        initial_state: ParserState | None = None,
+    ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
         self._initialize_history_tool_call_cnt(request)
         self._check_skip_tool_parsing(request)
         reasoning, content, tool_call_info = self._single_pass_parse(
             model_output,
             model_output_token_ids,
+            initial_state=initial_state,
         )
 
         tool_calls: list[FunctionCall] | None = None

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import functools
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -248,6 +249,23 @@ class Qwen3Parser(ParserEngine):
         vocab = self.vocab
         self._tool_call_token_id: int | None = vocab.get(self.TOOL_START)
         self._tool_call_end_token_id: int | None = vocab.get(self.TOOL_END)
+
+    def _initial_state_from_prompt(
+        self, prompt_token_ids: Sequence[int]
+    ) -> ParserState | None:
+        if not self.thinking_enabled:
+            return ParserState.CONTENT
+
+        start_id = self._reasoning_start_token_id
+        end_id = self._reasoning_end_token_id
+        if end_id is None:
+            return None
+        for token_id in reversed(prompt_token_ids):
+            if token_id == end_id:
+                return ParserState.CONTENT
+            if token_id == start_id or token_id in self._turn_boundary_token_ids:
+                return None
+        return None
 
     def extract_reasoning(
         self,

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -198,6 +198,15 @@ class ReasoningParser:
         """
         return
 
+    def reasoning_ended_in_prompt(self, prompt_token_ids: Sequence[int]) -> bool:
+        """Return whether generated output should start as content.
+
+        This is separate from :meth:`is_reasoning_end` because not every
+        parser can distinguish current-turn markers from reasoning in the
+        conversation history.
+        """
+        return False
+
     def prepare_structured_tag(
         self,
         original_tag: str | None,


### PR DESCRIPTION
## Purpose

Fixes #53284.

The official Qwen3.5 template can render an assistant prompt with an already closed `<think>...</think>` block while `chat_template_kwargs.enable_thinking` is omitted. The Qwen3 parser otherwise starts generated output in the reasoning state, which puts a plain answer in `reasoning` and leaves `content` null.

This change:

- adds a backward-compatible `Parser.parse_with_prompt` entry point;
- selects the Qwen3 initial parser state from the current ChatML turn while ignoring reasoning markers from conversation history;
- propagates rendered prompt token IDs through non-streaming Chat, Batch Chat, and Responses paths, matching the existing streaming path;
- preserves cumulative streaming reasoning-token accounting when the prompt starts generation in content state.

### Duplicate-work check

The required issue and open-PR searches were run immediately before submission. No open PR references #53284 or implements this prompt-aware serving fix. #56200 derives `is_reasoning_end` from parser-engine grammar and describes itself as the first step toward #53284, but it does not propagate prompt IDs into complete-output parsing or cover the serving and token-accounting paths above. The distinction was documented in [the issue](https://github.com/vllm-project/vllm/issues/53284#issuecomment-5617771488).

### AI assistance disclosure

OpenAI Codex assisted with investigation, implementation, test execution, and PR preparation. I reviewed every changed line, understand and can defend the change, and personally ran the compact relevant test suite below.

## Test Plan

Human-run focused regression:

```bash
.venv/bin/python -m pytest \
  tests/parser/engine/test_qwen3_reasoning.py \
  tests/entrypoints/openai/responses/test_parsable_context_unit.py::test_process_passes_prompt_token_ids_to_parser \
  tests/entrypoints/openai/responses/test_serving_responses.py::test_nonstreaming_parser_receives_prompt_token_ids \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_nonstreaming_parser_receives_prompt_token_ids \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_streaming_reasoning_usage_counts_across_deltas \
  tests/entrypoints/openai/chat_completion/test_batched_chat_completions.py::test_batched_parser_receives_prompt_token_ids \
  -q
```

Additional parser and serving regression:

```bash
.venv/bin/python -m pytest \
  tests/parser/engine/test_qwen3_reasoning.py \
  tests/parser/engine/test_parser_engine.py \
  tests/parser/engine/test_qwen3.py \
  tests/parser/test_parse.py \
  tests/parser/test_include_reasoning.py \
  tests/parser/test_harmony.py \
  tests/parser/test_streaming.py \
  tests/reasoning/test_qwen3_reasoning_parser.py \
  tests/tool_parsers/test_qwen3coder_tool_parser.py \
  tests/entrypoints/openai/responses/test_parsable_context_unit.py \
  tests/entrypoints/openai/responses/test_serving_responses.py \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_nonstreaming_parser_receives_prompt_token_ids \
  tests/entrypoints/openai/chat_completion/test_serving_chat.py::test_streaming_reasoning_usage_counts_across_deltas \
  tests/entrypoints/openai/chat_completion/test_batched_chat_completions.py::test_batched_parser_receives_prompt_token_ids \
  -q
```

Static checks:

```bash
.venv/bin/pre-commit run --from-ref upstream/main --to-ref HEAD
.venv/bin/pre-commit run mypy-3.12 --all-files --hook-stage manual
git diff upstream/main...HEAD --check
```

GPU model evaluation on an RTX 5070 Ti:

```bash
HF_HOME=/tmp/vllm-qwen35-hf \
VLLM_USE_FLASHINFER_SAMPLER=0 \
.venv/bin/vllm serve Qwen/Qwen3.5-2B \
  --reasoning-parser qwen3 \
  --enable-auto-tool-choice \
  --tool-call-parser qwen3_xml \
  --max-model-len 2048 \
  --gpu-memory-utilization 0.8 \
  --enforce-eager \
  --port 18080
```

`VLLM_USE_FLASHINFER_SAMPLER=0` was needed because the installed FlashInfer JIT rejected SM 12.x; the native sampler path was used for the parser evaluation.

## Test Result

- Human-run focused suite: **69 passed**, 14 warnings.
- Additional regression suite: **552 passed, 1 xfailed**, 38 warnings.
- All changed-file pre-commit hooks passed, including Ruff, formatting, Python 3.10 mypy, SPDX, import, and configuration checks.
- Manual Python 3.12 mypy and `git diff --check` passed.
- Qwen3.5-2B default Chat, both streaming and non-streaming: `content="OK"`, `reasoning=null`, `reasoning_tokens=0`.
- Chat with `include_reasoning=false`: `content="OK"`, `reasoning=null`.
- Explicit `enable_thinking=true`: reasoning remained enabled and all 128 generated tokens were counted as reasoning before length truncation.
- Batch Chat returned `OK` and `YES` as content with null reasoning.
- Responses, both streaming and non-streaming, returned `OK` as output text with no reasoning item and zero reasoning tokens.

Baseline note: `tests/parser/engine/test_delegating_replay.py` currently fails during collection on unchanged `upstream/main` because the newly registered `DeepSeekV41Parser` has no `trace_builder` entry. The final aggregate excludes only that unrelated baseline failure; this patch does not touch the affected DeepSeek files.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it resolves.
- [x] The test plan with exact commands.
- [x] The test and model-evaluation results.
- [x] No documentation update is needed for this parser bug fix.
</details>