### PR TITLE
[Multimodal] Add TorchCodec device option (CUDA/NVDEC decode) with host-frame conversion

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -850,13 +850,13 @@ backends are supported:
 | Backend | Device | Description |
 | --- | --- | --- |
 | `opencv` (default) | CPU | OpenCV-based decoder |
-| `torchcodec` | CPU | TorchCodec (PyTorch-native) decoder |
+| `torchcodec` | CPU / GPU | TorchCodec (PyTorch-native) decoder; CUDA (NVDEC) decode is optional |
 | `pynvvideocodec` | GPU | NVIDIA PyNvVideoCodec decoder |
 | `deepstream` | GPU | NVIDIA DeepStream decoder |
 
-The two CPU backends are ultimately backed by FFmpeg. `torchcodec` lets you
-choose which FFmpeg version is used while `opencv` relies on whichever
-FFmpeg build it was linked against.
+The `opencv` backend and the default CPU mode of `torchcodec` are ultimately
+backed by FFmpeg. `torchcodec` lets you choose which FFmpeg version is used
+while `opencv` relies on whichever FFmpeg build it was linked against.
 
 Select the backend by passing the `backend` parameter via `--media-io-kwargs`:
 
@@ -876,11 +876,25 @@ The following parameters only apply to the `torchcodec` backend:
   frame-accurate sampling by scanning the file when the decoder is created.
   `"approximate"` skips that scan for faster decoder creation, at the cost of
   relying on the file's metadata (which may yield less accurate seeking).
