### PR TITLE
[Bugfix][Rust Frontend][Renderer] Align DeepSeek tool-call arguments with deepseek-recipe

### DIFF
--- a/rust/src/chat/src/renderer/deepseek.rs
+++ b/rust/src/chat/src/renderer/deepseek.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::fmt::Write as _;
 
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use serde_json_fmt::JsonFormat;
 
 use llm_multimodal::DEEPSEEK_V41_IMAGE_PLACEHOLDER;
@@ -675,6 +675,41 @@ fn render_tool_call(
     Ok(())
 }
 
+/// Decode assistant tool-call arguments into the object the reference
+/// encoders iterate over.
+///
+/// Both references keep text that is not JSON as a single `arguments`
+/// parameter instead of failing the request. V4.1 additionally tolerates
+/// JSON strings, including double-encoded ones, and wraps any other
+/// non-object value the same way; V4 rejects non-object JSON.
+fn decode_arguments(raw: &str, dialect: DsDialect) -> Result<Map<String, Value>> {
+    let decoded = match dialect {
+        DsDialect::V4 => serde_json::from_str(raw).ok(),
+        DsDialect::V41 => {
+            let mut value = Value::String(raw.to_owned());
+            for _ in 0..2 {
+                let Value::String(text) = &value else { break };
+                match serde_json::from_str(text) {
+                    Ok(parsed) => value = parsed,
+                    Err(_) => break,
+                }
+            }
+            Some(value)
+        }
+    };
+
+    match (decoded, dialect) {
+        (Some(Value::Object(arguments)), _) => Ok(arguments),
+        (Some(_), DsDialect::V4) => Err(Error::ChatTemplate(
+            "assistant tool call arguments for DeepSeek must be a JSON object".to_string(),
+        )),
+        _ => Ok(Map::from_iter([(
+            "arguments".to_owned(),
+            Value::String(raw.to_owned()),
+        )])),
+    }
+}
+
 /// Convert one assistant tool-call arguments object into DSML parameter form.
 ///
 /// String values are emitted raw with `string="true"`, while all other JSON
