### PR TITLE
[Perf][KV Connector] Reuse Mooncake block grouping per group

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -29,6 +29,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     _compute_sender_transfer_plan,
     _validate_asymmetric_region_lengths,
     get_mooncake_bootstrap_addr,
+    group_concurrent_contiguous,
     should_launch_bootstrap_server,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
@@ -153,6 +154,44 @@ def _make_test_kv_cache_config() -> KVCacheConfig:
                 ),
             )
         ],
+    )
+
+
+def _make_lazy_grouping_case():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.tp_rank = 0
+    worker.tp_size = 1
+    worker.use_mla = False
+    worker.kv_cache_config = _make_test_kv_cache_config()
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.transfer_topo = SimpleNamespace(
+        local_replicates_kv_cache=False,
+        total_num_kv_heads=4,
+    )
+
+    def region(base_addr):
+        return SimpleNamespace(
+            base_addr=base_addr,
+            block_len=0x100,
+            kv_block_len=0x100,
+            group_index=0,
+        )
+
+    ready_reqs = [("d-group-cache", SimpleNamespace(local_block_ids=[[10, 11]]))]
+    xfer_meta = SimpleNamespace(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=1,
+        remote_tp_rank=0,
+        req_blocks={"d-group-cache": ("xfer-group-cache", [[20, 21]])},
+    )
+    return (
+        worker,
+        ready_reqs,
+        xfer_meta,
+        [region(0x1000), region(0x2000)],
+        [region(0xA000), region(0xB000)],
     )
 
 
@@ -343,24 +382,115 @@ async def test_build_transfer_params_separates_prefill_pp_layers():
             expected_by_pp_rank[pp_rank]["layers"]
         )
 
-        (
-            src_ptrs,
-            dst_ptrs,
-            lengths,
-            err_reqs,
-            err_msg,
-        ) = await worker._build_transfer_params(
-            ready_reqs=[("d-req-pp", send_meta)],
-            agent_meta=xfer_meta,
-            local_regions=aligned_local,
-            remote_regions=aligned_remote,
-        )
+        with patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.group_concurrent_contiguous",
+            wraps=group_concurrent_contiguous,
+        ) as group_spy:
+            (
+                src_ptrs,
+                dst_ptrs,
+                lengths,
+                err_reqs,
+                err_msg,
+            ) = await worker._build_transfer_params(
+                ready_reqs=[("d-req-pp", send_meta)],
+                agent_meta=xfer_meta,
+                local_regions=aligned_local,
+                remote_regions=aligned_remote,
+            )
 
+        group_spy.assert_called_once_with([10, 11], [20, 21])
         assert err_reqs == []
         assert err_msg is None
         assert src_ptrs == expected_by_pp_rank[pp_rank]["src_ptrs"]
         assert dst_ptrs == expected_by_pp_rank[pp_rank]["dst_ptrs"]
         assert lengths == [2 * block_len, 2 * block_len]
+
+
+@pytest.mark.asyncio
+async def test_build_transfer_params_grouping_cache_is_request_local():
+    worker, ready_reqs, xfer_meta, local_regions, remote_regions = (
+        _make_lazy_grouping_case()
+    )
+    ready_reqs.append(("d-group-cache-2", ready_reqs[0][1]))
+    xfer_meta.req_blocks["d-group-cache-2"] = (
+        "xfer-group-cache-2",
+        [[20, 21]],
+    )
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+        "mooncake_connector.group_concurrent_contiguous",
+        wraps=group_concurrent_contiguous,
+    ) as group_spy:
+        await worker._build_transfer_params(
+            ready_reqs,
+            xfer_meta,
+            local_regions,
+            remote_regions,
+        )
+
+    assert group_spy.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ("plans", "expected_events", "expected_result"),
+    [
+        pytest.param(
+            [(False, 0, 0, 0x100), (True, 0, 0, 0x100)],
+            ["plan", "plan", "group"],
+            ([0x2000 + 10 * 0x100], [0xB000 + 20 * 0x100], [2 * 0x100], [], None),
+            id="false-then-true",
+        ),
+        pytest.param(
+            [(False, 0, 0, 0x100), (False, 0, 0, 0x100)],
+            ["plan", "plan"],
+            ([], [], [], [], None),
+            id="all-false",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_build_transfer_params_groups_only_for_transferring_regions(
+    plans,
+    expected_events,
+    expected_result,
+):
+    worker, ready_reqs, xfer_meta, local_regions, remote_regions = (
+        _make_lazy_grouping_case()
+    )
+    events = []
+    remaining_plans = iter(plans)
+
+    def sender_plan(**kwargs):
+        events.append("plan")
+        return next(remaining_plans)
+
+    def group_blocks(src_ids, dst_ids):
+        events.append("group")
+        return group_concurrent_contiguous(src_ids, dst_ids)
+
+    with (
+        patch.object(worker, "_get_sender_transfer_plan", side_effect=sender_plan),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.group_concurrent_contiguous",
+            side_effect=group_blocks,
+        ) as group_spy,
+    ):
+        result = await worker._build_transfer_params(
+            ready_reqs,
+            xfer_meta,
+            local_regions,
+            remote_regions,
+        )
+
+    assert events == expected_events
+    assert group_spy.call_count == expected_events.count("group")
+    if group_spy.called:
+        group_spy.assert_called_once_with([10, 11], [20, 21])
+    assert result == expected_result
 
 
 @pytest.mark.asyncio

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
@@ -9,7 +9,7 @@ validated by this test module.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 import torch
@@ -24,6 +24,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     MooncakeXferMetadata,
     SendBlockMeta,
     TransferRegion,
+    group_concurrent_contiguous,
 )
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
@@ -526,9 +527,14 @@ def test_hybrid_gdn_transfer_params_preserve_group_identity(monkeypatch):
             ),
         ]
 
