### PR TITLE
[Feature][NIXL] Add /drop_peer endpoint to release a dead peer's state

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -595,6 +595,16 @@ class KVConnectorBase_V1(ABC):
         # scheduler alive (e.g. extend has_unfinished_requests).
         return False
 
+    def drop_peer(self, engine_id: str) -> None:
+        """Notify the connector that a remote engine has died.
+
+        Called by the scheduler (router-driven) after all requests routed to
+        the peer have been aborted. Connectors that track per-peer state
+        should release it so a replacement reusing the engine id can
+        re-handshake. The default implementation is a no-op.
+        """
+        return
+
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
         """

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -487,6 +487,11 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         for c in self._connectors:
             c.set_xfer_handshake_metadata_pp_aware(metadata)
 
+    def drop_peer(self, engine_id: str) -> None:
+        """Forward the dead-peer notification to all sub-connectors."""
+        for c in self._connectors:
+            c.drop_peer(engine_id)
+
     def _aggregate_request_finished(
         self,
         request: "Request",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -120,6 +120,10 @@ class NixlBaseConnectorScheduler:
         # remote prefill or aborted.
         self._reqs_not_processed: set[ReqId] = set()
 
+        # Remote engines declared dead by the router (drop_peer), queued for
+        # worker-side cleanup via the next connector metadata.
+        self._pending_dropped_engines: set[EngineId] = set()
+
         # Heartbeat tracking: requests needing periodic lease-renewal heartbeats to
         # remote P-side, stored as ready-to-send HeartbeatInfo grouped by remote engine
         self._heartbeat_by_engine: dict[EngineId, HeartbeatInfo] = {}
@@ -489,6 +493,9 @@ class NixlBaseConnectorScheduler:
         self._reqs_not_processed = set()
         self._reqs_need_send = {}
 
+        meta.dropped_engines = self._pending_dropped_engines
+        self._pending_dropped_engines = set()
+
         return meta
 
     def update_connector_output(self, connector_output: "KVConnectorOutput") -> None:
@@ -497,7 +504,13 @@ class NixlBaseConnectorScheduler:
             self._stop_heartbeat(req_id)
 
     def has_pending_push_work(self) -> bool:
-        return False
+        # Keep the engine stepping until dropped engines and un-flushed
+        # force-frees reach the worker through the next connector metadata.
+        return bool(self._pending_dropped_engines or self._reqs_not_processed)
+
+    def drop_peer(self, engine_id: EngineId) -> None:
+        """Queue a dead remote engine for worker-side NIXL cleanup."""
+        self._pending_dropped_engines.add(engine_id)
 
     ############################################################
     # Abstract methods that subclasses must implement

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_worker.py
@@ -3154,21 +3154,29 @@ class NixlBaseConnectorWorker:
             if now - last_active > self._engine_ttl:
                 self._cleanup_remote_engine(eid)
 
+    def drop_peer(self, engine_id: EngineId) -> None:
+        """Release all NIXL state for a remote engine declared dead by the
+        router (drop_peer).
+
+        Idempotent: engines we never handshaked with are a no-op. Releasing
+        the agents lets a replacement reusing the engine id re-handshake.
+        """
+        logger.info("Dropping remote engine %s (reported dead).", engine_id)
+        self._cleanup_remote_engine(engine_id, log_eviction=False)
+
     def _cleanup_remote_engine(
         self, engine_id: EngineId, *, log_eviction: bool = True
     ) -> None:
         """Remove all state for a single remote engine.
 
         Releases NIXL resources (dlist handles, remote agents) and clears
