### PR TITLE
[Bugfix][ROCm] Route NoPE FP8 KV sparse MLA to Triton instead of AITER asm

### DIFF
--- a/tests/v1/attention/test_rocm_glm5next_sparse.py
+++ b/tests/v1/attention/test_rocm_glm5next_sparse.py
@@ -74,9 +74,11 @@ def test_fit_kpool_indices_rejects_narrow_input():
         ("auto", 512, 1, 0, 0, 32, True),
         ("auto", 512, 1, 2, 2, 32, True),
         ("auto", 512, 0, 2, 2, 1, True),
-        ("fp8", 512, 1, 0, 0, 32, False),
+        ("fp8", 512, 1, 0, 0, 32, True),
+        ("fp8_e4m3", 512, 0, 2, 2, 1, True),
         ("auto", 576, 1, 0, 0, 32, False),
         ("auto", 512, 0, 2, 4, 2, False),
+        ("fp8", 576, 1, 0, 0, 32, False),
     ],
 )
 def test_rocm_sparse_triton_route(
@@ -177,3 +179,93 @@ def test_sparse_prefill_kv_row_offset_does_not_overflow_int32():
     _store_sparse_kv_row_offset_kernel[(1,)](slot, output, stride=512)
 
     assert output.item() == 6554 * 640 * 512
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="ROCm required")
+def test_sparse_prefill_fp8_nope_matches_bf16_reference():
+    """FP8 NoPE KV must dequant in-kernel, not route to the 576-wide asm kernel.
+
+    The AITER mla_a8w8 HSACO reads 576 B/row. A 512-wide GLM cache would
+    overrun. This kernel is the replacement path: same ragged gather, FP8
+    values, and a tensor scale.
+    """
+    from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+        _rocm_sparse_attn_prefill_ragged_triton,
+    )
+
+    torch.manual_seed(0)
+    device = "cuda"
+    num_queries, num_heads, head_dim = 4, 16, 512
+    num_kv = 32
+    kv_scale = 1.5
+    q = torch.randn(
+        num_queries, num_heads, head_dim, dtype=torch.bfloat16, device=device
+    )
+    kv_f32 = torch.randn(num_kv, head_dim, dtype=torch.float32, device=device)
+    # Must be the platform's cache dtype: gfx950 stores OCP e4m3, gfx942 fnuz.
+    kv_fp8 = (kv_f32 / kv_scale).to(current_platform.fp8_dtype())
+    kv_bf16 = (kv_fp8.float() * kv_scale).to(torch.bfloat16)
+    indices = torch.arange(num_queries * 8, device=device, dtype=torch.int32) % num_kv
+    indptr = torch.arange(0, num_queries * 8 + 1, 8, device=device, dtype=torch.int32)
+
+    out_fp8 = _rocm_sparse_attn_prefill_ragged_triton(
+        q=q,
+        kv=kv_fp8,
+        indices=indices,
+        indptr=indptr,
+        scale=head_dim**-0.5,
+        attn_sink=None,
+        nope_head_dim=head_dim,
+        rope_head_dim=0,
+        kv_scale=kv_scale,
+    )
+    out_bf16 = _rocm_sparse_attn_prefill_ragged_triton(
+        q=q,
+        kv=kv_bf16,
+        indices=indices,
+        indptr=indptr,
+        scale=head_dim**-0.5,
+        attn_sink=None,
+        nope_head_dim=head_dim,
+        rope_head_dim=0,
+        kv_scale=1.0,
+    )
+    # Both sides consume identical FP8 values, so the only spread is bf16
+    # rounding of the dequantized product. A dropped or doubled scale moves
+    # the result by ~50%, far outside this band.
+    torch.testing.assert_close(out_fp8, out_bf16, rtol=5e-3, atol=5e-3)
+
+
+def _nope_impl_for_asm_guard(num_decode_tokens, num_decodes, max_query_len):
+    impl = object.__new__(sparse_mod.ROCMAiterMLASparseImpl)
+    impl.num_heads = 16
+    impl.kv_lora_rank = 512
+    impl.kv_cache_dtype = "fp8_e4m3"
+    impl.scale = 512**-0.5
+    impl.sinks = None
+    q = torch.zeros(num_decode_tokens, 16, 512, dtype=torch.bfloat16)
+    kv = torch.zeros(4, 1, 512, dtype=torch.bfloat16)
+    metadata = SimpleNamespace(
+        attn_out_dtype=torch.bfloat16,
+        num_prefills=0,
+        num_decodes=num_decodes,
+        num_decode_tokens=num_decode_tokens,
+        max_query_len=max_query_len,
+        paged_kv_indices=torch.empty(0, dtype=torch.int32),
+        paged_kv_indptr=torch.zeros(num_decode_tokens + 1, dtype=torch.int32),
+    )
+    return impl, q, kv, metadata
+
+
+def test_nope_rows_never_reach_aiter_asm_kernels():
+    """Speculative decode widens the decode step past the Triton gate.
+
+    AITER's precompiled kernels assume a 576-byte row, so a 512-byte NoPE row
+    must raise rather than fault the GPU.
+    """
+    impl, q, kv, metadata = _nope_impl_for_asm_guard(
+        num_decode_tokens=4, num_decodes=2, max_query_len=2
+    )
+
+    with pytest.raises(NotImplementedError, match="576-byte KV row"):
+        impl._forward_mla(SimpleNamespace(), q, kv, metadata)

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -53,11 +53,25 @@ def _use_rocm_sparse_triton(
     num_decode_tokens: int,
     max_query_len: int,
 ) -> bool:
