### PR TITLE
[CI/Build] Add DSv4.1 auto-label rules and narrow DSv4

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -330,11 +330,31 @@ pull_request_rules:
     - label != stale
     - or:
       - files~=^vllm/models/deepseek_v4/
-      - title~=(?i)(?:\bDSv4\b|deepseek[-\s]?v4)
+      # Trailing (?![._]?1) keeps V4.1 out: DeepseekV41ForCausalLM is a
+      # distinct architecture with its own tree and label (DSv4.1).
+      - title~=(?i)(?:\bDSv4\b|deepseek[-\s_]?v4)(?![._]?1)
   actions:
     label:
       add:
         - DSv4
+
+- name: label-dsv4-1
+  description: Automatically apply DSv4.1 label
+  conditions:
+    - label != stale
+    - or:
+      # The 4.1 sources spell the model three ways: deepseek_v4_1 (models),
+      # deepseek_v41 (most) and deepseekv41 (tool parsers).
+      - files~=^vllm/models/deepseek_v4_1/
+      - files~=^vllm/(?:parser|tokenizers|reasoning|transformers_utils/configs)/deepseek_v41.*\.py
+      - files~=^vllm/tool_parsers/deepseekv41.*\.py
+      - files~=^rust/src/(?:chat|parser)/src/.*deepseek_v41
+      - files~=^tests/.*deepseek_?v41
+      - title~=(?i)(?:\bDSv4[._]?1\b|deepseek[-\s_]?v4[._]?1)
+  actions:
+    label:
+      add:
+        - DSv4.1
 
 - name: label-nvidia
   description: Automatically apply nvidia label

--- a/.github/workflows/issue_autolabel.yml
+++ b/.github/workflows/issue_autolabel.yml
@@ -197,9 +197,12 @@ jobs:
               deepseek: {
                 keywords: [{ term: "DeepSeek", searchIn: "title" }],
               },
