### PR TITLE
[Misc] Warn when NoopOffloader is silently selected despite a nonzero offload request

### DIFF
--- a/tests/model_executor/offloader/test_base.py
+++ b/tests/model_executor/offloader/test_base.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the offloader selection/diagnostics in
+vllm.model_executor.offloader.base.
+
+Covers https://github.com/vllm-project/vllm/issues/56283: a NoopOffloader
+being silently selected while a non-zero cpu_offload_gb / offload_group_size
+was requested should be loud, not silent, since that combination can only
+happen if the offload configuration was lost before reaching
+create_offloader()/set_offloader().
+"""
+
+import pytest
+
+from vllm.config.offload import OffloadConfig, PrefetchOffloadConfig, UVAOffloadConfig
+from vllm.model_executor.offloader import base
+from vllm.model_executor.offloader.base import (
+    NoopOffloader,
+    create_offloader,
+    set_offloader,
+)
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _capture_log_calls(monkeypatch):
+    calls: dict[str, list] = {"debug_once": [], "info_once": [], "warning_once": []}
+    for level in calls:
+        monkeypatch.setattr(
+            base.logger,
+            level,
+            lambda *args, _level=level, **kwargs: calls[_level].append(args),
+        )
+    return calls
+
+
+# --------------------------------------------------------------------------
+# create_offloader(): warn when an explicitly requested (non-"auto") backend
+# is handed a zero budget for that backend.
+# --------------------------------------------------------------------------
+
+
+def test_create_offloader_auto_zero_budget_is_silent(monkeypatch):
+    """cpu_offload_gb=0 with the default offload_backend='auto' is the
+    ordinary no-offload configuration and must not warn."""
+    calls = _capture_log_calls(monkeypatch)
+
+    offloader = create_offloader(OffloadConfig())
+
+    assert isinstance(offloader, NoopOffloader)
+    assert calls["warning_once"] == []
+
+
+def test_create_offloader_auto_nonzero_selects_uva_silently(monkeypatch):
+    calls = _capture_log_calls(monkeypatch)
+
+    offloader = create_offloader(
+        OffloadConfig(uva=UVAOffloadConfig(cpu_offload_gb=15.1))
+    )
+
+    assert type(offloader).__name__ == "UVAOffloader"
+    assert calls["warning_once"] == []
+
+
+def test_create_offloader_explicit_uva_backend_zero_budget_warns(monkeypatch):
+    """offload_backend='uva' explicitly requested but cpu_offload_gb=0: this
+    combination can only happen if the value was lost upstream."""
+    calls = _capture_log_calls(monkeypatch)
+
+    offloader = create_offloader(
+        OffloadConfig(offload_backend="uva", uva=UVAOffloadConfig(cpu_offload_gb=0))
+    )
+
+    # Still constructs a (zero-budget) UVAOffloader, matching prior behavior
+    # for an explicit backend selection.
+    assert type(offloader).__name__ == "UVAOffloader"
+    assert len(calls["warning_once"]) == 1
+    msg, *args = calls["warning_once"][0]
+    assert "uva" in (msg % tuple(args))
+    assert "0" in (msg % tuple(args))
+
+
+def test_offload_backend_prefetch_zero_group_size_is_rejected_at_construction():
+    """offload_backend='prefetch' with offload_group_size=0 can never reach
+    create_offloader() in the first place: validate_offload_config() rejects
+    it (offload_num_in_group > offload_group_size) before the OffloadConfig
+    object even exists. create_offloader's matching check for this backend
+    is therefore a defense against a corrupted/reconstructed config object,
+    not a reachable user-facing state -- this test documents that
+    invariant."""
+    with pytest.raises(ValueError):
+        OffloadConfig(
+            offload_backend="prefetch",
+            prefetch=PrefetchOffloadConfig(offload_group_size=0),
+        )
+
+
+# --------------------------------------------------------------------------
+# set_offloader(): warn when a NoopOffloader is selected despite a non-zero
+# offload budget having been requested. This is the exact signature of
+# issue #56283: cpu_offload_gb echoed in non-default args, NoopOffloader
+# selected, weights never offloaded.
+# --------------------------------------------------------------------------
+
+
+def test_set_offloader_warns_on_noop_with_nonzero_uva_request(monkeypatch):
+    calls = _capture_log_calls(monkeypatch)
+    cfg = OffloadConfig(uva=UVAOffloadConfig(cpu_offload_gb=15.1))
+
+    set_offloader(NoopOffloader(), cfg)
+
+    assert len(calls["warning_once"]) == 1
+    msg, *args = calls["warning_once"][0]
+    rendered = msg % tuple(args)
+    assert "15.1" in rendered
+    assert "NoopOffloader" in rendered
+    assert calls["debug_once"] == []
+
+
+def test_set_offloader_warns_on_noop_with_nonzero_prefetch_request(monkeypatch):
+    calls = _capture_log_calls(monkeypatch)
+    cfg = OffloadConfig(
+        prefetch=PrefetchOffloadConfig(offload_group_size=8, offload_num_in_group=7)
+    )
+
+    set_offloader(NoopOffloader(), cfg)
+
+    assert len(calls["warning_once"]) == 1
+    msg, *args = calls["warning_once"][0]
+    assert "8" in (msg % tuple(args))
+
+
+def test_set_offloader_noop_with_legitimate_zero_default_does_not_warn(monkeypatch):
+    """cpu_offload_gb=0 (the default, i.e. offloading genuinely not
+    requested) must keep logging at debug level, not warn."""
+    calls = _capture_log_calls(monkeypatch)
+
+    set_offloader(NoopOffloader(), OffloadConfig())
+
+    assert calls["warning_once"] == []
+    assert len(calls["debug_once"]) == 1
+
+
+def test_set_offloader_without_offload_config_arg_is_backward_compatible(monkeypatch):
+    calls = _capture_log_calls(monkeypatch)
+
+    set_offloader(NoopOffloader())
+
+    assert calls["warning_once"] == []
+    assert len(calls["debug_once"]) == 1
+
+
+def test_set_offloader_info_once_preserved_for_real_offloader(monkeypatch):
+    calls = _capture_log_calls(monkeypatch)
+    cfg = OffloadConfig(uva=UVAOffloadConfig(cpu_offload_gb=8.0))
+
+    offloader = create_offloader(cfg)
+    calls["warning_once"].clear()  # only inspect set_offloader's own logging
+    set_offloader(offloader, cfg)
+
+    assert calls["warning_once"] == []
+    assert len(calls["info_once"]) == 1

--- a/vllm/model_executor/offloader/base.py
+++ b/vllm/model_executor/offloader/base.py
@@ -128,12 +128,43 @@ def get_offloader() -> BaseOffloader:
     return _instance
 
 
-def set_offloader(instance: BaseOffloader) -> None:
-    """Set the global offloader instance."""
+def set_offloader(
+    instance: BaseOffloader,
+    offload_config: "OffloadConfig | None" = None,
+) -> None:
+    """Set the global offloader instance.
+
+    Args:
+        instance: The offloader to install as the global singleton.
+        offload_config: The config `instance` was derived from. Only used to
+            detect and warn about the case where a `NoopOffloader` is
+            selected despite a non-zero offload budget having been
+            requested, which can only mean the offload configuration was
+            lost or reset somewhere before this call.
+    """
     global _instance
     _instance = instance
     if isinstance(instance, NoopOffloader):
-        logger.debug_once("Offloader set to NoopOffloader (no offloading).")
+        requested_cpu_offload_gb = (
+            offload_config.uva.cpu_offload_gb if offload_config is not None else 0
+        )
+        requested_group_size = (
+            offload_config.prefetch.offload_group_size
+            if offload_config is not None
+            else 0
+        )
+        if requested_cpu_offload_gb > 0 or requested_group_size > 0:
+            logger.warning_once(
+                "Offloader set to NoopOffloader, but cpu_offload_gb=%s and "
+                "offload_group_size=%s were requested (offload_backend=%r). "
+                "No CPU offloading will occur. The offload configuration was "
+                "likely lost or reset before reaching create_offloader().",
+                requested_cpu_offload_gb,
+                requested_group_size,
+                offload_config.offload_backend,
+            )
+        else:
+            logger.debug_once("Offloader set to NoopOffloader (no offloading).")
     else:
         logger.info_once("Offloader set to %s", type(instance).__name__)
 
@@ -148,9 +179,33 @@ def create_offloader(offload_config: "OffloadConfig") -> BaseOffloader:
     from vllm.model_executor.offloader.prefetch import PrefetchOffloader
     from vllm.model_executor.offloader.uva import UVAOffloader
 
-    backend = offload_config.offload_backend
+    requested_backend = offload_config.offload_backend
+    backend = requested_backend
     uva = offload_config.uva
     prefetch = offload_config.prefetch
+
+    # An explicitly requested (non-"auto") backend handed a zero budget for
+    # that backend can only mean the offload configuration was lost or reset
+    # before reaching this call: there is no legitimate reason to force a
+    # specific backend and then configure it with nothing to offload.
+    if requested_backend == "uva" and uva.cpu_offload_gb <= 0:
+        logger.warning_once(
+            "offload_backend=%r was requested but uva.cpu_offload_gb=%s. "
+            "No CPU offloading will occur. This combination can only happen "
+            "if the offload configuration was lost or reset before reaching "
+            "create_offloader().",
+            requested_backend,
+            uva.cpu_offload_gb,
+        )
+    elif requested_backend == "prefetch" and prefetch.offload_group_size <= 0:
+        logger.warning_once(
+            "offload_backend=%r was requested but "
+            "prefetch.offload_group_size=%s. No CPU offloading will occur. "
+            "This combination can only happen if the offload configuration "
+            "was lost or reset before reaching create_offloader().",
+            requested_backend,
+            prefetch.offload_group_size,
+        )
 
     if backend == "auto":
         if prefetch.offload_group_size > 0:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -355,7 +355,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.eplb = EPLBController(self.parallel_config, self.device)
         self.routed_experts_capturer: RoutedExpertsCapturer | None = None
 
-        set_offloader(create_offloader(self.vllm_config.offload_config))
+        set_offloader(
+            create_offloader(self.vllm_config.offload_config),
+            self.vllm_config.offload_config,
+        )
 
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -978,7 +978,7 @@ class GPUModelRunner(
 
         # Model weight offloader
         # Make sure this is called before any get_offloader call
-        set_offloader(create_offloader(self.offload_config))
+        set_offloader(create_offloader(self.offload_config), self.offload_config)
 
         # Ephemeral state transferred between execute_model() and sample_tokens().
         self.execute_model_state: ExecuteModelState | None = None


### PR DESCRIPTION
## Purpose

Makes a silent misconfiguration loud: `--cpu-offload-gb` can be accepted and echoed in non-default args while `NoopOffloader` is installed and no weights are offloaded, with an OOM as the only visible symptom. That is the shape of #56283.

**Root cause of #56283 is resolved, and it is not a bug on main.** @raj-parihar traced it (comment on this PR, 2026-09-11): they were running the 0.27.1 release, whose `vllm/v1/worker/gpu/model_runner.py` has no `set_offloader` call at all. #51413 added it to that runner after 0.27.1 was cut, which is why it could not be reproduced against main. Verified against the tags: `set_offloader` appears 0 times in that file at `v0.27.1` and twice at both `v0.29.0` and `main`. They confirmed Qwen/QwQ-32B-AWQ with `--cpu-offload-gb 8` now reaches healthy on 0.29.0 with "Total CPU offloaded parameters: 8.02".

So the earlier hypothesis in this thread, that the config was lost crossing the `context.Process` boundary as a pickled kwarg, is dead. Nothing was lost in transit; the offloader was simply never installed on the runner in use. For the record, I had separately pickled and unpickled `OffloadConfig(uva=UVAOffloadConfig(cpu_offload_gb=15.1))` and the nested value survived intact, which pointed the same way.

**What is left is worth keeping on its own terms**, and the reporter asked for it explicitly: "A silent NoopOffloader with a non-zero budget requested is worth warning about regardless of how the config got lost, and it would have saved me the night." A user on any build old enough to be missing the wiring, or hitting any future path that drops the config, currently gets an OOM and no signal. This PR does not fix a live defect on main; it makes that class of failure self-describing.

The change:

- `set_offloader()` now warns (instead of only debug-logging) when it installs a `NoopOffloader` while the config it was derived from still requested a non-zero `cpu_offload_gb` or `offload_group_size`.
- `create_offloader()` warns when an explicitly requested (non-`"auto"`) backend is handed a zero budget for that backend, since that combination can only happen if the value was lost upstream.

Neither check fires for the ordinary default (`offload_backend="auto"`, `cpu_offload_gb=0`), so normal non-offloading runs are unaffected.

## Test Plan

Added `tests/model_executor/offloader/test_base.py`, covering:

- `create_offloader()` stays silent for the legitimate default (`auto`, `cpu_offload_gb=0`) and for a normal non-zero `auto` request.
- `create_offloader()` warns when `offload_backend="uva"` is explicit but `cpu_offload_gb=0`.
- A config with `offload_backend="prefetch"` and `offload_group_size=0` is rejected by `validate_offload_config()` at construction time, confirming that branch can only be reached via a corrupted/reconstructed config, not normal use.
- `set_offloader()` warns when a `NoopOffloader` is installed alongside a config that still requested a non-zero `cpu_offload_gb` or `offload_group_size`, and does not warn for the legitimate zero-budget default or when called without a config (back-compat).
- `set_offloader()` still logs at `info_once` for a real (non-Noop) offloader.

I do not have GPU hardware in this environment, so I could not run vLLM's real test suite or reproduce the reporter's OOM end to end. `vllm/model_executor/offloader/base.py` has unconditional local imports of the real UVA/prefetch offloader modules inside `create_offloader()`, which themselves import CUDA-touching torch APIs, so even the pure-Python branches in this file cannot be exercised through a normal `import vllm` in a CPU-only, no-build sandbox. To still validate the actual edited source (not a rewritten copy of it), I loaded `vllm/config/offload.py` and the real, edited `vllm/model_executor/offloader/base.py` directly from disk with `importlib`, stubbing only `torch`, `vllm.envs`, `vllm.logger`, and the `prefetch`/`uva` submodules (with lightweight stand-in offloader classes), and ran the new logic against real `OffloadConfig` objects.

## Test Result

```
$ ruff check vllm/model_executor/offloader/base.py vllm/v1/worker/gpu_model_runner.py vllm/v1/worker/gpu/model_runner.py tests/model_executor/offloader/test_base.py
[]
$ ruff format --diff vllm/model_executor/offloader/base.py vllm/v1/worker/gpu_model_runner.py vllm/v1/worker/gpu/model_runner.py tests/model_executor/offloader/test_base.py
(no output, no diff)
```

Running the 9 tests in `tests/model_executor/offloader/test_base.py` against the real edited source via the `importlib` harness described above:

```
PASS  test_create_offloader_auto_nonzero_selects_uva_silently
PASS  test_create_offloader_auto_zero_budget_is_silent
PASS  test_create_offloader_explicit_uva_backend_zero_budget_warns
PASS  test_offload_backend_prefetch_zero_group_size_is_rejected_at_construction
PASS  test_set_offloader_info_once_preserved_for_real_offloader
PASS  test_set_offloader_noop_with_legitimate_zero_default_does_not_warn
PASS  test_set_offloader_warns_on_noop_with_nonzero_prefetch_request
PASS  test_set_offloader_warns_on_noop_with_nonzero_uva_request
PASS  test_set_offloader_without_offload_config_arg_is_backward_compatible

9 passed, 0 failed out of 9
```

Sample of the new warning text (from the same run):

```
[WARNING_ONCE] Offloader set to NoopOffloader, but cpu_offload_gb=15.1 and offload_group_size=0 were requested (offload_backend='auto'). No CPU offloading will occur. The offload configuration was likely lost or reset before reaching create_offloader().
[WARNING_ONCE] offload_backend='uva' was requested but uva.cpu_offload_gb=0.0. No CPU offloading will occur. This combination can only happen if the offload configuration was lost or reset before reaching create_offloader().
```

I was not able to run `pytest tests/model_executor/offloader/test_base.py` directly, or any part of the real vLLM test suite, or a full vLLM build: this environment has no GPU and cannot build vLLM's CUDA extensions. I also did not run `typos` (pre-commit hook); it is not installed in this environment. `ruff` is the linter I could actually run.