-        all per-engine data structures. Used by both TTL eviction and
-        shutdown.
+        all per-engine data structures. Used by TTL eviction, shutdown and
+        drop_peer. Idempotent: engines with no registered agents are a no-op.
         """
-        assert engine_id in self._remote_agents
-
         # Notif-only engines (push-mode D side) have no descriptor state.
         for handle in self.dst_xfer_side_handles.pop(engine_id, {}).values():
             self.nixl_wrapper.release_dlist_handle(handle)
-        for agent_name in self._remote_agents.pop(engine_id).values():
+        for agent_name in self._remote_agents.pop(engine_id, {}).values():
             self.nixl_wrapper.remove_remote_agent(agent_name)
 
         self.kv_caches_base_addr.pop(engine_id, None)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/connector.py
@@ -291,6 +291,10 @@ class NixlBaseConnector(KVConnectorBase_V1, SupportsHMA):
             return self.connector_scheduler.has_pending_push_work()
         return False
 
+    def drop_peer(self, engine_id: EngineId) -> None:
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.drop_peer(engine_id)
+
     def shutdown(self):
         if self.connector_worker is not None:
             self.connector_worker.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -269,6 +269,9 @@ class NixlConnectorMetadata(KVConnectorMetadata):
         # Push mode (P side): newly finished request blocks to be matched
         # against pending D registrations on the P worker.
         self.push_finished_blocks: dict[ReqId, BlockIds] = {}
+        # Remote engines declared dead by the router (drop_peer): the worker
+        # releases their NIXL state (agents, dlist handles, topology).
+        self.dropped_engines: set[EngineId] = set()
 
     def _add_new_req(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_worker.py
@@ -99,8 +99,19 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
         # Remove all requests that are not to be processed (eg aborted).
         for req_id in metadata.reqs_not_processed:
             self._reqs_to_process.discard(req_id)
-            # We should never get an abort after setting an expiry timer
-            assert req_id not in self._reqs_to_send
+            # A re-aborted request (e.g. drop_peer when the remote engine
+            # died) may already be in _reqs_to_send with blocks held for the
+            # remote engine to read. Force-free the lease entry; the blocks
+            # were already freed on the scheduler side.
+            if req_id in self._reqs_to_send:
+                del self._reqs_to_send[req_id]
+                self.consumer_notification_counts_by_req.pop(req_id, None)
+                self.xfer_stats.record_kv_expired_req()
+                logger.info(
+                    "Force-freeing send blocks for request %s "
+                    "(re-aborted via drop_peer)",
+                    req_id,
+                )
 
         # Add to requests that are waiting to be read and track expiration.
         # Deadlines are stamped with the scheduler process's perf_counter,
@@ -118,6 +129,10 @@ class NixlPullConnectorWorker(NixlBaseConnectorWorker):
                         expiration_time - metadata.scheduler_clock
                     )
                 self._reqs_to_send[req_id] = expiration_time
+
+        # Release NIXL state for engines the router declared dead.
+        for engine_id in metadata.dropped_engines:
+            self.drop_peer(engine_id)
 
         # Send heartbeats to P-side engines to keep KV blocks alive while
         # requests sit in the D scheduler WAITING queue.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -343,7 +343,11 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         # - finished P blocks awaiting WRITE completion, or
         # - pending D registrations the worker has not yet shipped, or
         # - newly finished blocks not yet shipped to P workers.
-        return bool(self._finished_request_blocks or self._push_pending_registrations)
+        return bool(
+            self._finished_request_blocks
+            or self._push_pending_registrations
+            or super().has_pending_push_work()
+        )
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """Clean up finished request blocks after push completes."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_worker.py
@@ -46,6 +46,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_worker import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     PUSH_REG_NOTIF_PREFIX,
+    EngineId,
     NixlConnectorMetadata,
     RemoteMeta,
     ReqId,
@@ -117,6 +118,10 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
         # ``_push_finished_blocks`` so an unmatched entry doesn't keep the
         # writer busy-polling forever.
         self._evict_finished_inbox: queue.Queue[str] = queue.Queue()
+        # Main thread → writer: engines declared dead (drop_peer). Writer
+        # drops their pending registrations from
+        # ``_pending_d_registrations``.
+        self._drop_engine_inbox: queue.Queue[EngineId] = queue.Queue()
         # Handshakes that have just completed and are ready for the WRITE on wthread
         self._deferred_push_inbox = queue.Queue[tuple[str, BlockIds, dict[str, Any]]]()
 
@@ -200,7 +205,24 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
             self._reqs_to_process.add(req_id)
         for req_id in metadata.reqs_not_processed:
             self._reqs_to_process.discard(req_id)
