### PR TITLE
[Bugfix][Reasoning] Handle thinking markers in multi-token streaming deltas

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -367,6 +367,34 @@ class TestBaseThinkingReasoningParserStreaming:
         assert reasoning == "Reasoning content"
         assert content == "Final"
 
+    def test_streaming_start_token_grouped_with_text(self, test_tokenizer):
+        """Regression test for #55195: when the start marker and the first
+        reasoning token arrive in the same delta, the marker must be stripped,
+        matching what non-streaming extraction returns."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+
+        deltas = [
+            "<test:think>Some reasoning",
+            "</test:think>",
+            "Answer",
+        ]
+
+        reasoning, content = run_reasoning_extraction(parser, deltas, streaming=True)
+
+        assert reasoning == "Some reasoning"
+        assert content == "Answer"
+
+    def test_streaming_start_token_grouped_without_end(self, test_tokenizer):
+        """Start marker grouped with text and no end marker in the stream."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+
+        deltas = ["<test:think>Some reasoning"]
+
+        reasoning, content = run_reasoning_extraction(parser, deltas, streaming=True)
+
+        assert reasoning == "Some reasoning"
+        assert content is None
+
 
 class TestBaseThinkingReasoningParserMultipleImplementations:
     """

--- a/tests/reasoning/test_olmo3_reasoning_parser.py
+++ b/tests/reasoning/test_olmo3_reasoning_parser.py
@@ -161,3 +161,28 @@ def test_reasoning(
 
     assert reasoning == param_dict["reasoning"]
     assert content == param_dict["content"]
+
+
+def test_single_delta_preserves_content_after_end_marker():
+    """Regression test for #55195: when the whole output arrives in a single
+    delta, the text after the end marker must still be emitted instead of
+    being stranded in the buffer.
+
+    The parser is driven directly here rather than through
+    ``run_reasoning_extraction``: this transition delta legitimately carries
+    reasoning and content together, which ``StreamingReasoningReconstructor``
+    does not model.
+    """
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser: ReasoningParser = parser_cls(tokenizer)
+
+    output = SIMPLE_REASONING["output"]
+    token_ids = tokenizer.encode(output, add_special_tokens=False)
+
+    delta = parser.extract_reasoning_streaming(
+        "", output, output, [], token_ids, token_ids
+    )
+
+    assert delta is not None
+    assert delta.reasoning == SIMPLE_REASONING["reasoning"]
+    assert delta.content == SIMPLE_REASONING["content"]

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -148,8 +148,10 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 )
             else:
                 # start token in delta, no end token in delta,
-                # reasoning content continues
-                return DeltaMessage(reasoning=delta_text)
+                # strip the start token and keep the rest as reasoning
+                start_index = delta_text.find(self.start_token)
+                reasoning = delta_text[start_index + len(self.start_token) :]
+                return DeltaMessage(reasoning=reasoning if reasoning else None)
         else:
             # not find thinking start token
             return DeltaMessage(content=delta_text)

--- a/vllm/reasoning/olmo3_reasoning_parser.py
+++ b/vllm/reasoning/olmo3_reasoning_parser.py
@@ -109,8 +109,13 @@ class Olmo3ReasoningBuffer:
             )
             if end_think_idx > 0:
                 # this covers the case there's content before
-                # the end of the reasoning block
-                return DeltaMessage(reasoning=pretext)
+                # the end of the reasoning block. Any text after the end
+                # marker is emitted in the same delta; leaving it in the
+                # buffer drops it when no further delta arrives.
+                content, self.buffer = self.buffer, ""
+                return DeltaMessage(
+                    reasoning=pretext, content=content if content else None
+                )
 
         if self.state == Olmo3ReasoningState.REASONING:
             # we are inside reasoning block, return and empty


### PR DESCRIPTION
## Purpose

Fixes #55195.

Two related defects that only appear when a streaming delta carries more than one token — with speculative decoding or grouped streaming output. Token-at-a-time streaming never exposes either, because the marker arrives in its own delta and is filtered by the single-special-token check.

**1. `BaseThinkingReasoningParser` leaks the start marker.** The branch handling both markers strips them; the start-only branch returned `delta_text` unchanged:

```python
elif self.start_token_id in delta_token_ids:
    if self.end_token_id in delta_token_ids:
        ...strip both...
    else:
        return DeltaMessage(reasoning=delta_text)   # marker still in the text
```

So `<think>step one` in one delta streams `reasoning_content='<think>step one'`, while non-streaming extraction of the same output gives `'step one'`. Affects `deepseek_r1`, `ernie45`, `holo2`, `step3p5` and `hy_v4`.

**2. `olmo3` drops content after the end marker.** `process_buffer` returned the reasoning and left the text following `</think>` in the buffer. Another delta would flush it, but when the whole output arrives at once there is no other delta, so it is lost.

## Test Plan

```
pytest tests/reasoning/test_base_thinking_reasoning_parser.py -k grouped
pytest tests/reasoning/test_olmo3_reasoning_parser.py -k single_delta
```

Three regression tests: the start marker grouped with text (with and without an end marker in the stream), and the olmo3 whole-output-in-one-delta case. The existing per-token cases are left untouched and still cover the token-at-a-time path.

## Test Result

Running the parser logic directly over the affected input shapes, before and after:

| case | before | after |
|---|---|---|
| `<think>step one` in one delta | `reasoning='<think>step one'` | `reasoning='step one'` |
| marker alone (token-at-a-time) | `None` | `None` |
| both markers in one delta | `reasoning='r' content='c'` | unchanged |
| continuation after start | `reasoning='step'` | unchanged |
| olmo3, whole output in one delta | `content=None` (text dropped) | `content='This is the rest'` |
| olmo3, end marker split across deltas | tail dropped | tail emitted |

Every other shape I exercised is byte-identical. `ruff check` and `ruff format` report no new findings against the repo config.

I don't have a GPU host, so I've relied on CI for the full suite — these paths are parser-level string handling and don't need one.
