### PR TITLE
[Bugfix][V1] Serialize MultiprocExecutor.shutdown() against concurrent double-teardown

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -121,6 +121,8 @@ class MultiprocExecutor(Executor):
         self._finalizer = weakref.finalize(self, self.shutdown)
         self.is_failed = False
         self.failure_callback: FailureCallback | None = None
+        self.shutting_down = False
+        self.shutdown_lock = threading.Lock()
 
         tp_size, pp_size, pcp_size = self._get_parallel_sizes()
         assert self.world_size == tp_size * pp_size * pcp_size, (
@@ -501,28 +503,35 @@ class MultiprocExecutor(Executor):
 
     def shutdown(self):
         """Properly shut down the executor and its workers"""
-        if not getattr(self, "shutting_down", False):
-            worker_count = len(getattr(self, "workers", None) or [])
-            logger.debug(
-                "[shutdown] Executor: start worker_count=%d",
-                worker_count,
-            )
+        lock = getattr(self, "shutdown_lock", None)
+        if lock is None:
+            return
+
+        with lock:
+            if getattr(self, "shutting_down", False):
+                return
             self.shutting_down = True
 
-            # Make sure all the worker processes are terminated first.
-            if workers := getattr(self, "workers", None):
-                for w in workers:
-                    # Close death_writer to signal child processes to exit
-                    if w.death_writer is not None:
-                        w.death_writer.close()
-                        w.death_writer = None
-                self._ensure_worker_termination([w.proc for w in workers])
+        worker_count = len(getattr(self, "workers", None) or [])
+        logger.debug(
+            "[shutdown] Executor: start worker_count=%d",
+            worker_count,
+        )
 
-                for w in workers:
-                    # Shutdown response queues
-                    if w.worker_response_mq is not None:
-                        w.worker_response_mq.shutdown()
-                        w.worker_response_mq = None
+        # Make sure all the worker processes are terminated first.
+        if workers := getattr(self, "workers", None):
+            for w in workers:
+                # Close death_writer to signal child processes to exit
+                if w.death_writer is not None:
+                    w.death_writer.close()
+                    w.death_writer = None
+            self._ensure_worker_termination([w.proc for w in workers])
+
+            for w in workers:
+                # Shutdown response queues
+                if w.worker_response_mq is not None:
+                    w.worker_response_mq.shutdown()
+                    w.worker_response_mq = None
 
         if rpc_broadcast_mq := getattr(self, "rpc_broadcast_mq", None):
             rpc_broadcast_mq.shutdown()


### PR DESCRIPTION
  ## Summary

  `MultiprocExecutor.shutdown()` reads and writes the `shutting_down` flag
  without a lock (check-then-act TOCTOU), so concurrent entry points — the
  `weakref.finalize` finalizer, the worker-monitor thread, and the engine's
  explicit `shutdown()` — can all observe `False` and double-run teardown
  (double `_ensure_worker_termination`, double `MessageQueue.shutdown()`).

  This mirrors the existing `RayExecutorV2.shutdown()` in
  `vllm/v1/executor/ray_executor_v2.py`, which already guards the check-and-set
  with a `threading.Lock` and keeps teardown outside the lock.

  ## Changes

  - Initialize `shutting_down = False` and `shutdown_lock = threading.Lock()` in
    `_init_executor`.
  - Hold `shutdown_lock` only for the check-and-set in `shutdown()`; return early
    when already shutting down, so teardown runs at most once.

  ## Why this is not duplicating an existing PR

  Addresses Bug1 only of #56251 (shutdown TOCTOU in `multiproc_executor.py`); the
  other five bugs in that report are out of scope. No open PR fixes this location.

  ## Testing

  - `ruff check` / `ruff format --check` on the modified file: pass.
  - `pytest tests/distributed/test_multiproc_executor.py::test_multiproc_executor_shutdown_cleanup`
    (already asserts `shutting_down` is set and shutdown is idempotent).

  ## Notes

  Defensive concurrency fix: the race window is narrow and not deterministically
  reproducible, so correctness is established by mirroring the existing
  `RayExecutorV2` pattern plus the existing idempotency test, rather than a new
  flaky race test.

  ## AI assistance

  This PR was drafted with AI assistance; the human submitter has reviewed every
  changed line.

