### PR TITLE
[CI] Shard language Hybrid 2→9 and Extended Generation 1→8

### DIFF
--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -79,7 +79,7 @@ steps:
     - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
     # Shard the hybrid language model tests that are numerically stable on Hopper.
     - pytest -v -s models/language/generation -m hybrid_model -k 'not granite-4.0-tiny-preview' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
-  parallelism: 2
+  parallelism: 9
   mirror:
     amd:
       label: ":amd: (MI300) Language Models (Hybrid) Shard %N"
@@ -112,11 +112,12 @@ steps:
     - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
     - pytest -v -s models/language/generation -m hybrid_model -k 'granite-4.0-tiny-preview'
 
-- label: ":nvidia: (H200 MIG 35GB) Language Models (Extended Generation)"
+- label: ":nvidia: (H200 MIG 35GB) Language Models (Extended Generation) Shard %N"
   device: h200_35gb
   key: language-models-test-extended-generation
   timeout_in_minutes: 80
   optional: true
+  parallelism: 8
   source_file_dependencies:
   - vllm/
   - "!vllm/distributed/kv_transfer/"
@@ -127,10 +128,10 @@ steps:
     # mamba@v2.3.0 pins -std=c++17, so build from a patched checkout instead of the git URL.
     - rm -rf /tmp/mamba-src && git clone --depth 1 --branch v2.3.0 https://github.com/state-spaces/mamba /tmp/mamba-src && sed -i 's/-std=c++17/-std=c++20/g' /tmp/mamba-src/setup.py && MAMBA_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation /tmp/mamba-src
     - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
-    - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)'
+    - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
   mirror:
     amd:
-      label: ":amd: (MI355) Language Models (Extended Generation)"
+      label: ":amd: (MI355) Language Models (Extended Generation) Shard %N"
       dind: false
       device: mi355_1
       timeout_in_minutes: 70
@@ -139,7 +140,7 @@ steps:
       commands:
       - MAMBA_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/AndreasKaratzas/mamba@fix-rocm-7.0-warp-size-constexpr'
       - CAUSAL_CONV1D_FORCE_BUILD=TRUE uv pip install --system --no-build-isolation 'git+https://github.com/Dao-AILab/causal-conv1d@v1.6.0'
-      - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)'
+      - pytest -v -s models/language/generation -m '(not core_model) and (not hybrid_model)' --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
 
 - label: ":nvidia: (H200 MIG 18GB) Language Models (PPL)"
   key: language-models-test-ppl


### PR DESCRIPTION
Raise parallelism on the two longest language jobs (Hybrid p90 ~53 min, Extended Generation p90 ~66 min) so every shard's tests fit the 20-minute test-job budget (image/setup excluded). No test files, commands, marks or coverage change — only the shard counts. Counts are derived from 7 days of per-case CI runtimes hashed through pytest-shard's exact assignment (`sha256(nodeid) % N`), validated by reproducing the current real 2-shard Hybrid split exactly.

## Old → New

| Job | Old shards | p90 job | New shards | Expected slowest shard |
|---|---|---|---|---|
| Language Models (Hybrid) | 2 | ~53 min | 9 | ~12.3 min (simulated) |
| Language Models (Extended Generation) | 1 | ~66 min | 8 | ~11.6 min (simulated) |

## Notes

- 9 and 8 are the smallest counts whose simulated slowest shard lands comfortably under target with all shards non-empty; hash placement is chance per N, so adding/renaming a test reshuffles membership and the counts may need periodic re-derivation. The directory layout (#56291–#56294) remains the structural fix for that opacity.
- Validation plan: scoped build via `VLLM_CI_ONLY_STEP_KEYS` on the language steps to measure real per-shard runtimes; timeouts (65/80 min) intentionally unchanged until measured.
- Prior art: #52324 closed unmerged (same mechanism, estimated counts). AI assistance used (Kimi Code); commit carries the trailer; human-reviewed diff.
