### PR TITLE
docs(batch_invariance): add PLaMo3 to validated models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -135,6 +135,7 @@ Batch invariance has been tested and verified on the following models:
 - **Granite 3.1 (Dense)**: `ibm-granite/granite-3.1-2b-instruct`, `ibm-granite/granite-3.1-8b-instruct`
 - **EXAONE 4.0 series**: `LGAI-EXAONE/EXAONE-4.0-1.2B`, `LGAI-EXAONE/EXAONE-4.0.1-32B`, `LGAI-EXAONE/EXAONE-4.0-32B`
 - **OLMo 2**: `allenai/OLMo-2-0425-1B-Instruct`
+- **PLaMo3**: `pfnet/plamo-3-nict-2b-base` (hybrid SWA + full-attention; requires `trust_remote_code=True`; FLASH_ATTN and TRITON_ATTN backends validated; FLEX_ATTENTION excluded due to OOM with sliding-window attention)
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm/issues/new/choose).
 


### PR DESCRIPTION
## Why this is not duplicating an existing PR

No existing PR covers PLaMo3 (`pfnet/plamo-3-nict-2b-base`) batch invariance validation. Checked via:
```
gh pr list --repo vllm-project/vllm --state open --search "plamo batch invariance"
gh pr list --repo vllm-project/vllm --state open --search "PLaMo3 determinism"
```

## Changes

- `docs/features/batch_invariance.md`: add `pfnet/plamo-3-nict-2b-base` to the validated models list

## Test run (H100 NVL, SM90, vllm/vllm-openai:nightly)

```
NVIDIA H100 NVL, 9.0, 95830 MiB
Torch: 2.13.0+cu130 | CUDA: 13.0
vLLM: 0.28.1rc1.dev580+g385dce36b

VLLM_TEST_MODEL=pfnet/plamo-3-nict-2b-base VLLM_GPU_MEMORY_UTILIZATION=0.7 \
  python3 -m pytest -v tests/v1/determinism/test_batch_invariance.py \
  -k "not FLEX_ATTENTION" --tb=short -p no:cacheprovider

============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
rootdir: /tmp/det
plugins: anyio-4.9.2
collecting ... collected 19 items / 6 deselected / 13 selected

test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[default-FLASH_ATTN] PASSED [  7%]
test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[default-TRITON_ATTN] PASSED [ 15%]
test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[vllm_c-FLASH_ATTN] PASSED [ 23%]
test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[vllm_c-TRITON_ATTN] PASSED [ 30%]
test_batch_invariance.py::test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[16-16-FLASH_ATTN] PASSED [ 38%]
test_batch_invariance.py::test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[16-16-TRITON_ATTN] PASSED [ 46%]
test_batch_invariance.py::test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[8-16-FLASH_ATTN] PASSED [ 53%]
test_batch_invariance.py::test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[8-16-TRITON_ATTN] PASSED [ 61%]
test_batch_invariance.py::test_simple_generation[FLASH_ATTN] PASSED      [ 69%]
test_batch_invariance.py::test_simple_generation[TRITON_ATTN] PASSED     [ 76%]
test_batch_invariance.py::test_logprobs_without_batch_invariance_should_fail[FLASH_ATTN] PASSED [ 84%]
test_batch_invariance.py::test_logprobs_without_batch_invariance_should_fail[TRITON_ATTN] PASSED [ 92%]
test_batch_invariance.py::test_decode_logprobs_match_prefill_logprobs[FLASH_ATTN] PASSED [100%]

========== 13 passed, 6 deselected, 29 warnings in 658.91s (0:10:58) ===========
```

**Note on FLEX_ATTENTION:** PLaMo3 uses a hybrid SWA + full-attention architecture (`Plamo3ForCausalLM`, `trust_remote_code=True`). FLEX_ATTENTION's block-sparse memory allocator OOMs on the batch invariance tests against this architecture (`torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 6.52 GiB`). This is the same pattern seen with other SWA models. FLASH_ATTN and TRITON_ATTN are fully batch-invariant.

**Note on test patching needed:** The nightly `tests/v1/determinism/utils.py` imports `ModelArchConfigConvertorBase` at module level, which triggers a circular import for PLaMo3 (trust_remote_code model). The test was run with that import lazily deferred. A follow-up PR can address backend auto-detection for trust_remote_code models.

## AI assistance disclosure

This validation was performed with AI assistance (Claude Code). I reviewed all changes and ran the tests on real H100 NVL hardware.

Signed-off-by: Yuval Luria <yluria@redhat.com>