### PR TITLE
[Tokenizer] Drop dead Mistral tokenizer shims for transformers#41962

### DIFF
--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -354,22 +354,13 @@ class MistralTokenizer(TokenizerLike):
                 "`text_pair` is not supported by `MistralTokenizer.__call__`."
             )
 
-        encoded = self.transformers_tokenizer(
+        return self.transformers_tokenizer(
             text=text,
             text_pair=text_pair,
             add_special_tokens=add_special_tokens,
             truncation=truncation,
             max_length=max_length,
         )
-        # TODO(juliendenize): once https://github.com/huggingface/transformers/pull/41962
-        # is in, revert to only call self.transformers_tokenizer(...).
-        # Hack to fix wrongly added eos token, when fix will be supported the condition
-        # below will be False even before the revert is done.
-        if encoded["input_ids"] and encoded["input_ids"][-1] == self.eos_token_id:
-            encoded["input_ids"].pop(-1)
-            if attention_mask := encoded.get("attention_mask"):
-                attention_mask.pop(-1)
-        return encoded
 
     @property
     def vocab(self) -> list[str]:
@@ -389,8 +380,10 @@ class MistralTokenizer(TokenizerLike):
         max_length: int | None = None,
         add_special_tokens: bool = True,
     ) -> list[int]:
-        # TODO(juliendenize): once https://github.com/huggingface/transformers/pull/41962
-        # is in, directly call self.transformers_tokenizer.encode(...).
+        # NOTE: transformers guards truncation with `if max_length and ...`, so
+        # `max_length=0` returns the full sequence instead of an empty one. vLLM
+        # treats `truncate_prompt_tokens=0` as an empty prompt, so keep slicing
+        # here until that is fixed upstream.
         encoded = self.tokenizer.encode(text, bos=add_special_tokens, eos=False)
 
         if truncation is not False and max_length is not None:
@@ -437,11 +430,6 @@ class MistralTokenizer(TokenizerLike):
     def decode(
         self, ids: Sequence[int] | int, skip_special_tokens: bool = False
     ) -> str:
-        # TODO(juliendenize): once https://github.com/huggingface/transformers/pull/41962
-        # is in, directly call self.transformers_tokenizer.decode(...).
-        if isinstance(ids, int):
-            ids = [ids]
-
         return self.transformers_tokenizer.decode(
             ids, skip_special_tokens=skip_special_tokens
         )


### PR DESCRIPTION
## Purpose

Three `TODO(juliendenize)` workarounds in `MistralTokenizer` were waiting on [huggingface/transformers#41962](https://github.com/huggingface/transformers/pull/41962). That shipped in `v5.0.0`, and we now require `transformers >= 5.10.4`, so I checked whether they can go.

Two of them can:

- `__call__` popped a wrongly added eos token. We pin the backend to `ValidationMode.test`, and in that mode `build_inputs_with_special_tokens` returns `[BOS] seq0`. There is no eos to pop.
- `decode` wrapped a bare `int` in a list. `MistralCommonBackend._decode` already does that.

The third one could not be removed. 

- `transformers` writes `if max_length and ...` in `prepare_for_model`, so `max_length=0` skips truncation and you get the whole sequence back. 
- vLLM expects an empty prompt there: `truncate_prompt_tokens=0` is valid (`ge=-1`), `get_encode_kwargs` turns it into `encode(truncation=True, max_length=0)`, and `test_zero_truncation` asserts the result is empty. 
- GPT-2 returns `[]` for the same call. I swapped the TODO for a NOTE explaining this. Can file it upstream if that seems worth doing.

No behaviour change as such.

### Notes

**@juliendenize**: tagging you based on our discussion on Slack. The `encode` part needs your review especially.

**Duplicate check**: searched open PRs for `41962 in:body`, `mistral tokenizer TODO`, `juliendenize tokenizer shim`. Nothing open.

**AI assistance**: Claude Code traced the backend paths. I reviewed every line and ran the commands below.

**Model evaluation**: NA. tokenizer output is unchanged.

**Pre-existing failures**: `tests/v1/structured_output/test_mistral_common_tokenizer.py` fails 6 tests for me, but the same 6 fail on unmodified `main`. This is unrelated to the PR, but I still wanted to flag. 

## Test Plan

```bash
.venv/bin/python -m pytest -q tests/tokenizers_/test_mistral.py \
    tests/renderers/test_mistral.py tests/renderers/test_completions.py
ruff format --diff vllm/tokenizers/mistral.py
ruff check vllm/tokenizers/mistral.py
```

## Test Result

```
92 passed, 2 skipped, 15 warnings in 23.72s
1 file already formatted
All checks passed!
```

Skips are `test_apply_chat_template_reasoning_assistant`, tekken only. Warnings are a missing `vllm._version` in my editable checkout plus `torch.jit.script_method` deprecations, both present on `main`.
