### PR TITLE
[Kernel] Optimize Gemma RMSNorm memory traffic

### DIFF
--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -258,3 +258,65 @@ def test_gemma_rms_norm_mixed_input_weight_dtype(default_vllm_config) -> None:
 
     assert out.dtype == x.dtype
     torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 32, 1024])
+@pytest.mark.parametrize("hidden_size", [1024, 4096, 5120])
+@pytest.mark.parametrize("add_residual", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("weight_dtype", [torch.float32, torch.bfloat16, torch.float16])
+@torch.inference_mode()
+def test_gemma_rms_norm_triton_weight_dtypes(
+    num_tokens: int,
+    hidden_size: int,
+    add_residual: bool,
+    dtype: torch.dtype,
+    weight_dtype: torch.dtype,
+    default_vllm_config,
+) -> None:
+    if not current_platform.is_cuda():
+        pytest.skip("NVIDIA CUDA required")
+
+    device = CUDA_DEVICES[0]
+    generator = torch.Generator(device=device).manual_seed(20260910)
+    x = torch.randn(
+        num_tokens,
+        hidden_size,
+        dtype=dtype,
+        device=device,
+        generator=generator,
+    )
+    residual = (
+        torch.randn(
+            num_tokens,
+            hidden_size,
+            dtype=dtype,
+            device=device,
+            generator=generator,
+        )
+        if add_residual
+        else None
+    )
+    layer = GemmaRMSNorm(hidden_size, eps=1e-6).to(device=device)
+    layer.weight.data = layer.weight.data.to(weight_dtype)
+    layer.weight.data.normal_(mean=0.0, std=0.1, generator=generator)
+
+    out = layer(x, residual)
+    x_fp32 = x.float()
+    if residual is not None:
+        x_fp32 = x_fp32 + residual.float()
+        expected_residual = x_fp32.to(x.dtype)
+    weight_fp32 = layer.weight.data.float() + 1.0
+    variance = x_fp32.pow(2).mean(dim=-1, keepdim=True)
+    expected = (
+        x_fp32 * torch.rsqrt(variance + layer.variance_epsilon) * weight_fp32
+    ).to(x.dtype)
+
+    if residual is None:
+        assert isinstance(out, torch.Tensor)
+        torch.testing.assert_close(out, expected, atol=0, rtol=0)
+    else:
+        assert isinstance(out, tuple)
+        normalized, residual_out = out
+        torch.testing.assert_close(normalized, expected, atol=0, rtol=0)
+        torch.testing.assert_close(residual_out, expected_residual, atol=0, rtol=0)

--- a/vllm/kernels/triton/gemma_rms_norm.py
+++ b/vllm/kernels/triton/gemma_rms_norm.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton kernels for Gemma-style RMS normalization."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _gemma_rms_norm_residual_prelude_kernel(
+    x_ptr,
+    residual_ptr,
+    x_fp32_ptr,
+    residual_output_ptr,
+    n_elements: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    residual = tl.load(residual_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    summed = x + residual
+    tl.store(x_fp32_ptr + offsets, summed, mask=mask)
+    tl.store(residual_output_ptr + offsets, summed, mask=mask)
+
+
+@triton.jit
+def _gemma_rms_norm_affine_kernel(
+    x_fp32_ptr,
+    inverse_rms_ptr,
+    raw_weight_ptr,
+    output_ptr,
+    n_cols: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+    row_offset = row * n_cols
+
+    x = tl.load(x_fp32_ptr + row_offset + offsets, mask=mask, other=0.0)
+    inverse_rms = tl.load(inverse_rms_ptr + row)
+    raw_weight = tl.load(raw_weight_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    normalized = x * inverse_rms
+    output = normalized * (raw_weight + 1.0)
+    tl.store(output_ptr + row_offset + offsets, output, mask=mask)
+
+
+def gemma_rms_norm(
+    x: torch.Tensor,
+    raw_weight: torch.Tensor,
+    epsilon: float,
+    residual: torch.Tensor | None = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Apply Gemma RMSNorm with a fused FP32 affine tail.
+
+    Keep the native PyTorch FP32 reduction order, then fuse normalization,
+    zero-centered weight offset, FP32 affine multiplication, and the output
+    cast. This removes full-size FP32 intermediates without changing the
+    reduction tree used by ``forward_native``.
+    """
+    hidden_size = x.shape[-1]
+    orig_dtype = x.dtype
+    residual_output = None
+    if residual is None:
+        x_fp32 = x.to(torch.float32)
+    else:
+        x_fp32 = torch.empty(x.shape, device=x.device, dtype=torch.float32)
+        residual_output = torch.empty_like(x)
+        block_size = 1024
+        grid = (triton.cdiv(x.numel(), block_size),)
+        _gemma_rms_norm_residual_prelude_kernel[grid](
+            x,
+            residual,
+            x_fp32,
+            residual_output,
+            x.numel(),
+            BLOCK_SIZE=block_size,
+            num_warps=8,
+        )
+
+    variance = x_fp32.pow(2).mean(dim=-1, keepdim=True)
+    inverse_rms = torch.rsqrt(variance + epsilon)
+
+    x_2d = x_fp32.view(-1, hidden_size)
+    output = torch.empty(x_2d.shape, device=x.device, dtype=orig_dtype)
+    block_size = triton.next_power_of_2(hidden_size)
+    num_warps = 8 if block_size >= 4096 else 4
+
+    _gemma_rms_norm_affine_kernel[(x_2d.shape[0],)](
+        x_2d,
+        inverse_rms,
+        raw_weight,
+        output,
+        n_cols=hidden_size,
+        BLOCK_SIZE=block_size,
+        num_warps=num_warps,
+    )
+    output = output.view_as(x)
+    if residual is None:
+        return output
+    assert residual_output is not None
+    return output, residual_output

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -164,6 +164,34 @@ class GemmaRMSNorm(CustomOp):
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if (
+            x.dtype in (torch.float16, torch.bfloat16)
+            and x.numel() > 0
+            and self.weight.dtype in (torch.float16, torch.bfloat16, torch.float32)
+            and x.is_contiguous()
+            and self.weight.is_contiguous()
+            and (
+                residual is None
+                or (
+                    residual.dtype == x.dtype
+                    and residual.shape == x.shape
+                    and residual.is_contiguous()
+                )
+            )
+            and x.shape[-1] <= 8192
+        ):
+            from vllm.kernels.triton.gemma_rms_norm import gemma_rms_norm
+
+            return gemma_rms_norm(
+                x, self.weight, self.variance_epsilon, residual=residual
+            )
+        return self.forward_native(x, residual)
+
+    def forward_hip(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         return self.forward_native(x, residual)
 
     def forward_xpu(


### PR DESCRIPTION
## Purpose

Add a CUDA Triton path for `GemmaRMSNorm` when activations are contiguous FP16/BF16 and the raw zero-centered weight is FP16/BF16/FP32.

The optimized residual path fuses the two input casts, residual add, FP32 normalization-input store, and low-precision residual-output store into one pointwise kernel. The affine tail then fuses normalized-activation multiplication, `(raw_weight + 1)`, the FP32 affine multiply, and the output cast.

The change deliberately does **not** replace the RMS reduction: the existing PyTorch FP32 square/mean/epsilon/rsqrt sequence is preserved. This narrows the numerical-risk surface while removing full-tensor temporary traffic. HIP and unsupported layouts/dtypes retain the native implementation.

## Test Plan

- Ruff check, Ruff format, and forbidden-import check on all changed files.
- 108 CUDA correctness cases: FP16/BF16 activations × FP16/BF16/FP32 weights × plain/residual modes × 3 token counts × 3 hidden sizes.
- Two fresh-process control/candidate repeats with Qwen3.5-9B BF16, batch size 1, eager mode, one generated token, and prompt lengths 1024/4096/8192 on one RTX 5090.
- Control source: `db723d245`; candidate source/tree: `d78efdae2` / `5aa3c24c6`. Both arms used the same stable-ABI precompiled vLLM extensions; all Python/Triton files came from their exact source trees.

## Test Result

- All 108 CUDA cases were bit-identical, including residual outputs.
- Full-model generated token IDs and selected-token logprobs were bit-identical for all 24 paired measurements.
- The residual prelude alone is 1.326× / 1.553× / 1.734× faster at 1,024 / 4,096 / 8,192 tokens.

| Prompt tokens | Repeat 0 | Repeat 1 |
|---:|---:|---:|
| 1,024 | 1.0414× | 1.0419× |
| 4,096 | 1.0529× | 1.0539× |
| 8,192 | 1.0810× | 1.0802× |
| Equal-context arithmetic mean | 1.0584× | 1.0587× |

The performance claim is limited to single-GPU eager prefill/TTFT for this model and these shapes. It does not claim decode, CUDA-graph, online-serving throughput, multi-GPU, or cross-model gains.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] Purpose described.
- [x] Test plan provided.
- [x] Correctness and performance results provided.
- [ ] Documentation update required (not applicable; no public API or supported-model change).

</details>

### Default compiled-mode scope

With the default Inductor custom-op configuration (`none`), `GemmaRMSNorm` selects the unchanged `forward_native` implementation. This patch's CUDA path is therefore not used by that default; the reported speedups remain eager-only. Explicitly enabling the custom op under compilation now has the operator-level correctness coverage below; whole-model compiled/graph performance remains unqualified.

AI assistance was used for the implementation and follow-up validation. A source-bound dispatch check covered default Inductor, eager, and explicit enable/disable configurations; it is not a whole-model compile/CUDA-graph test.


### Follow-up operator compilation / CUDA graph checks

On the same PR head, RTX 5090 / Torch 2.13 / Triton 3.7.1:
- Registered Gemma tests: 109 passed (`test_layernorm.py -k gemma`).
- Six representative configurations passed eager-custom, fullgraph Inductor-native, and fullgraph Inductor-custom paths: 12 compilations, 18 explicit CUDA graph captures, 54 replays with replaced inputs.
- Replays were bit-identical to their matching uncaptured calls. Compiled outputs passed the existing native-reference tolerance (`atol=rtol=1e-2`); not every compiled output was bit-identical to eager native.

Exact PR Python/Triton source and imports were verified; native artifacts reused the existing `g7ee8a6dd` wheel. This is operator correctness coverage, not an exact-head native build, official CI, vLLM engine graph integration, or a new performance claim. The performance claim remains eager-only.
