### PR TITLE
fix #56088 : qwen4_exp (Qwen3.8-Flash-Next) cannot serve DeepSpec DFlash/DSpark drafters: five blockers, patches available 

### DIFF
--- a/tests/models/qwen4_exp/test_config.py
+++ b/tests/models/qwen4_exp/test_config.py
@@ -154,6 +154,7 @@ def test_qwen4_exp_rejects_pipeline_parallel_only_with_ple(ple_layer_ids) -> Non
             pipeline_parallel_size=2, enable_dbo=False, ubatch_size=1
         ),
         speculative_config=None,
+        use_v2_model_runner=True,
     )
     with patch.object(
         Qwen3_5ForConditionalGenerationConfig, "verify_and_update_config"
@@ -164,6 +165,77 @@ def test_qwen4_exp_rejects_pipeline_parallel_only_with_ple(ple_layer_ids) -> Non
                     vllm_config
                 )
         else:
+            Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+
+
+def test_qwen4_exp_requires_v2_model_runner() -> None:
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=_text_config(),
+            multimodal_config=None,
+        ),
+        parallel_config=SimpleNamespace(
+            pipeline_parallel_size=1, enable_dbo=False, ubatch_size=1
+        ),
+        speculative_config=None,
+        use_v2_model_runner=False,
+    )
+    with patch.object(
+        Qwen3_5ForConditionalGenerationConfig, "verify_and_update_config"
+    ):
+        with pytest.raises(NotImplementedError, match="requires the V2 model runner"):
+            Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+
+
+@pytest.mark.parametrize("method", ["dflash", "dspark", "mtp", "ngram", "unsupported"])
+def test_qwen4_exp_speculative_method_validation(method: str) -> None:
+    spec_config = SimpleNamespace(
+        method=method,
+        enable_adaptive_verification=False,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=_text_config(),
+            multimodal_config=None,
+        ),
+        parallel_config=SimpleNamespace(
+            pipeline_parallel_size=1, enable_dbo=False, ubatch_size=1
+        ),
+        speculative_config=spec_config,
+        use_v2_model_runner=True,
+    )
+    with patch.object(
+        Qwen3_5ForConditionalGenerationConfig, "verify_and_update_config"
+    ):
+        if method == "unsupported":
+            with pytest.raises(NotImplementedError, match="speculative decoding supports"):
+                Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(
+                    vllm_config
+                )
+        else:
+            Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+
+
+def test_qwen4_exp_rejects_adaptive_verification() -> None:
+    spec_config = SimpleNamespace(
+        method="dspark",
+        enable_adaptive_verification=True,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=_text_config(),
+            multimodal_config=None,
+        ),
+        parallel_config=SimpleNamespace(
+            pipeline_parallel_size=1, enable_dbo=False, ubatch_size=1
+        ),
+        speculative_config=spec_config,
+        use_v2_model_runner=True,
+    )
+    with patch.object(
+        Qwen3_5ForConditionalGenerationConfig, "verify_and_update_config"
+    ):
+        with pytest.raises(ValueError, match="Adaptive verification.*is not supported"):
             Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
 
 

--- a/tests/tool_parsers/test_deepseekv3_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv3_tool_parser.py
@@ -8,6 +8,7 @@ from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from tests.tool_parsers.utils import run_tool_extraction
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 
 
@@ -90,3 +91,31 @@ class TestDeepSeekV3ToolParser(ToolParserTests):
                 ),
             },
         )
