### PR TITLE
[Metrics][Spec Decode] Preserve acceptance counts by draft length

### DIFF
--- a/docs/features/speculative_decoding/acceptance_metrics.md
+++ b/docs/features/speculative_decoding/acceptance_metrics.md
@@ -70,10 +70,16 @@ A `summary` response's `metrics` looks like:
 | `num_spec_tokens` | Configured `num_speculative_tokens` (`k`), i.e. the maximum draft length per step. |
 
 For variable-length drafting, `acceptance_histogram_by_draft_length[k][j]`
-counts steps that accepted `j` of `k` proposed drafts. This preserves whether
-acceptance reached the proposal limit at each budget without retaining every
-step. Only observed draft lengths allocate rows, so storage is bounded by the
-configured draft length rather than the number of verification steps.
+counts verification steps that accepted `j` of `k` draft tokens. The length
+`k` is measured after grammar validation, so steps with the same configured
+budget can appear in different rows.
+
+Steps with no scheduled draft tokens are omitted, so the histogram does not
+show how often drafting is skipped. A `k = 0` row means a verification step
+had no valid drafts left after adjustment.
+
+Only observed draft lengths allocate rows. Storage depends on the maximum
+configured draft length and does not grow with the number of verification steps.
 
 With `detailed`, two ordered arrays are added, one entry per verification step:
 

--- a/docs/features/speculative_decoding/acceptance_metrics.md
+++ b/docs/features/speculative_decoding/acceptance_metrics.md
@@ -48,6 +48,7 @@ A `summary` response's `metrics` looks like:
       "mean_acceptance_length": 1.2325581395348837,
       "draft_acceptance_rate": 0.07751937984496124,
       "acceptance_histogram": [39, 1, 0, 3],
+      "acceptance_histogram_by_draft_length": {"3": [39, 1, 0, 3]},
       "num_spec_steps": 43,
       "num_accepted_draft_tokens": 10,
       "num_draft_tokens": 129,
@@ -62,10 +63,17 @@ A `summary` response's `metrics` looks like:
 | `mean_acceptance_length` | Mean tokens emitted per verification step, including the bonus token: `1 + num_accepted_draft_tokens / num_spec_steps`. Ranges from `1.0` (nothing accepted) to `num_spec_tokens + 1`. |
 | `draft_acceptance_rate` | Fraction of proposed draft tokens accepted: `num_accepted_draft_tokens / num_draft_tokens`. |
 | `acceptance_histogram` | Dense list of length `num_spec_tokens + 1`; index `j` is the number of steps that accepted exactly `j` draft tokens. Excludes the always-accepted bonus token. |
+| `acceptance_histogram_by_draft_length` | Maps each observed proposed draft length `k` to a dense list of `k + 1` accepted-count buckets. The proposed length excludes grammar-invalidated drafts; JSON object keys are strings. |
 | `num_spec_steps` | Number of verification steps for this request (the sum of the histogram). |
 | `num_accepted_draft_tokens` | Total accepted draft tokens, excluding bonus tokens. |
 | `num_draft_tokens` | Total proposed draft tokens, after subtracting drafts invalidated by structured-output constraints. |
 | `num_spec_tokens` | Configured `num_speculative_tokens` (`k`), i.e. the maximum draft length per step. |
+
+For variable-length drafting, `acceptance_histogram_by_draft_length[k][j]`
+counts steps that accepted `j` of `k` proposed drafts. This preserves whether
+acceptance reached the proposal limit at each budget without retaining every
+step. Only observed draft lengths allocate rows, so storage is bounded by the
+configured draft length rather than the number of verification steps.
 
 With `detailed`, two ordered arrays are added, one entry per verification step:
 

