### PR TITLE
[Perf][DSpark] Add KV-only context insertion across V4.1 cache formats

### DIFF
--- a/benchmarks/kernels/benchmark_dspark_context_kv.py
+++ b/benchmarks/kernels/benchmark_dspark_context_kv.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compare DSpark KV insertion with the former dummy-query implementation."""
+
+import argparse
+import json
+from functools import partial
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+from vllm.models.deepseek_v4_1.nvidia.dspark import _insert_context_kv
+from vllm.triton_utils import triton
+
+
+def legacy_insert(attn, kv, positions, slots):
+    cache = attn.swa_cache_layer.kv_cache
+    block_size = attn.swa_cache_layer.block_size
+    cos_sin = attn.rotary_emb.cos_sin_cache
+    q = torch.zeros(
+        kv.shape[0], attn.n_local_heads, 512, dtype=kv.dtype, device=kv.device
+    )
+    if cache.dtype == torch.uint8:
+        torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
+            q,
+            kv,
+            cache.view(cache.shape[0], -1),
+            slots,
+            positions,
+            cos_sin,
+            attn.padded_heads,
+            1e-20,
+            block_size,
+        )
+    elif cache.dtype == torch.bfloat16:
+        torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_bf16_insert(
+            q,
+            kv,
+            cache,
+            slots,
+            positions,
+            cos_sin,
+            1e-20,
+            block_size,
+        )
+    else:
+        q_fp8 = torch.zeros_like(q, dtype=cache.dtype)
+        torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_fp8_insert(
+            q,
+            kv,
+            q_fp8,
+            cache,
+            slots,
+            positions,
+            cos_sin,
+            attn._flashinfer_fp8_kv_scale,
+            attn._flashinfer_fp8_q_scale_inv,
+            1e-20,
+            block_size,
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tokens", type=int, nargs="+", default=[1, 8, 32, 128, 512, 2048]
+    )
+    parser.add_argument("--heads", type=int, default=16)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    torch.manual_seed(42)
+    results = []
+    for dtype in (torch.uint8, torch.bfloat16, torch.float8_e4m3fn):
+        for tokens in args.tokens:
+            block_size = 256
+            blocks = (tokens + block_size - 1) // block_size
+            cache = torch.zeros(
+                blocks,
+                block_size,
+                584 if dtype == torch.uint8 else 512,
+                device="cuda",
+                dtype=dtype,
+            )
+            kv = torch.randn(tokens, 512, device="cuda", dtype=torch.bfloat16)
+            positions = torch.arange(tokens, device="cuda")
+            slots = torch.arange(tokens, device="cuda")
+            angles = torch.randn(tokens, 32, device="cuda")
+            scale = torch.ones(1, device="cuda")
+            attn = SimpleNamespace(
+                swa_cache_layer=SimpleNamespace(kv_cache=cache, block_size=block_size),
+                head_dim=512,
+                n_local_heads=args.heads,
+                padded_heads=args.heads,
+                rotary_emb=SimpleNamespace(
+                    cos_sin_cache=torch.cat((angles.cos(), angles.sin()), -1)
+                ),
+                _flashinfer_fp8_kv_scale=scale,
+                _flashinfer_fp8_q_scale_inv=scale,
+            )
+            row = {"dtype": str(dtype), "tokens": tokens, "heads": args.heads}
+            for name, function in (
+                ("dummy_q", legacy_insert),
+                ("kv_only", _insert_context_kv),
+            ):
+                median, p10, p90 = triton.testing.do_bench(
+                    partial(function, attn, kv, positions, slots),
+                    warmup=50,
+                    rep=200,
+                    quantiles=[0.5, 0.1, 0.9],
+                )
+                row[name] = {
+                    "median_us": median * 1000,
+                    "p10_us": p10 * 1000,
+                    "p90_us": p90 * 1000,
+                }
+            row["speedup"] = row["dummy_q"]["median_us"] / row["kv_only"]["median_us"]
+            results.append(row)
+            print(json.dumps(row), flush=True)
+    args.output.write_text(
+        json.dumps({"gpu": torch.cuda.get_device_name(), "results": results}, indent=2)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/libtorch_stable/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu
+++ b/csrc/libtorch_stable/fused_deepseek_v4_qnorm_rope_kv_insert_kernel.cu
@@ -959,6 +959,86 @@ static void launchFullCacheKernel(
 // ────────────────────────────────────────────────────────────────────────────
 // Torch op wrapper
 // ────────────────────────────────────────────────────────────────────────────
+void fused_deepseek_v4_kv_rope_insert(
+    torch::stable::Tensor const& kv, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping,
+    torch::stable::Tensor const& position_ids,
+    torch::stable::Tensor const& cos_sin_cache, int64_t cache_block_size,
+    std::optional<torch::stable::Tensor> fp8_scale) {
+  using torch::headeronly::ScalarType;
+  STD_TORCH_CHECK(kv.device().is_cuda() && kv.is_contiguous() &&
+                      kv.dim() == 2 && kv.size(1) == 512 &&
+                      kv.scalar_type() == ScalarType::BFloat16,
+                  "kv must be contiguous CUDA bfloat16 [tokens, 512]");
+  auto const device = kv.get_device_index();
+  STD_TORCH_CHECK(k_cache.device().is_cuda() &&
+                      k_cache.get_device_index() == device &&
+                      k_cache.dim() == 3 && cache_block_size > 0 &&
+                      k_cache.size(1) == cache_block_size &&
+                      k_cache.stride(2) == 1,
+                  "k_cache must be a paged cache on the KV device");
+  for (auto const* tensor : {&slot_mapping, &position_ids}) {
+    STD_TORCH_CHECK(tensor->device().is_cuda() &&
+                        tensor->get_device_index() == device &&
+                        tensor->scalar_type() == ScalarType::Long &&
+                        tensor->dim() == 1 && tensor->is_contiguous(),
+                    "slots and positions must be contiguous int64 on the KV device");
+  }
+  STD_TORCH_CHECK(position_ids.size(0) == kv.size(0) &&
+                      slot_mapping.size(0) <= kv.size(0),
+                  "positions must match KV rows; slots may omit padded rows");
+  STD_TORCH_CHECK(cos_sin_cache.device().is_cuda() &&
+                      cos_sin_cache.get_device_index() == device &&
+                      cos_sin_cache.scalar_type() == ScalarType::Float &&
+                      cos_sin_cache.dim() == 2 &&
+                      cos_sin_cache.size(1) == 64 && cos_sin_cache.is_contiguous(),
+                  "cos_sin_cache must be contiguous float32 [max_pos, 64]");
+  bool const packed = k_cache.scalar_type() == ScalarType::Byte;
+  bool const fp8 = k_cache.scalar_type() == ScalarType::Float8_e4m3fn;
+  STD_TORCH_CHECK(packed || fp8 ||
+                      k_cache.scalar_type() == ScalarType::BFloat16,
+                  "cache must be uint8, bfloat16 or float8_e4m3fn");
+  STD_TORCH_CHECK(k_cache.size(2) == (packed ? 584 : 512),
+                  "cache row width does not match its dtype");
+  if (fp8) {
+    STD_TORCH_CHECK(fp8_scale.has_value() && fp8_scale->device().is_cuda() &&
+                        fp8_scale->get_device_index() == device &&
+                        fp8_scale->scalar_type() == ScalarType::Float &&
+                        fp8_scale->numel() == 1,
+                    "fp8 cache requires one float32 KV scale on the KV device");
+  }
+  int const num_tokens = static_cast<int>(slot_mapping.size(0));
+  if (num_tokens == 0) return;
+  const torch::stable::accelerator::DeviceGuard device_guard(device);
+  const cudaStream_t stream = get_current_cuda_stream(device);
+  using scalar_t = c10::BFloat16;
+  auto const* input = reinterpret_cast<scalar_t const*>(kv.const_data_ptr());
+  auto* cache = reinterpret_cast<uint8_t*>(k_cache.mutable_data_ptr());
+  auto const* slots = slot_mapping.const_data_ptr<int64_t>();
+  auto const* positions = position_ids.const_data_ptr<int64_t>();
+  auto const* cos_sin = cos_sin_cache.const_data_ptr<float>();
+  // Zero query heads schedules only the existing KV branch, preserving its
+  // RoPE rounding and quantization without allocating any query tensors.
+  if (packed) {
+    vllm::deepseek_v4_fused_ops::launchFusedDeepseekV4Templated<scalar_t, 0, false>(
+        nullptr, nullptr, input, cache, slots, positions, cos_sin, 0.0f,
+        num_tokens, num_tokens, 0, static_cast<int>(cache_block_size),
+        static_cast<int>(k_cache.stride(0)), stream);
+  } else if (fp8) {
+    vllm::deepseek_v4_fused_ops::launchFullCacheKernel<scalar_t, false, true>(
+        nullptr, nullptr, 0, 0, input, cache, slots, positions, cos_sin,
+        fp8_scale->const_data_ptr<float>(), nullptr, 0.0f, num_tokens, num_tokens,
+        0, static_cast<int>(cache_block_size), k_cache.stride(0),
+        k_cache.stride(1), false, "fused_deepseek_v4_kv_rope_insert", stream);
+  } else {
+    vllm::deepseek_v4_fused_ops::launchFullCacheKernel<scalar_t, false, false>(
+        nullptr, nullptr, 0, 0, input, cache, slots, positions, cos_sin, nullptr,
+        nullptr, 0.0f, num_tokens, num_tokens, 0, static_cast<int>(cache_block_size),
+        k_cache.stride(0) * 2, k_cache.stride(1) * 2, false,
+        "fused_deepseek_v4_kv_rope_insert", stream);
+  }
+}
+
 torch::stable::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
     torch::stable::Tensor const& q_in,           // [N, num_heads_q, 512] bf16
     torch::stable::Tensor const& kv,             // [N, 512] bf16 (read-only)

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -259,6 +259,13 @@ void fused_qk_norm_rope(torch::stable::Tensor& qkv, int64_t num_heads_q,
                         torch::stable::Tensor& position_ids,
                         int64_t forced_token_heads_per_warp);
 
+void fused_deepseek_v4_kv_rope_insert(
+    torch::stable::Tensor const& kv, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping,
+    torch::stable::Tensor const& position_ids,
+    torch::stable::Tensor const& cos_sin_cache, int64_t cache_block_size,
+    std::optional<torch::stable::Tensor> fp8_scale);
+
 torch::stable::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
     torch::stable::Tensor const& q_in, torch::stable::Tensor const& kv,
     torch::stable::Tensor& k_cache, torch::stable::Tensor const& slot_mapping,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -426,6 +426,11 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "int forced_token_heads_per_warp=-1) -> ()");
 
   ops.def(
+      "fused_deepseek_v4_kv_rope_insert("
+      "Tensor kv, Tensor! k_cache, Tensor slot_mapping, Tensor position_ids, "
+      "Tensor cos_sin_cache, int cache_block_size, Tensor? fp8_scale=None) -> "
+      "()");
+  ops.def(
       "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert("
       "Tensor q_in, Tensor kv, Tensor! k_cache, "
       "Tensor slot_mapping, Tensor position_ids, Tensor cos_sin_cache, "
@@ -807,6 +812,8 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   // Positional encoding kernels (shared CUDA/ROCm)
   ops.impl("rotary_embedding", TORCH_BOX(&rotary_embedding));
   ops.impl("fused_qk_norm_rope", TORCH_BOX(&fused_qk_norm_rope));
+  ops.impl("fused_deepseek_v4_kv_rope_insert",
+           TORCH_BOX(&fused_deepseek_v4_kv_rope_insert));
   ops.impl("fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert",
            TORCH_BOX(&fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert));
   ops.impl(

--- a/tests/kernels/test_compressor_kv_cache.py
+++ b/tests/kernels/test_compressor_kv_cache.py
@@ -42,6 +42,110 @@ from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
 from .test_fused_indexer_q_rope_quant import quantize_to_mxfp4
 
 
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA only")
+@pytest.mark.parametrize(
+    "cache_dtype", [torch.uint8, torch.bfloat16, torch.float8_e4m3fn]
+)
+@pytest.mark.parametrize("num_tokens", [1, 17, 1023, 1024])
+@pytest.mark.parametrize("use_graph", [False, True])
+def test_dspark_context_kv_matches_query_insert(cache_dtype, num_tokens, use_graph):
+    """KV-only insertion must preserve every cache byte, including graph replay."""
+    from vllm.models.deepseek_v4_1.nvidia.dspark import _insert_context_kv
+
+    torch.manual_seed(42)
+    block_size = 256
+    num_blocks = math.ceil((num_tokens + 7) / block_size)
+    row_size = 584 if cache_dtype == torch.uint8 else 512
+    page_stride = math.ceil(block_size * row_size / 576) * 576 + 576
+    backing = torch.full((num_blocks, page_stride), 3, device="cuda").to(cache_dtype)
+    cache = backing.as_strided(
+        (num_blocks, block_size, row_size), (page_stride, row_size, 1)
+    )
+    reference_backing = backing.clone()
+    reference = reference_backing.as_strided(cache.shape, cache.stride())
+    kv = torch.randn(num_tokens + 3, 512, device="cuda", dtype=torch.bfloat16)
+    positions = torch.arange(num_tokens + 3, device="cuda") + 7
+    angles = torch.randn(num_tokens + 16, 32, device="cuda")
+    cos_sin = torch.cat((angles.cos(), angles.sin()), dim=-1)
+    slots = torch.randperm(num_blocks * block_size, device="cuda")[:num_tokens]
+    slots[::5] = -1
+    scale = torch.tensor([0.7], device="cuda")
+    attn = SimpleNamespace(
+        swa_cache_layer=SimpleNamespace(kv_cache=cache, block_size=block_size),
+        head_dim=512,
+        rotary_emb=SimpleNamespace(cos_sin_cache=cos_sin),
+        _flashinfer_fp8_kv_scale=scale,
+    )
+
+    def legacy_insert():
+        q = torch.zeros(kv.shape[0], 8, 512, dtype=kv.dtype, device="cuda")
+        if cache_dtype == torch.uint8:
+            torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
+                q,
+                kv,
+                reference.view(num_blocks, -1),
+                slots,
+                positions,
+                cos_sin,
+                8,
+                1e-20,
+                block_size,
+            )
+        elif cache_dtype == torch.bfloat16:
+            torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_bf16_insert(
+                q,
+                kv,
+                reference,
+                slots,
+                positions,
+                cos_sin,
+                1e-20,
+                block_size,
+            )
+        else:
+            q_fp8 = torch.empty_like(q, dtype=cache_dtype)
+            torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_fp8_insert(
+                q,
+                kv,
+                q_fp8,
+                reference,
+                slots,
+                positions,
+                cos_sin,
+                scale,
+                scale,
+                1e-20,
+                block_size,
+            )
+
+    def insert():
+        _insert_context_kv(attn, kv, positions, slots)
+
+    insert()
+    graph = None
+    if use_graph:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            insert()
+    for iteration in range(3):
+        kv.normal_()
+        positions.add_(1)
+        if iteration == 2:
+            slots.fill_(-1)
+        backing.view(torch.uint8).fill_(165)
+        reference_backing.copy_(backing)
+        before = kv.clone()
+        legacy_insert()
+        insert() if graph is None else graph.replay()
+        torch.testing.assert_close(
+            backing.view(torch.uint8),
+            reference_backing.view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(kv, before, rtol=0, atol=0)
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda_alike(), reason="graph capture coverage"
 )

--- a/vllm/models/deepseek_v4_1/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4_1/nvidia/dspark.py
@@ -235,65 +235,19 @@ def _insert_context_kv(
     positions: torch.Tensor,
     slot_mapping: torch.Tensor,
 ) -> None:
-    """RoPE + quant + paged-cache insert of (already kv_norm'd) context KV.
-
-    Reuses the DSV4 fused insert ops (which also process a query; we pass a dummy
-    query and discard it, since context tokens have no query). Mirrors
-    ``DeepseekV4Attention._fused_qnorm_rope_kv_insert``.
-    """
-    swa_cache = attn.swa_cache_layer.kv_cache
+    """Insert normalized context KV without constructing an unused query."""
+    cache = attn.swa_cache_layer.kv_cache
     block_size = attn.swa_cache_layer.block_size
-    cos_sin_cache = attn.rotary_emb.cos_sin_cache
-    cache_dtype = swa_cache.dtype
-    n_ctx = kv.shape[0]
-    dummy_q = torch.zeros(
-        (n_ctx, attn.n_local_heads, attn.head_dim),
-        dtype=kv.dtype,
-        device=kv.device,
+    row_size = 584 if cache.dtype == torch.uint8 else attn.head_dim
+    torch.ops._C.fused_deepseek_v4_kv_rope_insert(
+        kv,
+        cache.view(-1, block_size, row_size),
+        slot_mapping,
+        positions,
+        attn.rotary_emb.cos_sin_cache,
+        block_size,
+        attn._flashinfer_fp8_kv_scale if cache.dtype == torch.float8_e4m3fn else None,
     )
-    if cache_dtype == torch.uint8:
-        # fp8_ds_mla UE8M0 paged layout
-        swa_2d = swa_cache.view(swa_cache.shape[0], -1)
-        torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
-            dummy_q,
-            kv,
-            swa_2d,
-            slot_mapping,
-            positions,
-            cos_sin_cache,
-            attn.padded_heads,
-            attn.eps,
-            block_size,
-        )
-    elif cache_dtype == torch.bfloat16:
-        swa_3d = swa_cache.view(-1, block_size, attn.head_dim)
-        torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_bf16_insert(
-            dummy_q,
-            kv,
-            swa_3d,
-            slot_mapping,
-            positions,
-            cos_sin_cache,
-            attn.eps,
-            block_size,
-        )
-    else:  # per-tensor fp8 (torch.float8_e4m3fn)
-        # TODO(ben): double-check if this is being dispatched correctly for FI backend
-        swa_3d = swa_cache.view(-1, block_size, attn.head_dim)
-        dummy_q_fp8 = torch.zeros_like(dummy_q, dtype=torch.float8_e4m3fn)
-        torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_fp8_insert(
-            dummy_q,
-            kv,
-            dummy_q_fp8,
-            swa_3d,
-            slot_mapping,
-            positions,
-            cos_sin_cache,
-            attn._flashinfer_fp8_kv_scale,
-            attn._flashinfer_fp8_q_scale_inv,
-            attn.eps,
-            block_size,
-        )
 
 
 class DSparkDeepseekV4ForCausalLM(nn.Module):


### PR DESCRIPTION
## Purpose

Replace the DeepSeek-V4.1 DSpark context insertion call's unused query allocation and query work with a KV-only wrapper. Dispatch the existing CUDA KV math with zero query heads for packed uint8 `fp8_ds_mla`, BF16 and ordinary FP8 e4m3fn caches. Keep projection, `kv_norm`, scheduling and acceptance logic unchanged. Validate device/dtype/layout inputs and preserve padded page strides.

**Related work was found:** #55654 adds uint8 KV-only insertion, fused `kv_norm` and projection changes for V4. There is overlap in the uint8 insertion goal. This PR differs materially by reusing the existing zero-query-head kernel paths across all three cache formats, including BF16/ordinary FP8 paths that #55654 retains as dummy-query fallbacks, and by changing only V4.1 insertion. It does not add another fused norm or projection implementation. The overlapping uint8 API should be consolidated if both approaches proceed. #54674's stacked projections are also a separate operation.

Based on #56214 (`dsv41-feat`, `c9d909e802a39292f54101bff8a36096761ea605`). The PR targets that feature branch so the model implementation is not repeated in this diff.

Rebased on 2026-09-11 after the feature branch was rewritten. Changed-file Python parsing and all applicable pre-commit hooks passed. GPU/full-model measurements below belong to the prior revision based on `e47aa780bccf59f59dfa2cbb18e17a10b4fe69ba`; they were not rerun on this rebased head.

AI assistance: OpenAI Codex assisted with implementation, review, test execution and preparation of this PR. This draft does not claim that a human has completed a line-by-line review.

## Test Plan

All six files in the isolated branch match the previously tested standalone DSpark source snapshot; the applicable pre-commit hooks and Python parsing were rerun and passed.

The prior H100 run compiled the affected CUDA source and passed **24 CUDA correctness cases** (three formats × four token counts × eager/graph), including page strides, padded/negative slots, repeated graph replay and unchanged input KV:

```text
.venv/bin/python -m pytest tests/kernels/test_compressor_kv_cache.py \
  -k test_dspark_context_kv_matches_query_insert
.venv/bin/python benchmarks/kernels/benchmark_dspark_context_kv.py \
  --tokens 512 2048 --heads 16 --output dspark-context-kv.json
```

No new CUDA compilation or GPU execution was performed during PR preparation.

## Test Result

Official `deepseek-ai/DeepSeek-V4.1-Flash`, revision `df42c109f1defefcbfcedbe7d905718a12266e40`, 4×H100, TP4+EP, V2 runner, eager, CPU offload 8 GiB, five speculative tokens. A used the unchanged dummy-query insertion; B used this KV-only entry point. Other model/runtime settings were held the same. The isolated source matches the previously tested standalone DSpark snapshot; preparation reran static checks, not CUDA compilation or GPU execution.

**Full-model and native CUDA validation**

| Check | Observed result | Interpretation |
| --- | --- | --- |
| Native CUDA cache correctness | 24/24 PASS | 3 formats × 4 token counts × eager/graph; byte-exact cache output |
| Cache comparison inside real model workers | 48/48 byte-exact (4 workers × 12 insertions) | Compared affected full cache pages, including unwritten rows |
| Six short questions | 6/6 expected answers on both sides; 5/6 text-identical | One sequence-answer wording difference; strict output_mismatch remains |
| Four concurrent 96-token continuations | 4/4 text-identical | Limited serving output check, not a standard accuracy benchmark |
| Serving load completion | 16/16 requests for each of 4 A/B × input-length runs | Concurrency 4, inputs 512/2048, output 128; no end-to-end speedup established |
| Fresh applicable pre-commit hooks and Python parsing | PASS; 6 changed files | Isolated source matches the prior standalone CUDA-tested snapshot |

**Insertion-only microbenchmark — H100, 16 local query heads**

| Cache format | Tokens | Dummy-query μs | KV-only μs | Local speedup |
| --- | --- | --- | --- | --- |
| uint8 / fp8_ds_mla | 512 | 21.344 | 7.360 | 2.90× |
| BF16 | 512 | 14.240 | 7.296 | 1.95× |
| FP8 e4m3fn | 512 | 16.032 | 7.392 | 2.17× |
| uint8 / fp8_ds_mla | 2048 | 43.936 | 10.624 | 4.14× |
| BF16 | 2048 | 36.384 | 8.416 | 4.32× |
| FP8 e4m3fn | 2048 | 47.264 | 7.968 | 5.93× |

These fixed-shape measurements isolate insertion. The single-run serving A/B did not establish an end-to-end speedup; the local ratios must not be extrapolated to whole-model throughput. No measured GPU-memory reduction is claimed. Kept Draft pending review of the related insertion work and full-model output equivalence.

---
<details>
<summary>PR description checklist</summary>

- [x] Purpose and related work described.
- [x] Test plan and actual results stated.
- [x] Model evaluation limitations stated.
- [x] AI assistance disclosed.

</details>