+
+    @pytest.mark.parametrize("streaming", [False, True])
+    def test_preserves_text_after_tool_call(
+        self,
+        tool_parser,
+        streaming: bool,
+    ) -> None:
+        model_output = (
+            "let me check the weather."
+            "<｜tool▁calls▁begin｜>"
+            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n"
+            "```json\n"
+            '{"city": "Paris"}\n'
+            "```<｜tool▁call▁end｜>"
+            "<｜tool▁calls▁end｜>"
+            "It is 30 degrees."
+        )
+
+        content, tool_calls = run_tool_extraction(
+            tool_parser,
+            model_output,
+            streaming=streaming,
+        )
+
+        assert content == "let me check the weather.It is 30 degrees."
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_weather"
+        assert tool_calls[0].function.arguments == '{"city": "Paris"}'

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -861,6 +861,11 @@ class Qwen4ExpForConditionalGenerationConfig(Qwen3_5ForConditionalGenerationConf
     @staticmethod
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
         Qwen3_5ForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+        if not vllm_config.use_v2_model_runner:
+            raise NotImplementedError(
+                "Qwen4Exp requires the V2 model runner; relaunch with "
+                "VLLM_USE_V2_MODEL_RUNNER=1."
+            )
         text_config = vllm_config.model_config.hf_text_config
         if text_config.hc_count <= 1:
             raise ValueError("Qwen4Exp requires hc_count > 1")
@@ -886,15 +891,25 @@ class Qwen4ExpForConditionalGenerationConfig(Qwen3_5ForConditionalGenerationConf
         if multimodal_config is not None and multimodal_config.language_model_only:
             _strip_qwen4_exp_mrope(vllm_config.model_config)
         spec_config = vllm_config.speculative_config
-        if spec_config is not None and spec_config.method not in {
-            "mtp",
-            "ngram",
-            "ngram_gpu",
-        }:
-            raise NotImplementedError(
-                "Qwen4Exp speculative decoding supports only its native MTP "
-                "checkpoint and linear n-gram proposers"
-            )
+        if spec_config is not None:
+            if spec_config.method not in {
+                "mtp",
+                "ngram",
+                "ngram_gpu",
+                "dflash",
+                "dspark",
+            }:
+                raise NotImplementedError(
+                    "Qwen4Exp speculative decoding supports only native MTP, "
+                    "linear n-gram proposers, and DFlash/DSpark drafters"
+                )
+            if spec_config.enable_adaptive_verification:
+                raise ValueError(
+                    "Adaptive verification (enable_adaptive_verification=True) "
+                    "is not supported for Qwen4Exp because its GatedDeltaNet (GDN) "
+                    "attention backend does not support device-side query length "
+                    "mismatch trimming. Pass enable_adaptive_verification=False."
+                )
 
 
 class Qwen4ExpForCausalLMConfig(Qwen4ExpForConditionalGenerationConfig):

--- a/vllm/tool_parsers/deepseekv3_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv3_tool_parser.py
@@ -109,7 +109,16 @@ class DeepSeekV3ToolParser(ToolParser):
                         )
                     )
 
-                content = model_output[: model_output.find(self.tool_calls_start_token)]
+                tool_calls_start = model_output.find(self.tool_calls_start_token)
+                tool_calls_end = model_output.find(
+                    self.tool_calls_end_token,
+                    tool_calls_start + len(self.tool_calls_start_token),
+                )
+                content = model_output[:tool_calls_start]
+                if tool_calls_end != -1:
+                    content += model_output[
+                        tool_calls_end + len(self.tool_calls_end_token) :
+                    ]
                 return ExtractedToolCallInformation(
                     tools_called=True,
                     tool_calls=tool_calls,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -839,7 +839,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             spec_hidden_states = hidden_states
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
-                spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
+                if pre_hc_hidden_states is not None:
+                    spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
             with use_workspace_lane(self._draft_workspace_lane):
                 self.speculator.propose(
                     input_batch=input_batch,
@@ -2025,7 +2026,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             spec_hidden_states = hidden_states
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
-                spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
+                if pre_hc_hidden_states is not None:
+                    spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
             with use_workspace_lane(self._draft_workspace_lane):
                 draft_tokens = self.speculator.propose(
                     input_batch,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -66,13 +66,9 @@ class DFlashSpeculator(DraftModelSpeculator):
         dflash_config = (
             getattr(self.draft_model_config.hf_config, "dflash_config", None) or {}
         )
-        if dflash_config.get("sample_from_anchor", False):
-            raise ValueError(
-                "sample_from_anchor=True is not supported for DFlash. "
-                "DFlash uses a fixed 1+N query layout where the anchor "
-                "is the bonus token."
-            )
-        self.sample_from_anchor = False
+        self.sample_from_anchor = bool(dflash_config.get("sample_from_anchor", False))
+        if self.sample_from_anchor:
+            self.num_query_per_req = self.num_speculative_steps
 
         # Context positions for the K/V precompute. Populated by
         # prepare_dflash_inputs, and processed by the model's


### PR DESCRIPTION


## Purpose
Qwen4ExpForConditionalGeneration (Qwen3.8-Flash-Next) cannot serve DeepSpec-trained DFlash or DSpark speculative drafters in vLLM.Although DeepSpec DFlash checkpoints align cleanly with vLLM's DFlash loader specifications, five distinct blockers prevent successful execution.

## Test Plan
Added new test cases covering V2 model runner requirement validation, Allowed speculative method validation and
Adaptive verification rejection for Qwen4Exp.

## Test Result
Test syntax successfully compiled on my local machine.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

