### PR TITLE
[ROCm] Fuse AR + RMSNorm + Per-token Quant for DeepSeek R1

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1010,6 +1010,43 @@ def _rocm_aiter_fused_allreduce_rmsnorm_fake(
     return torch.empty_like(input_), torch.empty_like(residual)
 
 
+def _rocm_aiter_fused_allreduce_rmsnorm_quant_per_token_impl(
+    input_: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused AllReduce + add-RMSNorm + per-token FP8 quant."""
+    aiter_ar = rocm_aiter_ops.get_aiter_allreduce()
+    assert aiter_ar is not None, "aiter allreduce must be initialized"
+    ca = aiter_ar.aiter_ca
+    use_1stage = aiter_ar.use_1stage_fused_ar_rms(input_)
+
+    result = ca.custom_fused_ar_rms_quant(
+        input_,
+        residual,
+        weight,
+        epsilon,
+        use_1stage=use_1stage,
+    )
+    assert result is not None
+    return result[0], result[1], result[2]
+
+
+def _rocm_aiter_fused_allreduce_rmsnorm_quant_per_token_fake(
+    input_: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    quant_out = torch.empty(input_.shape, dtype=FP8_DTYPE, device=input_.device)
+    residual_out = torch.empty_like(residual)
+    scale_out = torch.empty(
+        input_.shape[:-1] + (1,), dtype=torch.float32, device=input_.device
+    )
+    return quant_out, residual_out, scale_out
+
+
 def _rocm_aiter_fused_allreduce_rmsnorm_quant_per_group_impl(
     input_: torch.Tensor,
     residual: torch.Tensor,
@@ -2354,6 +2391,12 @@ class rocm_aiter_ops:
             )
 
             direct_register_custom_op(
+                op_name="rocm_aiter_fused_allreduce_rmsnorm_quant_per_token",
+                op_func=_rocm_aiter_fused_allreduce_rmsnorm_quant_per_token_impl,
+                fake_impl=_rocm_aiter_fused_allreduce_rmsnorm_quant_per_token_fake,
+            )
+
+            direct_register_custom_op(
                 op_name="rocm_aiter_fused_allreduce_rmsnorm_quant_per_group",
                 op_func=(_rocm_aiter_fused_allreduce_rmsnorm_quant_per_group_impl),
                 fake_impl=(_rocm_aiter_fused_allreduce_rmsnorm_quant_per_group_fake),
@@ -2432,6 +2475,10 @@ class rocm_aiter_ops:
     @staticmethod
     def get_fused_allreduce_rmsnorm_op() -> OpOverload:
         return torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm.default
+
+    @staticmethod
+    def get_fused_allreduce_rmsnorm_quant_per_token_op() -> OpOverload:
+        return torch.ops.vllm.rocm_aiter_fused_allreduce_rmsnorm_quant_per_token.default
 
     @staticmethod
     def get_fused_allreduce_rmsnorm_quant_per_group_op() -> OpOverload:

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1545,6 +1545,80 @@ class AiterAllreduceFusedAddRMSNormGroupQuantWithIndexerPattern(
         return _replacement
 
 
+class AiterAllreduceFusedAddRMSNormPerTokenQuantFP8Pattern(
+    BasePattern, VllmPatternReplacement
+):
+    """Fuse AllReduce + RMSNorm (fused_add) + per-token FP8 quant into 
+    a single AITER custom op.
+
+    Targets ``all_reduce -> fused_add_rms_norm -> per_token_fp8_quant``: the
+    MoE/MLP output all-reduce feeding the next layer's ``input_layernorm`` when
+    the attention projections use dynamic per-token FP8 activations.
+
+    Lowers to ``rocm_aiter_fused_allreduce_rmsnorm_quant_per_token``.
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        dtype: torch.dtype,
+        device: str | None,
+    ) -> None:
+        super().__init__(dtype, device)
+        self.epsilon = epsilon
+        self.dtype = dtype
+        self.FUSED_AR_RMS_QUANT_OP = (
+            rocm_aiter_ops.get_fused_allreduce_rmsnorm_quant_per_token_op()
+        )
+        self.quant_dtype = current_platform.fp8_dtype()
+        self.quant_matcher = MatcherQuantFP8(
+            QuantKey(
+                dtype=self.quant_dtype,
+                scale=ScaleDesc(torch.float32, False, GroupShape.PER_TOKEN),
+                symmetric=True,
+            ),
+            match_rocm_aiter=True,
+        )
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        # residual, input, weight
+        return [self.empty(5, 16), self.empty(5, 16), self.empty(16)]
+
+    @property
+    def pattern(self):
+        def _pattern(
+            residual: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            allreduce_output = tensor_model_parallel_all_reduce(input)
+            rms, residual_out = vllm.ir.ops.fused_add_rms_norm(
+                allreduce_output, residual, weight, self.epsilon
+            )
+            quant, scale = self.quant_matcher(rms)
+            return quant, scale, residual_out
+
+        return _pattern
+
+    @property
+    def replacement(self):
+        def _replacement(
+            residual: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            result = self.FUSED_AR_RMS_QUANT_OP(
+                input_=input,
+                residual=residual,
+                weight=weight.to(input.dtype),
+                epsilon=self.epsilon,
+            )
+            # quant_out, scale_out, residual_out
+            return result[0], result[2], result[1]
+
+        return _replacement
+
+
 class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
     def __init__(self, config: VllmConfig) -> None:
         super().__init__(config, "rocm_aiter_allreduce_fusion_pass")
@@ -1608,6 +1682,19 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
                 "FP8 quant fusion."
             )
 
+        pack_size = 16 // element_size
+        supports_per_token_quant = (
+            hidden_dim % (32 * pack_size) == 0 and hidden_dim // pack_size <= 1024
+        )
+        if not supports_per_token_quant:
+            logger.warning_once(
+                "AITER AR+RMS+per-token-FP8-quant fusion disabled: hidden_dim=%d "
+                "must be a multiple of %d and at most %d.",
+                hidden_dim,
+                32 * pack_size,
+                1024 * pack_size,
+            )
+
         for epsilon in [1e-5, 1e-6]:
             # Quant-fused variants must register first so the pattern matcher
             # tries them before the AR+RMS-only variants. Otherwise the
@@ -1632,6 +1719,14 @@ class RocmAiterAllReduceFusionPass(VllmFusionPatternMatcherPass):
                 )
                 self.register(
                     AiterAllreduceFusedAddRMSNormGroupQuantFP8Pattern(
+                        epsilon,
+                        self.model_dtype,
+                        self.device,
+                    )
+                )
+            if supports_per_token_quant:
+                self.register(
+                    AiterAllreduceFusedAddRMSNormPerTokenQuantFP8Pattern(
                         epsilon,
                         self.model_dtype,
                         self.device,


### PR DESCRIPTION


## Purpose

Fuse all reduce with fused add RMSNorm with per-token quant, which are all KLL-bound. ATOM already does this optimization.

## Test Plan

### Accuracy

```bash
lm_eval \
  --model local-completions \
  --model_args "model=/shareddata/amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4,base_url=http://localhost:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False,tokenizer_backend=None,trust_remote_code=True" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --seed 42
```

### Traces

Server:

```bash
#!/bin/bash

MODEL_PATH="${1:-/shareddata/amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4}"
TRACE_DIR="${TRACE_DIR:-${HOME}/traces}"

export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1

export ROCPROFILER_QUEUE_INTERPOSITION=0

USE_INDUCTOR_GRAPH_PARTITION="-cc.use_inductor_graph_partition=True"
FUSE_ROPE_KVCACHE="-cc.pass_config.fuse_rope_kvcache_cat_mla=True"

mkdir -p $TRACE_DIR
rm -rf ${HOME}/.cache/vllm /tmp/torchinductor*
vllm serve $MODEL_PATH \
  --tensor-parallel-size 8 \
  --gpu-memory-utilization 0.9 \
  --dtype auto \
  --kv-cache-dtype fp8 \
  --max-num-batched-tokens 8192 \
  --no-enable-prefix-caching \
  --disable-uvicorn-access-log \
  --max-model-len 32768 \
  --max-num-seqs 512 \
  --trust-remote-code \
  --profiler-config "{\"profiler\": \"torch\", \"torch_profiler_dir\": \"${TRACE_DIR}\", \"torch_profiler_with_stack\": false, \"torch_profiler_record_shapes\": true}" \
  $USE_INDUCTOR_GRAPH_PARTITION \
  $FUSE_ROPE_KVCACHE
```

Client:

```bash
#!/bin/bash

##################### need changed #######################
MODEL_PATH="${1:-/shareddata/amd/DeepSeek-R1-0528-MXFP4-MTP-MoEFP4}"
TRACE_DIR="${TRACE_DIR:-${HOME}/traces}"
ISL_LIST=(1024)
CONC_LIST=(64)
OSL=64
PORT=8000
##########################################################

LOG_FILE="result_profile.txt"
if [ -f "$LOG_FILE" ]; then
    rm "$LOG_FILE"
fi

curl -sf "http://localhost:$PORT/health" > /dev/null || {
    echo "ERROR: Server not running on port $PORT"
    exit 1
}

for ISL in "${ISL_LIST[@]}"; do
    for CONC in "${CONC_LIST[@]}"; do
        echo "=========================================" | tee -a "$LOG_FILE"
        echo "Start Test ISL=$ISL, OSL=$OSL, CONC=$CONC" | tee -a "$LOG_FILE"
        echo "=========================================" | tee -a "$LOG_FILE"
        vllm bench serve \
            --model="$MODEL_PATH" \
            --backend=vllm \
            --trust-remote-code \
            --base-url="http://localhost:$PORT" \
            --dataset-name=random \
            --random-input-len="$ISL" \
            --random-output-len="$OSL" \
            --num-prompts="$CONC" \
            --max-concurrency="$CONC" \
            --request-rate=inf \
            --ignore-eos \
            --temperature=0 \
            --profile \
            --percentile-metrics="ttft,tpot,itl,e2el"  2>&1 | tee -a "$LOG_FILE"
        echo -e "\n" | tee -a "$LOG_FILE"
    done
done

ls -lh "${TRACE_DIR}"
```

## Test Result

### Accuracy

Before:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9416|±  |0.0065|
|     |       |strict-match    |     5|exact_match|↑  |0.9401|±  |0.0065|

After:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9500|±  |0.0060|
|     |       |strict-match    |     5|exact_match|↑  |0.9454|±  |0.0063|

### Traces

Before (4.839us + 4.64us):

<img width="1449" height="588" alt="image" src="https://github.com/user-attachments/assets/80f45a1f-50a0-4c22-96b1-dcffe8ad13b0" />

After (5.639us):

<img width="1450" height="591" alt="image" src="https://github.com/user-attachments/assets/af56c340-316a-4aa2-ad59-aa0b64ded28c" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

