### PR TITLE
[Bugfix][DeepSeek-V4] Suppress pre-tool content in history to prevent in-context loop poisoning (#56022)

### DIFF
--- a/tests/tokenizers_/conftest.py
+++ b/tests/tokenizers_/conftest.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+
+@pytest.fixture()
+def should_do_global_cleanup_after_test() -> bool:
+    return False

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -292,6 +292,47 @@ def test_deepseek_v4_renders_parsed_history_tool_arguments():
     assert 'parameter name="arguments"' not in prompt
 
 
+def test_deepseek_v4_suppresses_content_in_history_with_tool_calls():
+    messages = [
+        {"role": "user", "content": "What is the weather in Boston?"},
+        {
+            "role": "assistant",
+            "content": "Let me check the weather in Boston.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"location": "Boston"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "Sunny, 72F",
+        },
+    ]
+    conversation, _, _ = parse_chat_messages(
+        messages,
+        _model_config(),
+        content_format="string",
+    )
+
+    prompt = _tokenizer().apply_chat_template(
+        conversation=conversation,
+        messages=messages,
+        tokenize=False,
+    )
+
+    # Verify assistant prose before tool calls is suppressed
+    assert "Let me check the weather in Boston." not in prompt
+    assert "<｜DSML｜tool_calls>" in prompt
+    assert '<｜DSML｜parameter name="location" string="true">Boston' in prompt
+
+
 @pytest.mark.parametrize(
     ("reasoning_effort", "expected_prefix"),
     [

--- a/tests/tool_parsers/test_deepseekv4_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv4_tool_parser.py
@@ -148,6 +148,14 @@ def test_extract_tool_calls():
     }
 
 
+def test_extract_tool_calls_plain_chat_preserves_content():
+    parser = make_parser()
+    model_output = "The weather is sunny."
+    result = parser.extract_tool_calls(model_output, make_request())
+    assert not result.tools_called
+    assert result.content == "The weather is sunny."
+
+
 def test_function_calls_wrapper_is_not_recognized():
     # The V3.2 wrapper is not a V4 terminal, so it passes through as content,
     # but the invoke inside it is still parsed (tool calls anchor on the invoke).

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -364,7 +364,9 @@ def render_message(
                 tc_block_name=tool_calls_block_name,
             )
 
-        summary_content = content or ""
+        # When tool_calls are present, suppress content so history replay does not
+        # inject pre-tool prose into the prompt context.
+        summary_content = "" if tool_calls else (content or "")
         reasoning = reasoning or ""
 
         # Check if previous message has a task - if so, this is a task output (no thinking)


### PR DESCRIPTION
Fixes #56022

### Summary & Motivation
When using DeepSeek-V4 in multi-turn agentic tool-calling sessions, if the model produces visible pre-tool prose alongside DSML tool calls, subsequent turns in the same session can become poisoned.

When the conversation history is formatted back into the model's chat template (`vllm/tokenizers/deepseek_v4_encoding.py`), an assistant message containing both `content` and `tool_calls` renders the visible prose immediately before `<｜DSML｜tool_calls>`. In-context learning causes the model to replicate this pattern on every subsequent turn, even when it should emit clean DSML tool calls.

This PR suppresses `summary_content` before `<｜DSML｜tool_calls>` during history replay when `tool_calls` are present:
```python
summary_content = "" if tool_calls else (content or "")
```

### Duplicate-Work Check
- Checked open issues and PRs targeting DeepSeek-V4 tool parsing and templates (`#55954`, `#56141`, `#56215`).
- While upstream PRs addressed missing or misspelled DSML tool call wrapper tokens in model output, none address history template encoding or in-context prompt loop poisoning across multi-turn sessions.
- No existing open PR addresses issue #56022.

### Proposed Changes
1. **`vllm/tokenizers/deepseek_v4_encoding.py`**:
   - Suppress `summary_content` in `render_message()` when `tool_calls` are present on an assistant message, preventing pre-tool prose from leaking into subsequent prompt contexts.
2. **`tests/tokenizers_/test_deepseek_v4.py`**:
   - Added `test_deepseek_v4_suppresses_content_in_history_with_tool_calls` verifying that assistant prose is omitted before `<｜DSML｜tool_calls>` in the rendered chat template prompt.
3. **`tests/tool_parsers/test_deepseekv4_tool_parser.py`**:
   - Added regression test `test_extract_tool_calls_plain_chat_preserves_content` to ensure plain chat output without tool calls continues to preserve content cleanly.
4. **`tests/tokenizers_/conftest.py`**:
   - Added `should_do_global_cleanup_after_test = False` fixture for CPU tokenizer tests to prevent distributed GPU teardown issues during local test runs.

### Test Commands Run & Results
```bash
.venv/bin/python -m pytest \
  tests/tokenizers_/test_deepseek_v4.py \
  tests/tool_parsers/test_deepseekv4_tool_parser.py \
  tests/parser/engine/test_deepseek_v4.py \
  tests/parser/engine/test_deepseek_v32.py -v
```
**Result**: `165 passed in 0.73s`

Pre-commit hooks:
```bash
pre-commit run --all-files
```
**Result**: All hooks (`ruff check`, `ruff format`, `typos`, `mypy (Python 3.10)`, SPDX headers, lazy import checks, configuration validation) passed.

### AI Assistance Statement
AI assistance was used to investigate the root cause, identify the template replay bug, and draft the regression test. But all changes and test results have been reviewed by the author.