### PR TITLE
[Bugfix] Avoid double context-length scaling for deepseek_yarn

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2465,7 +2465,7 @@ def _get_and_verify_max_len(
             # loading HF config
             rope_type = rp["rope_type"]
 
-            if rope_type not in ("su", "longrope", "llama3"):
+            if rope_type not in ("su", "longrope", "llama3", "deepseek_yarn"):
                 # NOTE: rope_type == "default" does not define factor https://github.com/huggingface/transformers/blob/v4.45.2/src/transformers/modeling_rope_utils.py
                 # NOTE: This assumes all layer types have the same scaling factor.
                 scaling_factor = rp.get("factor", scaling_factor)


### PR DESCRIPTION
## Purpose

Sarvam-105B declares `max_position_embeddings=131072` together with `deepseek_yarn` and `factor=40`. The maximum-length validator applies that factor to the already-scaled context limit, incorrectly deriving **5,242,880 tokens** when `max_model_len` is omitted.

Exclude `deepseek_yarn` from generic context-length multiplication. Sarvam now defaults to its declared **131,072-token limit**, and explicit limits above that value follow the existing maximum-length validation and override rules.

The change affects context-length inference and validation. RoPE frequency calculations, attention scaling, and rotary-cache construction are unchanged. The production diff is one line in `vllm/config/model.py`.

### Duplicate-work check

Searched open upstream PRs and issues for `deepseek_yarn max_model_len`, `sarvam rope`, and related RoPE maximum-length changes. No open PR addressing this fix was found. Related PR #55116 handles `telechat3-yarn`; #51480 changes the rotary kernel execution path. Neither implements this `deepseek_yarn` context-length fix.

## Test Plan

Completed read-only comparisons of the upstream validator against an in-memory version of this one-line change using 24 published checkpoint configurations. Fifteen representative checkpoints were additionally checked through their actual configuration classes and vLLM RoPE normalization. Additional validation covered 44 attribute and edge-case comparisons, including explicit limits, auto-fit, other RoPE types, alternate length fields, and nested configurations, plus native CPU RoPE execution.

No test cases were added or modified. These checks did not include full model inference evaluation.

Commands run:

```bash
.venv/bin/python -m ruff check vllm/config/model.py
.venv/bin/python -m ruff format --check vllm/config/model.py
git diff --check upstream/main..HEAD
```

The configuration comparisons and native CPU RoPE checks were run as inline scripts through `.venv/bin/python`. The active global and repository pre-commit hooks also ran during the commit.

## Test Result

The comparisons used upstream `73fb19151f`. The relevant validator, configuration utilities, architecture converter, and rotary-embedding code were confirmed unchanged on this branch's upstream base, `7d8d71e989`.

| Published checkpoint | Upstream limit | With fix |
| --- | ---: | ---: |
| sarvamai/sarvam-105b | 5,242,880 | 131,072 |
| deepseek-ai/DeepSeek-V2-Lite-Chat | 163,840 | 163,840 |
| deepseek-ai/DeepSeek-V2.5 | 163,840 | 163,840 |
| deepseek-ai/DeepSeek-V3 | 163,840 | 163,840 |
| deepseek-ai/DeepSeek-V3.2-Exp | 163,840 | 163,840 |
| deepseek-ai/DeepSeek-V4-Flash | 1,048,576 | 1,048,576 |
| deepseek-ai/DeepSeek-R1 | 163,840 | 163,840 |
| moonshotai/Kimi-K2-Instruct | 131,072 | 131,072 |
| moonshotai/Kimi-K2.5 | 262,144 | 262,144 |
| moonshotai/Kimi-K3 | 1,048,576 | 1,048,576 |
| moonshotai/Kimi-Linear-48B-A3B-Instruct | 1,048,576 | 1,048,576 |
| moonshotai/Kimi-VL-A3B-Instruct | 131,072 | 131,072 |
| skt/A.X-K1 | 131,072 | 131,072 |
| zai-org/GLM-4.7-Flash | 202,752 | 202,752 |
| zai-org/GLM-5 | 202,752 | 202,752 |
| zai-org/GLM-5.3-Flash | 1,048,576 | 1,048,576 |
| meituan-longcat/LongCat-Flash-Chat | 131,072 | 131,072 |
| meituan-longcat/LongCat-Flash-Lite | 327,680 | 327,680 |
| inclusionAI/Ling-mini-2.0 | 32,768 | 32,768 |
| inclusionAI/Ring-2.5-1T | 131,072 | 131,072 |
| inclusionAI/Ling-3.0-flash | 262,144 | 262,144 |
| FreedomIntelligence/openPangu-Embedded-7B-V1.1 | 32,768 | 32,768 |
| dots-studio/dots3-note-prev | 524,288 | 524,288 |
| tencent/Hy4-preview | 1,048,576 | 1,048,576 |

Of the **24 accessible configurations checked**, only Sarvam's inferred limit changed. The other 23 retained their existing inferred limits. The 15 configuration-class normalization comparisons also preserved the other models' inferred limits.

- All 44 attribute and edge-case comparisons matched their expected results.
- Native CPU RoPE checks completed successfully with finite outputs at the checked positions.
- Ruff checks, formatting checks, and whitespace checks passed.
- All applicable active commit hooks passed, including mypy for Python 3.10.

AI assistance was used to prepare and validate this change.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] The validation approach and commands are provided.
- [x] Validation results and before/after comparisons are provided.

</details>
