### PR TITLE
[Bugfix][Frontend] Improve Responses API compatibility for Codex clients

### DIFF
--- a/tests/entrypoints/openai/responses/test_responses_utils.py
+++ b/tests/entrypoints/openai/responses/test_responses_utils.py
@@ -4,6 +4,7 @@
 from unittest.mock import patch
 
 import pytest
+from openai.types.responses import CustomTool, FunctionTool, ResponseCustomToolCall
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 from openai.types.responses.response_function_tool_call_output_item import (
     ResponseFunctionToolCallOutputItem,
@@ -16,13 +17,18 @@ from openai.types.responses.response_reasoning_item import (
     Summary,
 )
 
+from vllm.entrypoints.generate.base.protocol import FunctionCall
 from vllm.entrypoints.openai.responses.utils import (
     _construct_message_from_response_item,
+    build_response_output_items,
     construct_chat_messages_with_tool_call,
     construct_input_messages,
+    decode_custom_tool_input,
+    decode_custom_tool_input_prefix,
+    decode_reasoning_state,
+    encode_reasoning_state,
     should_continue_final_message,
 )
-from vllm.exceptions import VLLMValidationError
 
 
 def _single_chat_message(item):
@@ -224,9 +230,9 @@ class TestResponsesUtils:
             encrypted_content="TOP_SECRET_MESSAGE",
             status=None,
         )