--- a/tests/v1/spec_decode/test_request_acceptance.py
+++ b/tests/v1/spec_decode/test_request_acceptance.py
@@ -7,6 +7,8 @@ accumulator ``RequestSpecDecodeMetrics`` and its ``to_dict`` payload surfaced in
 response as ``metrics.speculative_decoding``.
 """
 
+from collections import Counter
+
 import msgspec
 import pytest
 
@@ -56,6 +58,7 @@ def test_to_dict_summary_omits_per_step_arrays():
         "mean_acceptance_length": pytest.approx(1 + 9 / 5),  # j+1
         "draft_acceptance_rate": pytest.approx(9 / 15),
         "acceptance_histogram": [1, 1, 1, 2],  # dense, index j = step count
+        "acceptance_histogram_by_draft_length": {3: [1, 1, 1, 2]},
         "num_spec_steps": 5,
         "num_accepted_draft_tokens": 9,
         "num_draft_tokens": 15,
@@ -124,6 +127,7 @@ def test_engine_core_output_round_trips_spec_decode_metrics():
     assert decoded.spec_decode_metrics.histogram == [1, 0, 1, 1]
     assert decoded.spec_decode_metrics.num_draft_tokens == 9
     assert decoded.spec_decode_metrics.per_step_accepted == [0, 3, 2]
+    assert decoded.spec_decode_metrics.histogram_by_draft_length == {3: [1, 0, 1, 1]}
 
     without = EngineCoreOutput(request_id="r2", new_token_ids=[1])
     decoded_without = decoder.decode(msgspec.msgpack.encode(without))
@@ -148,3 +152,32 @@ def test_completion_output_carries_spec_decode_metrics():
     out = _completion_output(spec_decode_metrics=metrics)
     assert out.spec_decode_metrics is metrics
     assert _completion_output().spec_decode_metrics is None
+
+
+def test_summary_distinguishes_draft_budgets_with_equal_aggregate_counts():
+    first = _metrics([(1, 1), (3, 2)]).to_dict()
+    second = _metrics([(2, 1), (2, 2)]).to_dict()
+    assert first["acceptance_histogram"] == second["acceptance_histogram"]
+    assert first["num_draft_tokens"] == second["num_draft_tokens"] == 4
+    assert first["acceptance_histogram_by_draft_length"] == {
+        1: [0, 1],
+        3: [0, 0, 1, 0],
+    }
+    assert second["acceptance_histogram_by_draft_length"] == {2: [0, 1, 1]}
+
+
+def test_budget_histograms_match_detailed_pairs_without_storing_steps():
+    pairs = [(0, 0), (1, 0), (1, 1), (3, 2), (3, 3)] * 100
+    summary = _metrics(pairs)
+    detailed = _metrics(pairs, detailed=True)
+    expected = Counter(zip(detailed.per_step_drafted, detailed.per_step_accepted))
+    actual = {
+        (k, j): count
+        for k, counts in summary.histogram_by_draft_length.items()
+        for j, count in enumerate(counts)
+        if count
+    }
+    assert actual == expected
+    assert summary.histogram_by_draft_length == detailed.histogram_by_draft_length
+    assert sum(map(len, summary.histogram_by_draft_length.values())) == 7
+    assert summary.per_step_accepted == summary.per_step_drafted == []

--- a/vllm/entrypoints/generate/base/protocol.py
+++ b/vllm/entrypoints/generate/base/protocol.py
@@ -65,6 +65,8 @@ class SpeculativeDecodingMetrics(OpenAIBaseModel):
     # exactly j draft tokens (length num_spec_tokens + 1). Excludes the
     # always-accepted bonus token.
     acceptance_histogram: list[int]
+    # Actual proposed length k maps to a dense accepted-count histogram of k + 1.
+    acceptance_histogram_by_draft_length: dict[int, list[int]]
     num_spec_steps: int
     num_accepted_draft_tokens: int
     num_draft_tokens: int

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -317,6 +317,8 @@ class RequestSpecDecodeMetrics:
             also the histogram's upper bound.
         histogram: Dense counts indexed by accepted draft tokens ``j``
             (length ``num_spec_tokens + 1``).
+        histogram_by_draft_length: Accepted-count histograms keyed by actual
+            proposed draft length, after the grammar-invalidated adjustment.
         num_draft_tokens: Total proposed draft tokens, after the
             grammar-invalidated (``num_invalid_spec_tokens``) adjustment.
         per_step_accepted: Ordered accepted-draft count per verify step
@@ -330,6 +332,7 @@ class RequestSpecDecodeMetrics:
     num_draft_tokens: int = 0
     per_step_accepted: list[int] = field(default_factory=list)
     per_step_drafted: list[int] = field(default_factory=list)
+    histogram_by_draft_length: dict[int, list[int]] = field(default_factory=dict)
 
     @classmethod
     def new(cls, num_spec_tokens: int) -> "RequestSpecDecodeMetrics":
@@ -343,6 +346,11 @@ class RequestSpecDecodeMetrics:
     ) -> None:
         self.histogram[num_accepted] += 1
         self.num_draft_tokens += num_draft_tokens
+        histogram = self.histogram_by_draft_length.get(num_draft_tokens)
+        if histogram is None:
+            histogram = [0] * (num_draft_tokens + 1)
+            self.histogram_by_draft_length[num_draft_tokens] = histogram
+        histogram[num_accepted] += 1
         if detailed:
             self.per_step_accepted.append(num_accepted)
             self.per_step_drafted.append(num_draft_tokens)
@@ -364,6 +372,9 @@ class RequestSpecDecodeMetrics:
             "mean_acceptance_length": mean_al,
             "draft_acceptance_rate": rate,
             "acceptance_histogram": list(self.histogram),
+            "acceptance_histogram_by_draft_length": {
+                k: list(counts) for k, counts in self.histogram_by_draft_length.items()
+            },
             "num_spec_steps": num_spec_steps,
             "num_accepted_draft_tokens": num_accepted,
             "num_draft_tokens": self.num_draft_tokens,


### PR DESCRIPTION
## Purpose

With variable drafting budgets, `(drafted, accepted) = (1, 1), (3, 2)` and `(2, 1), (2, 2)` have identical existing summary metrics, although full acceptance occurs at different budgets. Add `acceptance_histogram_by_draft_length` to the existing opt-in response, preserving this distinction without retaining every verification step.

Each observed draft length `k` stores `k + 1` acceptance buckets. Storage is bounded by configured draft length, independently of sequence length.

This extends merged [#48915](https://github.com/vllm-project/vllm/pull/48915); [#43310](https://github.com/vllm-project/vllm/pull/43310), [#44487](https://github.com/vllm-project/vllm/pull/44487) and [#54748](https://github.com/vllm-project/vllm/pull/54748) cover native-response, Prometheus and scheduled-budget metrics respectively. The emitted-token corrections in [#56137](https://github.com/vllm-project/vllm/pull/56137) / [#56195](https://github.com/vllm-project/vllm/pull/56195) are separate from this raw-verifier histogram.

## Validation

```bash
PYTHONPATH=. .venv/bin/python -m pytest --noconftest tests/v1/spec_decode/test_request_acceptance.py -q