### PR TITLE
[CI/Build] Pin HyperCLOVAX V2 test model revision

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -963,6 +963,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "HCXVisionV2ForCausalLM": _HfExamplesInfo(
         "naver-hyperclovax/HyperCLOVAX-SEED-Think-32B",
         trust_remote_code=True,
+        revision="a6cdfd3464d1b767259cad23e164eaf39d3e3960",
     ),
     "HunYuanVLForConditionalGeneration": _HfExamplesInfo(
         "tencent/HunyuanOCR",


### PR DESCRIPTION
Fix the CI

## Why

Naver updated `naver-hyperclovax/HyperCLOVAX-SEED-Think-32B` to remove its remote-code implementation and advertise native Transformers support. The released Transformers version used by vLLM CI does not yet recognize the new `hyperclovax_vision_v2` configuration, which makes the CPU multimodal processor tests fail while constructing `ModelConfig`.

Pin the test registry entry to the last compatible model revision. This keeps the existing model coverage deterministic until native Transformers support is available.

## Duplicate work

I searched open PRs for HyperCLOVAX revision/configuration fixes. The only related open PR, #42366, adds frontend reasoning and tool parsers and does not address this checkpoint drift.

## Tests

- `pre-commit run --files tests/models/registry.py`
- `.venv/bin/python -m pytest tests/models/multimodal/processing/test_common.py -q -k HyperCLOVAX` — 3 passed
- Direct execution of the assertion wrapped by `test_model_tensor_schema[naver-hyperclovax/HyperCLOVAX-SEED-Think-32B]` — passed. The normal pytest wrapper forks, which crashes locally on macOS during Objective-C proxy initialization.

Model evaluations were not run because this only pins a CI test fixture revision and does not change model execution, outputs, or accuracy.

AI assistance was used to diagnose the CI failure, inspect the upstream checkpoint change, implement the revision pin, and run the tests. Human review is required before marking this draft ready.