-    """Select the rope-free BF16 path not supported by AITER sparse MLA."""
+    """Select the rope-free path not supported by AITER sparse MLA.
+
+    AITER's precompiled ``mla_a8w8`` / ``mla_a16w16`` kernels bake in the
+    DeepSeek MLA row width of 576 bytes (512 latent + 64 RoPE). NoPE models
+    such as GLM-5.3-Flash store a 512-byte row (``head_size == kv_lora_rank``).
+    Routing those to the asm kernel overruns Q by 1024 B/token and reads 64 B
+    past each KV slot.
+
+    The Triton sparse kernel is parameterized on
+    ``(head_dim, nope_head_dim, rope_head_dim)`` and is the only in-tree path
+    that can serve this geometry. FP8 KV is included: Q stays in the model
+    dtype and the Triton kernel dequantizes FP8 KV in registers. Previously
+    FP8 was excluded, which forced NoPE + ``--kv-cache-dtype fp8_e4m3`` onto
+    the asm kernel and GPU-faulted on gfx950.
+    """
+    del kv_cache_dtype  # dtype no longer gates this path; see docstring.
     plain_decode = num_decode_tokens == num_decodes
     return (
-        not kv_cache_dtype.startswith("fp8")
-        and head_size == kv_lora_rank
+        head_size == kv_lora_rank
         and plain_decode
         and (num_prefills > 0 or (num_decodes > 0 and max_query_len == 1))
     )
@@ -867,9 +881,25 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
                 output=output,
                 ragged_indices=attn_metadata.paged_kv_indices,
                 ragged_indptr=attn_metadata.paged_kv_indptr,
+                kv_scale=float(getattr(layer, "_k_scale_float", 1.0)),
             )
             output = AiterMLAHelper.get_mla_unpadded_o(self.num_heads, output)
             return output, None
