### PR TITLE
[ROCm][DSv4.1] Fix TileLang mHC pre on 64-wide wavefronts and use the fused kernels on the AMD path

### DIFF
--- a/vllm/model_executor/kernels/mhc/tilelang_kernels.py
+++ b/vllm/model_executor/kernels/mhc/tilelang_kernels.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import functools
 import math
 from functools import cache
 
@@ -13,6 +14,26 @@ from vllm.tilelang_utils import T, tilelang, tilelang_jit
 from vllm.utils.math_utils import cdiv
 
 ENABLE_PDL = current_platform.is_arch_support_pdl() and current_platform.is_cuda()
+
+
+# The mHC pre kernels split the block: the mix phase on warp 0, the weighted sum
+# and fused RMSNorm on the rest. `tid < 32` is warp-uniform only at 32 lanes; on
+# a 64-wide wavefront it splits a wave, TileLang hoists the barrier out of the
+# branch, and the fused RMSNorm's cross-lane reduction then covers only part of
+# the lanes. The two phases are launched separately there, each with the whole
+# block, by rebinding the kernels below. Callers and CUDA are untouched.
+_MHC_PRE_SPLIT_BLOCK = current_platform.is_cuda()
+
+
+def _mhc_pre_split_phases(kernel):
+    """Wrap a mHC pre kernel to run its two phases as separate launches."""
+
+    @functools.wraps(kernel)
+    def launch(*tensors, **fields):
+        kernel(*tensors, n_thr=64, mix_lanes=64, **fields)
+        return kernel(*tensors, n_thr=64, mix_lanes=0, **fields)
+
+    return launch
 
 
 @cache
