### PR TITLE
[Bugfix][V1] Preserve worker failure notifications during callback registration

### DIFF
--- a/tests/v1/executor/test_multiproc_executor.py
+++ b/tests/v1/executor/test_multiproc_executor.py
@@ -2,12 +2,97 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import weakref
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
-from vllm.v1.executor.multiproc_executor import WorkerProc
+from vllm.v1.executor import multiproc_executor
+from vllm.v1.executor.multiproc_executor import MultiprocExecutor, WorkerProc
+
+
+def _monitor_executor(monkeypatch, cls=MultiprocExecutor):
+    executor = cls.__new__(cls)
+    executor.is_failed = False
+    executor.failure_callback = None
+    executor._failure_callback_lock = Lock()
+    executor.shutdown = Mock()
+    executor.workers = [
+        SimpleNamespace(proc=SimpleNamespace(sentinel=1, name="worker", exitcode=1))
+    ]
+    monkeypatch.setattr(
+        multiproc_executor.multiprocessing.connection, "wait", lambda _: [1]
+    )
+    return executor
+
+
+@pytest.mark.parametrize("registration", ["before", "during_shutdown", "after"])
+def test_worker_failure_notifies_registered_callback_once(monkeypatch, registration):
+    executor = _monitor_executor(monkeypatch)
+
+    def check_callback_runs_without_lock():
+        assert executor._failure_callback_lock.acquire(blocking=False)
+        executor._failure_callback_lock.release()
+
+    callback = Mock(side_effect=check_callback_runs_without_lock)
+    if registration == "before":
+        executor.register_failure_callback(callback)
+    elif registration == "during_shutdown":
+        executor.shutdown.side_effect = lambda: executor.register_failure_callback(
+            callback
+        )
+
+    executor.start_worker_monitor(inline=True)
+    if registration == "after":
+        executor.register_failure_callback(callback)
+
+    callback.assert_called_once_with()
+    executor.shutdown.assert_called_once_with()
+    assert executor.is_failed
+    assert executor.failure_callback is None
+
+
+def test_worker_failure_during_callback_registration_is_not_lost(monkeypatch):
+    """Worker death between the failure check and callback storage must notify."""
+    registering = Event()
+    resume_registration = Event()
+    callback = Mock()
+    lock = Lock()
+
+    class PausedRegistrationExecutor(MultiprocExecutor):
+        def __setattr__(self, name, value):
+            if name == "failure_callback" and value is callback:
+                registering.set()
+                assert resume_registration.wait(5)
+            super().__setattr__(name, value)
+
+    class NotificationLock:
+        def __enter__(self):
+            if not lock.acquire(blocking=False):
+                # The monitor reached the registration's critical section.
+                resume_registration.set()
+                assert lock.acquire(timeout=5)
+
+        def __exit__(self, *exc):
+            lock.release()
+
+    executor = _monitor_executor(monkeypatch, PausedRegistrationExecutor)
+    executor._failure_callback_lock = NotificationLock()
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        registration = pool.submit(executor.register_failure_callback, callback)
+        try:
+            assert registering.wait(5)
+            executor.start_worker_monitor(inline=True)
+        finally:
+            resume_registration.set()
+        registration.result(timeout=5)
+
+    callback.assert_called_once_with()
+    assert executor.failure_callback is None
 
 
 class _ExitWorkerLoop(RuntimeError):

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -119,6 +119,7 @@ class MultiprocExecutor(Executor):
         # Call self.shutdown at exit to clean up
         # and ensure workers will be terminated.
         self._finalizer = weakref.finalize(self, self.shutdown)
+        self._failure_callback_lock = threading.Lock()
         self.is_failed = False
         self.failure_callback: FailureCallback | None = None
 
@@ -309,7 +310,8 @@ class MultiprocExecutor(Executor):
             if not _self or getattr(_self, "shutting_down", False):
                 logger.debug("MultiprocWorkerMonitor: shutdown already initiated")
                 return
-            _self.is_failed = True
+            with _self._failure_callback_lock:
+                _self.is_failed = True
             proc = next(h.proc for h in workers if h.proc.sentinel == died[0])
             logger.error(
                 "Worker proc %s died unexpectedly (exit code: %s), "
@@ -318,9 +320,10 @@ class MultiprocExecutor(Executor):
                 proc.exitcode,
             )
             _self.shutdown()
-            callback = _self.failure_callback
-            if callback is not None:
+            with _self._failure_callback_lock:
+                callback = _self.failure_callback
                 _self.failure_callback = None
+            if callback is not None:
                 callback()
 
         if not inline:
@@ -332,10 +335,11 @@ class MultiprocExecutor(Executor):
         monitor_workers()
 
     def register_failure_callback(self, callback: FailureCallback):
-        if self.is_failed:
-            callback()
-        else:
-            self.failure_callback = callback
+        with self._failure_callback_lock:
+            if not self.is_failed:
+                self.failure_callback = callback
+                return
+        callback()
 
     def execute_model(  # type: ignore[override]
         self, scheduler_output: SchedulerOutput, non_block: bool = False


### PR DESCRIPTION
## Summary

Addresses Bug2 in #56251. A worker can die after `register_failure_callback()` checks `is_failed` but before it stores the callback. The monitor then shuts down without notifying the engine, and the callback is never invoked.

This change protects the failure-state transition, callback registration, and callback consumption with one lock. Shutdown and callback execution remain outside the lock.

## Testing

Before the implementation change, the deterministic regression failed with `1 failed, 5 passed`; the callback was invoked zero times in the forced interleaving. After the change:

```text
12 passed, 5 deselected
```

Command:

```bash
.venv/bin/python -m pytest --confcutdir=tests/v1/executor \
  tests/v1/executor/test_multiproc_executor.py \
  tests/v1/executor/test_executor.py \
  -k 'worker_failure or worker_rpc or execute_worker_rpc or worker_termination_timeout or supports_async_scheduling' \
  -q --timeout=30
```

Also passed:

```bash
.venv/bin/pre-commit run --files \
  vllm/v1/executor/multiproc_executor.py \
  tests/v1/executor/test_multiproc_executor.py

.venv/bin/pre-commit run mypy-3.12 --files \
  vllm/v1/executor/multiproc_executor.py \
  tests/v1/executor/test_multiproc_executor.py --hook-stage manual
```

This is a process-failure notification change; it does not alter model output or accuracy, so model evaluation is not applicable. The tests use the production worker monitor with simulated worker-death readiness and mocked shutdown; no live model-serving test was run.

## Duplicate-work check

Checked #56251 and its comments, open PRs referencing the issue, and open PRs/searches for `failure_callback`, `register_failure_callback`, and the multiprocess callback race. #56282 addresses Bug1's separate shutdown guard race, while #54211 addresses spurious worker-sentinel readiness; neither fixes this callback-registration race.

## AI assistance

OpenAI Codex assisted with investigation, implementation, and tests. The human contributor reviewed the changed lines and personally ran the validation command before submission.
