### PR TITLE
[Bugfix][KV Offload] Include startup model configuration in cache identity

### DIFF
--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -121,6 +121,18 @@ The filesystem and object-store tiers can publish hash-only `BlockStored` KV eve
 
 Set the optional `locality` tier field to `LOCAL` or `REMOTE` to describe the tier's storage location relative to the publishing vLLM instance. `LOCAL` marks storage local to that instance, while `REMOTE` marks storage that is not local to it. When the setting is omitted, locality is unspecified. vLLM does not infer it from the tier type, so an `obj` tier is not implicitly `REMOTE`. A KV event includes `locality` only when the tier explicitly configures it. This metadata describes the tier property without implying that a consumer can already route requests to its blocks.
 
+### Model Configuration and Cache Reuse
+
+The filesystem, object-store and P2P tiers include a model configuration fingerprint when identifying compatible KV blocks. It captures the Hugging Face text configuration, model computation dtype and construction-time `max_model_len` before loading the model. The metadata fields `_commit_hash`, `_name_or_path` and `transformers_version` are excluded.
+
+Changing RoPE settings can change the cached keys even with identical weights and token IDs. Such changes use a separate filesystem directory or object-key namespace. The same configuration can reuse its namespace across restarts. This separation also applies to canonical cache layouts: rearranging the stored tensors does not make different positional encodings compatible.
+
+The fingerprint conservatively includes the full text configuration. Changes to output-related HF fields, or to `max_model_len` when it only acts as a limit for a particular model, can therefore cause extra cache misses. Keep these settings consistent across instances intended to share cached prefixes. The fingerprint identifies configuration; it does not verify weight contents or every runtime quantization or kernel choice.
+
+When upgrading from a version without this fingerprint, filesystem and object-store tiers start with a cold namespace. Existing files and objects remain intact and are not read as a fallback. Plan for the initial prefill and storage cost while the new namespace fills.
+
+P2P uses the same configuration in its handshake fingerprint. When both peers advertise nonempty fingerprints, a mismatch is rejected, including between old and new versions with different fingerprint fields. During a rolling upgrade, route transfers between peers with matching fingerprints. The existing compatibility behavior still accepts an absent peer fingerprint, so this change does not guarantee isolation from every legacy or custom peer.
+
 ### Filesystem (FS)
 
 The filesystem tier (`type: "fs"`) writes blocks to a filesystem directory.
@@ -138,7 +150,7 @@ Each thread group prefers its own queue but pulls from the other when its primar
 
 #### On-Disk Layout
 