+- `device`: Device used for decoding. Unset (default) or `"cpu"` decodes with
+  FFmpeg on the CPU; `"cuda"` decodes with NVDEC when the installed TorchCodec
+  build has CUDA support. Sampled frames are copied to host memory before
+  multimodal preprocessing either way, so the rest of the pipeline is
+  unchanged. GPU decoding runs in the API server process, so the
+  [PyNvVideoCodec guidance](#gpu-video-decoding-with-pynvvideocodec-nvdec)
+  on CUDA MPS and `--mm-ipc-gpu-memory-gb` applies to `"cuda"` as well, and
+  vLLM applies the same frontend GPU memory reservation.
 
 ```bash
 # Example: TorchCodec with approximate seek mode and 4 FFmpeg threads
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
   --media-io-kwargs '{"video": {"backend": "torchcodec", "seek_mode": "approximate", "num_ffmpeg_threads": 4}}'
+```
+
+```bash
+# Example: TorchCodec decoding on the GPU with NVDEC
+vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
+  --media-io-kwargs '{"video": {"backend": "torchcodec", "device": "cuda"}}'
 ```
 
 **PyNvVideoCodec-specific parameters:**

--- a/tests/config/test_multimodal_config.py
+++ b/tests/config/test_multimodal_config.py
@@ -66,6 +66,21 @@ def test_use_gpu_video_backend_from_media_io_kwargs(backend_arg: str):
     assert config.use_gpu_video_backend()
 
 
+@pytest.mark.parametrize(
+    ("device", "expected"),
+    [("cuda", True), ("cuda:1", True), ("cpu", False), (None, False)],
+)
+def test_use_gpu_video_backend_for_torchcodec_device(
+    device: str | None, expected: bool
+):
+    video_kwargs: dict[str, object] = {"backend": "torchcodec"}
+    if device is not None:
+        video_kwargs["device"] = device
+    config = MultiModalConfig(media_io_kwargs={"video": video_kwargs})
+
+    assert config.use_gpu_video_backend() is expected
+
+
 def test_mm_encoder_fp8_scale_path_requires_fp8():
     with pytest.raises(ValueError, match="mm_encoder_attn_dtype"):
         MultiModalConfig(mm_encoder_fp8_scale_path="/tmp/scales.json")

--- a/tests/multimodal/test_gpu_ipc_memory.py
+++ b/tests/multimodal/test_gpu_ipc_memory.py
@@ -209,6 +209,24 @@ def test_reserve_mm_ipc_gpu_memory_includes_pynvvideocodec_decoder_budget(
     )
 
 
+def test_reserve_mm_ipc_gpu_memory_includes_torchcodec_cuda_decoder_budget(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_VIDEO_LOADER_BACKEND", "opencv")
+    available_bytes = 4 * GiB_bytes
+    cpu_config = MultiModalConfig(
+        media_io_kwargs={"video": {"backend": "torchcodec"}},
+    )
+    cuda_config = MultiModalConfig(
+        media_io_kwargs={"video": {"backend": "torchcodec", "device": "cuda"}},
+    )
+
+    assert reserve_mm_ipc_gpu_memory(available_bytes, cpu_config) == available_bytes
+    assert reserve_mm_ipc_gpu_memory(available_bytes, cuda_config) == (
+        available_bytes - _pynvvideocodec_decoder_budget(hw_decoders=1)
+    )
+
+
 def test_reserve_mm_ipc_gpu_memory_uses_env_video_backend(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import numpy.typing as npt
@@ -175,7 +176,7 @@ def test_decode_video_imports_only_selected_backend(
             "torchcodec",
             {"min_frames": 4, "num_ffmpeg_threads": 2, "seek_mode": "approximate"},
             {"min_frames": 4},
-            {"num_ffmpeg_threads": 2, "seek_mode": "approximate"},
+            {"num_ffmpeg_threads": 2, "seek_mode": "approximate", "device": None},
         ),
         (
             "deepstream",
@@ -204,6 +205,16 @@ def test_video_backend_rejects_options_for_another_decoder():
         ValueError, match="num_ffmpeg_threads is not supported by the 'opencv' backend"
     ):
         resolve_video_backend_kwargs("opencv", {"num_ffmpeg_threads": 2})
+
+
+def test_video_backend_device_option_belongs_to_torchcodec():
+    _, backend_kwargs = resolve_video_backend_kwargs("torchcodec", {"device": "cuda"})
+    assert backend_kwargs["device"] == "cuda"
+
+    with pytest.raises(
+        ValueError, match="device is not supported by the 'opencv' backend"
+    ):
+        resolve_video_backend_kwargs("opencv", {"device": "cuda"})
 
 
 @pytest.mark.parametrize(
@@ -1203,6 +1214,103 @@ def test_torchcodec_backend_rejects_frame_recovery(dummy_video_path):
         loader.load_bytes(
             video_data, num_frames=8, backend="torchcodec", frame_recovery=True
         )
+
+
+def test_torchcodec_backend_forwards_decode_device(monkeypatch: pytest.MonkeyPatch):
+    """``device`` reaches ``VideoDecoder`` only when set, and sampled frames
+    are moved to the host before the NumPy conversion."""
+    from vllm.multimodal.video_decoders import torchcodec as torchcodec_module
+
+    constructor_kwargs: list[dict[str, object]] = []
+    requested_indices: list[list[int]] = []
+    cpu_calls: list[None] = []
+    acquired: list[int] = []
+
+    class RecordingPool:
+        @contextmanager
+        def acquire(self, size: int):
+            acquired.append(size)
+            yield
+
+    class FakeTensor:
+        def cpu(self):
+            cpu_calls.append(None)
+            return self
+
+        def numpy(self):
+            return np.zeros((len(requested_indices[-1]), 20, 10, 3), dtype=np.uint8)
+
+    class FakeDecoder:
+        metadata = SimpleNamespace(
+            num_frames=4, average_fps=2.0, duration_seconds=2.0, width=10, height=20
+        )
+
+        def __init__(self, data: bytes, **kwargs):
+            constructor_kwargs.append(kwargs)
+
+        def get_frames_at(self, frame_indices: list[int]):
+            requested_indices.append(list(frame_indices))
+            return SimpleNamespace(data=FakeTensor())
+
+    monkeypatch.setattr(torchcodec_module, "check_torchcodec_available", lambda: None)
+    monkeypatch.setattr(torchcodec_module, "VideoDecoder", FakeDecoder)
+    monkeypatch.setattr(
+        "vllm.multimodal.gpu_ipc_memory.get_mm_gpu_ipc_pool", RecordingPool
+    )
+
+    frames, metadata = VideoBackend.load_bytes(
+        b"fake video", num_frames=2, backend="torchcodec"
+    )
+    assert "device" not in constructor_kwargs[-1]
+    assert constructor_kwargs[-1]["dimension_order"] == "NHWC"
+    assert frames.shape == (2, 20, 10, 3)
+    # CPU decode never touches the frontend GPU budget.
+    assert acquired == []
+
+    frames, metadata = VideoBackend.load_bytes(
+        b"fake video", num_frames=2, backend="torchcodec", device="cuda"
+    )
+    assert constructor_kwargs[-1]["device"] == "cuda"
+    assert frames.shape == (2, 20, 10, 3)
+    assert metadata["frames_indices"] == requested_indices[-1]
+    assert len(cpu_calls) == 2
+    # CUDA decode accounts the sampled frames against the frontend budget.
+    assert acquired == [2 * 20 * 10 * 3]
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
+def test_torchcodec_cuda_backend_matches_cpu_frames():
+    """CUDA decode must select the same frames as CPU decode and return host
+    frames; NVDEC and FFmpeg color conversion may differ by a few levels."""
+    torchcodec = pytest.importorskip("torchcodec")
+    num_frames, height, width = 50, 64, 64
+    video_bytes = create_long_gop_video(
+        num_frames=num_frames, width=width, height=height
+    )
+    try:
+        torchcodec.decoders.VideoDecoder(video_bytes, device="cuda")
+    except Exception as exc:  # CPU-only TorchCodec build or no NVDEC
+        pytest.skip(f"TorchCodec CUDA decode unavailable: {exc}")
+
+    loader = VIDEO_LOADER_REGISTRY.load("opencv")
+    cpu_frames, cpu_meta = loader.load_bytes(
+        video_bytes, num_frames=4, backend="torchcodec"
+    )
+    gpu_frames, gpu_meta = loader.load_bytes(
+        video_bytes, num_frames=4, backend="torchcodec", device="cuda"
+    )
+
+    assert isinstance(gpu_frames, np.ndarray)
+    assert gpu_frames.shape == cpu_frames.shape == (4, height, width, 3)
+    assert gpu_meta["frames_indices"] == cpu_meta["frames_indices"]
+
+    # The long-GOP fixture stamps a per-frame green marker at the center.
+    cpu_markers = [int(f[height // 2, width // 2, 1]) for f in cpu_frames]
+    gpu_markers = [int(f[height // 2, width // 2, 1]) for f in gpu_frames]
+    assert len(set(gpu_markers)) == 4
+    assert all(abs(a - b) <= 8 for a, b in zip(cpu_markers, gpu_markers))
+    diff = np.abs(gpu_frames.astype(np.int16) - cpu_frames.astype(np.int16))
+    assert diff.mean() < 4.0
 
 
 def test_torchcodec_backend_returns_target_frames_not_keyframes():

--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -526,10 +526,16 @@ class MultiModalConfig:
             video_kwargs.get("video_backend") or envs.VLLM_VIDEO_LOADER_BACKEND
         )
         codec_backend = video_kwargs.get("backend")
-        return VIDEO_LOADER_REGISTRY.backend_requires_gpu(video_loader_backend) or (
+        if VIDEO_LOADER_REGISTRY.backend_requires_gpu(video_loader_backend) or (
             codec_backend is not None
             and VIDEO_LOADER_REGISTRY.backend_requires_gpu(codec_backend)
-        )
+        ):
+            return True
+        # TorchCodec decodes on the CPU by default but runs NVDEC inside the
+        # API server process when ``device`` selects CUDA.
+        return codec_backend == "torchcodec" and str(
+            video_kwargs.get("device") or ""
+        ).startswith("cuda")
 
     def is_multimodal_pruning_enabled(self):
         return self.get_video_pruning_spec() is not None

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -265,6 +265,11 @@ class VideoBackend(VideoLoader):
                   creation at the cost of relying on the file's metadata. See
                   https://meta-pytorch.org/torchcodec/stable/generated_examples/decoding/approximate_mode.html
                   for details.
+                - ``device`` (TorchCodec): decoder device. ``None`` (default)
+                  or ``"cpu"`` decodes with FFmpeg on the CPU; ``"cuda"``
+                  decodes with NVDEC when the installed TorchCodec build has
+                  CUDA support. Sampled frames are copied to host memory for
+                  multimodal preprocessing either way.
                 - ``hw_decoders`` (PyNvVideoCodec): maximum number of
                   concurrent decoder slots. Defaults to 2 and must be a
                   positive integer.

--- a/vllm/multimodal/video_decoders/__init__.py
+++ b/vllm/multimodal/video_decoders/__init__.py
@@ -19,6 +19,7 @@ _BACKEND_OPTION_DEFAULTS: dict[str, dict[str, Any]] = {
     "torchcodec": {
         "num_ffmpeg_threads": 0,
         "seek_mode": "exact",
+        "device": None,
     },
     PYNVVIDEOCODEC_VIDEO_BACKEND: {
         "hw_decoders": PYNVVIDEOCODEC_DEFAULT_HW_DECODERS,

--- a/vllm/multimodal/video_decoders/torchcodec.py
+++ b/vllm/multimodal/video_decoders/torchcodec.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Literal
+from contextlib import AbstractContextManager, nullcontext
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -13,6 +14,9 @@ from .base import (
     VideoTargetMetadata,
     check_frame_pixel_limit,
 )
+
+if TYPE_CHECKING:
+    import torch
 
 try:
     from torchcodec.decoders import VideoDecoder
@@ -30,12 +34,14 @@ def decode_torchcodec(
     *,
     num_ffmpeg_threads: int = 0,
     seek_mode: Literal["exact", "approximate"] = "exact",
+    device: "str | torch.device | None" = None,
 ) -> tuple[npt.NDArray, VideoSourceMetadata, list[int], list[int]]:
     check_torchcodec_available()
     decoder = TorchCodecVideoBackendMixin.make_torchcodec_decoder(
         data,
         num_ffmpeg_threads=num_ffmpeg_threads,
         seek_mode=seek_mode,
+        device=device,
     )
     check_frame_pixel_limit(
         decoder.metadata.width or 0,
@@ -47,10 +53,30 @@ def decode_torchcodec(
     frame_idx = loader_cls.compute_frames_index_to_sample(
         source=source, target=target, **sampling_kwargs
     )
-    frames, valid = TorchCodecVideoBackendMixin.decode_torchcodec_frames(
-        decoder, frame_idx
-    )
+    budget: AbstractContextManager[Any] = nullcontext()
+    if _is_cuda_device(device):
+        # GPU decode runs in the API server process. Account for the sampled
+        # frames against the frontend budget like the other GPU backends do.
+        from vllm.multimodal.gpu_ipc_memory import get_mm_gpu_ipc_pool
+
+        pool = get_mm_gpu_ipc_pool()
+        raw_frame_bytes = (
+            len(frame_idx)
+            * (decoder.metadata.height or 0)
+            * (decoder.metadata.width or 0)
+            * 3
+        )
+        if pool is not None and raw_frame_bytes > 0:
+            budget = pool.acquire(raw_frame_bytes)
+    with budget:
+        frames, valid = TorchCodecVideoBackendMixin.decode_torchcodec_frames(
+            decoder, frame_idx
+        )
     return frames, source, frame_idx, valid
+
+
+def _is_cuda_device(device: "str | torch.device | None") -> bool:
+    return device is not None and str(device).startswith("cuda")
 
 
 class TorchCodecVideoBackendMixin:
@@ -59,6 +85,11 @@ class TorchCodecVideoBackendMixin:
     Builds a :class:`~torchcodec.decoders.VideoDecoder` over the in-memory
     bytes and extracts the sampled indices with a single batched
     ``get_frames_at`` call, while releasing the GIL during decode.
+
+    ``device`` selects TorchCodec's decoder device. ``None`` keeps the CPU
+    (FFmpeg) default; ``"cuda"`` decodes with NVDEC when the installed
+    TorchCodec build has CUDA support. Sampled frames are always returned as
+    host NumPy arrays, which is what the multimodal processors consume.
     """
 
     @staticmethod
@@ -67,15 +98,20 @@ class TorchCodecVideoBackendMixin:
         *,
         num_ffmpeg_threads: int = 0,
         seek_mode: Literal["exact", "approximate"] = "exact",
+        device: "str | torch.device | None" = None,
     ) -> "VideoDecoder":
         # NHWC matches the (num_frames, H, W, 3) uint8 RGB layout the rest
         # of the pipeline expects, avoiding a transpose.
-        return VideoDecoder(
-            data,
-            dimension_order="NHWC",
-            num_ffmpeg_threads=num_ffmpeg_threads,
-            seek_mode=seek_mode,
-        )
+        decoder_kwargs: dict[str, Any] = {
+            "dimension_order": "NHWC",
+            "num_ffmpeg_threads": num_ffmpeg_threads,
+            "seek_mode": seek_mode,
+        }
+        # Forward ``device`` only when one was selected so the TorchCodec
+        # default (CPU) and its own validation errors stay untouched.
+        if device is not None:
+            decoder_kwargs["device"] = device
+        return VideoDecoder(data, **decoder_kwargs)
 
     @staticmethod
     def get_torchcodec_metadata(decoder: "VideoDecoder") -> VideoSourceMetadata:
@@ -97,4 +133,8 @@ class TorchCodecVideoBackendMixin:
             return np.empty((0,), dtype=np.uint8), []
         # Note: torchcodec releases the GIL for the entire call
         batch = decoder.get_frames_at(frame_indices)
-        return batch.data.numpy(), list(frame_indices)
+        # Multimodal processors consume host NumPy frames. A CUDA decoder
+        # returns device tensors, which cannot be converted directly, so copy
+        # only the sampled frames at this boundary. ``cpu()`` is a no-op for
+        # the default CPU decoder.
+        return batch.data.cpu().numpy(), list(frame_indices)


### PR DESCRIPTION
## Purpose

TorchCodec can decode on the GPU with NVDEC (`VideoDecoder(..., device="cuda")`) when the installed build has CUDA support, but the vLLM `torchcodec` video backend never forwards a device, so GPU decoding cannot be selected through `--media-io-kwargs`. Its CUDA output tensors also cannot be converted to NumPy directly, which is what the multimodal processors consume.

This PR adds an opt-in, TorchCodec-only `device` option:

- Register `device` (default `None`) with the torchcodec backend defaults so the existing backend-kwargs validator accepts it for `torchcodec` and rejects it for other backends.
- Forward it to `VideoDecoder` only when set, so the CPU default and TorchCodec's own device validation are untouched.
- Copy only the sampled frames to the host (`batch.data.cpu().numpy()`) before the NumPy conversion. This is a no-op for the CPU decoder.
- Treat `backend=torchcodec, device=cuda` as a GPU video backend in `MultiModalConfig.use_gpu_video_backend()`, so the frontend GPU memory reservation added for PyNvVideoCodec applies, and account the sampled frames against the `--mm-ipc-gpu-memory-gb` pool (`get_mm_gpu_ipc_pool().acquire(...)`) like the other GPU backends.
- Document the option, reuse the existing CUDA MPS / reservation guidance, and add unit tests plus a CUDA-gated frame-correctness test against the CPU decoder.

Why this is useful upstream:

- Video decoding runs in the API server process. With the CPU backends a single 1080p or 4K request pins several cores, so the frontend becomes CPU-bound under concurrent video traffic before the GPU is busy. NVDEC is fixed-function hardware that does not compete with the model for SMs. In the measurements below GPU decode uses roughly 20x less API-server CPU and gives higher throughput at concurrency 8, at the cost of higher single-request latency (decoder setup plus the device-to-host copy).
- It reuses a dependency vLLM already supports (TorchCodec) rather than adding a vendor-specific one, and the CUDA output matches the default OpenCV path within a mean absolute error of 0.4 (uint8), so switching does not change what the model sees.
- Off by default. Existing users see no change.
- Systems with few CPU cores per GPU (for example DGX Spark class machines) benefit the most, but nothing here is platform specific.

Related: #30839 (RFC: zero-copy video with PyNvVideoCodec and IPC) introduced the frontend GPU memory pool this change hooks into.

Not in scope, possible follow-ups: keeping decoded frames on the GPU through preprocessing (frames are still copied to host here), reusing a decoder across requests (most of the single-request latency gap), and NVDEC codec-coverage fallbacks. `device="cuda"` requires a CUDA-enabled TorchCodec build; other builds keep the CPU default.

## Test Plan

Unit tests (CPU; the CUDA-vs-CPU frame test runs only when CUDA and a CUDA TorchCodec build are available):

```bash
pytest tests/multimodal/test_video.py -k "torchcodec or backend_kwargs or device or lazy_imported or decoder_spec"
pytest tests/multimodal/test_gpu_ipc_memory.py
pytest tests/config/test_multimodal_config.py -k gpu_video_backend
```

Correctness and benchmark harness (synthetic H.264 clips generated with ffmpeg `testsrc2`, 1080p and 4K, 10 s at 30 fps, GOP 60; 8 and 32 sampled frames; concurrency 1 and 8; 5 rounds; sampled frames compared against the OpenCV reference decode):
https://github.com/arif-ahmed-nv/vllm-windows/tree/bench/video-decode

Environment: 1x H100 SXM (DGX Cloud Lepton), driver 570.195.03 with the CUDA 13 forward-compatibility package, `torch 2.13.0+cu130`, `torchcodec 0.16.0+cu130`, ffmpeg 6.1 (Ubuntu 24.04). Two runs of the unit tests and the correctness check: first on the original base (c7e6e36fa) with this branch installed as a precompiled editable build (`VLLM_USE_PRECOMPILED=1`), then again on the rebased head (32f4bd07f on top of main ae71862c5; the rebase onto ae71862c5 touched none of the changed files, and the only code change after the second run is a type annotation for mypy) installed as a Python-only editable build over the compiled libraries of nightly `0.28.1rc1.dev614+g26fec6d18`. The benchmarks below are from the first environment.

## Test Result

Unit tests, identical on both runs: `tests/multimodal/test_video.py` 20 passed, 0 skipped (including the CUDA-gated `test_torchcodec_cuda_backend_matches_cpu_frames`), `tests/multimodal/test_gpu_ipc_memory.py` 18 passed, `tests/config/test_multimodal_config.py` 6 passed.

Frame correctness, `torchcodec` + `device=cuda` vs OpenCV reference, 8 sampled frames, identical on both runs: matching frame indices and shapes on every clip (1080p, 4K, 720p); mean absolute error 0.401 / 0.401 / 0.342 (uint8), p99 absolute difference 2, max 2.

Decode benchmark, 8 sampled frames per request, 5 rounds, `conc` = concurrent requests decoding in one process. The container's CPU quota was about 20 cores (CPU decode plateaus there), so the concurrency 16 rows show the CPU-bound regime.

| clip | backend | p50 ms, conc 1 | p50 ms, conc 8 | p50 ms, conc 16 | frames/s, conc 8 | frames/s, conc 16 | avg CPU cores (conc 1 / 8 / 16) | process GPU MiB (conc 1 / 8 / 16) |
|---|---|---|---|---|---|---|---|---|
| 1080p | opencv | 199 | 1052 | 2354 | 57.4 | 50.9 | 9.6 / 19.6 / 19.8 | 0 |
| 1080p | torchcodec (cpu) | 158 | 782 | 2379 | 80.5 | 52.9 | 8.4 / 20.0 / 19.8 | 0 |
| 1080p | torchcodec `device=cuda` | 374 | 551 | 1034 | 88.1 | 100.2 | 0.19 / 1.16 / 1.42 | 690 / 1229 / 1846 |
| 4K | opencv | 704 | 4685 | 12416 | 13.2 | 9.8 | 11.6 / 19.7 / 19.9 | 0 |
| 4K | torchcodec (cpu) | 553 | 3592 | 10529 | 17.6 | 12.2 | 9.6 / 19.6 / 19.8 | 0 |
| 4K | torchcodec `device=cuda` | 1222 | 1867 | 3495 | 26.3 | 28.7 | 0.17 / 0.80 / 0.92 | 2120 / 3932 / 5905 |

Notes:

- With 20 cores available, single-request latency is higher on CUDA (decoder and CUDA context setup, plus the device-to-host copy of the sampled frames). Under concurrency the CPU backends saturate the available cores and their throughput falls as concurrency grows, while CUDA decode keeps scaling: at concurrency 16, 1.9x the frames/s of TorchCodec CPU at 1080p and 2.4x at 4K, with 2.3x to 3x lower request latency, using about 1 core instead of 20. This is a CPU-offload and scaling option, not a single-request latency optimization.
- Process GPU memory grows with resolution, frame count, and concurrency, reaching about 9.5 GiB in the worst case measured earlier (4K, 32 frames, concurrency 8). The reservation added here makes the engine account for it, and `--mm-ipc-gpu-memory-gb` bounds it.

CPU-constrained hosts. Same benchmark with the decoding process pinned (`taskset`) to 8 and to 4 cores, which is closer to the per-GPU CPU share on dense GPU nodes and on small systems such as DGX Spark. CUDA decode is unaffected by the pin (within noise of the 20-core numbers above); the CPU backends slow down proportionally.

| cores | clip | conc | opencv p50 ms / frames/s | torchcodec (cpu) p50 ms / frames/s | torchcodec `device=cuda` p50 ms / frames/s | CUDA vs TorchCodec CPU |
|---|---|---|---|---|---|---|
| 8 | 1080p | 1 | 302 / 26.3 | 235 / 33.8 | 371 / 21.4 | 1.6x slower |
| 8 | 1080p | 16 | 3450 / 35.8 | 2413 / 51.7 | 1020 / 100.6 | 2.4x faster, 1.9x throughput |
| 8 | 4K | 1 | 1140 / 7.0 | 795 / 10.0 | 1217 / 6.5 | 1.5x slower |
| 8 | 4K | 16 | 14822 / 8.3 | 9542 / 13.2 | 3464 / 28.9 | 2.8x faster, 2.2x throughput |
| 4 | 1080p | 1 | 486 / 16.4 | 375 / 21.0 | 371 / 21.4 | parity |
| 4 | 1080p | 16 | 6673 / 18.6 | 4520 / 27.8 | 1010 / 99.0 | 4.5x faster, 3.6x throughput |
| 4 | 4K | 1 | 1956 / 4.1 | 1316 / 6.1 | 1218 / 6.5 | 1.1x faster |
| 4 | 4K | 16 | 29796 / 4.2 | 17564 / 7.2 | 3502 / 28.1 | 5.0x faster, 3.9x throughput |

CPU used by the decoding process in these runs: 7.8 to 8.0 cores (8-core pin) and 3.9 to 4.0 cores (4-core pin) for both CPU backends at concurrency 8 and 16, versus 0.8 to 1.2 cores for CUDA decode. Process GPU memory for CUDA decode was identical to the 20-core runs (690 to 1846 MiB at 1080p, 2120 to 5905 MiB at 4K for 8 frames).