@@ -51,6 +72,8 @@ def mhc_pre_big_fuse_tilelang(
     use_pre_mix_in: bool = False,
     save_pre_mix: bool = False,
     rms_numel: int = 0,
+    n_thr: int = 96,
+    mix_lanes: int = 32,
 ):
     """Fuse coefficient generation and residual collapse after the projection.
 
@@ -76,7 +99,7 @@ def mhc_pre_big_fuse_tilelang(
     pre_mix_in: T.Tensor[[num_tokens, hc_mult], T.float32]  # type: ignore[no-redef, valid-type]
     pre_mix_out: T.Tensor[[num_tokens, hc_mult], T.float32]  # type: ignore[no-redef, valid-type]
 
-    with T.Kernel(num_tokens, threads=96) as i:
+    with T.Kernel(num_tokens, threads=n_thr) as i:
         if ENABLE_PDL:
             T.pdl_sync()
         ##################################################################
@@ -96,7 +119,7 @@ def mhc_pre_big_fuse_tilelang(
         mixes_shared = T.alloc_shared(hc_mult3, T.float32)
         T.copy(mixes, mixes_shared)
 
-        if T.get_thread_binding() < 32:
+        if T.get_thread_binding() < mix_lanes:
             ##################################################################
             # _pre_split_mixes_fwd (post & comb)
             cm = T.alloc_fragment((hc_mult, hc_mult), T.float32)
@@ -216,6 +239,8 @@ def mhc_pre_big_fuse_with_norm_tilelang(
     use_pre_mix_in: bool = False,
     save_pre_mix: bool = False,
     rms_numel: int = 0,
+    n_thr: int = 96,
+    mix_lanes: int = 32,
 ):
     num_tokens = T.dynamic("num_tokens")
     hc_mult3 = hc_mult * (2 + hc_mult)
@@ -238,7 +263,7 @@ def mhc_pre_big_fuse_with_norm_tilelang(
     pre_mix_in: T.Tensor[[num_tokens, hc_mult], T.float32]  # type: ignore[no-redef, valid-type]
     pre_mix_out: T.Tensor[[num_tokens, hc_mult], T.float32]  # type: ignore[no-redef, valid-type]
 
-    with T.Kernel(num_tokens, threads=96) as i:
+    with T.Kernel(num_tokens, threads=n_thr) as i:
         rms = T.alloc_fragment(1, T.float32)
         mixes = T.alloc_fragment(hc_mult3, T.float32)
         T.clear(mixes)
@@ -258,7 +283,7 @@ def mhc_pre_big_fuse_with_norm_tilelang(
         mixes_shared = T.alloc_shared(hc_mult3, T.float32)
         T.copy(mixes, mixes_shared)
 
-        if T.get_thread_binding() < 32:
+        if T.get_thread_binding() < mix_lanes:
             cm = T.alloc_fragment((hc_mult, hc_mult), T.float32)
             for j in T.Parallel(hc_mult):
                 if save_pre_mix:
@@ -399,6 +424,8 @@ def mhc_pre_big_fuse_broadcast_with_norm_tilelang(
     n_splits: int = 1,
     hc_mult: int = 4,
     gemm_last_dim: int = -1,
+    n_thr: int = 96,
+    mix_lanes: int = 32,
 ):
     num_tokens = T.dynamic("num_tokens")
     hc_mult3 = hc_mult * (2 + hc_mult)
@@ -417,7 +444,7 @@ def mhc_pre_big_fuse_broadcast_with_norm_tilelang(
     layer_input: T.Tensor[[num_tokens, hidden_size], T.bfloat16]  # type: ignore[no-redef, valid-type]
     norm_weight: T.Tensor[[hidden_size], T.bfloat16]  # type: ignore[no-redef, valid-type]
 
-    with T.Kernel(num_tokens, threads=96) as i:
+    with T.Kernel(num_tokens, threads=n_thr) as i:
         rms = T.alloc_fragment(1, T.float32)
         mixes = T.alloc_fragment(hc_mult3, T.float32)
         T.clear(mixes)
@@ -438,7 +465,7 @@ def mhc_pre_big_fuse_broadcast_with_norm_tilelang(
         mixes_shared = T.alloc_shared(hc_mult3, T.float32)
         T.copy(mixes, mixes_shared)
 
-        if T.get_thread_binding() < 32:
+        if T.get_thread_binding() < mix_lanes:
             cm = T.alloc_fragment((hc_mult, hc_mult), T.float32)
             for j in T.Parallel(hc_mult):
                 post_mix[i, j] = (
@@ -537,6 +564,16 @@ def mhc_pre_big_fuse_broadcast_with_norm_tilelang(
 
         if ENABLE_PDL:
             T.pdl_trigger()
+
+
+if not _MHC_PRE_SPLIT_BLOCK:
+    mhc_pre_big_fuse_tilelang = _mhc_pre_split_phases(mhc_pre_big_fuse_tilelang)
+    mhc_pre_big_fuse_with_norm_tilelang = _mhc_pre_split_phases(
+        mhc_pre_big_fuse_with_norm_tilelang
+    )
+    mhc_pre_big_fuse_broadcast_with_norm_tilelang = _mhc_pre_split_phases(
+        mhc_pre_big_fuse_broadcast_with_norm_tilelang
+    )
 
 
 @tilelang_jit

--- a/vllm/models/deepseek_v4_1/amd/dspark.py
+++ b/vllm/models/deepseek_v4_1/amd/dspark.py
@@ -24,7 +24,6 @@ from vllm.distributed import (
 )
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
-from vllm.model_executor.kernels.mhc.torch import mhc_post_torch
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
@@ -50,7 +49,9 @@ from vllm.models.common.ops.sequence_parallel import (
 from .model import (
     DeepseekV4DecoderLayer,
     DeepseekV4Model,
+    _fuse_mhc,
     _linear_scale_param_name,
+    _mhc_impls,
     _use_sequence_parallel,
 )
 
@@ -74,6 +75,9 @@ class DSparkDeepseekV4Model(nn.Module):
         self.num_hidden_layers = config.num_hidden_layers
         self.target_layer_ids = tuple(config.dspark_target_layer_ids)
         self.use_sequence_parallel = _use_sequence_parallel(vllm_config)
+        _, self._mhc_post = _mhc_impls(
+            _fuse_mhc(vllm_config.speculative_config.draft_model_config.dtype)
+        )
 
         self.num_dspark_layers = (
             getattr(config, "n_mtp_layers", None)
@@ -212,7 +216,7 @@ class DSparkDeepseekV4Model(nn.Module):
                 res_mix,
                 residual,
             )
-        hidden_states = mhc_post_torch(hidden_states, residual, post_mix, res_mix)
+        hidden_states = self._mhc_post(hidden_states, residual, post_mix, res_mix)
         if self.use_sequence_parallel:
             hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
             pre_mix = sp_all_gather(pre_mix)[:full_num_tokens]

--- a/vllm/models/deepseek_v4_1/amd/model.py
+++ b/vllm/models/deepseek_v4_1/amd/model.py
@@ -21,6 +21,15 @@ from vllm.model_executor.kernels.mhc.torch import (
     mhc_post_torch,
     mhc_pre_delayed_torch,
 )
+from vllm.model_executor.layers.mhc import HAS_TILELANG_MHC
+
+# Unconditional for mypy; only imported at runtime when the fused path is used.
+if typing.TYPE_CHECKING or HAS_TILELANG_MHC:
+    from vllm.model_executor.kernels.mhc.tilelang import (
+        mhc_post_tilelang,
+        mhc_pre_delayed_tilelang,
+    )
+
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
@@ -71,6 +80,25 @@ if typing.TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
 
 logger = init_logger(__name__)
+
+
+def _fuse_mhc(dtype: torch.dtype) -> bool:
+    """Fused TileLang mHC is bf16-only; other dtypes use the torch reference."""
+    return HAS_TILELANG_MHC and dtype == torch.bfloat16
+
+
+def _mhc_impls(fused: bool) -> tuple[Callable, Callable]:
+    """The (pre, post) mHC implementations for a fused or reference path."""
+    if fused:
+        return mhc_pre_delayed_tilelang, mhc_post_tilelang
+    return mhc_pre_delayed_torch, mhc_post_torch
+
+
+def _mhc_norm_kwargs(norm: RMSNorm, fused: bool) -> dict[str, typing.Any]:
+    """RMSNorm arguments folded into the fused pre-kernel; empty for torch."""
+    if not fused:
+        return {}
+    return {"norm_weight": norm.weight, "norm_eps": norm.variance_epsilon}
 
 
 class DeepseekV4MoE(DeepseekV4MoEBase):
@@ -166,6 +194,8 @@ class DeepseekV4DecoderLayer(nn.Module):
         super().__init__()
         config = vllm_config.model_config.hf_config
         self.hidden_size = config.hidden_size
+        self.fuse_mhc = _fuse_mhc(vllm_config.model_config.dtype)
+        self._mhc_pre, self._mhc_post = _mhc_impls(self.fuse_mhc)
         self.use_sequence_parallel = _use_sequence_parallel(vllm_config)
 
         self.engram: Engram | None = None
@@ -275,7 +305,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                 # copies and the identity pre-mix selects copy 0.
                 assert self.hc_attn_fn_broadcast is not None
                 residual = x.unsqueeze(1).expand(-1, self.hc_mult, -1).contiguous()
-                post_mix, res_mix, x, attn_pre = mhc_pre_delayed_torch(
+                post_mix, res_mix, x, attn_pre = self._mhc_pre(
                     residual,
                     self.hc_attn_fn_broadcast,
                     self.hc_attn_scale,
@@ -286,10 +316,11 @@ class DeepseekV4DecoderLayer(nn.Module):
                     self.hc_post_alpha,
                     self.hc_sinkhorn_iters,
                     x=x,
+                    **_mhc_norm_kwargs(self.attn_norm, self.fuse_mhc),
                 )
             else:
                 residual = x
-                post_mix, res_mix, x, attn_pre = mhc_pre_delayed_torch(
+                post_mix, res_mix, x, attn_pre = self._mhc_pre(
                     residual,
                     self.hc_attn_fn,
                     self.hc_attn_scale,
@@ -300,9 +331,10 @@ class DeepseekV4DecoderLayer(nn.Module):
                     self.hc_post_alpha,
                     self.hc_sinkhorn_iters,
                     pre_mix=pre_mix,
+                    **_mhc_norm_kwargs(self.attn_norm, self.fuse_mhc),
                 )
         else:
-            residual = mhc_post_torch(x, residual, post_mix, res_mix)
+            residual = self._mhc_post(x, residual, post_mix, res_mix)
             if self.engram is not None and engram_hashes is not None:
                 # Engram injection happens between the previous sublayer's
                 # post and this block's pre, on the full hc stream, so the
@@ -312,7 +344,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                     engram_hashes[:, self.engram.layer_hash_index],
                     engram_mask,
                 )
-            post_mix, res_mix, x, attn_pre = mhc_pre_delayed_torch(
+            post_mix, res_mix, x, attn_pre = self._mhc_pre(
                 residual,
                 self.hc_attn_fn,
                 self.hc_attn_scale,
@@ -323,8 +355,10 @@ class DeepseekV4DecoderLayer(nn.Module):
                 self.hc_post_alpha,
                 self.hc_sinkhorn_iters,
                 pre_mix=pre_mix,
+                **_mhc_norm_kwargs(self.attn_norm, self.fuse_mhc),
             )
-        x = self.attn_norm(x)
+        if not self.fuse_mhc:
+            x = self.attn_norm(x)
 
         if self.use_sequence_parallel:
             x = sp_all_gather(x)[: positions.shape[0]]
@@ -333,8 +367,8 @@ class DeepseekV4DecoderLayer(nn.Module):
         if self.use_sequence_parallel:
             x = sp_reduce_scatter(x)
 
-        residual = mhc_post_torch(x, residual, post_mix, res_mix)
-        post_mix, res_mix, x, ffn_pre = mhc_pre_delayed_torch(
+        residual = self._mhc_post(x, residual, post_mix, res_mix)
+        post_mix, res_mix, x, ffn_pre = self._mhc_pre(
             residual,
             self.hc_ffn_fn,
             self.hc_ffn_scale,
@@ -345,8 +379,10 @@ class DeepseekV4DecoderLayer(nn.Module):
             self.hc_post_alpha,
             self.hc_sinkhorn_iters,
             pre_mix=attn_pre,
+            **_mhc_norm_kwargs(self.ffn_norm, self.fuse_mhc),
         )
-        x = self.ffn_norm(x)
+        if not self.fuse_mhc:
+            x = self.ffn_norm(x)
         x = self.ffn(x, input_ids)
         return x, residual, post_mix, res_mix, ffn_pre
 
@@ -362,6 +398,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         self.parallel_config = vllm_config.parallel_config
         self.use_mega_moe = False
         self.use_sequence_parallel = _use_sequence_parallel(vllm_config)
+        _, self._mhc_post = _mhc_impls(_fuse_mhc(vllm_config.model_config.dtype))
         if self.use_mega_moe and not vllm_config.parallel_config.enable_expert_parallel:
             raise NotImplementedError(
                 "DeepSeek V4 MegaMoE currently requires expert parallel. "
@@ -603,7 +640,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             )
             if idx + 1 in self.aux_hidden_state_layers:
                 # Reconstruct the aux hidden state for draft models
-                aux_recon = mhc_post_torch(hidden_states, residual, post_mix, res_mix)
+                aux_recon = self._mhc_post(hidden_states, residual, post_mix, res_mix)
                 aux_hidden_state = aux_recon.mean(dim=1)
                 if self.use_sequence_parallel:
                     aux_hidden_state = sp_all_gather(aux_hidden_state)[:full_num_tokens]
@@ -614,7 +651,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             if self.end_layer in self.aux_hidden_state_layers:
                 hidden_states = final_aux_recon
             else:
-                hidden_states = mhc_post_torch(
+                hidden_states = self._mhc_post(
                     hidden_states, residual, post_mix, res_mix
                 )
 


### PR DESCRIPTION
Two commits: the first fixes the TileLang mHC pre kernels on 64-wide wavefronts, the second switches DeepSeek-V4.1's AMD path onto them. The second alone is a 91.1% -> 23.7% GSM8K regression, so they land together.

## The bug

The three `mhc_pre_big_fuse*` kernels are warp-specialized: `if tid < 32` puts the mix phase on warp 0 and the weighted sum with its fused RMSNorm on the rest. That is warp-uniform only at 32 lanes; on a 64-wide wavefront it splits a wave, TileLang hoists the barrier out of the branch, and the fused RMSNorm's cross-lane `sumsq` reduction then covers only part of the lanes. `layer_input` comes out a uniform sqrt(2) too large in every layer: measured ratio 1.41443 against sqrt(2) = 1.414214, implied `sumsq` factor 0.4998, constant at 1/8/64/256/1024 tokens.

Each phase needs a wave-aligned thread group starting at thread 0, and in one launch only one branch can start there. So the block size and split point become compile-time parameters instead of literals, and on a 64-wide wavefront the three kernel names are rebound at module scope to a wrapper that launches the two phases separately: `mix_lanes = n_thr`, then `mix_lanes = 0`.

Rebinding rather than editing call sites keeps `tilelang.py` and `warmup.py` out of the diff, and on CUDA those names still bind to the original kernel objects. CUDA compiles at (96, 32), which leaves the generated code **byte-identical** -- verified by dumping the kernel source at those values: same 23573 bytes, same 7 barriers, same md5. Restructuring the branch instead would not have been inert: rewriting the `if/else` as two complementary `if`s takes the same arrangement from 7 barriers to 15. The second launch is free with cudagraphs, paid at capture rather than per replay.

Not latent: `vllm/models/deepseek_v4/amd/model.py:754` uses `MHCPreOp()` with `norm_weight=`, so DeepSeek-V4 on ROCm reaches this kernel whenever the AITER gate fails.

## Repro

```bash
vllm serve /path/to/DeepSeek-V4.1-Flash --tokenizer-mode deepseek_v41 \
  --tensor-parallel-size 4 --moe-backend aiter_triton_mxfp4_bf16 \
  --no-async-scheduling --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'

# latency: the TPOT / TTFT / out tok/s columns below
vllm bench serve --backend vllm --model /path/to/DeepSeek-V4.1-Flash \
  --dataset-name random --random-input-len 1024 --random-output-len 1024 \
  --max-concurrency 1 --num-prompts 8 --ignore-eos

# the "without commit 1" row: revert the kernel commit only, keep the wiring
git revert --no-commit <commit 1>
```

For the GSM8K column: this checkpoint ships no chat template, so prompts come from its own `encoding/encoding.py` and sampling follows the model card. Per question, `encode_messages([{"role": "user", "content": question}], thinking_mode="thinking", reasoning_effort=100)`, POSTed to `/v1/completions` with `temperature=1.0, top_p=0.95, max_tokens=16384`, scoring the text after `</think>` against the integer after `####` over all 1319 test questions.

`tests/evals/gsm8k/gsm8k_eval.py --num-shots 8 --num-questions 1319` also runs, but scores about 90.3% on either build: it is a base-model few-shot completion protocol, and this is the instruct checkpoint.

## Measurements

4x MI355X (gfx950), ROCm 7.2.3, TP4. Latency 1k in / 1k out at concurrency 1. GSM8K is the full 1319-question set in the mode described above.

| | TPOT | out tok/s | TTFT | GSM8K |
|---|---:|---:|---:|---:|
| torch reference | 42.90 ms | 23.21 | 206.0 ms | 92.19 % |
| fused, without commit 1 | 15.80 ms | 62.67 | 133.8 ms | 23.65 % |
| **fused** | **15.95 ms** | **62.18** | **133.1 ms** | **92.72 %** |

Sampled, one run each, so the 0.53 points between the two is not a claim of improvement.

Commit 2 also moves the DSpark draft path (`dspark.py`) onto the fused post kernel, and enabling DSpark is the only thing that exercises it. With `--speculative-config '{"method":"dspark","model":"<same checkpoint>","num_speculative_tokens":5,"draft_sample_method":"probabilistic","enable_adaptive_verification":false}'` -- the `mtp.*` weights ship in this checkpoint, and 5 is its `dspark_block_size` -- median TPOT is 8.91 ms at 111.2 output tok/s, mean acceptance length 2.33. The same DSpark config on the torch reference gives 22.63 ms, so the fused kernels are still worth 2.54x with speculative decoding on. On greedy 8-shot GSM8K (not the protocol in the table above) DSpark scores 90.90% against 89.76% for the same build without it, with 21 questions regressed and 36 improved, so no accuracy loss.

The fold is not bit-identical to the reference -- `x * rsqrt * norm_weight` is evaluated in fp32 and rounded once where the torch path rounds several times. Capturing the first 24 greedy tokens and logprobs for 120 prompts, the same build run twice already diverges on 33% of sequences (median logprob delta 2.37e-04) from batch composition alone; torch against fused gives 38% and 2.68e-04, so the fused deviation is at the level of the stack's own nondeterminism. At the kernel level the fold is equal or better than the provider it replaces (`rms_norm` priority is `['aiter', 'native']`): NRMSE 0.0 / 4.3e-5 / 2.1e-5 / 3.0e-5 against AITER's 2.8e-7 / 7.9e-5 / 3.1e-5 / 3.1e-5 at 1/8/64/1024 tokens, against an exact fp64 evaluation of the same spec.

## Notes

- No test is added here, deliberately rather than by oversight. `tests/kernels/test_mhc_kernels.py::test_mhc_pre_tilelang` runs on gfx950 and **passes on the broken kernel**, because it calls the op with nine positional arguments and never passes `norm_weight`, and the no-norm path is the correct one. The four `*_applies_norm` tests monkeypatch `HAS_TILELANG_MHC = False`, so they cover the dispatch rather than the kernel. The TileLang with-norm kernel therefore has no in-tree coverage on any platform, and CI will not catch a regression of this bug. Happy to add a `fused_norm` parametrization if you want one.
- Validated on the head of #56214, because `main` cannot run DeepSeek-V4.1 on ROCm at all: `rocm_aiter_sparse_attn_indexer` takes 15 arguments there while the model passes 18. The code being changed is on `main`.
- Fusion is gated on `model_config.dtype == bfloat16`, the only dtype these kernels accept; other dtypes keep the torch reference with its separate norm.
- Not included: the AMD model registers no MHC JIT warmup keys, unlike `nvidia/model.py:214-238`, so a DSpark draft compile can land inside graph capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
