### PR TITLE
[XPU][CI] Add decord to test requirements

### DIFF
--- a/requirements/test/xpu.in
+++ b/requirements/test/xpu.in
@@ -41,4 +41,5 @@ pqdm
 # --- Vision & Multimodal ---
 timm
 albumentations
+decord==0.6.0
 mistral-common[image,audio]

--- a/requirements/test/xpu.txt
+++ b/requirements/test/xpu.txt
@@ -115,6 +115,8 @@ datasets==5.0.1
     #   mteb
 decorator==5.3.1
     # via librosa
+decord==0.6.0
+    # via -r requirements/test/xpu.in
 defusedxml==0.7.1
     # via nltk
 depyf==0.20.0
@@ -442,6 +444,7 @@ numpy==2.3.5
     #   albumentations
     #   bm25s
     #   datasets
+    #   decord
     #   evaluate
     #   librosa
     #   lm-eval


### PR DESCRIPTION
XPU CI needed the new decord==0.6.0 dependency because PR #55921 registered inclusionAI/Ling-3.0-flash-VL (with trust_remote_code=True) in the model registry, causing the registry-parameterized test_tensor_schema.py test to automatically start loading that model, whose HuggingFace remote code imports decord — a package already present for CUDA/ROCm but missing from the XPU requirements. It hadn't caused problems before because the XPU image had never previously exercised an online, trust_remote_code multimodal model through this generic tensor-schema suite, so the gap was latent until the registry expansion triggered it.