### PR TITLE
[Bugfix][Anthropic] Keep stop_sequence in streaming message_delta

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -1234,6 +1234,84 @@ class TestMessageStartIncludesTypeAndRole:
         assert message["role"] == "assistant"
 
 
+class TestMessageDeltaIncludesStopSequence:
+    """Regression test for issue #55324: the streaming message_delta event is
+    serialized with exclude_unset=True, so a ``stop_sequence`` that was never
+    assigned is dropped from the JSON. Anthropic declares ``stop_sequence`` as
+    a required, nullable member of ``MessageDelta``, and validating proxies
+    reject the stream one event from the end when the key is absent.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "finish_reason,expected_stop_reason",
+        [
+            ("stop", "end_turn"),
+            ("length", "max_tokens"),
+            ("tool_calls", "tool_use"),
+        ],
+    )
+    async def test_message_delta_carries_null_stop_sequence(
+        self, finish_reason, expected_stop_reason
+    ):
+        async def sse_input():
+            yield _make_stream_chunk(delta=DeltaMessage(content="Hello"))
+            yield _make_stream_chunk(finish_reason=finish_reason)
+            yield _make_stream_chunk(
+                choices=[],
+                usage=UsageInfo(
+                    prompt_tokens=10,
+                    total_tokens=30,
+                    completion_tokens=20,
+                ),
+            )
+            yield "data: [DONE]"
+
+        converter = _make_stream_converter()
+        output = []
+        async for event in converter.message_stream_converter(sse_input()):
+            output.append(event)
+
+        events = _parse_sse_events(output)
+        msg_deltas = [data for ev_type, data in events if ev_type == "message_delta"]
+
+        assert msg_deltas
+        delta = msg_deltas[0]["delta"]
+        assert delta["stop_reason"] == expected_stop_reason
+        assert "stop_sequence" in delta
+        assert delta["stop_sequence"] is None
+
+    @pytest.mark.asyncio
+    async def test_matched_stop_string_still_reports_the_value(self):
+        """The matched-stop-string branch already set the field; keep it."""
+
+        async def sse_input():
+            yield _make_stream_chunk(delta=DeltaMessage(content="Hello"))
+            yield _make_stream_chunk(finish_reason="stop", stop_reason="END")
+            yield _make_stream_chunk(
+                choices=[],
+                usage=UsageInfo(
+                    prompt_tokens=10,
+                    total_tokens=30,
+                    completion_tokens=20,
+                ),
+            )
+            yield "data: [DONE]"
+
+        converter = _make_stream_converter()
+        output = []
+        async for event in converter.message_stream_converter(sse_input()):
+            output.append(event)
+
+        events = _parse_sse_events(output)
+        msg_deltas = [data for ev_type, data in events if ev_type == "message_delta"]
+
+        assert msg_deltas
+        delta = msg_deltas[0]["delta"]
+        assert delta["stop_reason"] == "stop_sequence"
+        assert delta["stop_sequence"] == "END"
+
+
 class TestStreamingCacheUsageSemantics:
     """Locks in the documented streaming behavior of cache usage fields.
 

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -839,10 +839,14 @@ class AnthropicServingMessages(OpenAIServingChat):
                                     stop_sequence=stop_sequence,
                                 )
                             else:
+                                # stop_sequence is a required, nullable member
+                                # of Anthropic's MessageDelta. Set it explicitly
+                                # so exclude_unset=True below keeps the key.
                                 stop_delta = AnthropicDelta(
                                     stop_reason=self.stop_reason_map.get(
                                         finish_reason or "stop"
-                                    )
+                                    ),
+                                    stop_sequence=None,
                                 )
                             chunk = AnthropicStreamEvent(
                                 type="message_delta",


### PR DESCRIPTION
## Purpose

Fixes #55324.

The streaming `message_delta` event is serialized with `model_dump_json(exclude_unset=True)`. The `else` branch built `AnthropicDelta(stop_reason=...)` without touching `stop_sequence`, so the key was dropped for `end_turn`, `max_tokens` and `tool_use`. Anthropic declares `stop_sequence` as a required, nullable member of `MessageDelta`, and `message_start` already sets it explicitly — so the two events disagreed about the same field, and validating proxies reject the stream one event from the end, after every content token has arrived.

The field is present on the object as its default `None`, so `repr()` and `model_dump()` both show it. Only `exclude_unset=True` omits it, which is why this is easy to miss when debugging:

```
AnthropicDelta(stop_reason="end_turn")
  .model_dump_json(exclude_unset=True)  -> {"stop_reason":"end_turn"}
  .model_dump()                         -> {'stop_reason': 'end_turn', 'stop_sequence': None}
```

Same defect shape as #45367 on `message_start`, fixed the same way as #45376: set the field explicitly. The matched-stop-string branch already did this and is unchanged.

## Test Plan

```
pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -k StopSequence
```

Adds `TestMessageDeltaIncludesStopSequence`, mirroring the existing `TestMessageStartIncludesTypeAndRole` regression test for #45367. It asserts the key is present and `null` for all three mapped finish reasons, plus one case pinning that a matched stop string still reports its value.

## Test Result

The new parametrized cases fail on `main` (`KeyError: 'stop_sequence'`) and pass with the change; the matched-stop case passes both before and after.

I don't have a GPU host to run the full entrypoints suite on, so I've relied on CI for that — the touched tests are converter-level and don't need one. `ruff check` and `ruff format` report no new findings against the repo config.