-            assert req_id not in self._reqs_to_send
+            # A re-aborted request (e.g. drop_peer when the remote engine
+            # died) may already be in _reqs_to_send with blocks held for the
+            # remote engine to read. Force-free the lease entry; the blocks
+            # were already freed on the scheduler side.
+            if req_id in self._reqs_to_send:
+                del self._reqs_to_send[req_id]
+                self.consumer_notification_counts_by_req.pop(req_id, None)
+                self.xfer_stats.record_kv_expired_req()
+                logger.info(
+                    "Force-freeing send blocks for request %s "
+                    "(re-aborted via drop_peer)",
+                    req_id,
+                )
+            # The writer may still hold unmatched finished blocks for this
+            # request; without the eviction it would self-poll on them forever.
+            self._evict_finished_inbox.put(req_id)
+        if metadata.reqs_not_processed:
+            self._push_writer_wake.set()
         # Rebase scheduler-clock deadlines onto this worker's clock — see the
         # equivalent block in pull_worker.start_load_kv for the rationale.
         now_local = time.perf_counter()
@@ -212,8 +234,20 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                     )
                 self._reqs_to_send[req_id] = expiration_time
 
+        # Release NIXL state for engines the router declared dead.
+        for engine_id in metadata.dropped_engines:
+            self.drop_peer(engine_id)
+
         # Heartbeats still leave from the main thread (base worker behaviour).
         self._send_heartbeats(metadata)
+
+    def drop_peer(self, engine_id: EngineId) -> None:
+        super().drop_peer(engine_id)
+        # The writer owns ``_pending_d_registrations``; have it drop any
+        # registration sent by the dead engine so a replacement reusing the
+        # engine id never gets matched against stale P blocks.
+        self._drop_engine_inbox.put(engine_id)
+        self._push_writer_wake.set()
 
     # --- Writer thread ------------------------------------------------- #
 
@@ -261,6 +295,18 @@ class NixlPushConnectorWorker(NixlBaseConnectorWorker):
                         break
                     self._push_finished_blocks.pop(rid, None)
                     self._pending_d_registrations.pop(rid, None)
+
+                # 3c. Registrations from engines declared dead (drop_peer):
+                # never match them against new P blocks.
+                while True:
+                    try:
+                        eid = self._drop_engine_inbox.get_nowait()
+                    except queue.Empty:
+                        break
+                    for rid in list(self._pending_d_registrations):
+                        reg = self._pending_d_registrations[rid]
+                        if reg.get("decode_engine_id") == eid:
+                            del self._pending_d_registrations[rid]
 
                 # 4. NIXL notifs: route PUSH_REG; forward the rest.
                 for notifs in self.nixl_wrapper.get_new_notifs().values():

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -185,6 +185,17 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
+    async def drop_peer(self, engine_id: str) -> None:
+        """Release all resources tied to a remote engine declared dead.
+
+        The router calls this (e.g. via the ``/drop_peer`` endpoint) when a
+        peer engine in a disaggregated deployment (e.g. a whole decode
+        instance) goes down: requests routed to the peer are aborted, their
+        deferred blocks freed, and the connector's per-peer state released.
+        """
+        ...
+
+    @abstractmethod
     async def wake_up(self, tags: list[str] | None = None) -> None:
         """Wake up the engine"""
         ...

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -39,6 +39,12 @@ def register_vllm_serve_api_routers(app: FastAPI):
 
     attach_tokenize_router(app)
 