-        with pytest.raises(VLLMValidationError) as exc_info:
-            construct_chat_messages_with_tool_call([item])
-        assert exc_info.value.parameter == "input"
+        formatted_item = _single_chat_message(item)
+        assert formatted_item["role"] == "assistant"
+        assert formatted_item["reasoning"] == ""
 
         output_item = ResponseOutputMessage(
             id="msg_bf585bbbe3d500e0",
@@ -246,6 +252,98 @@ class TestResponsesUtils:
         formatted_item = _single_chat_message(output_item)
         assert formatted_item["role"] == "assistant"
         assert formatted_item["content"] == "dongyi"
+
+
+class TestCustomToolsAndEncryptedReasoning:
+    def test_custom_tool_call_output_item(self):
+        tools = [
+            CustomTool(type="custom", name="emit_command", format={"type": "text"}),
+            FunctionTool(
+                type="function", name="get_weather", parameters={}, strict=None
+            ),
+        ]
+        custom, function = build_response_output_items(
+            reasoning=None,
+            content=None,
+            tool_calls=[
+                FunctionCall(
+                    id="call_1", name="emit_command", arguments='{"input": "pwd"}'
+                ),
+                FunctionCall(
+                    id="call_2", name="get_weather", arguments='{"city": "Paris"}'
+                ),
+            ],
+            tools=tools,
+        )
+        assert isinstance(custom, ResponseCustomToolCall)
+        assert (custom.call_id, custom.input) == ("call_1", "pwd")
+        assert custom.id.startswith("ctc_")
+        assert isinstance(function, ResponseFunctionToolCall)
+        assert function.arguments == '{"city": "Paris"}'
+
+    def test_encrypted_reasoning_only_when_requested(self):
+        (plain,) = build_response_output_items(
+            reasoning="think", content=None, tool_calls=None
+        )
+        assert plain.encrypted_content is None
+        (encrypted,) = build_response_output_items(
+            reasoning="think", content=None, tool_calls=None, encrypted_reasoning=True
+        )
+        assert decode_reasoning_state(encrypted.encrypted_content) == "think"
+        assert decode_reasoning_state("not-ours") is None
+
+    def test_custom_tool_history_replays_through_function_shim(self):
+        messages = construct_chat_messages_with_tool_call(
+            [
+                make_reasoning_item(content_text="Run pwd."),
+                ResponseCustomToolCall(
+                    type="custom_tool_call",
+                    id="ctc_1",
+                    call_id="call_exec",
+                    name="emit_command",
+                    input='echo "hi"',
+                ),
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_exec",
+                    "output": "hi",
+                },
+                {"role": "user", "content": "Continue"},
+            ]
+        )
+        assert messages == [
+            {
+                "role": "assistant",
+                "reasoning": "Run pwd.",
+                "tool_calls": [
+                    {
+                        "id": "call_exec",
+                        "type": "function",
+                        "function": {
+                            "name": "emit_command",
+                            "arguments": '{"input": "echo \\"hi\\""}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "content": "hi", "tool_call_id": "call_exec"},
+            {"role": "user", "content": "Continue"},
+        ]
+
+    def test_decode_custom_tool_input(self):
+        assert decode_custom_tool_input('{"input": "pwd"}') == "pwd"
+        assert decode_custom_tool_input('{"cmd": "pwd"}') == "pwd"
+        assert decode_custom_tool_input("pwd") == "pwd"
+
+    def test_decode_custom_tool_input_prefix(self):
+        assert decode_custom_tool_input_prefix('{"inp') == ""
+        assert decode_custom_tool_input_prefix('{"input": "ls \\"dir') == 'ls "dir'
+        assert decode_custom_tool_input_prefix('{"input": "a\\') == "a"
+        assert decode_custom_tool_input_prefix('{"input": "\\ud83d') == ""
+        assert (
+            decode_custom_tool_input_prefix('{"input": "\\ud83d\\ude00!"}')
+            == "\U0001f600!"
+        )
 
 
 class TestReasoningItemContentPriority:
@@ -351,29 +449,25 @@ class TestReasoningItemContentPriority:
         formatted = _single_chat_message(item)
         assert formatted["reasoning"] == ""
 
-    def test_encrypted_content_raises(self):
-        """Encrypted content should raise VLLMValidationError."""
-        item = ResponseReasoningItem(
-            id="reasoning_6",
-            summary=[
-                Summary(
-                    text="Some summary",
-                    type="summary_text",
-                )
-            ],
-            type="reasoning",
-            content=[
-                Content(
-                    text="Some content",
-                    type="reasoning_text",
-                )
-            ],
-            encrypted_content="ENCRYPTED",
-            status=None,
+    def test_content_preferred_over_encrypted_content(self):
+        item = make_reasoning_item(
+            content_text="Some content",
+            encrypted_content=encode_reasoning_state("Other trace"),
         )
-        with pytest.raises(VLLMValidationError) as exc_info:
-            construct_chat_messages_with_tool_call([item])
-        assert exc_info.value.parameter == "input"
+        assert _single_chat_message(item)["reasoning"] == "Some content"
+
+    def test_encrypted_content_restores_reasoning(self):
+        """A store=false client may replay nothing but the opaque blob."""
+        item = make_reasoning_item(
+            encrypted_content=encode_reasoning_state("Restored trace")
+        )
+        assert _single_chat_message(item)["reasoning"] == "Restored trace"
+
+    def test_foreign_encrypted_content_falls_back_to_summary(self):
+        item = make_reasoning_item(
+            summary_text="Some summary", encrypted_content="ENCRYPTED"
+        )
+        assert _single_chat_message(item)["reasoning"] == "Some summary"
 
     @patch("vllm.entrypoints.openai.responses.utils.logger")
     def test_summary_with_multiple_entries_uses_first(self, mock_logger):

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -1712,3 +1712,74 @@ class TestAutoToolStreaming:
         assert len(function_done) == 1
         assert function_done[0].item.name == "get_weather"
         assert function_done[0].item.arguments == tool_args
+
+    @pytest.mark.skip_global_cleanup
+    @pytest.mark.asyncio
+    async def test_completed_response_reuses_streamed_items(self, monkeypatch):
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_with_reasoning()
+        response_parser = _mock_parser_with_reasoning(
+            serving,
+            [
+                DeltaMessage(reasoning="think"),
+                DeltaMessage(content="The weather is mild."),
+                DeltaMessage(
+                    tool_calls=[
+                        DeltaToolCall(
+                            index=0,
+                            function=DeltaFunctionCall(
+                                name="get_weather",
+                                arguments='{"location":"Berlin"}',
+                            ),
+                        )
+                    ]
+                ),
+            ],
+        )
+        response_parser.count_reasoning_tokens = MagicMock(return_value=0)
+        ctx = _make_simple_context_with_output("chunk", [10], response_parser)
+
+        async def result_generator():
+            for _ in range(3):
+                yield ctx
+
+        request = ResponsesRequest(
+            input="hi",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
+                }
+            ],
+            tool_choice="auto",
+            stream=True,
+            include=["reasoning.encrypted_content"],
+        )
+        events = [
+            event
+            async for event in serving.responses_stream_generator(
+                request=request,
+                sampling_params=SamplingParams(max_tokens=64),
+                result_generator=result_generator(),
+                context=ctx,
+                model_name="test-model",
+                tokenizer=MagicMock(),
+                request_metadata=RequestResponseMetadata(request_id="req"),
+                created_time=0,
+            )
+        ]
+
+        done_items = [e.item for e in events if e.type == "response.output_item.done"]
+        completed = next(e for e in events if e.type == "response.completed")
+        assert [item.type for item in done_items] == [
+            "reasoning",
+            "message",
+            "function_call",
+        ]
+        assert completed.response.output == done_items
+        assert done_items[0].encrypted_content
+        assert [item.id[:3] for item in done_items] == ["rs_", "msg", "fc_"]

--- a/tests/entrypoints/openai/responses/test_streaming_events.py
+++ b/tests/entrypoints/openai/responses/test_streaming_events.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from openai.types.responses import CustomTool, ResponseCustomToolCall
+
 from vllm.entrypoints.generate.base.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
@@ -11,6 +13,7 @@ from vllm.entrypoints.openai.responses.streaming_events import (
     _StateType,
     split_delta,
 )
+from vllm.entrypoints.openai.responses.utils import decode_reasoning_state
 
 
 def _make_tool_call(
@@ -124,3 +127,75 @@ class TestProcessorCompoundDeltas:
         types = [e.type for e in events]
         assert "response.reasoning_text.delta" in types
         assert "response.output_text.delta" in types
+
+
+class TestSimpleItemShapes:
+    def test_done_items_match_final_shape(self):
+        processor = SimpleStreamingEventProcessor()
+        events = _run_through_processor(processor, DeltaMessage(reasoning="r"))
+        events += _run_through_processor(processor, DeltaMessage(content="c"))
+        events += processor.close_current()
+
+        added = [e.item for e in events if e.type == "response.output_item.added"]
+        done = [e.item for e in events if e.type == "response.output_item.done"]
+        assert [item.id for item in done] == [item.id for item in added]
+        assert done[0].id.startswith("rs_")
+        assert done[1].id.startswith("msg_")
+        assert "summary" not in done[1].model_dump()
+        assert done[0].encrypted_content is None
+
+    def test_encrypted_reasoning_on_done_item(self):
+        processor = SimpleStreamingEventProcessor(encrypt_reasoning=True)
+        events = _run_through_processor(processor, DeltaMessage(reasoning="secret"))
+        events += processor.close_current()
+        assert decode_reasoning_state(events[-1].item.encrypted_content) == "secret"
+
+    def test_arguments_done_emitted_without_deltas(self):
+        processor = SimpleStreamingEventProcessor()
+        events = _run_through_processor(
+            processor, DeltaMessage(tool_calls=[_make_tool_call(0, name="noop")])
+        )
+        events += processor.close_current()
+        assert [e.type for e in events] == [
+            "response.output_item.added",
+            "response.function_call_arguments.done",
+            "response.output_item.done",
+        ]
+        assert events[-1].item.id.startswith("fc_")
+
+
+class TestCustomToolStreaming:
+    def test_custom_tool_input_events(self):
+        processor = SimpleStreamingEventProcessor(
+            tools=[CustomTool(type="custom", name="emit_command")]
+        )
+        events = _run_through_processor(
+            processor,
+            DeltaMessage(
+                tool_calls=[
+                    _make_tool_call(0, name="emit_command", arguments='{"input": "ls ')
+                ]
+            ),
+        )
+        events += _run_through_processor(
+            processor,
+            DeltaMessage(tool_calls=[_make_tool_call(0, arguments='-la \\"x\\""}')]),
+        )
+        events += processor.close_current()
+
+        assert [e.type for e in events] == [
+            "response.output_item.added",
+            "response.custom_tool_call_input.delta",
+            "response.custom_tool_call_input.delta",
+            "response.custom_tool_call_input.done",
+            "response.output_item.done",
+        ]
+        done = events[-1].item
+        assert isinstance(done, ResponseCustomToolCall)
+        assert done.input == 'ls -la "x"'
+        assert "".join(e.delta for e in events[1:3]) == done.input
+        assert events[3].input == done.input
+        assert events[0].item.type == "custom_tool_call"
+        assert events[0].item.id == done.id
+        assert done.id.startswith("ctc_")
+        assert done.call_id.startswith("call_")

--- a/tests/entrypoints/openai/responses/test_streaming_events.py
+++ b/tests/entrypoints/openai/responses/test_streaming_events.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from openai.types.responses import CustomTool, ResponseCustomToolCall
+from openai.types.responses import (
+    CustomTool,
+    ResponseCustomToolCall,
+    response_text_delta_event,
+)
 
 from vllm.entrypoints.generate.base.protocol import (
     DeltaFunctionCall,
@@ -142,7 +146,29 @@ class TestSimpleItemShapes:
         assert done[0].id.startswith("rs_")
         assert done[1].id.startswith("msg_")
         assert "summary" not in done[1].model_dump()
+        assert done[1].content[0].logprobs is None
         assert done[0].encrypted_content is None
+
+    def test_content_logprobs_carried_to_done_item(self):
+        top = response_text_delta_event.LogprobTopLogprob(token="hi", logprob=-0.5)
+        logprob = response_text_delta_event.Logprob(
+            token="hi", logprob=-0.5, top_logprobs=[top]
+        )
+        processor = SimpleStreamingEventProcessor()
+        events = processor.open(_StateType.CONTENT)
+        events += processor.emit_delta(
+            DeltaMessage(content="hi"), None, lambda _: [logprob]
+        )
+        events += processor.close_current()
+
+        delta = next(e for e in events if e.type == "response.output_text.delta")
+        assert delta.logprobs == [logprob]
+        part = events[-1].item.content[0]
+        assert [lp.token for lp in part.logprobs] == ["hi"]
+        assert part.logprobs[0].bytes == [104, 105]
+        assert part.logprobs[0].top_logprobs[0].bytes == [104, 105]
+        content_done = next(e for e in events if e.type == "response.content_part.done")
+        assert content_done.part == part
 
     def test_encrypted_reasoning_on_done_item(self):
         processor = SimpleStreamingEventProcessor(encrypt_reasoning=True)

--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -700,6 +700,29 @@ class TestConvertDeveloperToSystem:
         assert original["role"] == "developer"
         assert "tools" in original
 
+    def test_labels_developer_block_alongside_system_message(self):
+        conversation = [
+            {"role": "system", "content": "Be brief."},
+            {"role": "developer", "content": "Reply with exactly OK."},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = _convert_developer_to_system(conversation)
+        assert result[1]["role"] == "system"
+        assert result[1]["content"] == "Developer instructions:\nReply with exactly OK."
+
+    def test_labels_first_text_part_of_list_content(self):
+        conversation = [
+            {"role": "system", "content": "Be brief."},
+            {
+                "role": "developer",
+                "content": [{"type": "text", "text": "Reply with exactly OK."}],
+            },
+        ]
+        result = _convert_developer_to_system(conversation)
+        assert result[1]["content"] == [
+            {"type": "text", "text": "Developer instructions:\nReply with exactly OK."}
+        ]
+
 
 # --- Developer role detection and conversion tests ---
 

--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from openai.types.responses import CustomTool
 from xgrammar import Grammar, StructuralTag
 from xgrammar.testing import _is_grammar_accept_string
 
@@ -448,6 +449,19 @@ def test_get_model_structural_tag_supports_named_tool_choice(
     )
 
     assert isinstance(tag, StructuralTag)
+
+
+def test_glm_4_7_forced_custom_tool_uses_function_shim():
+    tools = [CustomTool(type="custom", name="emit_command", description="Emit.")]
+    tag = get_model_structural_tag(
+        model="glm_4_7",
+        tools=tools,
+        tool_choice="required",
+        reasoning=False,
+    )
+
+    assert isinstance(tag, StructuralTag)
+    assert "emit_command" in tag.model_dump_json()
 
 
 @pytest.mark.parametrize(

--- a/tests/tool_use/test_tool_choice_required.py
+++ b/tests/tool_use/test_tool_choice_required.py
@@ -5,7 +5,12 @@ from copy import deepcopy
 
 import pytest
 import regex as re
-from openai.types.responses import FunctionTool, WebSearchTool
+from openai.types.responses import (
+    CustomTool,
+    FunctionTool,
+    ToolChoiceCustom,
+    WebSearchTool,
+)
 from pydantic import TypeAdapter
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -13,8 +18,10 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.tool_parsers.streaming import extract_required_tool_call_streaming
 from vllm.tool_parsers.utils import (
+    custom_tool_parameters,
     find_tool_properties,
     get_json_schema_from_tools,
+    iter_response_function_tool_dicts,
 )
 
 pytestmark = pytest.mark.cpu_test
@@ -394,3 +401,42 @@ class TestNonFunctionToolsSkipped:
         any_of = schema["items"]["anyOf"]
         assert len(any_of) == 1
         assert any_of[0]["properties"]["name"]["enum"] == ["get_weather"]
+
+
+class TestCustomToolShim:
+    """``custom`` tools are shown to the model as a single-string function."""
+
+    def test_rendered_as_single_string_function(self):
+        tool = CustomTool(
+            type="custom", name="emit_command", description="Emit a command."
+        )
+        [tool_dict] = iter_response_function_tool_dicts([tool])
+        assert tool_dict["type"] == "function"
+        assert tool_dict["name"] == "emit_command"
+        assert tool_dict["description"] == "Emit a command."
+        assert tool_dict["parameters"] == custom_tool_parameters()
+        assert tool_dict["parameters"]["required"] == ["input"]
+
+    def test_grammar_format_is_described(self):
+        tool = CustomTool(
+            type="custom",
+            name="emit_command",
+            format={"type": "grammar", "syntax": "lark", "definition": 'start: "pwd"'},
+        )
+        [tool_dict] = iter_response_function_tool_dicts([tool])
+        assert tool_dict["description"].endswith('lark grammar:\nstart: "pwd"')
+
+    def test_forced_tool_choice_sees_custom_tool(self):
+        tools = [CustomTool(type="custom", name="emit_command"), FUNCTION_TOOL]
+        schema = get_json_schema_from_tools(tools=tools, tool_choice="required")
+        names = [e["properties"]["name"]["enum"] for e in schema["items"]["anyOf"]]
+        assert names == [["emit_command"], ["get_weather"]]
+        named = get_json_schema_from_tools(
+            tools=tools,
+            tool_choice=ToolChoiceCustom(type="custom", name="emit_command"),
+        )
+        assert named == custom_tool_parameters()
+        assert (
+            find_tool_properties(tools, "emit_command")
+            == custom_tool_parameters()["properties"]
+        )

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -359,6 +359,7 @@ class ParsableContext(ConversationContext):
                     content=content,
                     tool_calls=tool_calls,
                     tools=self.request.tools,
+                    encrypted_reasoning=self.request.is_include_encrypted_reasoning(),
                 )
             )
         elif completion.text:

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -14,6 +14,8 @@ from openai.types.responses import (
     ResponseCodeInterpreterCallInterpretingEvent,
     ResponseContentPartAddedEvent,
     ResponseContentPartDoneEvent,
+    ResponseCustomToolCallInputDeltaEvent,
+    ResponseCustomToolCallInputDoneEvent,
     ResponseFunctionToolCall,
     ResponseInputItemParam,
     ResponseMcpCallArgumentsDeltaEvent,
@@ -468,6 +470,9 @@ class ResponsesRequest(OpenAIBaseModel):
             and "message.output_text.logprobs" in self.include
         )
 
+    def is_include_encrypted_reasoning(self) -> bool:
+        return bool(self.include and "reasoning.encrypted_content" in self.include)
+
     @model_validator(mode="before")
     @classmethod
     def check_cache_salt_support(cls, data: Any) -> Any:
@@ -610,9 +615,9 @@ class ResponsesRequest(OpenAIBaseModel):
         tools = data.get("tools")
         tool_choice = data.get("tool_choice", "auto")
         has_tools = tools is not None and len(tools) > 0
-        is_named_tool_choice = (
-            isinstance(tool_choice, dict) and tool_choice.get("type") == "function"
-        )
+        is_named_tool_choice = isinstance(tool_choice, dict) and tool_choice.get(
+            "type"
+        ) in ("function", "custom")
 
         if not has_tools:
             if tool_choice in ("auto", "none"):
@@ -869,6 +874,8 @@ StreamingResponsesResponse: TypeAlias = (
     | ResponseOutputItemDoneEvent
     | ResponseContentPartAddedEvent
     | ResponseContentPartDoneEvent
+    | ResponseCustomToolCallInputDeltaEvent
+    | ResponseCustomToolCallInputDoneEvent
     | ResponseReasoningTextDeltaEvent
     | ResponseReasoningTextDoneEvent
     | ResponseReasoningPartAddedEvent

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -12,6 +12,7 @@ from typing import Any, Final, cast
 from fastapi import Request
 from openai.types.responses import (
     ResponseOutputItem,
+    ResponseOutputItemDoneEvent,
     ResponseOutputMessage,
     ResponseOutputText,
     ResponseStatus,
@@ -719,6 +720,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         tokenizer: TokenizerLike,
         request_metadata: RequestResponseMetadata,
         created_time: int | None = None,
+        output_items: list[ResponseOutputItem] | None = None,
     ) -> ErrorResponse | ResponsesResponse:
         if created_time is None:
             created_time = int(time.time())
@@ -796,13 +798,12 @@ class OpenAIServingResponses(GenerateBaseServing):
             if final_output.finish_reason == "length":
                 status = "incomplete"
 
-            # TODO: Build final response items from the accumulated streaming
-            # parser results instead of reparsing the complete output.
             output = self._make_response_output_items(
                 request,
                 final_output,
                 tokenizer,
                 parser=context.response_parser,
+                streamed_items=output_items,
             )
 
             if request.enable_response_messages:
@@ -974,6 +975,7 @@ class OpenAIServingResponses(GenerateBaseServing):
         final_output: CompletionOutput,
         tokenizer: TokenizerLike,
         parser: Parser | None = None,
+        streamed_items: list[ResponseOutputItem] | None = None,
     ) -> list[ResponseOutputItem]:
         # Log complete response if output logging is enabled
         if self.enable_log_outputs and self.request_logger:
@@ -985,6 +987,9 @@ class OpenAIServingResponses(GenerateBaseServing):
                 is_streaming=False,
                 delta=False,
             )
+
+        if streamed_items is not None:
+            return streamed_items
 
         # Compute logprobs if requested
         logprobs = None
@@ -1013,6 +1018,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 tool_calls=tool_calls,
                 logprobs=logprobs,
                 tools=request.tools,
+                encrypted_reasoning=request.is_include_encrypted_reasoning(),
             )
 
         # Fallback when no parser is configured
@@ -1172,7 +1178,10 @@ class OpenAIServingResponses(GenerateBaseServing):
             [StreamingResponsesResponse], StreamingResponsesResponse
         ],
     ) -> AsyncGenerator[StreamingResponsesResponse, None]:
-        processor = SimpleStreamingEventProcessor(tools=request.tools)
+        processor = SimpleStreamingEventProcessor(
+            tools=request.tools,
+            encrypt_reasoning=request.is_include_encrypted_reasoning(),
+        )
 
         hide_stream_metadata = not request.include_reasoning and self.parser is not None
 
@@ -1335,6 +1344,9 @@ class OpenAIServingResponses(GenerateBaseServing):
                 )
             )
 
