### PR TITLE
[Perf][Spec Decode] Optimize draft_token_ids assembly in NgramProposer from O(N^2) to O(N)

### DIFF
--- a/vllm/v1/spec_decode/ngram_proposer.py
+++ b/vllm/v1/spec_decode/ngram_proposer.py
@@ -88,7 +88,7 @@ class NgramProposer:
                 A list where each element is a list of proposed
                 token IDs for the corresponding request.
         """
-        draft_token_ids: list[list[int]] = []
+        draft_token_ids: list[list[int]] = [[] for _ in range(num_requests)]
 
         # Only run batch propose if there are requests needing ngram proposals.
         # avoid calling numba function with empty list which causes error
@@ -122,13 +122,10 @@ class NgramProposer:
             # Restore original number of threads.
             set_num_threads(original_num_numba_threads)
 
-        for i in range(num_requests):
-            if i in valid_ngram_requests and self.valid_ngram_num_drafts[i] > 0:
-                draft_token_ids.append(
-                    self.valid_ngram_draft[i, : self.valid_ngram_num_drafts[i]].tolist()
-                )
-            else:
-                draft_token_ids.append([])
+        for i in valid_ngram_requests:
+            num_drafts = self.valid_ngram_num_drafts[i]
+            if num_drafts > 0:
+                draft_token_ids[i] = self.valid_ngram_draft[i, :num_drafts].tolist()
 
         return draft_token_ids
 


### PR DESCRIPTION
## Purpose
In `NgramProposer.batch_propose()`, `valid_ngram_requests` is a `list[int]`. The previous implementation iterated through `range(num_requests)` and performed `if i in valid_ngram_requests`, which executes an $O(N)$ linear scan for each request index in pure Python. For large batch sizes (e.g., $N=512$), this executes up to $O(N^2)$ (~130,000) membership comparisons during every drafting step.

This PR optimizes the result assembly to $O(N)$ by:
1. Pre-allocating `draft_token_ids = [[] for _ in range(num_requests)]`.
2. Iterating directly through `valid_ngram_requests` and populating `draft_token_ids[i]` by index.

Thread capping logic is left unchanged.

## Duplicate Work Check
Checked open issues and PRs on `vllm-project/vllm` for `ngram_proposer` and `valid_ngram_requests`; no duplicate PRs or issues exist.

## Test Plan
Ran unit tests for N-gram speculative decoding:
```bash
VLLM_TARGET_DEVICE=cpu pytest tests/v1/spec_decode/test_ngram.py -v
```

## Test Result
```text
============================= test session starts ==============================
platform darwin -- Python 3.12.14, pytest-9.1.1, pluggy-1.6.0
collected 2 items

tests/v1/spec_decode/test_ngram.py::test_find_longest_matched_ngram_and_propose_tokens PASSED [ 50%]
tests/v1/spec_decode/test_ngram.py::test_ngram_proposer PASSED           [100%]

======================== 2 passed, 6 warnings in 2.80s =========================
```

All `ruff check` and `ruff format` checks pass cleanly.

## Attribution
AI assistance was used to analyze complexity and prepare the patch.