+    from vllm.entrypoints.serve.kv_transfer.api_router import (
+        attach_router as attach_kv_transfer_router,
+    )
+
+    attach_kv_transfer_router(app)
+
 
 def register_vllm_dev_api_routers(app: FastAPI):
     logger.warning(

--- a/vllm/entrypoints/serve/kv_transfer/api_router.py
+++ b/vllm/entrypoints/serve/kv_transfer/api_router.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from http import HTTPStatus
+
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from vllm.engine.protocol import EngineClient
+
+router = APIRouter()
+
+
+def engine_client(request: Request) -> EngineClient:
+    return request.app.state.engine_client
+
+
+@router.post("/drop_peer")
+async def drop_peer(raw_request: Request):
+    """Release all resources tied to a remote engine declared dead.
+
+    Intended for disaggregated (P/D) deployments: the router calls this on
+    the *peer* of an engine that went down (e.g. P's `/drop_peer` with the
+    dead decode engine's id, or vice versa). The whole engine's requests
+    routed to the dead peer are aborted and their blocks freed, and the
+    connector's per-peer NIXL state is released so a replacement reusing
+    the same engine id can re-handshake.
+
+    Requests are attributed to the peer via
+    `kv_transfer_params["decode_engine_id"]` (P side, router-provided);
+    untagged requests are left untouched.
+    """
+    try:
+        body = await raw_request.json()
+    except json.JSONDecodeError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail=f"JSON decode error: {e}",
+        ) from e
+
+    engine_id = body.get("engine_id")
+    if not isinstance(engine_id, str) or not engine_id:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail="Missing or invalid 'engine_id' in request body",
+        )
+
+    await engine_client(raw_request).drop_peer(engine_id)
+    return JSONResponse(content={"status": "ok"})
+
+
+def attach_router(app: FastAPI):
+    app.include_router(router)

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -166,6 +166,19 @@ class SchedulerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def drop_peer(self, engine_id: str) -> None:
+        """Abort all requests routed to a dead remote engine and release the
+        resources kept for it.
+
+        The router calls this (e.g. via the /drop_peer endpoint) when it
+        declares a peer engine dead.
+
+        Args:
+            engine_id: The id of the dead remote engine.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def get_num_unfinished_requests(self) -> int:
         """Number of unfinished requests in the scheduler's internal queue."""
         raise NotImplementedError

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2563,6 +2563,45 @@ class Scheduler(SchedulerInterface):
 
         return valid_requests
 