+              // DSv4 and DSv4.1 are distinct architectures; these keep them exclusive.
               DSv4: {
-                keywords: [{ term: "DSv4", searchIn: "title" }],
-                substrings: [{ term: "deepseek-v4", searchIn: "title" }],
+                regexPatterns: [{ pattern: "(?:\\bDSv4\\b|deepseek[-\\s_]?v4)(?![._]?1)", flags: "gi", searchIn: "title" }],
+              },
+              "DSv4.1": {
+                regexPatterns: [{ pattern: "(?:\\bDSv4[._]?1\\b|deepseek[-\\s_]?v4[._]?1)", flags: "gi", searchIn: "title" }],
               },
               llama: {
                 keywords: [{ term: "Llama", searchIn: "title" }],


### PR DESCRIPTION
## Purpose

DeepSeek-V4.1 had no label of its own, and the existing `DSv4` patterns were
claiming all of its traffic.

`DeepseekV41ForCausalLM` is a distinct architecture from `DeepseekV4ForCausalLM`:
its own model tree (`vllm/models/deepseek_v4_1/`), its own `tokenizer_mode`
(`deepseek_v41`), and its own tokenizer, parser, reasoning parser, tool parser and
config class. It adds `common/engram.py`, `nvidia/model_state.py`,
`common/ops/indexer_k_store.py` and `common/ops/query_quant.py`, and carries none
of V4's `mtp.py`, `cpu/`, `xpu/`, `fi_moe.py` or `common/vision.py`.

Two concrete defects follow from having no separate label:

1. **`DSv4` captures every V4.1 title.** Nothing bounded the version after `v4`,
   so `deepseek[-\s]?v4` matched `DeepSeek-V4.1-Flash` and `\bDSv4\b` matched
   `DSv4.1`. #56228, a pure V4.1 PR, is labeled `DSv4`.
2. **The issue labeler missed space-separated titles.** Its `DSv4` matcher was the
   substring `deepseek-v4` plus the keyword `DSv4`, while mergify allowed
   `[-\s]?`. #56297 ("DeepSeek V4.1 rejects Responses API text content types") got
   `deepseek` and nothing else. This is a pre-existing V4 gap, not a V4.1 one.

## Changes

- `.github/mergify.yml`: add `label-dsv41`; bound `label-dsv4`'s title pattern
  with `(?![._]?1)`.
- `.github/workflows/issue_autolabel.yml`: add a `"DSv4.1"` entry; convert `DSv4`
  from substring matching to the same bounded regex so both labelers agree.

The 4.1 sources spell the model three ways — `deepseek_v4_1` (models),
`deepseek_v41` (most), `deepseekv41` (tool parsers) — so the file conditions cover
all three.

**Flash and Pro share one label per generation.** They are the same code path in
vLLM: one arch string, one config class, no variant branching anywhere in
`vllm/models/deepseek_v4/`, and the V4-Flash and V4-Pro eval configs are identical
but for the model name and load timeout. No file condition could distinguish them,
so a per-variant label would only ever be title-routable.

## Prerequisite

The `DSv4.1` label must exist before this merges; a rule naming a nonexistent
label does not create it.

## Not a duplicate

- `gh pr list --state open --search "dsv4.1 label"` — no results.
- `gh pr list --state open --search "mergify label automation"` — no results
  touching label config.
- `gh issue view 56217 --comments` (the V4.1 kernel tracking issue) — no labeling
  work claimed.

No open PR modifies `.github/mergify.yml` or the issue labeler.

## Testing

```bash
.venv/bin/pre-commit run --files .github/mergify.yml .github/workflows/issue_autolabel.yml
.venv/bin/python tools/pre_commit/check_label_rules.py
```

Both pass, including `actionlint` and `check-label-rules`. I verified
`check-label-rules` is not passing vacuously: injecting a deliberately dead glob
makes it fail and name `label-dsv41`.

Beyond the hooks, I validated out of tree against 25 real V4/V4.1 titles taken
from this repo's history, in both engines the two labelers use — Python `re` for
mergify and JS `RegExp` for the workflow — and by executing the workflow's own
`labelConfig` and matching functions with stubbed `core`/`github`/`context`:

| Check | Result |
| --- | --- |
| 25 real titles, Python | 25/25 |
| 25 real titles, JS | 25/25 |
| Workflow's real matching logic | all pass |
| File conditions vs tree | 44/44 V4.1 files, no overmatch, no bleed onto `DSv4` |
| `DSv4` conditions still live | 51 files |
| No title receives both labels | confirmed |
| Noisy body does not leak model labels | confirmed; title-only design holds |

Representative outcomes:

| Title | Before | After |
| --- | --- | --- |
| `[Bug]: DeepSeek V4.1 rejects Responses API text content types` (#56297) | `deepseek` | `deepseek`, `DSv4.1` |
| `[Model] Support DeepSeek-V4.1-Flash` | `deepseek`, `DSv4` | `deepseek`, `DSv4.1` |
| `[Bugfix][DSv4] Keep indexer scoring in breakable graphs` | `deepseek`, `DSv4` | unchanged |
| `[Model] Support DeepSeek-V4-Pro` | `deepseek`, `DSv4` | unchanged |

Happy to commit the title-regex cases as a test if reviewers want a permanent
guard; there is no existing suite covering `.github/` matcher behavior, and
`check-label-rules` covers only the file conditions.

## Model evaluation

Not applicable. This touches CI labeling configuration only — no engine, kernel,
model or serving code, so there is no effect on output or accuracy.

## Follow-up

Once the label exists, ~14 open V4.1 PRs and 2 issues need backfilling, and
#56228's `DSv4` should be corrected to `DSv4.1`.

## AI assistance

AI assistance (Claude Code) was used to investigate the labeling gap, write these
rules and run the validation above. I have reviewed every changed line, confirmed
the architectural distinction the change rests on, and run the test commands
listed.
