### PR TITLE
[Bugfix][Frontend] Support Responses text types in DeepSeek V4.1

### DIFF
--- a/tests/tokenizers_/test_deepseek_v41.py
+++ b/tests/tokenizers_/test_deepseek_v41.py
@@ -99,6 +99,24 @@ def test_raw_text_parts_preserve_reference_separator():
     assert messages == original
 
 
+@pytest.mark.parametrize(
+    ("role", "responses_type"),
+    [("user", "input_text"), ("assistant", "output_text")],
+)
+def test_responses_text_parts_match_chat_text_parts(role, responses_type):
+    responses_message = {
+        "role": role,
+        "content": [{"type": responses_type, "text": "hello"}],
+    }
+    chat_message = {
+        "role": role,
+        "content": [{"type": "text", "text": "hello"}],
+    }
+    assert render([responses_message], thinking=False) == render(
+        [chat_message], thinking=False
+    )
+
+
 def test_mid_system_gets_its_own_marker_and_generation_header():
     assert render(
         [

--- a/vllm/tokenizers/deepseek_v41.py
+++ b/vllm/tokenizers/deepseek_v41.py
@@ -32,7 +32,7 @@ def _normalize_messages(
             parts = []
             for block in content:
                 part_type = block.get("type")
-                if part_type == "text":
+                if part_type in ("text", "input_text", "output_text"):
                     parts.append(block.get("text", ""))
                 elif part_type in ("image_url", "input_image", "image_pil"):
                     parts.append(IMAGE_PLACEHOLDER)


### PR DESCRIPTION
## Purpose

Fixes #56297.

Normalize Responses API `input_text` and `output_text` parts as text in the DeepSeek V4.1 tokenizer. Existing image handling is unchanged.

No matching issue or PR was open when this work started.

## Test Plan

```bash
VLLM_TARGET_DEVICE=cpu .venv/bin/python -m pytest tests/tokenizers_/test_deepseek_v41.py -q
.venv/bin/pre-commit run --files vllm/tokenizers/deepseek_v41.py tests/tokenizers_/test_deepseek_v41.py
```

## Test Result

```text
32 passed
pre-commit passed
```

The new tests assert that Responses text parts render identically to existing `text` parts. This does not change model execution or output accuracy, so no model evaluation was needed.

AI assistance: Codex helped prepare the patch and tests. I reviewed every changed line and ran the tests above.