+    def drop_peer(self, engine_id: str) -> None:
+        """Abort all requests routed to a dead remote engine and drop the
+        connector's state for it.
+
+        The router calls this when it declares a peer engine (e.g. a decode
+        instance) dead. Requests are attributed via
+        ``kv_transfer_params["decode_engine_id"]``; untagged requests are
+        left untouched.
+
+        Live requests go through the normal abort path. Requests that
+        already finished with their blocks deferred for the dead peer are
+        not reachable that way: ``finish_requests`` skips finished
+        requests, and their id no longer exists at the serving layer, so
+        the router cannot abort them either. They are re-aborted here
+        instead, which reruns the connector's ``request_finished`` with an
+        aborted status (queuing the worker-side transfer drop) and frees
+        the pinned blocks immediately. The connector then releases any
+        per-peer state so a replacement reusing the engine id can
+        re-handshake.
+        """
+        deferred: list[Request] = []
+        live_ids: list[str] = []
+        for request in self.requests.values():
+            params = request.kv_transfer_params
+            if params is None or params.get("decode_engine_id") != engine_id:
+                continue
+            if request.is_finished():
+                deferred.append(request)
+            else:
+                live_ids.append(request.request_id)
+
+        self.finish_requests(live_ids, RequestStatus.FINISHED_ABORTED)
+        for request in deferred:
+            request.status = RequestStatus.FINISHED_ABORTED
+            self._free_request(request)
+
+        if self.connector is not None:
+            self.connector.drop_peer(engine_id)
+
     def _free_request(
         self, request: Request, delay_free_blocks: bool = False
     ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1064,6 +1064,9 @@ class AsyncLLM(EngineClient):
         if self.logger_manager is not None:
             self.logger_manager.record_sleep_state(1, level)
 
+    async def drop_peer(self, engine_id: str) -> None:
+        await self.engine_core.drop_peer_async(engine_id)
+
     async def wake_up(self, tags: list[str] | None = None) -> None:
         await self.engine_core.wake_up_async(tags)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -495,6 +495,16 @@ class EngineCore:
         # (i.e. client-aborted vs stop criteria met).
         self.scheduler.finish_requests(request_ids, RequestStatus.FINISHED_ABORTED)
 
+    def drop_peer(self, engine_id: str) -> None:
+        """Release all resources tied to a remote engine declared dead.
+
+        Called by the router (e.g. via the ``/drop_peer`` endpoint) when a
+        peer engine (whole decode instance) goes down. Aborts this engine's
+        requests routed to the peer, freeing deferred prefill blocks
+        immediately, and clears the connector's per-peer state.
+        """
+        self.scheduler.drop_peer(engine_id)
+
     @contextmanager
     def log_error_detail(self, scheduler_output: SchedulerOutput):
         """Execute the model and log detailed info on failure."""

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -194,6 +194,9 @@ class EngineCoreClient(ABC):
     def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None:
         raise NotImplementedError
 
+    def drop_peer(self, engine_id: str) -> None:
+        raise NotImplementedError
+
     def wake_up(self, tags: list[str] | None = None) -> None:
         raise NotImplementedError
 
@@ -284,6 +287,9 @@ class EngineCoreClient(ABC):
         raise NotImplementedError
 
     async def sleep_async(self, level: int = 1, mode: PauseMode = "abort") -> None:
+        raise NotImplementedError
+
+    async def drop_peer_async(self, engine_id: str) -> None:
         raise NotImplementedError
 
     async def wake_up_async(self, tags: list[str] | None = None) -> None:
@@ -401,6 +407,9 @@ class InprocClient(EngineCoreClient):
 
     def wake_up(self, tags: list[str] | None = None) -> None:
         self.engine_core.wake_up(tags)
+
+    def drop_peer(self, engine_id: str) -> None:
+        self.engine_core.drop_peer(engine_id)
 
     def is_sleeping(self) -> bool:
         return self.engine_core.is_sleeping()
@@ -1013,6 +1022,9 @@ class SyncMPClient(MPClient):
     def sleep(self, level: int = 1, mode: PauseMode = "abort") -> None:
         self.call_utility("sleep", level, mode)
 
+    def drop_peer(self, engine_id: str) -> None:
+        self.call_utility("drop_peer", engine_id)
+
     def wake_up(self, tags: list[str] | None = None) -> None:
         self.call_utility("wake_up", tags)
 
@@ -1256,6 +1268,9 @@ class AsyncMPClient(MPClient):
 
     async def sleep_async(self, level: int = 1, mode: PauseMode = "abort") -> None:
         await self.call_utility_async("sleep", level, mode)
+
+    async def drop_peer_async(self, engine_id: str) -> None:
+        await self.call_utility_async("drop_peer", engine_id)
 
     async def wake_up_async(self, tags: list[str] | None = None) -> None:
         await self.call_utility_async("wake_up", tags)


### PR DESCRIPTION
When a decode instance dies in a P/D disaggregated deployment, the prefill nodes paired with it are left holding two kinds of garbage: the NIXL agents, rkeys and registrations cached for the dead engine, and the prefill blocks of requests whose KV transfer will never complete. Nothing inside P can clean this up on its own. A failed transfer is not a reliable death signal, and with pinned engine ids the replacement D reuses the same key, so P keeps serving stale state for it — the pair stays broken until P is restarted (#49238, discussion in #50047). With generated ids the stale agents eventually age out, but the blocks pinned for in-flight transfers still sit there, and requests waiting on the dead D hang until their lease expires.

Whether D is alive is something only the router knows — that's where the deployment keeps the full picture, by design. So this PR gives the router a way to say it out loud instead of leaving P to guess. On D's death, the router hits `POST /drop_peer` on every P that was paired with it:

```
{"engine_id": "<dead decode engine id>"}
```

P then aborts the requests it routed to that D, frees the blocks pinned for them — including the ones whose prefill already finished and whose blocks are deferred pending a read that will never come — and drops the connector's per-peer state, so a replacement reusing the same engine id can re-handshake cleanly.

A few properties that matter for the router contract:

- The call is idempotent and broadcasting is fine. Dropping an engine P has never seen, or has already dropped, is a no-op, so routers don't need to track P↔D pairs; they can notify the whole pool.
- Requests are attributed to a decode engine via `kv_transfer_params["decode_engine_id"]`, which the router sets when building the request for P. Untagged requests are untouched, so routers that don't participate in this contract get exactly today's behavior.
- The call is destructive by design: it encodes the router's declaration that D is gone, and calling it for a live D will abort the requests routed to it. It belongs in the failure path (D crashed, D's pod replaced), not in graceful scale-down — drain the pair first, then drop.

This is the P-side half of the story discussed in #50047. The D-side equivalent (P dies, D holds the stale state) and the "single link failed while both engines are alive" case from #55471 are complementary and stay where they are.

Draft: tests, docs and a final lint pass still to come.