+
+        # Everything below dispatches to AITER's precompiled MLA kernels, which
+        # bake in the 576-byte DeepSeek row. A NoPE row is 512 bytes, so they
+        # would read past both Q and the KV cache and take a GPU memory fault
+        # instead of raising. Refuse the shape rather than corrupting memory.
+        if q.shape[-1] == self.kv_lora_rank:
+            raise NotImplementedError(
+                "ROCm sparse MLA cannot serve rope-free (NoPE) attention with "
+                f"query length {attn_metadata.max_query_len} over "
+                f"{attn_metadata.num_decode_tokens} decode tokens: AITER's "
+                "precompiled kernels assume a 576-byte KV row and only the "
+                "Triton path handles the 512-byte NoPE row. This combination "
+                "usually means speculative decoding or MTP is enabled; "
+                "disable it for this model on ROCm."
+            )
 
         # AITER's nonpersistent return-LSE dispatch has discrete head kernels.
         supported_head_buckets: tuple[int, ...] | None = None
@@ -1018,9 +1048,20 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         # MQA 576/512 approach for both prefill and decode
 
         fp8_attention = self.kv_cache_dtype.startswith("fp8")
+        use_triton_sparse = _use_rocm_sparse_triton(
+            kv_cache_dtype=self.kv_cache_dtype,
+            head_size=self.head_size,
+            kv_lora_rank=self.kv_lora_rank,
+            num_prefills=attn_metadata.num_prefills,
+            num_decodes=attn_metadata.num_decodes,
+            num_decode_tokens=attn_metadata.num_decode_tokens,
+            max_query_len=attn_metadata.max_query_len,
+        )
         if isinstance(q, tuple):
             ql_nope, q_pe = q
-            if fp8_attention:
+            # Triton NoPE path consumes bf16/fp16 Q. Quantizing Q to fp8 is
+            # only required for the AITER asm kernel.
+            if fp8_attention and not use_triton_sparse:
                 q = layer._decode_concat_quant_fp8_op(  # type: ignore[attr-defined]
                     ql_nope, q_pe, layer._q_scale
                 )
@@ -1054,7 +1095,7 @@ class ROCMAiterMLASparseImpl(MLAAttentionImpl[ROCMAiterMLASparseMetadata]):
         # write the latent and rope to kv cache
         if fp8_attention:
             kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(current_platform.fp8_dtype())
-            if q.dtype != current_platform.fp8_dtype():
+            if not use_triton_sparse and q.dtype != current_platform.fp8_dtype():
                 original_q_shape = q.shape
                 q, _ = ops.scaled_fp8_quant(q.view(q.shape[0], -1), layer._q_scale)
                 q = q.view(original_q_shape)

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -29,6 +29,13 @@ else:
 
 logger = init_logger(__name__)
 
+_FP8_DTYPES = (
+    torch.float8_e4m3fn,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2,
+    torch.float8_e5m2fnuz,
+)
+
 
 @functools.cache
 def _get_aiter_topk_ops() -> tuple[Callable[..., None], Callable[..., None]] | None:
@@ -1416,7 +1423,9 @@ def _sparse_attn_prefill_ragged_kernel(
     head_dim,
     num_kv,
     scale,
+    kv_scale,
     HAS_ATTN_SINK: tl.constexpr,
+    KV_IS_FP8: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_D: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -1464,6 +1473,12 @@ def _sparse_attn_prefill_ragged_kernel(
             mask=valid[:, None] & dim_mask[None, :],
             other=0.0,
         )
+        if KV_IS_FP8:
+            # Hop through bf16 rather than converting fp8 straight to f32: the
+            # fnuz encodings used on gfx942 are unreliable in that direct form,
+            # which is why the fp8_ds_mla loaders below take the same detour.
+            # bf16 holds every e4m3/e5m2 value exactly, so this is lossless.
+            kv = (kv.to(tl.bfloat16).to(tl.float32) * kv_scale).to(q.dtype)
 
         next_k_pos = k_start + BLOCK_K + k_offsets
         slot = tl.load(
@@ -2599,6 +2614,7 @@ def _rocm_sparse_attn_prefill_ragged_triton(
     attn_sink: torch.Tensor | None,
     nope_head_dim: int,
     rope_head_dim: int,
+    kv_scale: float = 1.0,
 ) -> torch.Tensor:
     assert q.ndim == 3, f"expected q=[sq,h,d], got {q.shape}"
     assert kv.ndim == 2, f"expected kv=[skv,d], got {kv.shape}"
@@ -2625,6 +2641,12 @@ def _rocm_sparse_attn_prefill_ragged_triton(
         "_rocm_sparse_attn_prefill_ragged_triton",
     )
 
+    kv_is_fp8 = kv.dtype in _FP8_DTYPES
+    # The kernel dequantizes fp8 KV into the query dtype, so a quantized query
+    # would collapse the dequantized values back to fp8.
+    assert not (kv_is_fp8 and q.dtype in _FP8_DTYPES), (
+        f"fp8 KV requires an unquantized query, got q={q.dtype}"
+    )
     block_h = 16
     block_d = triton.next_power_of_2(head_dim)
     block_k = 16 if head_dim >= 256 else 32
@@ -2649,7 +2671,9 @@ def _rocm_sparse_attn_prefill_ragged_triton(
         head_dim,
         kv.shape[0],
         float(scale),
+        float(kv_scale),
         HAS_ATTN_SINK=has_attn_sink,
+        KV_IS_FP8=kv_is_fp8,
         BLOCK_H=block_h,
         BLOCK_D=block_d,
         BLOCK_K=block_k,
@@ -2667,6 +2691,7 @@ def _rocm_sparse_attn_prefill_triton(
     nope_head_dim: int,
     rope_head_dim: int,
     topk_length: torch.Tensor | None = None,
+    kv_scale: float = 1.0,
 ) -> torch.Tensor:
     ragged_indices, ragged_indptr = build_ragged_indices_from_dense(
         indices,
@@ -2684,6 +2709,7 @@ def _rocm_sparse_attn_prefill_triton(
         attn_sink=attn_sink,
         nope_head_dim=nope_head_dim,
         rope_head_dim=rope_head_dim,
+        kv_scale=kv_scale,
     )
 
 
@@ -3240,6 +3266,7 @@ def rocm_sparse_attn_prefill(
     output: torch.Tensor,
     ragged_indices: torch.Tensor | None = None,
     ragged_indptr: torch.Tensor | None = None,
+    kv_scale: float = 1.0,
 ) -> None:
     assert kv.ndim == 3 and kv.shape[1] == 1, (
         f"ROCm Triton sparse prefill expects kv=[skv,1,d], got {kv.shape}"
@@ -3287,6 +3314,7 @@ def rocm_sparse_attn_prefill(
             attn_sink=None if attn_sink is None else attn_sink[: q.shape[1]],
             nope_head_dim=nope_head_dim,
             rope_head_dim=rope_head_dim,
+            kv_scale=kv_scale,
         )
     else:
         assert indices is not None
@@ -3300,6 +3328,7 @@ def rocm_sparse_attn_prefill(
             nope_head_dim=nope_head_dim,
             rope_head_dim=rope_head_dim,
             topk_length=topk_length,
+            kv_scale=kv_scale,
         )
     output.copy_(output_chunk[..., : output.shape[-1]].to(output.dtype))
 


### PR DESCRIPTION
## Purpose

`--kv-cache-dtype fp8_e4m3` on a rope-free (NoPE) MLA model memory-faults every TP rank during warmup on gfx950. The server never reaches `Application startup complete`.

AITER's precompiled `mla_a8w8` kernels bake in the DeepSeek MLA row width of 576 bytes (512 latent + 64 RoPE) — `0x240` appears as an immediate in the HSACO, and the kernel loads `stride_Q` into `s70` and never uses it. GLM-5.3-Flash has `qk_rope_head_dim=0` and `kv_lora_rank=512`, so its row is 512 bytes. The host computes the correct strides (`stride_Q=8192`, `stride_Page=512`), but the kernel walks 576-byte rows anyway:

- Q overruns by 1024 B per token (8 tokens → +8 KiB, 16 → +16 KiB).
- KV issues 9 unpredicated 64-byte loads covering `[0,576)`; the last 64 B is a phantom RoPE tail, so the final slot reads past the page-aligned cache.

Those offsets match the observed faults: the four ranks faulted at +0, +8 KiB, +16 KiB and +16 KiB past the end of one of their own allocations — a bounded overrun, not a wild pointer.

The routing gate `_use_rocm_sparse_triton` excluded `kv_cache_dtype.startswith("fp8")`, so BF16 NoPE went to the geometry-parameterized Triton kernel (which loads zero `mla_a8w8` kernels and does not fault) while FP8 NoPE was forced onto the asm kernel.

Fix:

1. Stop gating the rope-free Triton route on the KV dtype.
2. Keep the query in the model dtype on that route (the FP8 quantization exists only for the asm kernel).
3. Dequantize FP8 KV inside the Triton kernel using `layer._k_scale_float`, which is the exact inverse of the `x / k_scale` performed by `concat_and_cache_mla`.
4. Raise `NotImplementedError` for any NoPE row that would still reach the asm kernels. Speculative decode / MTP raises the reorder-batch threshold above 1, which makes the plain-decode predicate false and would otherwise drop NoPE back onto the 576-byte kernel with the same overrun. A clear error beats a memory fault; a shape guard on the ROCm lane was also requested independently in #53963.

Related: #53963 documents the same fault on the ROCm lane.

**Not a duplicate:** #36855 fixes a different AITER sparse MLA crash (`num_heads < 16` head repeat). #54031 adds NoPE geometry to the CUDA `TRITON_MLA_SPARSE` backend and is explicitly BF16-only. No open PR touches ROCm NoPE FP8 KV routing.

## Test Plan

```bash
docker run --rm --entrypoint python3 --device /dev/kfd --device /dev/dri \
  --group-add video --ipc=host -e HIP_VISIBLE_DEVICES=2 \
  -v $PWD:/vllm-src -w /vllm-src -e PYTHONPATH=/vllm-src \
  vllm/vllm-openai-rocm:glm53-flash \
  -m pytest tests/v1/attention/test_rocm_glm5next_sparse.py --noconftest -q
```

New/changed coverage:

- Routing: NoPE + `fp8` / `fp8_e4m3` now expect the Triton path; DeepSeek's 576-wide row still stays off it for both `auto` and `fp8`.
- `test_sparse_prefill_fp8_nope_matches_bf16_reference`: in-kernel FP8 dequant vs a pre-dequantized BF16 reference, using `current_platform.fp8_dtype()` so gfx950 exercises OCP e4m3 and gfx942 exercises fnuz.
- `test_nope_rows_never_reach_aiter_asm_kernels`: the widened-decode case raises instead of dispatching.

## Test Result

`19 passed` on MI355X (gfx950), ROCm, including the three GPU tests.

Sensitivity check on the dequant test, so it is not passing vacuously — max abs difference vs the BF16 reference:

| scale applied | max abs diff |
|---|---|
| correct `kv_scale` | 0.000000 |
| scale dropped (1.0) | 1.171875 |
| scale doubled | 4.703125 |

Exactly zero for the correct scale, because BF16 represents every e4m3 value exactly; the assertion band is 5e-3.

`ruff check` and `ruff format --check` clean on all three files.

## Model evaluation

Not yet run, and I want to be explicit about it: this fixes a fault that prevented the server from starting, so there is no FP8 "before" number — the reference run died during warmup with `Memory access fault ... Reason: Unknown` on all four ranks. A BF16 baseline for this model exists and is unaffected by this patch (BF16 already took the Triton route). An FP8 end-to-end eval needs a 4-GPU TP run; I will post GSM8K/GPQA numbers before asking for merge, which is why this is still a draft.

One caveat worth flagging: with an uncalibrated `_k_scale_float` of 1.0 a native-FP8 checkpoint can still clip. The value round-trips (the same 1.0 is used on the cache write and the read), but the dynamic range is not adapted. That is orthogonal to this PR, which is about not faulting.
