### PR TITLE
[CI] Enable ruff `INP` to require `__init__.py` under `vllm/`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ where = ["."]
 include = ["vllm*"]
 
 [tool.ruff.lint.per-file-ignores]
+# `vllm` is the only installed package; everything else is standalone scripts
+"!vllm/**" = ["INP"]
 "vllm/third_party/**" = ["ALL"]
 "vllm/version.py" = ["F401"]
 "vllm/_version.py" = ["ALL"]
@@ -77,6 +79,8 @@ select = [
     "I",
     # flake8-logging-format
     "G",
+    # flake8-no-pep420
+    "INP",
 ]
 ignore = [
     # star imports


### PR DESCRIPTION
## Purpose

The docs build emitted:

```
WARNING - api-autonav: Skipping implicit namespace package (without an __init__.py file) at .../latest/vllm/models/deepseek_v4_1/common. Set 'on_implicit_namespace_package' to 'skip' to omit it without warning.
```

Cause: #56208 added `vllm/models/deepseek_v4_1/common/mm_preprocess.py` as the only file in a new directory tree with no `__init__.py`, making `deepseek_v4_1` and `deepseek_v4_1/common` implicit namespace packages. `api-autonav` skips those directories entirely, so every module underneath silently vanishes from the API reference. #56228 has since added the missing `__init__.py` files, so the warning is already gone from `main` and there is nothing left to fix by hand.

This PR stops it happening again instead: ruff's flake8-no-pep420 (`INP001`) flags any `.py` file in a directory without an `__init__.py`. It is selected for `vllm/` only and ignored elsewhere, since scripts under `tests/`, `examples/`, `benchmarks/`, `tools/`, `docs/`, `csrc/`, `.buildkite/`, `.github/` and `.agents/` are intentionally not packages (479 files there would otherwise be flagged).

Not duplicating an existing PR: `gh pr list --repo vllm-project/vllm --state open --search "INP001 implicit namespace"`, `--search "ruff select INP"` and `--search "__init__.py deepseek_v4_1"` return no related PRs.

## Test Plan

Lint-config-only change, so no runtime behaviour or model output is affected and no evals are applicable.

1. `ruff check .` over the whole repo, to confirm the new rule is clean today.
2. Recreate the #56208 state and confirm the rule fires.

## Test Result

1. Clean, no `INP001` violations repo-wide.
2. Recreating the situation is caught:

```console
$ mkdir -p vllm/models/deepseek_v4_2/common
$ echo "import torch" > vllm/models/deepseek_v4_2/common/mm_preprocess.py
$ ruff check vllm/models/deepseek_v4_2/
vllm/models/deepseek_v4_2/common/mm_preprocess.py:1:1: INP001 File `vllm/models/deepseek_v4_2/common/mm_preprocess.py` is part of an implicit namespace package. Add an `__init__.py`.
```

`pre-commit run --files pyproject.toml` passes.

AI assistance (Claude Code) was used for this change; I have reviewed every changed line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01695eEhXLmqRbKTeVwwSGg5