### PR TITLE
[Bugfix][Frontend] Stream DeepSeek DSML tool calls incrementally in Rust

### DIFF
--- a/rust/src/parser/src/tool/deepseek_dsml/deepseek_v32.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/deepseek_v32.rs
@@ -21,7 +21,7 @@ use crate::tool::{Result, StructuralTagBuilder, Tool, ToolParser, ToolParserOutp
 /// </｜DSML｜function_calls>
 /// ```
 ///
-/// Arguments are emitted only after a full `invoke` block is parsed.
+/// Stable argument fragments are emitted incrementally while the `invoke` block is parsed.
 ///
 /// DeepSeek V3.2 relies on DSML markers such as `｜DSML｜`, which are
 /// represented as special tokens in the tokenizer and therefore must be

--- a/rust/src/parser/src/tool/deepseek_dsml/deepseek_v4.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/deepseek_v4.rs
@@ -21,7 +21,7 @@ use crate::tool::{Result, StructuralTagBuilder, Tool, ToolParser, ToolParserOutp
 /// </｜DSML｜tool_calls>
 /// ```
 ///
-/// Arguments are emitted only after a full `invoke` block is parsed.
+/// Stable argument fragments are emitted incrementally while the `invoke` block is parsed.
 ///
 /// V4 reuses the V3.2 DSML invoke/parameter grammar but wraps calls in
 /// `<｜DSML｜tool_calls>` instead of `<｜DSML｜function_calls>`.

--- a/rust/src/parser/src/tool/deepseek_dsml/deepseek_v41.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/deepseek_v41.rs
@@ -8,7 +8,7 @@ mod structural_tag;
 
 /// Tool parser for DeepSeek V4.1's spaced DSML tags.
 ///
-/// Arguments are emitted only after a full `invoke` block is parsed.
+/// Stable argument fragments are emitted incrementally while the `invoke` block is parsed.
 pub struct DeepSeekV41ToolParser(DeepSeekDsmlToolParser);
 
 impl ToolParser for DeepSeekV41ToolParser {

--- a/rust/src/parser/src/tool/deepseek_dsml/deepseek_v41/tests.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/deepseek_v41/tests.rs
@@ -111,3 +111,83 @@ fn structural_tag_ignores_parameter_schemas_and_strict() {
         }
     }
 }
+
+#[test]
+fn spaced_dsml_streaming_emits_arguments_before_invoke_closes() {
+    let mut parser = DeepSeekV41ToolParser::create(&tools()).unwrap();
+    let mut output = crate::tool::ToolParserOutput::default();
+    parser
+        .parse_into(
+            concat!(
+                "<｜DSML｜ calls>\n",
+                "<｜DSML｜ invoke name=\"lookup\">\n",
+                "<｜DSML｜ parameter name=\"query\" string=\"true\">hello",
+                "</｜DSML｜ parameter>\n",
+            ),
+            &mut output,
+        )
+        .unwrap();
+
+    let calls = output.calls();
+    assert!(calls.iter().any(|call| call.name.as_deref() == Some("lookup")));
+    let arguments = calls.iter().map(|call| call.arguments.as_str()).collect::<String>();
+    assert_eq!(arguments, r#"{"query":"hello""#);
+    assert!(parser.finish().is_err());
+}
+
+#[test]
+fn spaced_dsml_streaming_matches_pr42879_mixed_argument_semantics() {
+    let tool = Tool {
+        name: "plan_trip".into(),
+        description: None,
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "days": {"type": "integer"},
+                "flexible": {"type": "boolean"},
+                "cities": {"type": "array", "items": {"type": "string"}},
+                "notes": {"type": "string"}
+            }
+        }),
+        strict: None,
+    };
+    let wire = concat!(
+        "<｜DSML｜ calls>\n",
+        "<｜DSML｜ invoke name=\"plan_trip\">\n",
+        "<｜DSML｜ parameter name=\"days\" string=\"false\">3</｜DSML｜ parameter>\n",
+        "<｜DSML｜ parameter name=\"flexible\" string=\"false\">false</｜DSML｜ parameter>\n",
+        "<｜DSML｜ parameter name=\"cities\" string=\"false\">[\"Beijing\",\"Shanghai\",\"Tokyo\",\"New York\"]</｜DSML｜ parameter>\n",
+        "<｜DSML｜ parameter name=\"notes\" string=\"true\">靠窗座位</｜DSML｜ parameter>\n",
+        "</｜DSML｜ invoke>\n",
+        "</｜DSML｜ calls>",
+    );
+    let chunks = crate::tool::test_utils::split_by_chars(wire, 4);
+    let mut parser = DeepSeekV41ToolParser::create(&[tool]).unwrap();
+    let mut output = crate::tool::ToolParserOutput::default();
+    let mut non_empty_argument_deltas = 0;
+    for chunk in chunks {
+        let before = output.events.len();
+        parser.parse_into(chunk, &mut output).unwrap();
+        non_empty_argument_deltas += output.events[before..]
+            .iter()
+            .filter(|event| match event {
+                crate::tool::ToolParserEvent::ToolCall(call) => !call.arguments.is_empty(),
+                crate::tool::ToolParserEvent::Text(_) => false,
+            })
+            .count();
+    }
+    output.append(parser.finish().unwrap());
+    let output = output.coalesce();
+
+    assert!(non_empty_argument_deltas > 2);
+    assert_eq!(output.calls().len(), 1);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&output.calls()[0].arguments).unwrap(),
+        json!({
+            "days": 3,
+            "flexible": false,
+            "cities": ["Beijing", "Shanghai", "Tokyo", "New York"],
+            "notes": "靠窗座位"
+        })
+    );
+}