+            streamed_items: list[ResponseOutputItem] | None = (
+                None if self.use_harmony else []
+            )
             try:
                 async for event_data in processor(
                     request,
@@ -1347,6 +1359,10 @@ class OpenAIServingResponses(GenerateBaseServing):
                     created_time,
                     _increment_sequence_number_and_return,
                 ):
+                    if streamed_items is not None and isinstance(
+                        event_data, ResponseOutputItemDoneEvent
+                    ):
+                        streamed_items.append(event_data.item)
                     yield event_data
             except GenerationError as e:
                 error_json = self._convert_generation_error_to_streaming_response(e)
@@ -1370,6 +1386,7 @@ class OpenAIServingResponses(GenerateBaseServing):
                 tokenizer,
                 request_metadata,
                 created_time=created_time,
+                output_items=streamed_items,
             )
             yield _increment_sequence_number_and_return(
                 ResponseCompletedEvent(

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -59,6 +59,10 @@ from openai.types.responses import (
     response_text_delta_event,
 )
 from openai.types.responses.response_output_item import McpCall
+from openai.types.responses.response_output_text import Logprob as OutputTextLogprob
+from openai.types.responses.response_output_text import (
+    LogprobTopLogprob as OutputTextTopLogprob,
+)
 from openai.types.responses.response_reasoning_item import (
     Content as ResponseReasoningTextContent,
 )
@@ -833,7 +837,29 @@ class SimpleStreamingState:
     tool_call_is_custom: bool = False
     tool_call_payload: str = ""
     encrypt_reasoning: bool = False
+    accumulated_logprobs: list[OutputTextLogprob] = field(default_factory=list)
     current_state: _StateType = field(default_factory=lambda: _StateType.NONE)
+
+
+def _output_text_logprobs(
+    logprobs: list[response_text_delta_event.Logprob],
+) -> list[OutputTextLogprob]:
+    return [
+        OutputTextLogprob(
+            token=lp.token,
+            logprob=lp.logprob,
+            bytes=list(lp.token.encode("utf-8", errors="replace")),
+            top_logprobs=[
+                OutputTextTopLogprob(
+                    token=tl.token,
+                    logprob=tl.logprob,
+                    bytes=list(tl.token.encode("utf-8", errors="replace")),
+                )
+                for tl in lp.top_logprobs
+            ],
+        )
+        for lp in logprobs
+    ]
 
 
 def emit_simple_content_open(
@@ -843,6 +869,7 @@ def emit_simple_content_open(
     state.current_item_id = f"msg_{random_uuid()}"
     state.content_index = 0
     state.accumulated_text = ""
+    state.accumulated_logprobs = []
     return [
         ResponseOutputItemAddedEvent(
             type="response.output_item.added",
@@ -878,6 +905,8 @@ def emit_simple_content_delta(
     logprobs: list[response_text_delta_event.Logprob] | None = None,
 ) -> list[StreamingResponsesResponse]:
     state.accumulated_text += delta
+    if logprobs:
+        state.accumulated_logprobs.extend(_output_text_logprobs(logprobs))
     return [
         ResponseTextDeltaEvent(
             type="response.output_text.delta",
@@ -898,6 +927,7 @@ def emit_simple_content_done(
         type="output_text",
         text=state.accumulated_text,
         annotations=[],
+        logprobs=state.accumulated_logprobs or None,
     )
     events: list[StreamingResponsesResponse] = [
         ResponseTextDoneEvent(

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -30,6 +30,9 @@ from openai.types.responses import (
     ResponseCodeInterpreterToolCallParam,
     ResponseContentPartAddedEvent,
     ResponseContentPartDoneEvent,
+    ResponseCustomToolCall,
+    ResponseCustomToolCallInputDeltaEvent,
+    ResponseCustomToolCallInputDoneEvent,
     ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent,
     ResponseFunctionToolCall,
@@ -39,6 +42,7 @@ from openai.types.responses import (
     ResponseMcpCallArgumentsDoneEvent,
     ResponseMcpCallCompletedEvent,
     ResponseMcpCallInProgressEvent,
+    ResponseOutputItem,
     ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
     ResponseOutputMessage,
@@ -74,6 +78,10 @@ from vllm.entrypoints.openai.responses.protocol import (
 )
 from vllm.entrypoints.openai.responses.utils import (
     build_responses_tool_call_name_map,
+    custom_tool_names,
+    decode_custom_tool_input,
+    decode_custom_tool_input_prefix,
+    encode_reasoning_state,
     resolve_responses_tool_call_name,
 )
 from vllm.outputs import CompletionOutput
@@ -822,7 +830,9 @@ class SimpleStreamingState:
     tool_call_name: str = ""
     tool_call_namespace: str | None = None
     tool_call_index: int | None = None
-    has_emitted_tool_call_delta: bool = False
+    tool_call_is_custom: bool = False
+    tool_call_payload: str = ""
+    encrypt_reasoning: bool = False
     current_state: _StateType = field(default_factory=lambda: _StateType.NONE)
 
 
@@ -830,7 +840,7 @@ def emit_simple_content_open(
     state: SimpleStreamingState,
 ) -> list[StreamingResponsesResponse]:
     state.current_state = _StateType.CONTENT
-    state.current_item_id = random_uuid()
+    state.current_item_id = f"msg_{random_uuid()}"
     state.content_index = 0
     state.accumulated_text = ""
     return [
@@ -917,7 +927,6 @@ def emit_simple_content_done(
                 role="assistant",
                 content=[part] if state.accumulated_text else [],
                 status="completed",
-                summary=[],
             ),
         ),
     ]
@@ -930,7 +939,7 @@ def emit_simple_reasoning_open(
     state: SimpleStreamingState,
 ) -> list[StreamingResponsesResponse]:
     state.current_state = _StateType.REASONING
-    state.current_item_id = random_uuid()
+    state.current_item_id = f"rs_{random_uuid()}"
     state.content_index = 0
     state.accumulated_text = ""
     return [
@@ -1010,6 +1019,11 @@ def emit_simple_reasoning_done(
                 status="completed",
                 id=state.current_item_id,
                 summary=[],
+                encrypted_content=(
+                    encode_reasoning_state(state.accumulated_text)
+                    if state.encrypt_reasoning
+                    else None
+                ),
             ),
         ),
     ]
@@ -1023,30 +1037,62 @@ def emit_simple_tool_call_open(
     name: str,
     index: int | None,
     namespace: str | None = None,
+    is_custom: bool = False,
 ) -> list[StreamingResponsesResponse]:
     state.current_state = _StateType.TOOL_CALL
-    state.current_item_id = random_uuid()
+    state.current_item_id = f"{'ctc' if is_custom else 'fc'}_{random_uuid()}"
     state.tool_call_id = f"call_{random_uuid()}"
     state.tool_call_name = name
     state.tool_call_namespace = namespace
     state.tool_call_index = index
+    state.tool_call_is_custom = is_custom
+    state.tool_call_payload = ""
     state.accumulated_text = ""
-    state.has_emitted_tool_call_delta = False
+    item: ResponseOutputItem
+    if is_custom:
+        item = ResponseCustomToolCall(
+            type="custom_tool_call",
+            id=state.current_item_id,
+            call_id=state.tool_call_id,
+            name=name,
+            input="",
+        )
+    else:
+        item = ResponseFunctionToolCallItem(
+            type="function_call",
+            id=state.current_item_id,
+            call_id=state.tool_call_id,
+            name=name,
+            namespace=namespace,
+            arguments="",
+            status="in_progress",
+        )
     return [
         ResponseOutputItemAddedEvent(
             type="response.output_item.added",
             sequence_number=-1,
             output_index=state.output_index,
-            item=ResponseFunctionToolCallItem(
-                type="function_call",
-                id=state.current_item_id,
-                call_id=state.tool_call_id,
-                name=name,
-                namespace=namespace,
-                arguments="",
-                status="in_progress",
-            ),
+            item=item,
         ),
+    ]
+
+
+def _emit_custom_tool_input_delta(
+    state: SimpleStreamingState,
+    payload: str,
+) -> list[StreamingResponsesResponse]:
+    streamed = state.tool_call_payload
+    if not payload.startswith(streamed) or len(payload) == len(streamed):
+        return []
+    state.tool_call_payload = payload
+    return [
+        ResponseCustomToolCallInputDeltaEvent(
+            type="response.custom_tool_call_input.delta",
+            sequence_number=-1,
+            output_index=state.output_index,
+            item_id=state.current_item_id,
+            delta=payload[len(streamed) :],
+        )
     ]
 
 
@@ -1055,7 +1101,10 @@ def emit_simple_tool_call_delta(
     delta: str,
 ) -> list[StreamingResponsesResponse]:
     state.accumulated_text += delta
-    state.has_emitted_tool_call_delta = True
+    if state.tool_call_is_custom:
+        return _emit_custom_tool_input_delta(
+            state, decode_custom_tool_input_prefix(state.accumulated_text)
+        )
     return [
         ResponseFunctionCallArgumentsDeltaEvent(
             type="response.function_call_arguments.delta",
@@ -1070,9 +1119,31 @@ def emit_simple_tool_call_delta(
 def emit_simple_tool_call_done(
     state: SimpleStreamingState,
 ) -> list[StreamingResponsesResponse]:
-    events: list[StreamingResponsesResponse] = []
-    if state.has_emitted_tool_call_delta:
+    events: list[StreamingResponsesResponse]
+    item: ResponseOutputItem
+    if state.tool_call_is_custom:
+        payload = decode_custom_tool_input(state.accumulated_text)
+        if not payload.startswith(state.tool_call_payload):
+            payload = state.tool_call_payload or payload
+        events = _emit_custom_tool_input_delta(state, payload)
         events.append(
+            ResponseCustomToolCallInputDoneEvent(
+                type="response.custom_tool_call_input.done",
+                sequence_number=-1,
+                output_index=state.output_index,
+                item_id=state.current_item_id,
+                input=payload,
+            )
+        )
+        item = ResponseCustomToolCall(
+            type="custom_tool_call",
+            id=state.current_item_id,
+            call_id=state.tool_call_id,
+            name=state.tool_call_name,
+            input=payload,
+        )
+    else:
+        events = [
             ResponseFunctionCallArgumentsDoneEvent(
                 type="response.function_call_arguments.done",
                 sequence_number=-1,
@@ -1081,25 +1152,27 @@ def emit_simple_tool_call_done(
                 arguments=state.accumulated_text,
                 name=state.tool_call_name,
             )
+        ]
+        item = ResponseFunctionToolCall(
+            type="function_call",
+            name=state.tool_call_name,
+            namespace=state.tool_call_namespace,
+            arguments=state.accumulated_text,
+            status="completed",
+            id=state.current_item_id,
+            call_id=state.tool_call_id,
         )
     events.append(
         ResponseOutputItemDoneEvent(
             type="response.output_item.done",
             sequence_number=-1,
             output_index=state.output_index,
-            item=ResponseFunctionToolCall(
-                type="function_call",
-                name=state.tool_call_name,
-                namespace=state.tool_call_namespace,
-                arguments=state.accumulated_text,
-                status="completed",
-                id=state.current_item_id,
-                call_id=state.tool_call_id,
-            ),
-        ),
+            item=item,
+        )
     )
     state.output_index += 1
     state.tool_call_namespace = None
+    state.tool_call_is_custom = False
     state.current_state = _StateType.NONE
     return events
 
@@ -1181,9 +1254,12 @@ class SimpleStreamingEventProcessor:
         self,
         state: SimpleStreamingState | None = None,
         tools: list[Tool] | None = None,
+        encrypt_reasoning: bool = False,
     ) -> None:
         self.state = state or SimpleStreamingState()
+        self.state.encrypt_reasoning = encrypt_reasoning
         self.tool_call_name_map = build_responses_tool_call_name_map(tools)
+        self.custom_tool_names = custom_tool_names(tools)
 
     def resolve_target_state(
         self, delta_message: DeltaMessage
@@ -1249,6 +1325,7 @@ class SimpleStreamingEventProcessor:
                 call_name.name,
                 tool_call.index,
                 call_name.namespace,
+                call_name.name in self.custom_tool_names,
             )
         return handlers.open_fn(self.state)
 

--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
+import zlib
 from collections.abc import Iterable
 from typing import Any
 
+import pybase64 as base64
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
     ChatCompletionMessageToolCallParam,
@@ -13,6 +16,7 @@ from openai.types.chat.chat_completion_message_tool_call_param import (
     Function as FunctionCallTool,
 )
 from openai.types.responses import (
+    ResponseCustomToolCall,
     ResponseFunctionToolCall,
     ResponseOutputItem,
     ResponseOutputMessage,
@@ -40,6 +44,7 @@ from vllm.entrypoints.openai.responses.protocol import ResponseInputOutputItem
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.tool_parsers.utils import (
+    CUSTOM_TOOL_INPUT_KEY,
     build_responses_tool_call_name_map,
     flat_namespace_tool_name,
     iter_response_function_tool_dicts,
@@ -49,6 +54,131 @@ from vllm.utils import random_uuid
 
 logger = init_logger(__name__)
 
+_REASONING_STATE_PREFIX = "vllm-reasoning-v1."
+
+
+def encode_reasoning_state(text: str) -> str:
+    """Opaque ``reasoning.encrypted_content`` blob for ``store=false`` replay.
+
+    Encoded rather than encrypted: vLLM holds no key, the blob only has to
+    survive a client round trip intact.
+    """
+    packed = base64.urlsafe_b64encode(zlib.compress(text.encode("utf-8")))
+    return _REASONING_STATE_PREFIX + packed.decode("ascii")
+
+
+def decode_reasoning_state(blob: str | None) -> str | None:
+    if not blob or not blob.startswith(_REASONING_STATE_PREFIX):
+        return None
+    try:
+        raw = base64.urlsafe_b64decode(blob[len(_REASONING_STATE_PREFIX) :])
+        return zlib.decompress(raw).decode("utf-8")
+    except (ValueError, zlib.error, UnicodeDecodeError):
+        return None
+
+
+def custom_tool_names(tools: list[Tool] | None) -> frozenset[str]:
+    return frozenset(tool.name for tool in tools or [] if tool.type == "custom")
+
+
+def encode_custom_tool_input(payload: str) -> str:
+    return json.dumps({CUSTOM_TOOL_INPUT_KEY: payload}, ensure_ascii=False)
+
+
+def decode_custom_tool_input(arguments: str) -> str:
+    """Payload of a completed shim call; bare text is passed through."""
+    try:
+        parsed = json.loads(arguments)
+    except ValueError:
+        return arguments
+    if isinstance(parsed, dict):
+        value = parsed.get(CUSTOM_TOOL_INPUT_KEY)
+        if not isinstance(value, str) and len(parsed) == 1:
+            value = next(iter(parsed.values()))
+        if isinstance(value, str):
+            return value
+    return arguments
+
+
+_JSON_SIMPLE_ESCAPES = {
+    '"': '"',
+    "\\": "\\",
+    "/": "/",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+}
+
+
+def _decode_unicode_escape(buffer: str, i: int) -> tuple[str, int] | None:
+    """Decode ``\\uXXXX`` at ``buffer[i]``, joining a complete surrogate pair."""
+
+    def code_at(pos: int) -> int | None:
+        if pos + 6 > len(buffer) or buffer[pos : pos + 2] != "\\u":
+            return None
+        try:
+            return int(buffer[pos + 2 : pos + 6], 16)
+        except ValueError:
+            return None
+
+    code = code_at(i)
+    if code is None:
+        return None
+    if not 0xD800 <= code <= 0xDBFF:
+        return chr(code), i + 6
+    if i + 8 <= len(buffer) and buffer[i + 6 : i + 8] != "\\u":
+        return chr(code), i + 6
+    low = code_at(i + 6)
+    if low is None:
+        return None
+    if not 0xDC00 <= low <= 0xDFFF:
+        return chr(code), i + 6
+    return chr(0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00)), i + 12
+
+
+def decode_custom_tool_input_prefix(arguments: str) -> str:
+    """Longest decodable payload prefix of partial shim arguments, so that
+    streamed ``custom_tool_call_input`` deltas stay a prefix of the final input."""
+    key = json.dumps(CUSTOM_TOOL_INPUT_KEY)
+    key_at = arguments.find(key)
+    colon = arguments.find(":", key_at + len(key)) if key_at >= 0 else -1
+    start = arguments.find('"', colon + 1) if colon >= 0 else -1
+    if start < 0:
+        return ""
+    out: list[str] = []
+    i, n = start + 1, len(arguments)
+    while i < n:
+        ch = arguments[i]
+        if ch == '"':
+            break
+        if ch != "\\":
+            out.append(ch)
+            i += 1
+            continue
+        if i + 1 >= n:
+            break
+        escaped = arguments[i + 1]
+        if escaped in _JSON_SIMPLE_ESCAPES:
+            out.append(_JSON_SIMPLE_ESCAPES[escaped])
+            i += 2
+            continue
+        decoded = _decode_unicode_escape(arguments, i) if escaped == "u" else None
+        if decoded is None:
+            break
+        out.append(decoded[0])
+        i = decoded[1]
+    return "".join(out)
+
+
+def _item_type(item: ResponseInputOutputItem) -> str | None:
+    return item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
+
+
+def _item_dict(item: ResponseInputOutputItem) -> dict[str, Any]:
+    return item if isinstance(item, dict) else item.model_dump()
+
 
 def build_response_output_items(
     reasoning: str | None,
@@ -56,9 +186,11 @@ def build_response_output_items(
     tool_calls: list[FunctionCall] | None,
     logprobs: list[Logprob] | None = None,
     tools: list[Tool] | None = None,
+    encrypted_reasoning: bool = False,
 ) -> list[ResponseOutputItem]:
     outputs: list[ResponseOutputItem] = []
     tool_call_name_map = build_responses_tool_call_name_map(tools)
+    custom_names = custom_tool_names(tools)
 
     if reasoning:
         outputs.append(
@@ -69,6 +201,9 @@ def build_response_output_items(
                 content=[
                     ResponseReasoningTextContent(text=reasoning, type="reasoning_text")
                 ],
+                encrypted_content=(
+                    encode_reasoning_state(reasoning) if encrypted_reasoning else None
+                ),
                 status=None,
             )
         )
@@ -93,14 +228,27 @@ def build_response_output_items(
 
     if tool_calls:
         for idx, tool_call in enumerate(tool_calls):
+            call_id = tool_call.id or make_tool_call_id(
+                func_name=tool_call.name, idx=idx
+            )
+            if tool_call.name in custom_names:
+                outputs.append(
+                    ResponseCustomToolCall(
+                        id=f"ctc_{random_uuid()}",
+                        call_id=call_id,
+                        type="custom_tool_call",
+                        name=tool_call.name,
+                        input=decode_custom_tool_input(tool_call.arguments),
+                    )
+                )
+                continue
             call_name = resolve_responses_tool_call_name(
                 tool_call.name, tool_call_name_map=tool_call_name_map
             )
             outputs.append(
                 ResponseFunctionToolCall(
                     id=f"fc_{random_uuid()}",
-                    call_id=tool_call.id
-                    or make_tool_call_id(func_name=tool_call.name, idx=idx),
+                    call_id=call_id,
                     type="function_call",
                     status="completed",
                     name=call_name.name,
@@ -234,6 +382,7 @@ def _construct_message_from_response_item(
         prev_msg if prev_msg and prev_msg.get("role") == "assistant" else None
     )
 
+    tool_call: ChatCompletionMessageToolCallParam | None = None
     if isinstance(item, ResponseFunctionToolCall):
         tool_name = item.name
         if item.namespace:
@@ -246,6 +395,17 @@ def _construct_message_from_response_item(
             ),
             type="function",
         )
+    elif _item_type(item) == "custom_tool_call":
+        call = _item_dict(item)
+        tool_call = ChatCompletionMessageToolCallParam(
+            id=call["call_id"],
+            function=FunctionCallTool(
+                name=call["name"],
+                arguments=encode_custom_tool_input(call.get("input") or ""),
+            ),
+            type="function",
+        )
+    if tool_call is not None:
         if prev_assistant_msg:
             tool_calls = prev_assistant_msg.get("tool_calls")
             if tool_calls is None:
@@ -264,22 +424,19 @@ def _construct_message_from_response_item(
             logger.warning(
                 "Previous assistant message has unknown tool_calls format. "
                 "Tool call merging is skipped and a new assistant message is created. "
-                "Item %s",
-                item.id,
+                "Call %s",
+                tool_call["id"],
             )
         return ChatCompletionAssistantMessageParam(
             role="assistant",
             tool_calls=[tool_call],
         )
-    elif isinstance(item, ResponseReasoningItem):
+    if isinstance(item, ResponseReasoningItem):
         reasoning = ""
-        if item.encrypted_content:
-            raise VLLMValidationError(
-                "Encrypted content is not supported.",
-                parameter="input",
-            )
-        elif item.content and len(item.content) >= 1:
+        if item.content and len(item.content) >= 1:
             reasoning = item.content[0].text
+        elif (restored := decode_reasoning_state(item.encrypted_content)) is not None:
+            reasoning = restored
         elif len(item.summary) >= 1:
             reasoning = item.summary[0].text
             logger.warning(
@@ -315,12 +472,12 @@ def _construct_message_from_response_item(
             content=item.output,
             tool_call_id=item.call_id,
         )
-    elif isinstance(item, dict) and item.get("type") == "function_call_output":
-        # Append the function call output as a tool message.
+    elif _item_type(item) in ("function_call_output", "custom_tool_call_output"):
+        output = _item_dict(item)
         return ChatCompletionToolMessageParam(
             role="tool",
-            content=item.get("output"),
-            tool_call_id=item.get("call_id"),
+            content=output.get("output"),
+            tool_call_id=output.get("call_id"),
         )
     elif isinstance(item, dict) and item.get("role") == "assistant":
         content = item.get("content")

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
 
-from openai.types.responses import ToolChoiceFunction
+from openai.types.responses import ToolChoiceCustom, ToolChoiceFunction
 from pydantic import TypeAdapter, ValidationError
 
 from vllm.entrypoints.chat_utils import (
@@ -424,7 +424,9 @@ class DelegatingParser(Parser):
     def _get_function_name(
         self, request: ChatCompletionRequest | ResponsesRequest
     ) -> str:
-        if request.tool_choice and isinstance(request.tool_choice, ToolChoiceFunction):
+        if request.tool_choice and isinstance(
+            request.tool_choice, (ToolChoiceFunction, ToolChoiceCustom)
+        ):
             return request.tool_choice.name
         if request.tool_choice and isinstance(
             request.tool_choice, ChatCompletionNamedToolChoiceParam
@@ -463,7 +465,7 @@ class DelegatingParser(Parser):
         supports_required_and_named = tool_parser.supports_required_and_named
         is_named_tool_choice = request.tool_choice and isinstance(
             request.tool_choice,
-            (ToolChoiceFunction, ChatCompletionNamedToolChoiceParam),
+            (ToolChoiceFunction, ToolChoiceCustom, ChatCompletionNamedToolChoiceParam),
         )
         is_required_tool_choice = request.tool_choice == "required"
         is_auto_tool_choice = enable_auto_tools and (
@@ -572,7 +574,11 @@ class DelegatingParser(Parser):
             or request.tool_choice == "required"
             or isinstance(
                 request.tool_choice,
-                (ChatCompletionNamedToolChoiceParam, ToolChoiceFunction),
+                (
+                    ChatCompletionNamedToolChoiceParam,
+                    ToolChoiceFunction,
+                    ToolChoiceCustom,
+                ),
             )
         )
         if not need_tool_calling:
@@ -721,7 +727,11 @@ class DelegatingParser(Parser):
             and request.tool_choice
             and isinstance(
                 request.tool_choice,
-                (ToolChoiceFunction, ChatCompletionNamedToolChoiceParam),
+                (
+                    ToolChoiceFunction,
+                    ToolChoiceCustom,
+                    ChatCompletionNamedToolChoiceParam,
+                ),
             )
         ):
             delta_message, function_name_returned = extract_named_tool_call_streaming(

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -507,15 +507,38 @@ def _detect_developer_role_support(chat_template: str) -> bool:
     return '"developer"' in chat_template or "'developer'" in chat_template
 
 
+DEVELOPER_BLOCK_LABEL = "Developer instructions:"
+
+
+def _label_developer_content(content: Any) -> Any:
+    if isinstance(content, str):
+        return f"{DEVELOPER_BLOCK_LABEL}\n{content}"
+    if isinstance(content, list):
+        for index, part in enumerate(content):
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                labelled = {**part, "text": f"{DEVELOPER_BLOCK_LABEL}\n{part['text']}"}
+                return [*content[:index], labelled, *content[index + 1 :]]
+        return [{"type": "text", "text": DEVELOPER_BLOCK_LABEL}, *content]
+    return content
+
+
 def _convert_developer_to_system(
     conversation: list[ConversationMessage],
 ) -> list[ConversationMessage]:
+    """Collapse ``developer`` to ``system``.
+
+    Alongside a system message the block is labelled, so the instruction tier
+    survives instead of reading as one more paragraph of the system prompt.
+    """
+    has_system = any(msg["role"] == "system" for msg in conversation)
     converted: list[ConversationMessage] = []
     for msg in conversation:
         if msg["role"] == "developer":
             new_msg = dict(msg)
             new_msg["role"] = "system"
             new_msg.pop("tools", None)
+            if has_system:
+                new_msg["content"] = _label_developer_content(new_msg.get("content"))
             converted.append(new_msg)  # type: ignore[arg-type]
         else:
             converted.append(msg)

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -4,7 +4,7 @@
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, TypeAlias
 
-from openai.types.responses import FunctionTool
+from openai.types.responses import CustomTool, FunctionTool, ToolChoiceCustom
 from openai.types.responses.response import ToolChoice as ResponsesToolChoice
 from openai.types.responses.tool import Tool as ResponsesTool
 from openai.types.responses.tool_choice_allowed import ToolChoiceAllowed
@@ -34,6 +34,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolsParam,
 )
+from vllm.tool_parsers.utils import custom_tool_description, custom_tool_parameters
 
 ToolChoice: TypeAlias = (
     Literal["none", "auto", "required"]
@@ -167,6 +168,11 @@ def _dump_tool_for_xgrammar(
         if tool.strict is not None:
             function["strict"] = tool.strict
         return {"type": "function", "function": function}
+    if isinstance(tool, CustomTool):
+        function = {"name": tool.name, "parameters": custom_tool_parameters()}
+        if (description := custom_tool_description(tool)) is not None:
+            function["description"] = description
+        return {"type": "function", "function": function}
     dumped_tool = tool.model_dump(mode="json", exclude_none=True)
     if isinstance(tool, ChatCompletionToolsParam):
         return dumped_tool
@@ -187,7 +193,7 @@ def _dump_tool_choice_for_xgrammar(
     if isinstance(tool_choice, ChatCompletionNamedToolChoiceParam):
         return tool_choice.model_dump(mode="json", exclude_none=True)
 
-    if isinstance(tool_choice, ToolChoiceFunction):
+    if isinstance(tool_choice, (ToolChoiceFunction, ToolChoiceCustom)):
         return {
             "type": "function",
             "function": {"name": tool_choice.name},

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -12,11 +12,14 @@ from typing import Any, TypeAlias
 
 import partial_json_parser
 from openai.types.responses import (
+    CustomTool,
     FunctionTool,
     NamespaceTool,
+    ToolChoiceCustom,
     ToolChoiceFunction,
 )
 from openai.types.responses.tool import Tool as ResponsesTool
+from openai.types.shared.custom_tool_input_format import Grammar as CustomToolGrammar
 from partial_json_parser.core.options import Allow
 
 from vllm.entrypoints.generate.base.protocol import (
@@ -34,6 +37,44 @@ from vllm.logger import init_logger
 Tool: TypeAlias = ChatCompletionToolsParam | ResponsesTool
 
 logger = init_logger(__name__)
+
+CUSTOM_TOOL_INPUT_KEY = "input"
+
+
+def custom_tool_parameters() -> dict[str, Any]:
+    """Schema of the single-string function shim a ``custom`` tool is shown as."""
+    return {
+        "type": "object",
+        "properties": {
+            CUSTOM_TOOL_INPUT_KEY: {
+                "type": "string",
+                "description": "The freeform text payload for this tool.",
+            }
+        },
+        "required": [CUSTOM_TOOL_INPUT_KEY],
+        "additionalProperties": False,
+    }
+
+
+def custom_tool_description(tool: CustomTool) -> str | None:
+    """Fold a grammar format into the description: the payload is generated
+    inside the model's tool-call envelope, so the grammar cannot be enforced."""
+    parts = [tool.description] if tool.description else []
+    if isinstance(tool.format, CustomToolGrammar):
+        parts.append(
+            f"The payload must conform to this {tool.format.syntax} grammar:\n"
+            f"{tool.format.definition}"
+        )
+    return "\n\n".join(parts) or None
+
+
+def custom_tool_as_function_dict(tool: CustomTool) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "name": tool.name,
+        "description": custom_tool_description(tool),
+        "parameters": custom_tool_parameters(),
+    }
 
 
 def safe_literal_eval(text: str):
@@ -187,6 +228,8 @@ def iter_response_function_tool_info(
 ) -> list[tuple[str, dict[str, Any] | None]]:
     if isinstance(tool, FunctionTool):
         return [(tool.name, tool.parameters)]
+    if isinstance(tool, CustomTool):
+        return [(tool.name, custom_tool_parameters())]
     if not isinstance(tool, NamespaceTool):
         return []
 
@@ -218,6 +261,8 @@ def iter_response_function_tool_dicts(
                 function_tools.append(tool_dict)
         elif isinstance(tool, FunctionTool):
             function_tools.append(tool.model_dump())
+        elif isinstance(tool, CustomTool):
+            function_tools.append(custom_tool_as_function_dict(tool))
     return function_tools
 
 
@@ -277,7 +322,7 @@ def find_tool_properties(
     if not tools:
         return {}
     for tool in tools:
-        if isinstance(tool, (FunctionTool, NamespaceTool)):
+        if isinstance(tool, (FunctionTool, NamespaceTool, CustomTool)):
             for name, params in iter_response_function_tool_info(tool):
                 if name == tool_name:
                     return (params or {}).get("properties", {})
@@ -298,7 +343,7 @@ def find_tool_name(
     if not tools:
         return False
     for tool in tools:
-        if isinstance(tool, (FunctionTool, NamespaceTool)):
+        if isinstance(tool, (FunctionTool, NamespaceTool, CustomTool)):
             for name, _ in iter_response_function_tool_info(tool):
                 if name == tool_name:
                     return True
@@ -354,7 +399,7 @@ def _get_json_schema_from_tools(
     fn_tool_schemas: list[dict[str, Any]] = []
     fn_tools: list[Tool] = []
     for tool in tools:
-        if isinstance(tool, (FunctionTool, NamespaceTool)):
+        if isinstance(tool, (FunctionTool, NamespaceTool, CustomTool)):
             fn_tool_schemas.extend(
                 _get_tool_schema_from_name_and_params(name, params)
                 for name, params in iter_response_function_tool_info(tool)
@@ -379,7 +424,9 @@ def _get_json_schema_from_tools(
 
 
 def get_json_schema_from_tools(
-    tool_choice: str | ToolChoiceFunction | ChatCompletionNamedToolChoiceParam,
+    tool_choice: (
+        str | ToolChoiceFunction | ToolChoiceCustom | ChatCompletionNamedToolChoiceParam
+    ),
     tools: list[Tool] | None,
 ) -> str | dict | None:
     # tool_choice: "none"
@@ -387,12 +434,12 @@ def get_json_schema_from_tools(
         return None
     # tool_choice: Forced Function (Responses)
     if (not isinstance(tool_choice, str)) and isinstance(
-        tool_choice, ToolChoiceFunction
+        tool_choice, (ToolChoiceFunction, ToolChoiceCustom)
     ):
         tool_name = tool_choice.name
         responses_tool_map: dict[str, dict[str, Any] | None] = {}
         for tool in tools:
-            if not isinstance(tool, (FunctionTool, NamespaceTool)):
+            if not isinstance(tool, (FunctionTool, NamespaceTool, CustomTool)):
                 continue
             for name, params in iter_response_function_tool_info(tool):
                 responses_tool_map[name] = params


### PR DESCRIPTION
## Purpose

Running the Codex Responses-API conformance suite (26 cases; the Codex CLI exercises the same shapes) against `vllm serve GLM-5.3-Flash --tool-call-parser glm47 --reasoning-parser glm45` failed 11 of 26 cases on `main`. This PR fixes the four server-side defects behind them on the non-Harmony (`SimpleContext`) path:

1. **Streamed items and the final response disagreed.** `responses_stream_generator` re-parsed the complete text to build `response.completed`, so `response.output_item.done` items had bare-uuid ids, `status="completed"` reasoning items and a stray `summary` field, while the final `output` carried fresh `rs_`/`msg_`/`fc_` ids and `chatcmpl-tool-*` call ids. Clients that pair `output_item.done` with the final output (Codex does, by `call_id`) saw two identities per item. The final response now reuses the streamed items (resolving the TODO in `responses_full_generator`), streamed ids use the same prefixes as non-streaming, `response.function_call_arguments.done` is always emitted, and the streamed message item carries the `output_text` logprobs that were sent on the deltas so `include=["message.output_text.logprobs"]` still shows them in `response.completed`.

2. **`custom` tools were unusable.** They were filtered out of the rendered tool list; with `tool_choice="required"` xgrammar's `get_glm_4_7_structural_tag` received zero function tools and crashed with `AssertionError` (HTTP 500); replaying `custom_tool_call` / `custom_tool_call_output` raised "Unsupported input item type". Custom tools are now offered to the model as a single-string function shim (`{"input": "<payload>"}`, grammar formats described in the tool description), model calls to them are emitted as `custom_tool_call` items with `response.custom_tool_call_input.delta/done` events (payload un-escaped incrementally so deltas stay a prefix of the final `input`), history is replayed through the same shim, and `{"type": "custom", "name": ...}` is accepted as a named `tool_choice`.

3. **`reasoning.encrypted_content` was never produced and rejected on input.** With `include=["reasoning.encrypted_content"]` reasoning items now carry an opaque blob (`vllm-reasoning-v1.` + base64(zlib(text)); encoded, not encrypted, vLLM holds no key), and a replayed item restores its reasoning from content, then the blob, then summary. Foreign blobs no longer raise; they fall back to content/summary.

4. **Developer messages lost their tier.** Templates without a `developer` role collapse it to `system`; merged after `instructions` it read as one more paragraph and a later user instruction won. When a system message is present the block is now labelled `Developer instructions:`. Measured on the suite payload (8 samples, default sampling): 4/8 -> 8/8 compliant.

## Test Plan

```bash
PYTHONPATH=$PWD .venv/bin/python -m pytest \
  tests/entrypoints/openai/responses/test_streaming_events.py \
  tests/entrypoints/openai/responses/test_responses_utils.py tests/entrypoints/openai/responses/test_protocol.py \
  tests/entrypoints/openai/responses/test_serving_responses.py tests/tool_use/test_tool_choice_required.py \
  tests/tool_parsers/test_structural_tag_registry.py tests/renderers/test_hf.py -q
```

End to end: `vllm serve /path/GLM-5.3-Flash --served-model-name glm-5.3-flash -tp 8
--enable-expert-parallel --tool-call-parser glm47 --enable-auto-tool-choice --reasoning-parser glm45
--speculative-config '{"method":"mtp","num_speculative_tokens":5}'` with `VLLM_ENABLE_RESPONSES_API_STORE=1`, then the Codex conformance suite (`codex_response_test.py --skip compaction_replay`) for 20 consecutive runs, and real Codex CLI sessions (`codex exec --profile glm53`) through a local logging proxy.

## Test Result

* Unit: 352 passed / 1 xfailed across the touched suites (responses, tool choice, structural tags, hf renderer); all pre-commit hooks pass, mypy passes.
* Conformance suite 
  - On `main`: PASS 14 / FAIL 11 / SKIP 1. 
  - On this branch, 20 consecutive runs: PASS 25 / FAIL 0 / SKIP 1 in 19 of 20; The SKIP is `reasoning_replay` self-skipping because GLM produces no reasoning for that prompt; `encrypted_content` is exercised by `tool_roundtrip` and unit tests instead. 
  - Server log over all runs: 0 tracebacks, the only non-200 answers are the 404s that `error_bad_model` asks for.
* Streamed `include=["message.output_text.logprobs"]` probe: every `output_text.delta` carries logprobs and `response.completed` keeps them with `top_logprobs` (second commit).

## Real Codex validation

Real Codex CLI 0.154.0 sessions (`codex exec --profile glm53`, provider `wire_api="responses"`, `store=false`, `stream=true`, `include=["reasoning.encrypted_content"]`, 12 tools including `namespace` and `web_search`, ~17 KB `instructions`, `parallel_tool_calls=true`), all traffic captured by a local logging proxy in front of the server:
  * Debugged a broken calculator: rewrote `calc.py` as a recursive-descent parser with precedence, parentheses and unary minus; 7/7 tests pass; 15 requests.
  * Built a terminal snake game from scratch: `snake.py` (curses UI over a curses-free logic class), `test_snake.py` with 44 passing tests, `README.md`, `smoke_test.py` (pty launch, keys, `q`, clean exit; exit code 0). 27 requests, history up to 106 input items / 189 KB per request.
  * Proxy log: 48/48 Codex requests HTTP 200 (42 `POST /v1/responses`, 6 `GET /v1/models`), zero 4xx/5xx; every replayed turn carried `reasoning` items with `encrypted_content`, `function_call` and `function_call_output` items; `output_item.done` items matched the  final `output` on the sampled streams. vLLM server log: 0 tracebacks. One stream was  closed by the client mid-reasoning (Codex restarted its thread); the server answered 200 and logged nothing.

## Scope

The changes are limited to Responses API protocol / streaming / rendering behavior. There are no scheduler, sampling, tokenization, or model-execution changes.

