### PR TITLE
[Bugfix][Multimodal] Restore cached audio inputs with UUIDs

### DIFF
--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -2384,8 +2384,10 @@ def test_parse_chat_messages_include_thinking_chunk(mistral_model_config):
     assert conversation_with_thinking == expected_conversation
 
 
+@pytest.mark.parametrize("input_audio", [None, {}, {"data": "", "format": "wav"}])
 def test_parse_chat_messages_single_empty_audio_with_uuid(
     qwen2_audio_model_config,
+    input_audio,
 ):
     audio_uuid = "abcd"
     conversation, mm_data, mm_uuids = parse_chat_messages(
@@ -2395,7 +2397,7 @@ def test_parse_chat_messages_single_empty_audio_with_uuid(
                 "content": [
                     {
                         "type": "input_audio",
-                        "input_audio": {},
+                        "input_audio": input_audio,
                         "uuid": audio_uuid,
                     },
                     {"type": "text", "text": "What does the audio say?"},
@@ -2418,8 +2420,10 @@ def test_parse_chat_messages_single_empty_audio_with_uuid(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("input_audio", [None, {}, {"data": "", "format": "wav"}])
 async def test_parse_chat_messages_single_empty_audio_with_uuid_async(
     qwen2_audio_model_config,
+    input_audio,
 ):
     audio_uuid = "abcd"
     conversation, mm_data, mm_uuids = await parse_chat_messages_async(
@@ -2429,7 +2433,7 @@ async def test_parse_chat_messages_single_empty_audio_with_uuid_async(
                 "content": [
                     {
                         "type": "input_audio",
-                        "input_audio": {},
+                        "input_audio": input_audio,
                         "uuid": audio_uuid,
                     },
                     {"type": "text", "text": "What does the audio say?"},

--- a/tests/multimodal/test_parse.py
+++ b/tests/multimodal/test_parse.py
@@ -6,6 +6,7 @@ import torch
 from PIL import Image
 
 from vllm.multimodal.parse import (
+    AudioProcessorItems,
     ImageProcessorItems,
     MultiModalDataParser,
     VideoProcessorItems,
@@ -58,6 +59,7 @@ def test_frame_size_hwc_chw(frame):
 @pytest.mark.parametrize(
     "modality,processor_cls",
     [
+        ("audio", AudioProcessorItems),
         ("image", ImageProcessorItems),
         ("video", VideoProcessorItems),
     ],
@@ -68,3 +70,19 @@ def test_parse_mm_data_accepts_none_cached_item(modality, processor_cls):
     assert isinstance(items, processor_cls)
     assert len(items) == 1
     assert items.get(0) is None
+
+
+def test_cached_audio_items_preserve_positions_during_resampling():
+    waveform = np.arange(16, dtype=np.float32)
+    parser = MultiModalDataParser(
+        target_sr=16000, target_channels=1, audio_resample_method="scipy"
+    )
+    items = parser.parse_mm_data(
+        {"audio": [None, (waveform, 8000), None, (waveform, 16000)]}
+    )["audio"]
+
+    assert len(items) == 4
+    assert items.get(0) is None
+    assert items.get(2) is None
+    assert len(items.get(1)) == 32
+    np.testing.assert_array_equal(items.get(3), waveform)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1773,7 +1773,7 @@ def _parse_chat_message_content_mm_part(
                 # with url as a dict of {"url": url}
                 audio_url = audio_url.get("url", None)
             return "audio_url", audio_url
-        if part.get("input_audio") is not None:
+        if "input_audio" in part:
             input_audio_params = _InputAudioParser(part).get("input_audio", None)
             return "input_audio", input_audio_params
         if "video_url" in part:

--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -678,7 +678,7 @@ class MultiModalDataParser:
         if self.is_embeddings(data):
             return AudioEmbeddingItems(data, self.expected_hidden_size)
 
-        data_items: list[AudioItem]
+        data_items: list[AudioItem | None]
         if (
             (is_list_of(data, float) and len(data) > 0)
             or (isinstance(data, (np.ndarray, torch.Tensor)) and data.ndim == 1)
@@ -690,8 +690,13 @@ class MultiModalDataParser:
         else:
             data_items = data  # type: ignore[assignment]
 
-        new_audios = list[np.ndarray]()
+        new_audios = list[np.ndarray | None]()
         for data_item in data_items:
+            # Requests can omit audio samples when reusing a cached UUID.
+            if data_item is None:
+                new_audios.append(None)
+                continue
+
             audio, orig_sr = self._get_audio_with_sr(data_item)
             if orig_sr is None:
                 new_audio = audio


### PR DESCRIPTION
## Purpose

The [documented cached-audio request](https://docs.vllm.ai/en/latest/features/multimodal_inputs/#cached-inputs) fails even after the audio has been cached:

```json
{"type": "input_audio", "input_audio": null, "uuid": "clip-a"}
```

Chat parsing rejects this as a missing `type`. Using `{}` gets past that check, but the resulting `audio: [None]` then hits `assert_never` in the audio data parser before cache lookup.

This preserves the null payload and missing audio items until the processor cache resolves their UUIDs. Cached placeholders keep their positions when mixed with new audio; new audio still goes through resampling and channel normalization. An unknown UUID still produces the existing cache-miss error.

Duplicate check: #43414 fixed extraction of nonempty audio payloads for #43415; this fixes omitted payloads used on subsequent requests. Searches for open `input_audio`/audio UUID fixes found no equivalent change. #55583 and #55616 address early image/video lookups and URL cache keys, respectively.

## Test Plan

Run from the checkout using the selected virtualenv:

```bash
CUDA_VISIBLE_DEVICES=4 .venv/bin/python -m pytest -q tests/multimodal/test_parse.py
CUDA_VISIBLE_DEVICES=4 .venv/bin/python -m pytest -q \
  tests/entrypoints/unit_tests/test_chat_utils.py -k audio
pre-commit run --files vllm/entrypoints/chat_utils.py vllm/multimodal/parse.py \
  tests/entrypoints/unit_tests/test_chat_utils.py tests/multimodal/test_parse.py
```

## Test Result

- The focused regression selection went from **4 failed / 6 passed** to **10 passed**. Failures before the fix were null dispatch in sync/async chat parsing, a cached audio item, and cached items mixed with resampled audio.
- Full parser module: **14 passed**. Audio chat tests: **9 passed**.
- Applicable pre-commit hooks passed, including Ruff and mypy.
- Serving-input validation with the real Phi4 multimodal processor passed all four combinations of sync/async chat parsing and processor-only/sender-receiver caches. It warms an actual WAV, combines cached and new audio, reorders UUIDs, checks bit-exact reused features, and checks the missing-data error for an unknown UUID. The pre-fix run fails after successfully processing the first WAV. This checks preprocessing/cache behavior without model weights; no generated-text accuracy claim is made.

Environment: Python 3.12.14, PyTorch 2.13.0+cu129, Transformers 5.16.1. The tests use CPU tensors.

AI assistance: developed and tested with OpenAI Codex.