@@ -685,19 +720,10 @@ fn encode_arguments_to_dsml(
     dialect: DsDialect,
 ) -> Result<()> {
     let parameter_tag = dialect.parameter_tag();
-    let arguments: Value = serde_json::from_str(&tool_call.arguments).map_err(|error| {
-        Error::ChatTemplate(format!(
-            "assistant tool call has invalid JSON arguments for DeepSeek: {error}"
-        ))
-    })?;
-    let Some(arguments) = arguments.as_object() else {
-        return Err(Error::ChatTemplate(
-            "assistant tool call arguments for DeepSeek must be a JSON object".to_string(),
-        ));
-    };
+    let arguments = decode_arguments(&tool_call.arguments, dialect)?;
 
     let mut wrote_parameter = false;
-    for (key, value) in arguments {
+    for (key, value) in &arguments {
         if wrote_parameter {
             out.push('\n');
         }

--- a/rust/src/chat/src/renderer/deepseek.rs
+++ b/rust/src/chat/src/renderer/deepseek.rs
@@ -675,44 +675,6 @@ fn render_tool_call(
     Ok(())
 }
 
-/// Decode assistant tool-call arguments into the object the reference
-/// encoder iterates over.
-///
-/// V4 requires a JSON object. V4.1 tolerates JSON strings, including
-/// double-encoded ones, and keeps anything that still is not an object as a
-/// single `arguments` parameter, matching the reference `encoding.py`.
-fn decode_arguments(raw: &str, dialect: DsDialect) -> Result<Map<String, Value>> {
-    match dialect {
-        DsDialect::V4 => {
-            let arguments: Value = serde_json::from_str(raw).map_err(|error| {
-                Error::ChatTemplate(format!(
-                    "assistant tool call has invalid JSON arguments for DeepSeek: {error}"
-                ))
-            })?;
-            match arguments {
-                Value::Object(arguments) => Ok(arguments),
-                _ => Err(Error::ChatTemplate(
-                    "assistant tool call arguments for DeepSeek must be a JSON object".to_string(),
-                )),
-            }
-        }
-        DsDialect::V41 => {
-            let mut value = Value::String(raw.to_owned());
-            for _ in 0..2 {
-                let Value::String(text) = &value else { break };
-                match serde_json::from_str(text) {
-                    Ok(parsed) => value = parsed,
-                    Err(_) => break,
-                }
-            }
-            Ok(match value {
-                Value::Object(arguments) => arguments,
-                _ => Map::from_iter([("arguments".to_owned(), Value::String(raw.to_owned()))]),
-            })
-        }
-    }
-}
-
 /// Convert one assistant tool-call arguments object into DSML parameter form.
 ///
 /// String values are emitted raw with `string="true"`, while all other JSON
@@ -723,7 +685,15 @@ fn encode_arguments_to_dsml(
     dialect: DsDialect,
 ) -> Result<()> {
     let parameter_tag = dialect.parameter_tag();
-    let arguments = decode_arguments(&tool_call.arguments, dialect)?;
+    // Match deepseek-recipe's render_tool_arguments for both V4 and V4.1:
+    // https://github.com/deepseek-ai/deepseek-recipe/blob/8cadfede7063c896b944e7bae05daa3549ae97ea/deepseek-recipe-encoding/src/v4/mod.rs#L48-L58
+    let arguments = serde_json::from_str::<Map<String, Value>>(&tool_call.arguments)
+        .unwrap_or_else(|_| {
+            Map::from_iter([(
+                "arguments".to_owned(),
+                Value::String(tool_call.arguments.clone()),
+            )])
+        });
 
     let mut wrote_parameter = false;
     for (key, value) in &arguments {

--- a/rust/src/chat/src/renderer/deepseek.rs
+++ b/rust/src/chat/src/renderer/deepseek.rs
@@ -676,15 +676,26 @@ fn render_tool_call(
 }
 
 /// Decode assistant tool-call arguments into the object the reference
-/// encoders iterate over.
+/// encoder iterates over.
 ///
-/// Both references keep text that is not JSON as a single `arguments`
-/// parameter instead of failing the request. V4.1 additionally tolerates
-/// JSON strings, including double-encoded ones, and wraps any other
-/// non-object value the same way; V4 rejects non-object JSON.
+/// V4 requires a JSON object. V4.1 tolerates JSON strings, including
+/// double-encoded ones, and keeps anything that still is not an object as a
+/// single `arguments` parameter, matching the reference `encoding.py`.
 fn decode_arguments(raw: &str, dialect: DsDialect) -> Result<Map<String, Value>> {
-    let decoded = match dialect {
-        DsDialect::V4 => serde_json::from_str(raw).ok(),
+    match dialect {
+        DsDialect::V4 => {
+            let arguments: Value = serde_json::from_str(raw).map_err(|error| {
+                Error::ChatTemplate(format!(
+                    "assistant tool call has invalid JSON arguments for DeepSeek: {error}"
+                ))
+            })?;
+            match arguments {
+                Value::Object(arguments) => Ok(arguments),
+                _ => Err(Error::ChatTemplate(
+                    "assistant tool call arguments for DeepSeek must be a JSON object".to_string(),
+                )),
+            }
+        }
         DsDialect::V41 => {
             let mut value = Value::String(raw.to_owned());
             for _ in 0..2 {
@@ -694,19 +705,11 @@ fn decode_arguments(raw: &str, dialect: DsDialect) -> Result<Map<String, Value>>
                     Err(_) => break,
                 }
             }
-            Some(value)
+            Ok(match value {
+                Value::Object(arguments) => arguments,
+                _ => Map::from_iter([("arguments".to_owned(), Value::String(raw.to_owned()))]),
+            })
         }
-    };
-
-    match (decoded, dialect) {
-        (Some(Value::Object(arguments)), _) => Ok(arguments),
-        (Some(_), DsDialect::V4) => Err(Error::ChatTemplate(
-            "assistant tool call arguments for DeepSeek must be a JSON object".to_string(),
-        )),
-        _ => Ok(Map::from_iter([(
-            "arguments".to_owned(),
-            Value::String(raw.to_owned()),
-        )])),
     }
 }
 

--- a/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 
 use super::DeepSeekV4ChatRenderer;
 use crate::ChatRenderer;
+use crate::error::Error;
 use crate::event::{AssistantContentBlock, AssistantToolCall};
 use crate::renderer::test_utils::{FixtureRequestOptions, fixture_chat_request};
 use crate::request::{ChatMessage, ChatRequest, ChatTool, GenerationPromptMode, ReasoningEffort};
@@ -397,6 +398,59 @@ fn reasoning_effort_template_kwarg_is_ignored() {
 
     assert!(rendered.starts_with("<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"));
     assert!(rendered.ends_with("<｜Assistant｜><think>"));
+}
+
+#[test]
+fn non_json_tool_call_arguments_become_one_string_parameter() {
+    let mut request = ChatRequest {
+        messages: vec![
+            ChatMessage::assistant_blocks(vec![AssistantContentBlock::ToolCall(
+                AssistantToolCall {
+                    id: "text".to_string(),
+                    name: "search".to_string(),
+                    arguments: "not json".to_string(),
+                },
+            )]),
+            ChatMessage::tool_response("text result", "text"),
+        ],
+        ..ChatRequest::for_test()
+    };
+    request
+        .chat_options
+        .template_kwargs
+        .insert("thinking".to_string(), Value::Bool(false));
+
+    expect![[r#"
+        <｜begin▁of▁sentence｜>
+
+        <｜DSML｜tool_calls>
+        <｜DSML｜invoke name="search">
+        <｜DSML｜parameter name="arguments" string="true">not json</｜DSML｜parameter>
+        </｜DSML｜invoke>
+        </｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>text result</tool_result><｜Assistant｜></think>"#]]
+    .assert_eq(&render_request(&request));
+}
+
+#[test]
+fn rejects_non_object_json_tool_call_arguments() {
+    let request = ChatRequest {
+        messages: vec![
+            ChatMessage::assistant_blocks(vec![AssistantContentBlock::ToolCall(
+                AssistantToolCall {
+                    id: "array".to_string(),
+                    name: "search".to_string(),
+                    arguments: "[1, 2]".to_string(),
+                },
+            )]),
+            ChatMessage::tool_response("array result", "array"),
+        ],
+        ..ChatRequest::for_test()
+    };
+
+    assert!(matches!(
+        DeepSeekV4ChatRenderer::new().render(&request),
+        Err(Error::ChatTemplate(message)) if message.contains("must be a JSON object")
+    ));
 }
 
 #[test]

--- a/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
@@ -8,8 +8,8 @@ use serde_json::Value;
 
 use super::DeepSeekV4ChatRenderer;
 use crate::ChatRenderer;
-use crate::error::Error;
 use crate::event::{AssistantContentBlock, AssistantToolCall};
+use crate::renderer::deepseek_v41::DeepSeekV41ChatRenderer;
 use crate::renderer::test_utils::{FixtureRequestOptions, fixture_chat_request};
 use crate::request::{ChatMessage, ChatRequest, ChatTool, GenerationPromptMode, ReasoningEffort};
 
@@ -401,10 +401,20 @@ fn reasoning_effort_template_kwarg_is_ignored() {
 }
 
 #[test]
-fn rejects_tool_call_arguments_that_are_not_a_json_object() {
-    for (arguments, message) in [
-        ("not json", "invalid JSON arguments"),
-        ("[1, 2]", "must be a JSON object"),
+fn tool_call_arguments_preserve_non_objects_like_recipe() {
+    let renderers: [(&dyn ChatRenderer, &str); 2] = [
+        (&DeepSeekV4ChatRenderer::new(), "parameter"),
+        (&DeepSeekV41ChatRenderer::new(), " parameter"),
+    ];
+    for arguments in [
+        "not json",
+        "[1, 2]",
+        "null",
+        "42",
+        "true",
+        "",
+        r#""text""#,
+        r#""{\"query\":\"double\"}""#,
     ] {
         let request = ChatRequest {
             messages: vec![
@@ -420,10 +430,18 @@ fn rejects_tool_call_arguments_that_are_not_a_json_object() {
             ..ChatRequest::for_test()
         };
 
-        assert!(matches!(
-            DeepSeekV4ChatRenderer::new().render(&request),
-            Err(Error::ChatTemplate(error)) if error.contains(message)
-        ));
+        for (renderer, tag) in renderers {
+            let prompt = renderer.render(&request).unwrap().prompt.into_text().unwrap();
+            let parameters: Vec<_> =
+                prompt.lines().filter(|line| line.contains("parameter name=")).collect();
+            assert_eq!(
+                parameters,
+                [format!(
+                    "<｜DSML｜{tag} name=\"arguments\" string=\"true\">{arguments}</｜DSML｜{tag}>"
+                )],
+                "arguments: {arguments:?}, tag: {tag:?}",
+            );
+        }
     }
 }
 

--- a/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
@@ -401,56 +401,30 @@ fn reasoning_effort_template_kwarg_is_ignored() {
 }
 
 #[test]
-fn non_json_tool_call_arguments_become_one_string_parameter() {
-    let mut request = ChatRequest {
-        messages: vec![
-            ChatMessage::assistant_blocks(vec![AssistantContentBlock::ToolCall(
-                AssistantToolCall {
-                    id: "text".to_string(),
-                    name: "search".to_string(),
-                    arguments: "not json".to_string(),
-                },
-            )]),
-            ChatMessage::tool_response("text result", "text"),
-        ],
-        ..ChatRequest::for_test()
-    };
-    request
-        .chat_options
-        .template_kwargs
-        .insert("thinking".to_string(), Value::Bool(false));
+fn rejects_tool_call_arguments_that_are_not_a_json_object() {
+    for (arguments, message) in [
+        ("not json", "invalid JSON arguments"),
+        ("[1, 2]", "must be a JSON object"),
+    ] {
+        let request = ChatRequest {
+            messages: vec![
+                ChatMessage::assistant_blocks(vec![AssistantContentBlock::ToolCall(
+                    AssistantToolCall {
+                        id: "call".to_string(),
+                        name: "search".to_string(),
+                        arguments: arguments.to_string(),
+                    },
+                )]),
+                ChatMessage::tool_response("result", "call"),
+            ],
+            ..ChatRequest::for_test()
+        };
 
-    expect![[r#"
-        <｜begin▁of▁sentence｜>
-
-        <｜DSML｜tool_calls>
-        <｜DSML｜invoke name="search">
-        <｜DSML｜parameter name="arguments" string="true">not json</｜DSML｜parameter>
-        </｜DSML｜invoke>
-        </｜DSML｜tool_calls><｜end▁of▁sentence｜><｜User｜><tool_result>text result</tool_result><｜Assistant｜></think>"#]]
-    .assert_eq(&render_request(&request));
-}
-
-#[test]
-fn rejects_non_object_json_tool_call_arguments() {
-    let request = ChatRequest {
-        messages: vec![
-            ChatMessage::assistant_blocks(vec![AssistantContentBlock::ToolCall(
-                AssistantToolCall {
-                    id: "array".to_string(),
-                    name: "search".to_string(),
-                    arguments: "[1, 2]".to_string(),
-                },
-            )]),
-            ChatMessage::tool_response("array result", "array"),
-        ],
-        ..ChatRequest::for_test()
-    };
-
-    assert!(matches!(
-        DeepSeekV4ChatRenderer::new().render(&request),
-        Err(Error::ChatTemplate(message)) if message.contains("must be a JSON object")
-    ));
+        assert!(matches!(
+            DeepSeekV4ChatRenderer::new().render(&request),
+            Err(Error::ChatTemplate(error)) if error.contains(message)
+        ));
+    }
 }
 
 #[test]

--- a/rust/src/chat/src/renderer/deepseek_v41/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v41/tests.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 
 use super::DeepSeekV41ChatRenderer;
 use crate::ChatRenderer;
-use crate::event::{AssistantContentBlock, AssistantToolCall};
+use crate::event::AssistantContentBlock;
 use crate::renderer::test_utils::{FixtureRequestOptions, fixture_chat_request};
 use crate::request::{ChatContent, ChatContentPart, ChatMessage, ChatRequest, ReasoningEffort};
 
@@ -81,59 +81,6 @@ fn inlines_image_placeholder_at_image_part_positions() {
         rendered.contains("<｜User｜><｜deepseek_image｜>\n\nwhat is in the image?"),
         "unexpected prompt: {rendered:?}"
     );
-}
-
-#[test]
-fn tool_call_arguments_follow_reference_tolerance() {
-    // The reference encoder decodes JSON strings up to twice and keeps
-    // anything that still is not an object as a single `arguments` parameter.
-    let request = ChatRequest {
-        messages: vec![
-            ChatMessage::assistant_blocks(vec![
-                AssistantContentBlock::ToolCall(AssistantToolCall {
-                    id: "double".to_string(),
-                    name: "search".to_string(),
-                    arguments: r#""{\"query\":\"double\"}""#.to_string(),
-                }),
-                AssistantContentBlock::ToolCall(AssistantToolCall {
-                    id: "text".to_string(),
-                    name: "search".to_string(),
-                    arguments: "not json".to_string(),
-                }),
-                AssistantContentBlock::ToolCall(AssistantToolCall {
-                    id: "array".to_string(),
-                    name: "search".to_string(),
-                    arguments: "[1, 2]".to_string(),
-                }),
-            ]),
-            ChatMessage::tool_response("double result", "double"),
-            ChatMessage::tool_response("text result", "text"),
-            ChatMessage::tool_response("array result", "array"),
-        ],
-        ..ChatRequest::for_test()
-    };
-
-    expect![[r#"
-        <｜begin▁of▁sentence｜><｜System｜>Reasoning Effort: 50 (range 1-100, the higher the value, the more thorough the reasoning)
-
-
-
-        <｜DSML｜ calls>
-        <｜DSML｜ invoke name="search">
-        <｜DSML｜ parameter name="query" string="true">double</｜DSML｜ parameter>
-        </｜DSML｜ invoke>
-        <｜DSML｜ invoke name="search">
-        <｜DSML｜ parameter name="arguments" string="true">not json</｜DSML｜ parameter>
-        </｜DSML｜ invoke>
-        <｜DSML｜ invoke name="search">
-        <｜DSML｜ parameter name="arguments" string="true">[1, 2]</｜DSML｜ parameter>
-        </｜DSML｜ invoke>
-        </｜DSML｜ calls><｜end▁of▁sentence｜><｜User｜><tool_result>double result</tool_result>
-
-        <tool_result>text result</tool_result>
-
-        <tool_result>array result</tool_result><｜Assistant｜><think>"#]]
-    .assert_eq(&render(&request));
 }
 
 #[test]

--- a/rust/src/chat/src/renderer/deepseek_v41/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v41/tests.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 
 use super::DeepSeekV41ChatRenderer;
 use crate::ChatRenderer;
-use crate::event::AssistantContentBlock;
+use crate::event::{AssistantContentBlock, AssistantToolCall};
 use crate::renderer::test_utils::{FixtureRequestOptions, fixture_chat_request};
 use crate::request::{ChatContent, ChatContentPart, ChatMessage, ChatRequest, ReasoningEffort};
 
@@ -81,6 +81,59 @@ fn inlines_image_placeholder_at_image_part_positions() {
         rendered.contains("<｜User｜><｜deepseek_image｜>\n\nwhat is in the image?"),
         "unexpected prompt: {rendered:?}"
     );
+}
+
+#[test]
+fn tool_call_arguments_follow_reference_tolerance() {
+    // The reference encoder decodes JSON strings up to twice and keeps
+    // anything that still is not an object as a single `arguments` parameter.
+    let request = ChatRequest {
+        messages: vec![
+            ChatMessage::assistant_blocks(vec![
+                AssistantContentBlock::ToolCall(AssistantToolCall {
+                    id: "double".to_string(),
+                    name: "search".to_string(),
+                    arguments: r#""{\"query\":\"double\"}""#.to_string(),
+                }),
+                AssistantContentBlock::ToolCall(AssistantToolCall {
+                    id: "text".to_string(),
+                    name: "search".to_string(),
+                    arguments: "not json".to_string(),
+                }),
+                AssistantContentBlock::ToolCall(AssistantToolCall {
+                    id: "array".to_string(),
+                    name: "search".to_string(),
+                    arguments: "[1, 2]".to_string(),
+                }),
+            ]),
+            ChatMessage::tool_response("double result", "double"),
+            ChatMessage::tool_response("text result", "text"),
+            ChatMessage::tool_response("array result", "array"),
+        ],
+        ..ChatRequest::for_test()
+    };
+
+    expect![[r#"
+        <｜begin▁of▁sentence｜><｜System｜>Reasoning Effort: 50 (range 1-100, the higher the value, the more thorough the reasoning)
+
+
+
+        <｜DSML｜ calls>
+        <｜DSML｜ invoke name="search">
+        <｜DSML｜ parameter name="query" string="true">double</｜DSML｜ parameter>
+        </｜DSML｜ invoke>
+        <｜DSML｜ invoke name="search">
+        <｜DSML｜ parameter name="arguments" string="true">not json</｜DSML｜ parameter>
+        </｜DSML｜ invoke>
+        <｜DSML｜ invoke name="search">
+        <｜DSML｜ parameter name="arguments" string="true">[1, 2]</｜DSML｜ parameter>
+        </｜DSML｜ invoke>
+        </｜DSML｜ calls><｜end▁of▁sentence｜><｜User｜><tool_result>double result</tool_result>
+
+        <tool_result>text result</tool_result>
+
+        <tool_result>array result</tool_result><｜Assistant｜><think>"#]]
+    .assert_eq(&render(&request));
 }
 
 #[test]


### PR DESCRIPTION
## Purpose

Align Rust DeepSeek V4 and V4.1 assistant tool-call argument encoding with the shared [deepseek-recipe reference implementation](https://github.com/deepseek-ai/deepseek-recipe/blob/8cadfede7063c896b944e7bae05daa3549ae97ea/deepseek-recipe-encoding/src/v4/mod.rs#L48-L69).

Both dialects attempt one JSON object parse. Objects are rendered as individual DSML parameters; invalid JSON and non-object JSON are preserved verbatim as a single `arguments` parameter with `string="true"`. This also preserves double-encoded JSON strings verbatim. For example, `not json` renders as `<｜DSML｜ parameter name="arguments" string="true">not json</｜DSML｜ parameter>` in V4.1.

## Test Plan

```sh
cd rust
cargo nextest run -p vllm-chat --lib -E 'test(renderer::deepseek)'
cargo clippy -p vllm-chat --lib --tests --no-deps -- -D warnings
```

`tool_call_arguments_preserve_non_objects_like_recipe` exercises both renderers with plain text, arrays, null, numbers, booleans, empty text, JSON strings, and double-encoded objects.

## Test Result

- All 50 selected DeepSeek renderer tests passed, including the existing object-argument fixtures.
- Clippy and pre-commit passed.
- CPU reference checks confirmed recipe's shared V4/V4.1 fallback behavior. GPU/model evaluation was not run.

AI assistance: Claude Code for the original patch; Codex for recipe alignment and validation.
