### PR TITLE
[Bugfix][Rust Frontend] Backport integer KV handoff conversion to v0.29

### DIFF
--- a/rust/src/server/src/grpc/convert.rs
+++ b/rust/src/server/src/grpc/convert.rs
@@ -516,6 +516,10 @@ fn positions_to_proto(
 // KV transfer params conversion (serde_json::Value ↔ prost_types::Struct)
 // ========================================================================================
 
+/// Largest safe integer in `f64` (2^53 - 1). Struct numbers within this bound
+/// retain integer types for consumers such as NIXL's parallelism metadata.
+const MAX_SAFE_INTEGER_F64: f64 = ((1u64 << 53) - 1) as f64;
+
 fn proto_struct_to_json(s: &prost_types::Struct) -> serde_json::Value {
     serde_json::Value::Object(
         s.fields.iter().map(|(k, v)| (k.clone(), proto_value_to_json(v))).collect(),
@@ -527,6 +531,9 @@ fn proto_value_to_json(v: &prost_types::Value) -> serde_json::Value {
     match v.kind.as_ref() {
         None | Some(Kind::NullValue(_)) => serde_json::Value::Null,
         Some(Kind::BoolValue(b)) => serde_json::Value::Bool(*b),
+        Some(Kind::NumberValue(n)) if n.fract() == 0.0 && n.abs() <= MAX_SAFE_INTEGER_F64 => {
+            serde_json::Value::Number(serde_json::Number::from(*n as i64))
+        }
         Some(Kind::NumberValue(n)) => serde_json::json!(*n),
         Some(Kind::StringValue(s)) => serde_json::Value::String(s.clone()),
         Some(Kind::ListValue(list)) => {
@@ -681,6 +688,29 @@ mod tests {
         assert_eq!(text.sampling_params.skip_reading_prefix_cache, None);
         // Prompt conversion still succeeds and reaches the expected variant.
         assert!(matches!(text.prompt, Prompt::Text(s) if s == "hi"));
+    }
+
+    #[test]
+    fn kv_handoff_preserves_integer_sizes_and_fractional_expiry() {
+        // NIXL consumes sizes and block IDs as integers, but its lease expiry is fractional.
+        let metadata = serde_json::json!({
+            "pp_size": 1,
+            "dcp_size": 1,
+            "remote_block_ids": [[0, 25, 9_007_199_254_740_991_i64]],
+            "remote_blocks_expiry_time": 1_789_062_400.25,
+            "sentinel": -1,
+            "outside_safe_integer_range": 9.0e18,
+        });
+        let req = pb::GenerateRequest {
+            kv: Some(pb::KvCacheParameters {
+                kv_transfer_params: super::json_to_proto_struct(&metadata),
+                ..Default::default()
+            }),
+            ..base_request()
+        };
+        let text = to_text_request(req, false, &["test-model".to_string()]).expect("convert ok");
+        let args = text.sampling_params.vllm_xargs.expect("handoff metadata");
+        assert_eq!(args["kv_transfer_params"], metadata);
     }
 
     fn finished(reason: FinishReason) -> Finished {


### PR DESCRIPTION
## Purpose

Backport the integral protobuf-number conversion from #54814 to `releases/v0.29.0`. Main already contains the fix and handoff coverage; the release branch diverged before that commit. No overlapping release backport was found.

v0.29.0's Rust gRPC receiver converts `pp_size: 1` into JSON `1.0`. NIXL then fails at `range(remote_pp_size)` with `TypeError: 'float' object cannot be interpreted as an integer`, preventing native prefill/decode transfer.

This takes only the numeric conversion from #54814, preserving safe integral values recursively while leaving fractional expiry timestamps and out-of-range values as floats. One request-conversion regression checks the KV metadata delivered to the engine.

## Test plan and results

- The new regression fails after removing the normalization guard; with the backport, all 14 `grpc::convert::tests` pass:
  `cargo +1.95 test --locked --manifest-path rust/Cargo.toml -p vllm-server --lib grpc::convert::tests`
- `rustfmt +1.95 --edition 2024 --check rust/src/server/src/grpc/convert.rs` and `git diff --check` pass.
- Real native gRPC P/D validation: Qwen/Qwen3-0.6B, vLLM 0.29.0, Dynamo 1.5.0.dev20260910, NIXL 1.3.2, separate prefill/decode engines sharing an RTX 6000 Ada. The same 641-token prompt with eight requested tokens and KV load failure policy `fail` fails on the stock binary with the TypeError above and zero completion tokens. Replacing only the Rust binary with this backport passes with eight completion tokens and finish reason `length`.
- No model, kernel, or sampling behavior is changed; validation covers the serving protocol regression rather than model quality.

AI assistance was used to investigate, implement, and test this draft.