-        src_ptrs, dst_ptrs, lengths, err_reqs, err_msg = asyncio.run(
-            build_transfer_params()
-        )
+        with patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.group_concurrent_contiguous",
+            wraps=group_concurrent_contiguous,
+        ) as group_spy:
+            src_ptrs, dst_ptrs, lengths, err_reqs, err_msg = asyncio.run(
+                build_transfer_params()
+            )
 
         assert err_reqs == []
         assert err_msg is None
@@ -541,6 +547,10 @@ def test_hybrid_gdn_transfer_params_preserve_group_identity(monkeypatch):
             0x2000 + 30 * block_len,
         ]
         assert lengths == [block_len, 2 * block_len]
+        assert group_spy.call_args_list == [
+            call([4], [7]),
+            call([10, 11], [30, 31]),
+        ]
 
         worker.shutdown()
         worker.shutdown = noop_shutdown

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -1533,6 +1533,10 @@ class MooncakeConnectorWorker:
                 remote_block_ids_by_group
             )
 
+            grouped_block_ids_by_group: dict[
+                int, tuple[list[list[int]], list[list[int]]]
+            ] = {}
+
             for local_region, remote_region in zip(local_regions, remote_regions):
                 assert local_region.group_index == remote_region.group_index, (
                     "Aligned Mooncake transfer regions must belong to the same "
@@ -1547,10 +1551,6 @@ class MooncakeConnectorWorker:
                 if not local_block_ids:
                     continue
 
-                # Group by indices within this region's KV-cache group only.
-                group_local_block_ids, group_remote_block_ids = (
-                    group_concurrent_contiguous(local_block_ids, remote_block_ids)
-                )
                 (
                     should_transfer,
                     src_region_offset,
@@ -1569,6 +1569,14 @@ class MooncakeConnectorWorker:
                     # get_target_remote_ranks() so we can avoid sending
                     # unnecessary ZMQ requests and remove this branch.
                     continue
+
+                grouped_block_ids = grouped_block_ids_by_group.get(group_index)
+                if grouped_block_ids is None:
+                    grouped_block_ids = group_concurrent_contiguous(
+                        local_block_ids, remote_block_ids
+                    )
+                    grouped_block_ids_by_group[group_index] = grouped_block_ids
+                group_local_block_ids, group_remote_block_ids = grouped_block_ids
 
                 assert src_region_offset + transfer_len <= local_region.kv_block_len, (
                     "Computed source transfer region exceeds local KV block size."


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Mooncake currently calls `group_concurrent_contiguous` once for every aligned
transfer region. Regions belonging to the same KV-cache group use the same
post-validation block-ID vectors, so this repeats identical NumPy grouping work
while the sender walks layers or subregions.

This change adds a request-local cache keyed by `group_index` inside
`_build_transfer_params`. Each region still computes its own sender plan first,
and the cache is populated only after `should_transfer` is true. NULL filtering,
block-count alignment, logical-to-physical expansion, addresses, TP offsets,
lengths, coalescing, fallback descriptors, and descriptor order remain
region-specific and unchanged.

The cache is scoped to one request iteration. This avoids sharing grouped lists
between requests while reducing grouping calls from one per active region to one
per active KV-cache group.

This is distinct from PRs
[#53078](https://github.com/vllm-project/vllm/pull/53078) and
[#55097](https://github.com/vllm-project/vllm/pull/55097), and from
issue [#53237](https://github.com/vllm-project/vllm/issues/53237), which cover
heterogeneous-TP correctness, NULL-block alignment, or transfer-descriptor
granularity rather than request-local reuse of identical grouping inputs. A
bounded current-source and GitHub search found no exact duplicate.

No public API, configuration, or supported-model documentation changes.

## Test Plan

```bash
ruff check \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
ruff format --check \
  vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector.py \
  tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
git diff HEAD^ HEAD --check
```

```bash
pytest -v \
  tests/v1/kv_connector/unit/test_mooncake_connector.py::test_build_transfer_params_separates_prefill_pp_layers \
  tests/v1/kv_connector/unit/test_mooncake_connector.py::test_build_transfer_params_grouping_cache_is_request_local \
  tests/v1/kv_connector/unit/test_mooncake_connector.py::test_build_transfer_params_groups_only_for_transferring_regions \
  tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py::test_build_transfer_params_uses_non_overlapping_physical_pages \
  tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py::test_hybrid_gdn_transfer_params_preserve_group_identity \
  tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py::test_logical_to_kernel_block_ids_expands_fa_not_gdn
```

Before merge or any native/production claim, run the official Mooncake import
canary and accuracy workflow on its B200 accelerator pool. Record the selected
transport and cover symmetric TP 1→1 and 2→2. Cross-host RDMA and representative
HMA/Mamba workloads remain explicit qualification cells for any native or
production claim. The reduced-scope local CUDA run below supports code review
but is not equivalent to that official topology.

Any performance result must use unchanged-control/candidate pairs on the same
workload and topology. Report cold and warm states separately, verify identical
descriptor tuples and transferred bytes, and measure the unchanged-control
whole-path grouping fraction. Planner-only CPU timing is not a whole-workload
performance result.

## Test Result

Exact source identity:

- Base: `86aca6619161b308d675c753f228201e70b59ed7`
- Candidate: `42af250010ec974733fe492a135ed656586e3d72`
- Stable patch-id: `b4b990262496ebb49ca89399bcca23b0b94db76a`
- Production-only patch-id: `1bf1b33207f9ef5bcbbe6add8ee73b0aa3ee7205`
- Diff: three files, 168 insertions and 20 deletions; production hunk `+12/-4`

Completed on the exact candidate commit:

- `git diff --check`, ruff check, and ruff format check: pass.
- Sender-plan and asymmetric-region portfolio: 44/44 CPU cases pass.
- Core cache-contract portfolio: 7/7 CPU cases pass with zero lifecycle
  warnings. It covers request isolation with distinct IDs, false→true,
  all-false, physical-block expansion, hybrid group identity, and cache
  miss/hit behavior.
- Two existing end-to-end heterogeneous-TP cases pass 2/2. The nonexact image
  emits one destructor warning that is already present with unchanged-control
  production/test blobs; this feature PR intentionally does not include an
  unrelated lifecycle cleanup.
- Focused branch coverage on the byte-identical production hunk executes cache
  miss/hit and transfer false/true branches.
- Descriptor outputs and grouping call-order/count oracles match the expected
  unchanged behavior in the executed contract cases.
- A formal deterministic-output parity screen passed all 44 observations:
  unchanged control and candidate, two isolated process repeats each, across 11
  planner cases. The exact `src_ptrs`, `dst_ptrs`, `lengths`, `err_reqs`, and
  `err_msg` projection had zero mismatches. No timing was performed in this
  screen.
- A reduced-scope CUDA 13 run on one RTX 4060 imported
  `mooncake-transfer-engine-cuda13==0.3.13.post1`, passed the focused contract
  portfolio 7/7, and passed all 86 tests in the two Mooncake unit files. The
  candidate Python production source was SHA256-bound exactly; the precompiled
  vLLM extension build was from `g41848caa6`, so this is not the official exact
  B200/RDMA qualification cell. The previously documented late destructor
  warning remained outside the feature slice.

The CPU tests used a network-disabled, GPU-disabled vLLM CI image whose
dependency closure is not exact for this commit. Candidate source files were
mounted read-only and SHA256-verified before collection. Manual Python 3.12
mypy was not run because the offline local tool cache does not contain mypy;
run the official manual-stage hook in upstream CI.

The candidate was created directly on `main` at
`86aca6619161b308d675c753f228201e70b59ed7`. Immediately before publication
preflight, observed `main` was
`08426d51ef1dd2b86921b9810e9d8b966f97a63a`; the base blobs for all three
touched files remained byte-identical, the merge tree was clean, and a bounded
current-source scan still found no exact group-cache duplicate.

Not run: native Mooncake transport, supported-accelerator model accuracy,
cross-host RDMA, runtime GPU/host memory, representative real workload, or
whole-workload performance. This Draft makes no latency, throughput,
model-accuracy, RDMA, cross-hardware, or production-benefit claim.

The change and this description were prepared with OpenAI Codex assistance.
The human submitter reviewed the rationale and corrected final diff, confirmed
personal supervision of the relevant CPU/static checks executed in the shared
task session, and accepts end-to-end ownership of the submitted change. Exact
test outputs were retained.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and non-duplicate boundary are documented.
- [x] Reproducible focused test commands are provided.
- [x] Executed results and environment limitations are separated from pending
  native tests.
- [x] No documentation update is needed because public behavior and
  configuration are unchanged.
- [x] Real Git/DCO identity is bound to the exact candidate commit.
- [x] Human review of the corrected final diff is complete.
- [x] Human execution or supervision of the relevant checks is explicitly
  confirmed.
- [x] Final source replay and bounded duplicate check are complete.
- [ ] Upstream CI and any native claims intended for merge are
  complete.

</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>**

