### PR TITLE
Fix #56263 : Tool parser non-streaming parse drops post-tool-call text that streaming returns

### DIFF
--- a/tests/tool_parsers/test_deepseekv3_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv3_tool_parser.py
@@ -8,6 +8,7 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import run_tool_extraction
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 
 
@@ -90,3 +91,31 @@ class TestDeepSeekV3ToolParser(ToolParserTests):
                 ),
             },
         )
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    def test_preserves_text_after_tool_call(
+        self,
+        tool_parser,
+        streaming: bool,
+    ) -> None:
+        model_output = (
+            "let me check the weather."
+            "<｜tool▁calls▁begin｜>"
+            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+            "```json\n"
+            '{"city": "Paris"}\n'
+            "```<｜tool▁call▁end｜>"
+            "<｜tool▁calls▁end｜>"
+            "It is 30 degrees."
+        )
+
+        content, tool_calls = run_tool_extraction(
+            tool_parser,
+            model_output,
+            streaming=streaming,
+        )
+
+        assert content == "let me check the weather.It is 30 degrees."
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_weather"
+        assert tool_calls[0].function.arguments == '{"city": "Paris"}'

--- a/vllm/tool_parsers/deepseekv3_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv3_tool_parser.py
@@ -109,7 +109,16 @@ class DeepSeekV3ToolParser(ToolParser):
                         )
                     )
 
-                content = model_output[: model_output.find(self.tool_calls_start_token)]
+                tool_calls_start = model_output.find(self.tool_calls_start_token)
+                tool_calls_end = model_output.find(
+                    self.tool_calls_end_token,
+                    tool_calls_start + len(self.tool_calls_start_token),
+                )
+                content = model_output[:tool_calls_start]
+                if tool_calls_end != -1:
+                    content += model_output[
+                        tool_calls_end + len(self.tool_calls_end_token) :
+                    ]
                 return ExtractedToolCallInformation(
                     tools_called=True,
                     tool_calls=tool_calls,


### PR DESCRIPTION



## Purpose
For a model output that contains text before AND after a tool call, the two delivery modes disagree: streaming returns the post-tool text, non-streaming drops it. The tool parser is inconsistent with its own streaming mode.

## Changes made
The parser now appends text following a complete outer tool-call wrapper while preserving the existing behavior for an incomplete wrapper. The new test verifies identical content and tool extraction in both delivery modes.

## Test Plan
Added a regression test in `tests/tool_parsers/test_deepseekv3_tool_parser.py`. It runs in both streaming and non streaming mode.

## Test Result
Test ran successfully on my local machine.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

