### PR TITLE
[Docs] Correct API key authentication scope (/inference does NOT bypass the API key)

### DIFF
--- a/docs/usage/security.md
+++ b/docs/usage/security.md
@@ -147,13 +147,13 @@ firewall configuration instructions.
 
 ### Overview
 
-The `--api-key` flag (or `VLLM_API_KEY` environment variable) provides authentication for vLLM's HTTP server, but **only for OpenAI-compatible API endpoints under the `/v1` path prefix**, and other similar `/v2`, `/inference` path prefix**. Many other sensitive endpoints are exposed on the same HTTP server without any authentication enforcement.
+The `--api-key` flag (or `VLLM_API_KEY` environment variable) provides authentication for vLLM's HTTP server, but **only for endpoints under the `/v1`, `/v2`, `/inference`, and `/cohere` path prefixes**. Many other sensitive endpoints are exposed on the same HTTP server without any authentication enforcement.
 
 **Important:** Do not rely exclusively on `--api-key` for securing access to vLLM. Additional security measures are required for production deployments.
 
 ### Protected Endpoints (Require API Key)
 
-When `--api-key` is configured, the following `/v1` endpoints require Bearer token authentication:
+When `--api-key` is configured, the following endpoints require Bearer token authentication:
 
 - `/v1/models` - List available models
 - `/v1/chat/completions` - Chat completions
@@ -249,7 +249,7 @@ These endpoints are only available when profiling is enabled and should only be 
 
 An attacker who can reach the vLLM HTTP server can:
 
-1. **Bypass authentication** by using non-`/v1` endpoints like `/invocations`, `/inference/v1/generate`, `/generative_scoring`, `/pooling`, `/classify`, `/score`, or `/rerank` to run arbitrary inference without credentials
+1. **Bypass authentication** by using endpoints outside the protected path prefixes, such as `/invocations`, `/generative_scoring`, `/pooling`, `/classify`, `/score`, or `/rerank`, to run arbitrary inference without credentials
 2. **Cause denial of service** by calling `/pause`, `/scale_elastic_ep`, or `/abort_requests` without a token
 3. **Access operational controls** to manipulate server state (e.g., pausing generation, updating model weights via `/update_weights`)
 4. **If `--enable-tokenizer-info-endpoint` is set:** Access sensitive tokenizer configuration including chat templates, which may reveal prompt engineering strategies or other implementation details
@@ -346,7 +346,7 @@ vLLM supports loading out-of-tree HTTP routes via the `vllm.endpoint_plugins` en
 
 1. **Only allowlist plugins you trust.** Set `VLLM_PLUGINS` to the exact plugin names you intend to run and never wildcard or copy an allowlist between deployments without reviewing what each named plugin does.
 2. **Audit routes before deploying.** A plugin's `attach_router` can add routes under any path, including ones that duplicate existing `/v1/*` paths. There is currently no route conflict enforcement (tracked as a follow-up to RFC [#46565](https://github.com/vllm-project/vllm/issues/46565)), so a malicious or buggy plugin can **shadow a core route** and silently replace its behavior. Prefer plugins that namespace their routes under a distinct prefix (e.g. `/plugins/<plugin-name>/...`) instead of reusing `/v1/...` and review `app.routes` after startup if you need certainty about what is actually being served.
-3. **Treat plugin routes like any other unauthenticated by default surface.** `--api-key` only protects the `/v1`, `/v2`, and `/inference` path prefixes (see [API Key Authentication Limitations](#api-key-authentication-limitations)). A plugin route outside those prefixes is unauthenticated unless the plugin implements its own authentication. Deploy behind a reverse proxy that allowlists only the plugin routes you intend to expose externally.
+3. **Treat plugin routes like any other unauthenticated by default surface.** `--api-key` only protects the `/v1`, `/v2`, `/inference`, and `/cohere` path prefixes (see [API Key Authentication Limitations](#api-key-authentication-limitations)). A plugin route outside those prefixes is unauthenticated unless the plugin implements its own authentication. Deploy behind a reverse proxy that allowlists only the plugin routes you intend to expose externally.
 4. **Remember the `vllm.general_plugins` pairing.** A plugin that also needs new engine side behavior ships that half separately via `vllm.general_plugins` which loads in every worker process under the default (load all unless restricted) posture. Allowlisting the endpoint plugin does not by itself restrict its paired engine side plugin. Need to review both.
 
 ## gRPC Interface


### PR DESCRIPTION


## Purpose

Currently, this page indicates that /inference is both protected by the api-key and also vulnerable by default. 
Indeed, it currently displays

```
Security Implications[¶](https://docs.vllm.ai/en/latest/usage/security/#security-implications)

An attacker who can reach the vLLM HTTP server can:

    Bypass authentication by using non-/v1 endpoints like [...], /inference
```

AND

```
The --api-key flag (or VLLM_API_KEY environment variable) provides authentication for vLLM's HTTP server, but only for [...] /inference path prefix
```

This inconsistency makes configuring the reverse proxy harder. The correct answer is that `/inference` IS protected by `--api-key`

List all guarded path prefixes and remove `/inference/v1/generate` from the authentication bypass examples.

Also corrects a bold formatting mistake.

## Test Plan

I tested the following curl command when vLLM is or is not started with the `--api-key` set

```bash
curl -i http://localhost:8000/inference/v1/generate \
    -H 'Content-Type: application/json' \
    -d '{"token_ids":[1],"sampling_params":{"max_tokens":1}}'
```

## Test Result

When `--api-key` is NOT set, this is the result

```bash
HTTP/1.1 401 Unauthorized
date: Thu, 10 Sep 2026 12:40:04 GMT
server: uvicorn
content-length: 24
content-type: application/json

{"error":"Unauthorized"}
```

When it IS set, this is the result

```bash
HTTP/1.1 200 OK
date: Thu, 10 Sep 2026 12:33:26 GMT
server: uvicorn
content-length: 371
content-type: application/json

{"request_id":"generate-tokens-83f6a24b43fbb1e3","model":"MODEL","created":1789043606,"choices":[{"index":0,"logprobs":null,"finish_reason":"length","token_ids":[3312],"routed_experts":null}],"usage":{"prompt_tokens":1,"total_tokens":2,"completion_tokens":1,"prompt_tokens_details":null},"prompt_logprobs":null,"kv_transfer_params":null,"ec_transfer_params":null}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