-Under `root_dir`, vLLM creates a subdirectory `<model>_<digest>`, where `<model>` is the model name with `/` replaced by `_` (so HuggingFace IDs like `meta-llama/Llama-3-8B` don't nest), and `<digest>` is a short SHA256 prefix derived from the run configuration (model, block size, parallelism, dtype, etc.). Runs with the same configuration share the same subdirectory; runs with different configurations live side-by-side under the same `root_dir` without colliding.
+Under `root_dir`, vLLM creates a subdirectory `<model>_<digest>`, where `<model>` is the model name with `/` replaced by `_` (so HuggingFace IDs like `meta-llama/Llama-3-8B` don't nest), and `<digest>` is a short SHA256 prefix derived from the run configuration (model, block size, parallelism, dtype, [model configuration fingerprint](#model-configuration-and-cache-reuse), etc.). Runs with the same configuration share the same subdirectory; runs with different configurations live side-by-side under the same `root_dir` without colliding.
 
 Inside that subdirectory, blocks are sharded across hash-prefix subdirectories to limit directory fan-out:
 
@@ -156,7 +168,7 @@ Inside that subdirectory, blocks are sharded across hash-prefix subdirectories t
 
 #### Cross-Process Sharing
 
-KV cache sharing between multiple vLLM instances using the same `root_dir` (e.g., via a shared PVC) works by default: `NONE_HASH` (the chain-hash seed for block content hashes) is derived from a fixed default seed, so identical token content produces identical block filenames across instances. To use a custom shared seed instead, set the `PYTHONHASHSEED` environment variable to the same value on every instance.
+KV cache sharing between multiple vLLM instances using the same cache namespace under `root_dir` (e.g., via a shared PVC) works by default: `NONE_HASH` (the chain-hash seed for block content hashes) is derived from a fixed default seed, so identical token content produces identical block filenames across instances. See [Model Configuration and Cache Reuse](#model-configuration-and-cache-reuse) for namespace compatibility. To use a custom shared seed instead, set the `PYTHONHASHSEED` environment variable to the same value on every instance.
 
 The exception is the non-cryptographic `xxhash` and `xxhash_cbor` values of `--prefix-caching-hash-algo`, which seed `NONE_HASH` randomly per process so the seed stays unpredictable. Sharing a cache across instances with those algorithms requires setting the same `PYTHONHASHSEED` on every instance.
 
@@ -167,6 +179,8 @@ PYTHONHASHSEED=<shared-value> vllm serve ...
 ### Object Store (OBJ)
 
 The object-store tier (`type: "obj"`) offloads blocks to an S3-compatible object store through the NIXL OBJ backend.
+
+The [model configuration and migration rules](#model-configuration-and-cache-reuse) also apply to object-key namespaces within the configured bucket and prefix.
 
 | Key | Required | Default | Notes |
 | --- | --- | --- | --- |
@@ -188,11 +202,13 @@ The object-store tier (`type: "obj"`) offloads blocks to an S3-compatible object
 | `region` | no | `""` | Bucket region, if the endpoint requires one. |
 | `ca_bundle` | no | `""` | CA bundle path for TLS verification. |
 
-Object keys follow the same run-configuration digest scheme as the filesystem tier (see [On-Disk Layout](#on-disk-layout)) and are stored under the optional `prefix`. The [Cross-Process Sharing](#cross-process-sharing) behavior applies to shared buckets as well, so instances sharing a bucket produce identical keys for identical content; set a shared `PYTHONHASHSEED` if you want a custom seed. At startup the tier probes object store connectivity and fails fast with a configuration error if the bucket is unreachable.
+Object keys follow the same run-configuration digest scheme as the filesystem tier (see [On-Disk Layout](#on-disk-layout)) and are stored under the optional `prefix`. The [Cross-Process Sharing](#cross-process-sharing) behavior applies to shared buckets as well, so instances sharing a bucket, prefix and cache namespace produce identical keys for identical content; set a shared `PYTHONHASHSEED` if you want a custom seed. At startup the tier probes object store connectivity and fails fast with a configuration error if the bucket is unreachable.
 
 ### P2P (Including P/D)
 
 The P2P tier (`type: "p2p"`) shares completed KV blocks between vLLM instances over RDMA via NIXL. Each instance binds a control socket on `host:port` and exchanges blocks directly with peers — no shared filesystem required.
+
+Peers must satisfy the [configuration fingerprint compatibility rules](#model-configuration-and-cache-reuse), including the rolling-upgrade limitations, as well as the block-hash seed check below.
 
 Block content hashes must match across instances for peers to exchange blocks (see [Cross-Process Sharing](#cross-process-sharing)). This works by default via the deterministic `NONE_HASH` seed, so setting `PYTHONHASHSEED` is optional. If you do set it, it must be the same value on all nodes. Each peer's effective seed is verified during the connect handshake — a peer advertising a different seed is rejected. With the `xxhash`/`xxhash_cbor` algorithms the seed is random per process, so `PYTHONHASHSEED` must be set on every peer or the handshake rejects them.
 
@@ -304,7 +320,7 @@ Implement `SecondaryTierManager` (`vllm/v1/kv_offload/tiering/base.py`) in your 
 - For single-tier (CPU-only) setups, set `cpu_bytes_to_use` larger than the aggregate GPU KV cache. Because offloading is immediate, a smaller CPU tier just mirrors what the GPU already holds and adds no hit rate.
 - `block_size` / `blocks_per_chunk`: larger offloaded chunks reduce per-block bookkeeping overhead but increase the granularity of lookups.
 - FS thread counts: tune `n_read_threads` and `n_write_threads` to the parallelism your storage can sustain. Reads are latency-sensitive on the prefill path, so prefer more read threads when prefill hit rates are high.
-- Sharing `root_dir` across runs: runs with the same model, `block_size`, parallelism layout, and dtype share files under the same `<digest>` subdirectory. Changing any of these produces a new subdirectory; old ones are orphaned but harmless. Delete them to reclaim disk.
+- Sharing `root_dir` across runs: runs whose recorded configuration produces the same `<digest>` share files. Configuration changes that alter the digest create a separate subdirectory; see [Model Configuration and Cache Reuse](#model-configuration-and-cache-reuse). Supported canonical layouts can normalize parallelism differences while retaining model configuration identity. Old directories remain intact; remove them when they are no longer needed to reclaim disk.
 
 ## Per-Request Selective Offload
 

--- a/tests/v1/kv_connector/unit/offloading_connector/test_config.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_config.py
@@ -2,11 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for translating vLLM cache metadata to native offloading config."""
 
+import copy
+from contextlib import nullcontext
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from transformers import PretrainedConfig
 
 from tests.v1.kv_connector.unit.offloading_connector.utils import MockOffloadingSpec
 from vllm.config import KVTransferConfig, ParallelConfig, VllmConfig
@@ -17,6 +21,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     SchedulerOffloadConfig,
 )
 from vllm.platforms import current_platform
+from vllm.v1.core.kv_cache_utils import (
+    get_kv_cache_model_config_hash,
+)
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     HiddenStateCacheSpec,
@@ -32,6 +39,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+from vllm.v1.kv_offload.file_mapper import FileMapper
 
 
 def _make_vllm_config(
@@ -92,6 +100,270 @@ def _make_kv_cache_config() -> KVCacheConfig:
         kv_cache_tensors=[kv_tensor],
         kv_cache_groups=[KVCacheGroupSpec(["layer"], spec)],
     )
+
+
+def _make_identity_config() -> VllmConfig:
+    config = _make_vllm_config()
+    config.model_config.hf_text_config = PretrainedConfig(
+        max_position_embeddings=16,
+        rope_parameters={
+            "full_attention": {
+                "rope_type": "linear",
+                "factor": 1.0,
+                "rope_theta": 10000.0,
+                "partial_rotary_factor": 1.0,
+            },
+            "sliding_attention": None,
+        },
+    )
+    config.model_config.dtype = torch.bfloat16
+    config.model_config.max_model_len = 16
+    return config
+
+
+def _identity_mapper(config: VllmConfig, kv_config: KVCacheConfig) -> FileMapper:
+    return FileMapper.from_offloading_spec(
+        "/tmp/cache",
+        MockOffloadingSpec(build_offloading_config(config, kv_config)),
+    )
+
+
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        (("rope_parameters", "full_attention", "factor"), 2.0),
+        (("rope_parameters", "full_attention", "rope_theta"), 20000.0),
+        (("rope_parameters", "full_attention", "partial_rotary_factor"), 0.5),
+        (
+            ("rope_parameters", "sliding_attention"),
+            {"rope_type": "default", "rope_theta": 10000.0},
+        ),
+        (("max_position_embeddings",), 32),
+    ],
+)
+def test_model_config_changes_isolate_persisted_blocks(path, value):
+    config = _make_identity_config()
+    first = _make_kv_cache_config()
+    first.model_config_hash = get_kv_cache_model_config_hash(config.model_config)
+    old_path = _identity_mapper(config, first).base_path
+
+    hf_config = config.model_config.hf_text_config
+    if len(path) == 1:
+        setattr(hf_config, path[0], value)
+    else:
+        target = getattr(hf_config, path[0])
+        for name in path[1:-1]:
+            target = target[name]
+        target[path[-1]] = value
+    changed = _make_kv_cache_config()
+    changed.model_config_hash = get_kv_cache_model_config_hash(config.model_config)
+    assert _identity_mapper(config, changed).base_path != old_path
+
+
+def test_model_dtype_isolates_blocks_with_the_same_kv_dtype():
+    config = _make_identity_config()
+    first = _make_kv_cache_config()
+    first.model_config_hash = get_kv_cache_model_config_hash(config.model_config)
+    config.model_config.dtype = torch.float16
+    changed = _make_kv_cache_config()
+    changed.model_config_hash = get_kv_cache_model_config_hash(config.model_config)
+    first_mapper = _identity_mapper(config, first)
+    changed_mapper = _identity_mapper(config, changed)
+    assert first_mapper.fields["dtype"] == changed_mapper.fields["dtype"]
+    assert first_mapper.base_path != changed_mapper.base_path
+
+
+def test_metadata_and_mapping_order_preserve_model_identity():
+    config = _make_identity_config()
+    serialized = config.model_config.hf_text_config.to_dict()
+    metadata = {
+        "_name_or_path": "old-path",
+        "_commit_hash": "old-revision",
+        "transformers_version": "old-version",
+    }
+    serialized.update(metadata)
+    serialized["decoder"] = {**metadata, "hidden_size": 8}
+    # PretrainedConfig.to_dict itself drops or rewrites some metadata. Return
+    # the serialized values directly to exercise our own metadata filtering.
+    config.model_config.hf_text_config = SimpleNamespace(to_dict=lambda: serialized)
+    before = copy.deepcopy(serialized)
+    expected = get_kv_cache_model_config_hash(config.model_config)
+    assert serialized == before
+
+    for name in metadata:
+        serialized[name] = "new-value"
+        serialized["decoder"][name] = "new-nested-value"
+    serialized["rope_parameters"] = dict(
+        reversed(serialized["rope_parameters"].items())
+    )
+    full = serialized["rope_parameters"]["full_attention"]
+    serialized["rope_parameters"]["full_attention"] = dict(reversed(full.items()))
+    assert get_kv_cache_model_config_hash(config.model_config) == expected
+
+
+def test_engine_propagates_snapshot_after_model_loading_and_auto_fit():
+    from vllm.v1.engine.core import EngineCore
+
+    config = _make_identity_config()
+    snapshot = get_kv_cache_model_config_hash(config.model_config)
+    workers = [_make_kv_cache_config(), _make_kv_cache_config()]
+    executor = MagicMock()
+    executor.get_kv_cache_specs.return_value = [
+        {"layer": worker.kv_cache_groups[0].kv_cache_spec} for worker in workers
+    ]
+    executor.determine_available_memory.return_value = [1 << 20] * len(workers)
+    engine = SimpleNamespace(
+        model_executor=executor,
+        _kv_cache_model_config_hash=snapshot,
+        available_gpu_memory_for_kv_cache=-1,
+        collective_rpc=executor.collective_rpc,
+    )
+    config.compilation_config.compilation_time = 0
+    config.compilation_config.encoder_compilation_time = 0
+    config.cache_config.kv_cache_layout = "LBNHC"
+
+    # Model loading may rewrite RoPE types; auto-fit may shorten the context.
+    config.model_config.hf_text_config.rope_parameters["full_attention"][
+        "rope_type"
+    ] = "deepseek_yarn"
+
+    def auto_fit(vllm_config, specs, available_memory):
+        vllm_config.model_config.max_model_len = 8
+        return workers
+
+    with (
+        patch("vllm.v1.engine.core.register_all_kvcache_specs"),
+        patch(
+            "vllm.v1.engine.core.resolve_kv_cache_layout",
+            return_value=SimpleNamespace(name="LBNHC"),
+        ),
+        patch("vllm.v1.engine.core.get_kv_cache_configs", side_effect=auto_fit),
+        patch("vllm.v1.engine.core.update_kv_cache_capacity"),
+    ):
+        scheduler_config = EngineCore._initialize_kv_caches(engine, config)
+
+    remote_configs = executor.initialize_from_config.call_args.args[0]
+    assert len(remote_configs) == len(workers)
+    assert scheduler_config is not workers[0]
+    assert config.model_config.max_model_len == 8
+    assert get_kv_cache_model_config_hash(config.model_config) != snapshot
+    for retained in [*remote_configs, scheduler_config]:
+        assert retained.model_config_hash == snapshot
+        assert (
+            _identity_mapper(config, retained).fields["model_config_hash"] == snapshot
+        )
+
+
+@pytest.mark.parametrize(
+    "connector,should_snapshot",
+    [
+        pytest.param("OffloadingConnector", True, id="native"),
+        pytest.param(["NixlConnector", "OffloadingConnector"], True, id="mixed-multi"),
+        pytest.param(
+            ["NixlConnector", ["LMCacheConnectorV1", "OffloadingConnector"]],
+            True,
+            id="nested-native",
+        ),
+        pytest.param(None, False, id="no-connector"),
+        pytest.param("NixlConnector", False, id="nixl-with-unrelated-extra-config"),
+        pytest.param("LMCacheConnectorV1", False, id="lmcache"),
+        pytest.param(
+            ["NixlConnector", ["LMCacheConnectorV1"]], False, id="nested-unrelated"
+        ),
+    ],
+)
+def test_engine_snapshots_identity_before_model_loading(connector, should_snapshot):
+    from vllm.v1.engine.core import EngineCore
+
+    def connector_options(name_or_children):
+        if isinstance(name_or_children, list):
+            return {
+                "kv_connector": "MultiConnector",
+                "kv_role": "kv_both",
+                "kv_connector_extra_config": {
+                    "connectors": [connector_options(c) for c in name_or_children]
+                },
+            }
+        return {"kv_connector": name_or_children, "kv_role": "kv_both"}
+
+    config = _make_identity_config()
+    config.kv_transfer_config = (
+        KVTransferConfig(**connector_options(connector))
+        if connector is not None
+        else None
+    )
+    if connector == "NixlConnector":
+        config.kv_transfer_config.kv_connector_extra_config = {
+            "connectors": [{"kv_connector": "OffloadingConnector"}]
+        }
+    expected = (
+        get_kv_cache_model_config_hash(config.model_config) if should_snapshot else None
+    )
+    engine = EngineCore.__new__(EngineCore)
+
+    def load_model(vllm_config):
+        vllm_config.model_config.hf_text_config.rope_parameters["full_attention"][
+            "rope_type"
+        ] = "deepseek_yarn"
+        return MagicMock()
+
+    with (
+        patch("vllm.plugins.load_general_plugins"),
+        (
+            nullcontext()
+            if should_snapshot
+            else patch.object(
+                config.model_config.hf_text_config,
+                "to_dict",
+                side_effect=AssertionError(
+                    "Unrelated connectors must not snapshot HF config"
+                ),
+            )
+        ),
+        patch.object(
+            EngineCore, "_initialize_kv_caches", side_effect=RuntimeError("stop init")
+        ),
+        pytest.raises(RuntimeError, match="stop init"),
+    ):
+        EngineCore.__init__(engine, config, load_model, log_stats=False)
+
+    assert engine._kv_cache_model_config_hash == expected
+    if should_snapshot:
+        assert get_kv_cache_model_config_hash(config.model_config) != expected
+
+
+def test_longrope_runtime_choice_changes_keys_and_persistent_identity():
+    from vllm.model_executor.layers.rotary_embedding.phi3_long_rope_scaled_rope import (  # noqa: E501
+        Phi3LongRoPEScaledRotaryEmbedding,
+    )
+
+    config = _make_identity_config()
+    config.model_config.hf_text_config.rope_parameters = {
+        "rope_type": "longrope",
+        "short_factor": [1.0] * 4,
+        "long_factor": [2.0] * 4,
+        "original_max_position_embeddings": 8,
+    }
+    paths, keys = [], []
+    for max_model_len in (8, 16):
+        config.model_config.max_model_len = max_model_len
+        kv_config = _make_kv_cache_config()
+        kv_config.model_config_hash = get_kv_cache_model_config_hash(
+            config.model_config
+        )
+        paths.append(_identity_mapper(config, kv_config).base_path)
+        with patch(
+            "vllm.model_executor.layers.rotary_embedding."
+            "phi3_long_rope_scaled_rope.get_current_vllm_config",
+            return_value=config,
+        ):
+            rope = Phi3LongRoPEScaledRotaryEmbedding(
+                8, 8, 16, 8, 10000.0, True, torch.float32, [1.0] * 4, [2.0] * 4
+            )
+        _, key = rope(torch.arange(8), torch.ones(8, 8), torch.ones(8, 8))
+        keys.append(key)
+    assert not torch.equal(keys[0], keys[1])
+    assert paths[0] != paths[1]
 
 
 def _make_sizing_kv_cache_config(packed: bool) -> KVCacheConfig:

--- a/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_worker.py
@@ -158,7 +158,9 @@ def _offloading_config(rank: int = 0) -> OffloadingConfig:
         enable_kv_cache_events=False,
         extra_config={},
         engine_id="test-engine",
-        model=OffloadingModelConfig(name="test-model", dtype="float16"),
+        model=OffloadingModelConfig(
+            name="test-model", dtype="float16", config_hash="test-model-config"
+        ),
         cache=OffloadingCacheConfig(tokens_per_hash=16, blocks_per_chunk=1),
         parallel=OffloadingParallelConfig(
             rank=rank,

--- a/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
+++ b/tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py
@@ -103,6 +103,7 @@ def _run_engine_core_handshake(
             async_scheduling=False,
         ),
         speculative_config=None,
+        kv_transfer_config=None,
         ec_transfer_config=None,
         max_concurrent_batches=1,
         model_config=SimpleNamespace(runner_type="generate", is_diffusion=False),

--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -70,7 +70,9 @@ def _make_offloading_config(
         enable_kv_cache_events=False,
         extra_config=normalized_extra_config,
         engine_id="test-engine",
-        model=OffloadingModelConfig(name="test-model", dtype="float16"),
+        model=OffloadingModelConfig(
+            name="test-model", dtype="float16", config_hash="test-model-config"
+        ),
         cache=OffloadingCacheConfig(
             tokens_per_hash=tokens_per_hash,
             blocks_per_chunk=blocks_per_chunk,

--- a/tests/v1/kv_offload/test_file_mapper.py
+++ b/tests/v1/kv_offload/test_file_mapper.py
@@ -4,6 +4,8 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from vllm.v1.kv_offload.base import OffloadingSpec, make_offload_key
 from vllm.v1.kv_offload.config import (
     OffloadingCacheConfig,
@@ -39,6 +41,7 @@ def make_mapper_from_offloading_spec(**kwargs) -> FileMapper:
         model=OffloadingModelConfig(
             name=kwargs.get("model_name", "test-model"),
             dtype=kwargs.get("dtype", "float16"),
+            config_hash=kwargs.get("model_config_hash", "test-model-config"),
         ),
         cache=OffloadingCacheConfig(
             tokens_per_hash=kwargs.get("tokens_per_hash", 16),
@@ -92,9 +95,7 @@ def test_get_file_name_full_structure():
     key = make_offload_key(block_hash, group_idx)
     path = fm.get_file_name(key)
 
-    expected_path = (
-        "/tmp/cache/test-model_de3bba26cf36_r3/000/10_g2/0001020304050607.bin"
-    )
+    expected_path = f"{fm.base_path}_r3/000/10_g2/0001020304050607.bin"
     assert path == expected_path
 
 
@@ -128,7 +129,24 @@ def test_get_run_config_fields():
         ],
         "inference_engine": "vllm",
         "parallel_agnostic": False,
+        "model_config_hash": "test-model-config",
     }
+
+
+@pytest.mark.parametrize("model_config_hash", [None, ""])
+def test_persistent_namespace_requires_model_identity(model_config_hash):
+    with pytest.raises(ValueError, match="requires a model configuration hash"):
+        make_mapper_from_offloading_spec(model_config_hash=model_config_hash)
+
+
+def test_model_identity_isolates_the_same_token_block():
+    key = make_offload_key(bytes(range(8)), 0)
+    first = make_mapper_from_offloading_spec(model_config_hash="config-a")
+    restarted = make_mapper_from_offloading_spec(model_config_hash="config-a")
+    changed = make_mapper_from_offloading_spec(model_config_hash="config-b")
+
+    assert first.get_file_name(key) == restarted.get_file_name(key)
+    assert first.get_file_name(key) != changed.get_file_name(key)
 
 
 def test_get_config_file_path():

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -12,6 +12,7 @@ import mmap
 import os
 import threading
 import time
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -35,6 +36,7 @@ from vllm.v1.kv_offload.config import (
     OffloadingModelConfig,
     OffloadingParallelConfig,
 )
+from vllm.v1.kv_offload.file_mapper import FileMapper
 from vllm.v1.kv_offload.tiering.base import TransferJob
 from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
 from vllm.v1.kv_offload.tiering.fs.manager import (
@@ -71,7 +73,9 @@ def _make_offloading_spec(
         enable_kv_cache_events=enable_kv_cache_events,
         extra_config={},
         engine_id="test-engine",
-        model=OffloadingModelConfig(name="test-model", dtype="float32"),
+        model=OffloadingModelConfig(
+            name="test-model", dtype="float32", config_hash="test-model-config"
+        ),
         cache=OffloadingCacheConfig(tokens_per_hash=16, blocks_per_chunk=1),
         parallel=OffloadingParallelConfig(
             rank=rank,
@@ -217,6 +221,25 @@ def test_lookup_empty_tier(fs_tier):
     tier, _ = fs_tier
     results = lookup_and_wait(tier, [key(1), key(2)])
     assert results == [LookupResult.MISS, LookupResult.MISS]
+
+
+def test_legacy_blocks_are_not_reused_without_model_identity(fs_tier, tmp_path):
+    tier, tensor = fs_tier
+    legacy_fields = tier.file_mapper.get_run_config()
+    legacy_fields.pop("model_config_hash")
+    legacy_mapper = FileMapper(root_dir=str(tmp_path), rank=0, **legacy_fields)
+    legacy_path = Path(legacy_mapper.get_file_name(key(1)))
+    legacy_path.parent.mkdir(parents=True)
+    legacy_data = tensor[0].numpy().tobytes()
+    legacy_path.write_bytes(legacy_data)
+
+    assert lookup_and_wait(tier, [key(1)]) == [LookupResult.MISS]
+    tier.on_request_finished(_CTX)
+    tier.submit_store(make_job(1, [key(1)], [0]))
+    assert all(result.success for result in drain(tier))
+    assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
+    assert Path(tier.file_mapper.get_file_name(key(1))) != legacy_path
+    assert legacy_path.read_bytes() == legacy_data
 
 
 def test_store_creates_file_and_lookup_succeeds(fs_tier):

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -64,7 +64,9 @@ def _make_offloading_config(
         enable_kv_cache_events=enable_kv_cache_events,
         extra_config={},
         engine_id="test-engine",
-        model=OffloadingModelConfig(name="test/model", dtype="float16"),
+        model=OffloadingModelConfig(
+            name="test/model", dtype="float16", config_hash="test-model-config"
+        ),
         cache=OffloadingCacheConfig(tokens_per_hash=16, blocks_per_chunk=1),
         parallel=OffloadingParallelConfig(
             rank=rank,

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -155,10 +155,19 @@ class KVTransferConfig:
         return self.kv_connector_extra_config.get(key, default)
 
     def has_connector(self, connector_name: str) -> bool:
-        """Whether ``connector_name`` is configured, directly or in MultiConnector."""
-        if self.kv_connector == connector_name:
-            return True
-        return self.kv_connector == "MultiConnector" and any(
-            child.get("kv_connector") == connector_name
-            for child in self.kv_connector_extra_config.get("connectors", [])
-        )
+        """Whether a connector is configured directly or in nested MultiConnectors."""
+
+        def contains(name: str | None, extra_config: dict[str, Any]) -> bool:
+            if name == connector_name:
+                return True
+            if name != "MultiConnector":
+                return False
+            return any(
+                contains(
+                    child.get("kv_connector"),
+                    child.get("kv_connector_extra_config", {}),
+                )
+                for child in extra_config.get("connectors", [])
+            )
+
+        return contains(self.kv_connector, self.kv_connector_extra_config)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/config.py
@@ -237,6 +237,7 @@ def build_offloading_config(
         model=OffloadingModelConfig(
             name=vllm_config.model_config.model,
             dtype=str(cache_dtype).removeprefix("torch."),
+            config_hash=kv_cache_config.model_config_hash,
         ),
         cache=OffloadingCacheConfig(
             tokens_per_hash=tokens_per_hash,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -7,13 +7,14 @@ import hashlib
 import math
 import os
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from functools import partial
 from typing import TYPE_CHECKING, Any, NamedTuple, NewType, TypeAlias, cast, overload
 
 from vllm import envs
-from vllm.config import VllmConfig
+from vllm.config import ModelConfig, VllmConfig
+from vllm.config.utils import hash_factors, normalize_value
 from vllm.logger import init_logger
 from vllm.utils.hashing import xxhash, xxhash_cbor
 from vllm.utils.math_utils import cdiv, round_up
@@ -53,6 +54,40 @@ from vllm.v1.utils import tensor_data
 
 if TYPE_CHECKING:
     from vllm.v1.core.block_pool import BlockPool
+
+
+def get_kv_cache_model_config_hash(model_config: ModelConfig) -> str:
+    """Snapshot model configuration before construction can mutate it.
+
+    Persistent KV can depend on more than the checkpoint name or RoPE settings:
+    for example, Phi3 selects its LongRoPE factors using the runtime maximum
+    length. Keep the complete text configuration, model computation dtype, and
+    construction-time maximum length. This is configuration identity, not a
+    fingerprint of checkpoint weights or every runtime kernel choice.
+    """
+    metadata_keys = {"_commit_hash", "_name_or_path", "transformers_version"}
+
+    def strip_metadata(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {
+                key: strip_metadata(item)
+                for key, item in value.items()
+                if key not in metadata_keys
+            }
+        if isinstance(value, (list, tuple)):
+            return [strip_metadata(item) for item in value]
+        return value
+
+    return hash_factors(
+        {
+            "schema_version": 1,
+            "hf_text_config": normalize_value(
+                strip_metadata(model_config.hf_text_config.to_dict())
+            ),
+            "dtype": normalize_value(model_config.dtype),
+            "max_model_len": model_config.max_model_len,
+        }
+    )
 
 
 # BlockHash represents the hash of a single KV-cache block used for

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -49,6 +49,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     generate_scheduler_kv_cache_config,
     get_kv_cache_configs,
+    get_kv_cache_model_config_hash,
     get_request_block_hasher,
     init_none_hash,
     resolve_kv_cache_block_sizes,
@@ -129,6 +130,17 @@ class EngineCore:
         self.log_stats = log_stats
         # Opaque weight version supplied by the caller.
         self._weight_version = "default"
+
+        # Freeze before model construction mutates HF settings (e.g. DeepSeek's
+        # internal RoPE type), and before KV profiling can reduce max_model_len.
+        # The same identity is sent to workers with their KV cache configuration.
+        kv_transfer_config = vllm_config.kv_transfer_config
+        self._kv_cache_model_config_hash = (
+            get_kv_cache_model_config_hash(vllm_config.model_config)
+            if kv_transfer_config is not None
+            and kv_transfer_config.has_connector("OffloadingConnector")
+            else None
+        )
 
         # Setup Model.
         self.model_executor = executor_class(vllm_config)
@@ -321,6 +333,7 @@ class EngineCore:
         )
         for kv_cache_config in kv_cache_configs:
             kv_cache_config.kv_cache_layout = vllm_config.cache_config.kv_cache_layout
+            kv_cache_config.model_config_hash = self._kv_cache_model_config_hash
 
         # If auto-fit reduced max_model_len, sync the new value to workers.
         # This is needed because workers were spawned before memory profiling

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -1434,6 +1434,8 @@ class KVCacheConfig:
     """The KV cache layout resolved by the engine core, adopted by all workers."""
     hisparse_host_num_blocks: int | None = None
     """Capacity of the dedicated HiSparse host-block manager, when enabled."""
+    model_config_hash: str | None = None
+    """Model configuration identity frozen before construction by the engine core."""
 
     @cached_property
     def transfer_group_ids(self) -> tuple[int, ...]:

--- a/vllm/v1/kv_offload/config.py
+++ b/vllm/v1/kv_offload/config.py
@@ -24,6 +24,8 @@ class OffloadingModelConfig:
     name: str
     # KV cache data type (e.g. "float16").
     dtype: str
+    # Model configuration identity frozen before model construction.
+    config_hash: str | None = None
 
 
 @dataclass(frozen=True)

--- a/vllm/v1/kv_offload/file_mapper.py
+++ b/vllm/v1/kv_offload/file_mapper.py
@@ -40,6 +40,7 @@ class FileMapper:
         parallel_agnostic: bool = False,
         replicated_layout: bool = False,
         canonical_format: str | None = None,
+        model_config_hash: str | None = None,
     ):
         """
         Initialize the file mapper. Each worker constructs its own, but
@@ -63,6 +64,8 @@ class FileMapper:
             "kv_cache_groups": kv_cache_groups or [],
             "inference_engine": inference_engine,
         }
+        if model_config_hash is not None:
+            self.fields["model_config_hash"] = model_config_hash
         if not parallel_agnostic:
             self.fields["parallel_agnostic"] = False
         # Only written when True so existing deployments' hashed fields are
@@ -86,6 +89,11 @@ class FileMapper:
     ) -> "FileMapper":
         """Build a FileMapper from an OffloadingSpec."""
         config = offloading_spec.config
+        if not config.model.config_hash:
+            raise ValueError(
+                "Persistent KV offloading requires a model configuration hash "
+                "from EngineCore."
+            )
         kv_cache_groups = [
             {
                 "tokens_per_block": group.tokens_per_block,
@@ -116,6 +124,7 @@ class FileMapper:
             ),
             replicated_layout=(parallel_agnostic and config.replicated_layout),
             canonical_format=canonical_format,
+            model_config_hash=config.model.config_hash,
         )
 
     def get_file_name(self, key: OffloadKey) -> str:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Addresses #56311. Native KV offloading can reuse persisted keys after a restart
with the same checkpoint and token prefix but different RoPE settings. In the
Qwen3-0.6B reproduction, changing linear scaling from factor 1 to 2 reused
1,168 cached tokens and changed generation starting at the first token
compared with a clean factor-2 cache.

This change snapshots the HF text configuration, computation dtype and
construction-time `max_model_len`, then includes that identity in native
offloading namespaces. It excludes `_commit_hash`, `_name_or_path` and
`transformers_version`. Snapshotting before executor construction matters:
loading can rewrite RoPE settings, and memory auto-fit can shorten the maximum
length after Phi3 has already selected its LongRoPE mode. Only
`OffloadingConnector`, including nested `MultiConnector` configurations,
creates the snapshot.

I'd like feedback on using the full text configuration here. It can cause
extra misses for output-related fields or context limits that do not change
a particular model's KV. It does not fingerprint weight contents or every
runtime quantization/kernel choice. Is that conservative boundary reasonable
for native offloading?

The usage guide documents the migration cost: FS/object storage start cold,
retain legacy data and never fall back to it. P2P rejects mismatched nonempty
fingerprints, but its existing acceptance of an absent peer fingerprint is
unchanged. Canonical layouts retain configuration isolation.

Overlap checks, refreshed on September 12, found no PR addressing #56311. The related
#55907 separates physical KV layouts; this change separates model
configurations even when the physical layout matches.

## Test Plan

Check namespace separation, metadata stability, snapshot timing,
worker/scheduler propagation, unrelated-connector behavior and legacy lookup.

Run from the repository root; `PYTHON` denotes the virtual-environment
interpreter, with its local path abbreviated below. The runner also verified
the imported source checkout:

```bash
CUDA_VISIBLE_DEVICES=4 PYTHONPATH=. "$PYTHON" -c '
import pytest, torch
assert not torch.cuda.is_initialized()
code = pytest.main([
    "-q",
    "tests/v1/kv_offload/test_file_mapper.py",
    "tests/v1/kv_connector/unit/offloading_connector/test_config.py",
    "tests/v1/kv_offload/tiering/test_fs_tier.py",
    "tests/v1/kv_offload/tiering/test_obj_tier.py",
    "tests/v1/kv_offload/test_factory.py",
    "tests/v1/kv_connector/unit/test_handshake_pp_aggregation.py",
])
assert not torch.cuda.is_initialized()
raise SystemExit(code)
'
```

Also ran `pre-commit run --files` with all 15 changed paths, and reconstructed
both Qwen startup configurations before model loading to compare their hashes
with the recorded GPU runs.

The model experiment uses four fresh processes: Qwen3-0.6B revision
`c1899de289a04d12100db370d81485cdf75e47ca`, A100 80 GB, BF16, batch-invariant
execution, a 1,182-token prompt and 48-token greedy generation. It compares
legacy-cache migration, cross-configuration isolation and each configuration's
restart reuse against clean-cache controls.

## Test Result

On head `fc838ce3` (rebased onto `2c88fb13` on September 18): **218 passed**,
with 14 existing Torch JIT deprecation warnings. CUDA remained uninitialized
before and after the suite. All applicable pre-commit hooks passed on the
same source tree.

The rebase preserves the upstream tests and combines their imports with this
change. The new canonical MLA layout fixture now supplies the model
configuration hash expected by `FileMapper`, covering its six TP/worker/scheduler
variants. The configuration-identity production changes are unchanged apart
from upstream context. The filesystem, object-store and P2P paths remain the
scope of this change; the new KVCR tier has a separate compatibility contract.

The GPU results below were recorded on the previous head `d73c9bfa`, including
the final native-connector selection change. GPU inference was not rerun after
the September 18 rebase.

| Run | External cached tokens | FS bytes read | Versus clean control |
| --- | ---: | ---: | --- |
| Factor 1, legacy cache | 0 | 0 | Exact match |
| Factor 1, restart | 1,168 | 133,955,584 | Exact match |
| Factor 2, same directory | 0 | 0 | Exact match |
| Factor 2, restart | 1,168 | 133,955,584 | Exact match |

All four processes exited successfully. Every generated token and captured
top-20 logprob dictionary matched. All 73 legacy files remained byte-identical;
each configuration wrote 73 files in its own namespace.

The September 12 rerun used the byte-identical original inference harness and
verified the source checkout inside every inference process. The checkout
remained clean at `d73c9bfa` throughout. It reproduced the earlier prototype
results and matched the frozen clean-cache controls from `db723d24` exactly.
Both patched and baseline GPU runs used native extensions from the official
September 10 wheel at `2a02f6efe319c885e3ccbcecde402e0028f9ec1e`, rather than an
exact source-commit binary build. The rebased run uses a separate environment
for the new base's hub/CUTLASS/QuACK requirements; Torch, Transformers and
NumPy retain their baseline versions. The driver, results and package versions
are included in the evidence gist below. An earlier September 12 attempt was
stopped to release the GPU; these results are from the subsequent complete run.

An additional **TP2 × PP2** experiment on the same head used four A100 GPUs
and independent cold controls at that topology. The factor-1 restart read
1,168 cached tokens; factor 2 read none from the shared directory. Both
matched their respective cold controls in every output token and captured
logprob. All four workers had the expected stage-local layers and matching
configuration fingerprints. The scheduler persisted complete shared-region
chunks, and factor 1's files remained unchanged. The
[distributed validation record](https://gist.github.com/JiataiWang/3efe0744be7bddf118edf928e0e9f763#file-tp2-pp2-validation-md)
includes the four-process provenance and corrected file-layout assertion.

Object-store/P2P deployments, other TP/PP topologies and GPU worker unit tests
were not run. Distributed legacy migration and the factor-2 distributed
restart were not tested; those cases remain covered only by the TP1 run.
Two additionally selected DCP tests previously failed on log
capture on both the prototype and unchanged baseline, with correct config
values. These limits and the full reproduction are in the
[evidence gist](https://gist.github.com/JiataiWang/3efe0744be7bddf118edf928e0e9f763).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including the issue it addresses.
- [x] The test plan, including the current validation commands.
- [x] The test results, including the current validation results.
- [x] The necessary documentation update, including cache migration behavior.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