--- a/rust/src/parser/src/tool/deepseek_dsml/mod.rs
+++ b/rust/src/parser/src/tool/deepseek_dsml/mod.rs
@@ -2,13 +2,13 @@
 // SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 use winnow::ascii::{multispace0 as ws0, multispace1 as ws1};
-use winnow::combinator::{alt, delimited, eof, repeat, seq, terminated};
+use winnow::combinator::{alt, delimited};
 use winnow::prelude::*;
 use winnow::stream::Partial;
-use winnow::token::{literal, rest, take_until};
+use winnow::token::{literal, take_until};
 
 use super::parameters::ToolSchemas;
-use super::utils::{MarkerScanState, parse_buffered_event, safe_text_len_mul, take_until_marker};
+use super::utils::{parse_buffered_event, partial_prefix_len};
 use super::{Result, ToolCallDelta, ToolParserOutput};
 use crate::tool::Tool;
 
@@ -60,32 +60,25 @@ impl DsmlTokens {
     };
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DsmlMode {
     Text,
-    ToolBlock { invoke_end_scan: MarkerScanState },
+    ToolBlock,
     Done,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum DsmlEvent {
-    Text {
-        len: usize,
-    },
-    ToolCallsStart,
-    Invoke {
-        name: String,
-        raw_params: Vec<DsmlParameter>,
-    },
-    ToolCallsEnd,
-    IgnoredRest,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParamMode {
+    String,
+    Raw,
+    Buffered,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct DsmlParameter {
+struct ActiveParam {
     name: String,
-    value: String,
-    is_string: bool,
+    mode: ParamMode,
+    buffered: String,
 }
 
 /// Tool parser core for DeepSeek DSML tool calls.
@@ -93,6 +86,10 @@ struct DeepSeekDsmlToolParser {
     buffer: String,
     mode: DsmlMode,
     emitted_invoke_count: usize,
+    active_tool_index: Option<usize>,
+    active_tool_name: Option<String>,
+    args_started: bool,
+    active_param: Option<ActiveParam>,
     tool_parameters: ToolSchemas,
     tokens: DsmlTokens,
 }
@@ -104,73 +101,303 @@ impl DeepSeekDsmlToolParser {
             buffer: String::new(),
             mode: DsmlMode::Text,
             emitted_invoke_count: 0,
+            active_tool_index: None,
+            active_tool_name: None,
+            args_started: false,
+            active_param: None,
             tool_parameters: ToolSchemas::from_tools(tools),
             tokens,
         }
     }
 
-    /// Apply one parsed DSML event to parser state and output.
-    fn apply_event(&mut self, event: DsmlEvent, output: &mut ToolParserOutput) -> Result<()> {
-        match event {
-            DsmlEvent::Text { len: consumed_len } => {
-                output.push_text(&self.buffer[..consumed_len]);
-            }
-            DsmlEvent::ToolCallsStart => {
-                self.mode = DsmlMode::ToolBlock {
-                    invoke_end_scan: MarkerScanState::default(),
-                };
-            }
-            DsmlEvent::Invoke { name, raw_params } => {
-                let mut arguments = serde_json::Map::with_capacity(raw_params.len());
-                for param in raw_params {
-                    let value = if param.is_string {
-                        serde_json::Value::String(param.value)
-                    } else {
-                        self.tool_parameters.convert_param_with_schema(
-                            &name,
-                            &param.name,
-                            param.value,
-                        )
-                    };
-                    arguments.insert(param.name, value);
-                }
-                let arguments = serde_json::to_string(&arguments)
-                    .map_err(|error| parsing_failed!("failed to serialize arguments: {}", error))?;
+    /// Emit one function-call update.
+    fn push_call(
+        &self,
+        output: &mut ToolParserOutput,
+        index: usize,
+        name: Option<String>,
+        arguments: impl Into<String>,
+    ) {
+        output.push_call(ToolCallDelta {
+            tool_index: index,
+            name,
+            arguments: arguments.into(),
+        });
+    }
 
-                output.push_call(ToolCallDelta {
-                    tool_index: self.emitted_invoke_count,
-                    name: Some(name),
-                    arguments,
-                });
-                self.emitted_invoke_count += 1;
-            }
-            DsmlEvent::ToolCallsEnd => self.mode = DsmlMode::Done,
-            DsmlEvent::IgnoredRest => {}
-        };
+    /// Emit the JSON object key prefix for one parameter.
+    fn push_param_prefix(
+        &mut self,
+        output: &mut ToolParserOutput,
+        index: usize,
+        name: &str,
+        as_string: bool,
+    ) -> Result<()> {
+        let key = serde_json::to_string(name)
+            .map_err(|error| parsing_failed!("failed to serialize parameter name: {}", error))?;
+        let separator = if self.args_started { ',' } else { '{' };
+        self.args_started = true;
+        let quote = if as_string { "\"" } else { "" };
+        self.push_call(output, index, None, format!("{separator}{key}:{quote}"));
         Ok(())
+    }
+
+    /// Emit a complete schema-converted parameter value.
+    fn push_buffered_param(
+        &mut self,
+        output: &mut ToolParserOutput,
+        index: usize,
+        tool_name: &str,
+        param: ActiveParam,
+    ) -> Result<()> {
+        let value =
+            self.tool_parameters
+                .convert_param_with_schema(tool_name, &param.name, param.buffered);
+        self.push_param_prefix(output, index, &param.name, false)?;
+        let value = serde_json::to_string(&value)
+            .map_err(|error| parsing_failed!("failed to serialize argument value: {}", error))?;
+        self.push_call(output, index, None, value);
+        Ok(())
+    }
+
+    /// JSON-escape a string fragment without adding surrounding quotes.
+    fn escape_string_fragment(value: &str) -> Result<String> {
+        let encoded = serde_json::to_string(value)
+            .map_err(|error| parsing_failed!("failed to serialize string argument: {}", error))?;
+        Ok(encoded[1..encoded.len() - 1].to_string())
+    }
+
+    /// Remove leading DSML whitespace from the buffered tool block.
+    fn trim_tool_whitespace(&mut self) -> bool {
+        let trimmed = self.buffer.trim_start();
+        let len = self.buffer.len() - trimmed.len();
+        if len == 0 {
+            return false;
+        }
+        self.buffer.drain(..len);
+        true
+    }
+
+    /// Start one invoke and emit its metadata immediately.
+    fn begin_invoke(&mut self, name: String, output: &mut ToolParserOutput) {
+        let index = self.emitted_invoke_count;
+        self.emitted_invoke_count += 1;
+        self.active_tool_index = Some(index);
+        self.active_tool_name = Some(name.clone());
+        self.args_started = false;
+        self.active_param = None;
+        self.push_call(output, index, Some(name), "");
+    }
+
+    /// Finish one invoke by closing its streamed JSON object.
+    fn finish_invoke(&mut self, output: &mut ToolParserOutput) {
+        let Some(index) = self.active_tool_index.take() else {
+            return;
+        };
+        self.push_call(
+            output,
+            index,
+            None,
+            if self.args_started { "}" } else { "{}" },
+        );
+        self.active_tool_name = None;
+        self.args_started = false;
+        self.active_param = None;
+    }
+
+    /// Consume plain text until a complete or partial tool-call marker.
+    fn process_text(&mut self, output: &mut ToolParserOutput) -> bool {
+        let markers = [
+            self.tokens.framed_tool_calls_start,
+            self.tokens.tool_calls_start,
+        ];
+        if let Some((start, marker)) = markers
+            .iter()
+            .filter_map(|marker| self.buffer.find(*marker).map(|start| (start, *marker)))
+            .min_by_key(|(start, _)| *start)
+        {
+            if start > 0 {
+                output.push_text(self.buffer[..start].to_string());
+                self.buffer.drain(..start);
+                return true;
+            }
+            self.buffer.drain(..marker.len());
+            self.mode = DsmlMode::ToolBlock;
+            return true;
+        }
+
+        let keep = markers
+            .iter()
+            .map(|marker| partial_prefix_len(&self.buffer, marker))
+            .max()
+            .unwrap_or(0);
+        let emit = self.buffer.len().saturating_sub(keep);
+        if emit == 0 {
+            return false;
+        }
+        output.push_text(self.buffer[..emit].to_string());
+        self.buffer.drain(..emit);
+        true
+    }
+
+    /// Consume the next invoke header or the tool-calls closing marker.
+    fn process_between_invokes(&mut self, output: &mut ToolParserOutput) -> Result<bool> {
+        if self.trim_tool_whitespace() {
+            return Ok(true);
+        }
+        if self.buffer.is_empty() {
+            return Ok(false);
+        }
+
+        if self.buffer.starts_with(self.tokens.tool_calls_end) {
+            self.buffer.drain(..self.tokens.tool_calls_end.len());
+            self.mode = DsmlMode::Done;
+            return Ok(true);
+        }
+        if self.tokens.tool_calls_end.starts_with(&self.buffer) {
+            return Ok(false);
+        }
+
+        let parsed =
+            parse_buffered_event(&self.buffer, |input| parse_invoke_start(input, self.tokens))?;
+        let Some((name, consumed)) = parsed else {
+            return Ok(false);
+        };
+        self.buffer.drain(..consumed);
+        self.begin_invoke(name, output);
+        Ok(true)
+    }
+
+    /// Consume one active parameter's content incrementally.
+    fn process_active_param(&mut self, output: &mut ToolParserOutput) -> Result<bool> {
+        let Some(index) = self.active_tool_index else {
+            return Ok(false);
+        };
+        let Some(mode) = self.active_param.as_ref().map(|param| param.mode) else {
+            return Ok(false);
+        };
+
+        if let Some(end) = self.buffer.find(self.tokens.parameter_end) {
+            let raw = self.buffer[..end].to_string();
+            self.buffer.drain(..end + self.tokens.parameter_end.len());
+            match mode {
+                ParamMode::String => {
+                    let arguments = Self::escape_string_fragment(&raw)? + "\"";
+                    self.push_call(output, index, None, arguments);
+                    self.active_param = None;
+                }
+                ParamMode::Raw => {
+                    self.push_call(output, index, None, raw);
+                    self.active_param = None;
+                }
+                ParamMode::Buffered => {
+                    let mut param = self.active_param.take().expect("active parameter exists");
+                    param.buffered.push_str(&raw);
+                    let tool_name = self.active_tool_name.clone().unwrap_or_default();
+                    self.push_buffered_param(output, index, &tool_name, param)?;
+                }
+            }
+            return Ok(true);
+        }
+
+        let keep = partial_prefix_len(&self.buffer, self.tokens.parameter_end);
+        let emit = self.buffer.len().saturating_sub(keep);
+        if emit == 0 {
+            return Ok(false);
+        }
+        let raw = self.buffer[..emit].to_string();
+        self.buffer.drain(..emit);
+        match mode {
+            ParamMode::String => {
+                self.push_call(output, index, None, Self::escape_string_fragment(&raw)?);
+            }
+            ParamMode::Raw => self.push_call(output, index, None, raw),
+            ParamMode::Buffered => {
+                if let Some(param) = self.active_param.as_mut() {
+                    param.buffered.push_str(&raw);
+                }
+            }
+        }
+        Ok(true)
+    }
+
+    /// Consume an invoke closing marker or begin its next parameter.
+    fn process_invoke(&mut self, output: &mut ToolParserOutput) -> Result<bool> {
+        if self.active_param.is_some() {
+            return self.process_active_param(output);
+        }
+        if self.trim_tool_whitespace() {
+            return Ok(true);
+        }
+        if self.buffer.is_empty() {
+            return Ok(false);
+        }
+
+        if self.buffer.starts_with(self.tokens.invoke_end) {
+            self.buffer.drain(..self.tokens.invoke_end.len());
+            self.finish_invoke(output);
+            return Ok(true);
+        }
+        if self.tokens.invoke_end.starts_with(&self.buffer) {
+            return Ok(false);
+        }
+
+        let parsed = parse_buffered_event(&self.buffer, |input| {
+            parse_parameter_start(input, self.tokens)
+        })?;
+        let Some(((name, is_string), consumed)) = parsed else {
+            return Ok(false);
+        };
+        self.buffer.drain(..consumed);
+
+        let index = self.active_tool_index.expect("active tool exists");
+        let tool_name = self.active_tool_name.clone().unwrap_or_default();
+        let mode = if is_string {
+            self.push_param_prefix(output, index, &name, true)?;
+            ParamMode::String
+        } else if self.tool_parameters.can_stream_raw_param(&tool_name, &name) {
+            self.push_param_prefix(output, index, &name, false)?;
+            ParamMode::Raw
+        } else {
+            ParamMode::Buffered
+        };
+        self.active_param = Some(ActiveParam {
+            name,
+            mode,
+            buffered: String::new(),
+        });
+        Ok(true)
     }
 
     fn reset(&mut self) -> String {
         self.mode = DsmlMode::Text;
         self.emitted_invoke_count = 0;
+        self.active_tool_index = None;
+        self.active_tool_name = None;
+        self.args_started = false;
+        self.active_param = None;
         std::mem::take(&mut self.buffer)
     }
 
     fn parse_into(&mut self, chunk: &str, output: &mut ToolParserOutput) -> Result<()> {
-        // Extract tool calls from streaming model output.
-        //
-        // Uses a buffer-until-complete-invoke strategy: text is buffered until
-        // a complete invoke block is available, then parsed and emitted in one
-        // shot.
+        // Extract tool calls from streaming model output. DSML framing is
+        // buffered, while stable function metadata and argument fragments are
+        // emitted as soon as they can no longer change.
         self.buffer.push_str(chunk);
 
-        while let Some((event, consumed_len)) = parse_buffered_event(&self.buffer, |input| {
-            parse_next_dsml_event(input, &mut self.mode, self.tokens)
-        })? {
-            self.apply_event(event, output)?;
-            self.buffer.drain(..consumed_len);
+        loop {
+            let progressed = match self.mode {
+                DsmlMode::Text => self.process_text(output),
+                DsmlMode::ToolBlock if self.active_tool_index.is_none() => {
+                    self.process_between_invokes(output)?
+                }
+                DsmlMode::ToolBlock => self.process_invoke(output)?,
+                DsmlMode::Done => false,
+            };
+            if !progressed {
+                break;
+            }
         }
-
         Ok(())
     }
 
@@ -179,7 +406,7 @@ impl DeepSeekDsmlToolParser {
         match self.mode {
             DsmlMode::Text => output.push_text(&self.buffer),
             DsmlMode::Done => {}
-            DsmlMode::ToolBlock { .. } => {
+            DsmlMode::ToolBlock => {
                 return Err(parsing_failed!("incomplete DeepSeek DSML tool call"));
             }
         }
@@ -188,137 +415,37 @@ impl DeepSeekDsmlToolParser {
     }
 }
 
-/// Parse a DSML event for the current parser mode.
-fn parse_next_dsml_event(
-    input: &mut DsmlInput<'_>,
-    mode: &mut DsmlMode,
-    tokens: DsmlTokens,
-) -> ModalResult<DsmlEvent> {
-    match mode {
-        DsmlMode::Text => parse_text_event(input, tokens),
-        DsmlMode::ToolBlock { invoke_end_scan } => {
-            parse_tool_block_event(input, tokens, invoke_end_scan)
-        }
-        DsmlMode::Done => ignored_rest_event(input),
-    }
-}
-
-/// Parse a text-mode DSML event.
-fn parse_text_event(input: &mut DsmlInput<'_>, tokens: DsmlTokens) -> ModalResult<DsmlEvent> {
-    alt((
-        |input: &mut DsmlInput<'_>| tool_calls_start_event(input, tokens),
-        |input: &mut DsmlInput<'_>| safe_text_event(input, tokens),
-    ))
-    .parse_next(input)
-}
-
-/// Parse a tool-block DSML event.
-fn parse_tool_block_event(
-    input: &mut DsmlInput<'_>,
-    tokens: DsmlTokens,
-    invoke_end_scan: &mut MarkerScanState,
-) -> ModalResult<DsmlEvent> {
+/// Parse a DSML invoke start tag.
+fn parse_invoke_start(input: &mut DsmlInput<'_>, tokens: DsmlTokens) -> ModalResult<String> {
+    literal(tokens.invoke_start).parse_next(input)?;
+    ws1.void().parse_next(input)?;
+    let name = dsml_name_attr(input)?.to_string();
     ws0.void().parse_next(input)?;
-    alt((
-        |input: &mut DsmlInput<'_>| invoke_event(input, tokens, invoke_end_scan),
-        |input: &mut DsmlInput<'_>| tool_calls_end_event(input, tokens),
-    ))
-    .parse_next(input)
+    literal(">").parse_next(input)?;
+    Ok(name)
 }
 
-/// Parse a DSML function-calls start marker.
-fn tool_calls_start_event(input: &mut DsmlInput<'_>, tokens: DsmlTokens) -> ModalResult<DsmlEvent> {
-    alt((
-        literal(tokens.framed_tool_calls_start),
-        literal(tokens.tool_calls_start),
-    ))
-    .value(DsmlEvent::ToolCallsStart)
-    .parse_next(input)
-}
-
-/// Parse a DSML function-calls end marker.
-fn tool_calls_end_event(input: &mut DsmlInput<'_>, tokens: DsmlTokens) -> ModalResult<DsmlEvent> {
-    literal(tokens.tool_calls_end).value(DsmlEvent::ToolCallsEnd).parse_next(input)
-}
-
-/// Parse a trailing rest after DSML function calls.
-fn ignored_rest_event(input: &mut DsmlInput<'_>) -> ModalResult<DsmlEvent> {
-    rest.value(DsmlEvent::IgnoredRest).parse_next(input)
-}
-
-/// Parse a safe text run before the next DSML marker.
-fn safe_text_event(input: &mut DsmlInput<'_>, tokens: DsmlTokens) -> ModalResult<DsmlEvent> {
-    safe_text_len_mul(
-        input,
-        &[tokens.framed_tool_calls_start, tokens.tool_calls_start],
-    )
-    .map(|len| DsmlEvent::Text { len })
-}
-
-/// Parse a DSML invoke block.
-fn invoke_event(
+/// Parse a DSML parameter start tag.
+fn parse_parameter_start(
     input: &mut DsmlInput<'_>,
     tokens: DsmlTokens,
-    invoke_end_scan: &mut MarkerScanState,
-) -> ModalResult<DsmlEvent> {
-    let (name, body) = seq!(
-        _: literal(tokens.invoke_start),
-        _: ws1,
-        dsml_name_attr,
-        _: ws0,
-        _: ">",
-        take_until_marker(tokens.invoke_end, invoke_end_scan),
-        _: literal(tokens.invoke_end),
-    )
-    .parse_next(input)?;
-    let raw_params = parse_invoke_params(body, tokens)?;
-    Ok(DsmlEvent::Invoke {
-        name: name.to_string(),
-        raw_params,
-    })
-}
-
-/// Parse a DSML invoke body.
-fn parse_invoke_params(invoke_body: &str, tokens: DsmlTokens) -> ModalResult<Vec<DsmlParameter>> {
-    let mut input = invoke_body;
-    delimited(
-        ws0,
-        repeat(
-            0..,
-            terminated(|input: &mut &str| parse_parameter(input, tokens), ws0),
-        ),
-        eof,
-    )
-    .parse_next(&mut input)
-}
-
-/// Parse a DSML parameter block.
-fn parse_parameter(input: &mut &str, tokens: DsmlTokens) -> ModalResult<DsmlParameter> {
-    seq! {DsmlParameter {
-        _: literal(tokens.parameter_start),
-        _: ws1,
-        name: name_attr.map(|name: &str| name.to_string()),
-        _: ws1,
-        is_string: string_attr.map(|value| value == "true"),
-        _: ws0,
-        _: ">",
-        value: take_until(0.., tokens.parameter_end).map(str::to_string),
-        _: literal(tokens.parameter_end),
-    }}
-    .parse_next(input)
-}
-
-/// Parse a name attribute.
-fn name_attr<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
-    delimited("name=\"", take_until(1.., "\""), "\"").parse_next(input)
-}
-
-/// Parse a string attribute.
-fn string_attr<'i>(input: &mut &'i str) -> ModalResult<&'i str> {
-    delimited("string=\"", alt(("true", "false")), "\"").parse_next(input)
+) -> ModalResult<(String, bool)> {
+    literal(tokens.parameter_start).parse_next(input)?;
+    ws1.void().parse_next(input)?;
+    let name = dsml_name_attr(input)?.to_string();
+    ws1.void().parse_next(input)?;
+    let is_string = dsml_string_attr(input)? == "true";
+    ws0.void().parse_next(input)?;
+    literal(">").parse_next(input)?;
+    Ok((name, is_string))
 }
 
 /// Parse a DSML name attribute.
 fn dsml_name_attr<'i>(input: &mut DsmlInput<'i>) -> ModalResult<&'i str> {
     delimited("name=\"", take_until(1.., "\""), "\"").parse_next(input)
+}
+
+/// Parse a DSML string attribute.
+fn dsml_string_attr<'i>(input: &mut DsmlInput<'i>) -> ModalResult<&'i str> {
+    delimited("string=\"", alt(("true", "false")), "\"").parse_next(input)
 }

--- a/rust/src/parser/src/tool/parameters.rs
+++ b/rust/src/parser/src/tool/parameters.rs
@@ -110,6 +110,14 @@ impl ToolSchemas {
         let tool_schema = self.tools.get(function_name).unwrap_or(ToolSchema::empty());
         tool_schema.convert(name, value.into())
     }
+
+    /// Return whether a parameter can be streamed as raw JSON without scalar coercion.
+    pub(super) fn can_stream_raw_param(&self, function_name: &str, name: &str) -> bool {
+        self.tools
+            .get(function_name)
+            .and_then(|schema| schema.params.get(name))
+            .is_some_and(JsonParamType::can_stream_raw)
+    }
 }
 
 impl ToolSchema {
@@ -149,6 +157,15 @@ impl ToolSchema {
 }
 
 impl JsonParamType {
+    /// Return whether this schema type can preserve raw incremental JSON fragments.
+    fn can_stream_raw(&self) -> bool {
+        match self {
+            Self::Object { .. } | Self::Array { .. } => true,
+            Self::OneOf(types) => !types.is_empty() && types.iter().all(Self::can_stream_raw),
+            Self::String | Self::Integer | Self::Number | Self::Boolean | Self::Null => false,
+        }
+    }
+
     /// Normalize one parameter property schema.
     fn from_schema(schema: &Value) -> Option<Self> {
         let schema = schema.as_object()?;


### PR DESCRIPTION
## Purpose

Port the incremental DeepSeek DSML tool-call streaming behavior from the Python frontend fix in #42879 to the Rust frontend.

The Rust DeepSeek DSML parser currently buffers an entire `invoke` block before emitting the tool call. This change instead emits stable function metadata and argument fragments as soon as they can no longer change, while preserving schema-conversion semantics:

- string arguments are JSON-escaped and streamed incrementally;
- object/array arguments remain buffered until the parameter closes to preserve empty-value normalization and malformed-JSON fallback;
- scalar/union values that may require schema coercion remain buffered until the parameter closes;
- incomplete DSML still fails closed at `finish()`;
- both framed and unframed DSML start markers already supported on `main` remain supported.

The shared implementation covers DeepSeek V3.2, V4, and V4.1, with regression coverage added for the spaced V4.1 dialect.

## Test Plan

```bash
cargo fmt --all -- --check
cargo test --locked -p vllm-parser deepseek_v41 --lib -- --nocapture
cargo test --locked -p vllm-parser --lib
```

## Test Result

- `cargo fmt --all -- --check`: PASS
- DeepSeek V4.1 targeted parser tests: **7 passed, 0 failed**
- Full `vllm-parser` library suite: **461 passed, 0 failed**


## Review follow-up

The follow-up also discards same-chunk and subsequent trailing output immediately after the DSML block closes. Regression coverage spans V3.2, V4, and V4.1. The full parser suite was rerun on HLA42 with `cargo test --offline --locked -p vllm-parser --lib`: 461 passed. Both new regression tests failed before the fix.

This PR implements the Rust frontend counterpart of Python PR #42879; it does not modify that Python implementation. AI assistance was used (GPT-6 Astra). Validation is at the parser level; no live model evaluation or serving rollout was performed.
