### PR TITLE
[Perf][Engram] Deepseek V41 Prefetch offloaded engram lookups; share host tables via mmap

### DIFF
--- a/tests/distributed/test_engram_dp_shard.py
+++ b/tests/distributed/test_engram_dp_shard.py
@@ -12,13 +12,11 @@ With shared host storage, DP replicas instead map the same TP slice and
 prefetch only their own tokens without DP gathers.
 """
 
-import inspect
 from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.multiprocessing as mp
-from torch import nn
 
 from vllm.config import (
     EngramConfig,
@@ -27,6 +25,7 @@ from vllm.config import (
     set_current_vllm_config,
 )
 from vllm.config.parallel import ParallelConfig
+from vllm.config.scheduler import SchedulerConfig
 from vllm.distributed import cleanup_dist_env_and_memory, parallel_state
 from vllm.distributed.parallel_state import (
     get_engram_dp_group,
@@ -38,6 +37,7 @@ from vllm.forward_context import set_forward_context
 from vllm.models.deepseek_v4_1.common import engram as engram_ops
 from vllm.models.deepseek_v4_1.common.engram import (
     Engram,
+    EngramLayout,
     ParallelEngramEmbedding,
     engram_head_shard_rank,
     gather_engram_hashes,
@@ -99,7 +99,6 @@ def _worker(
 ) -> None:
     monkeypatch = pytest.MonkeyPatch()
     with monkeypatch.context() as m:
-        # Any DeepSeek V4.1 config would do; only the answer matters here.
         m.setattr("vllm.config.engram.model_has_engram_layers", lambda config: True)
         torch.accelerator.set_device_index(torch.device(f"cuda:{rank}"))
         update_environment_variables(
@@ -112,15 +111,33 @@ def _worker(
             }
         )
         dp_rank, tp_rank = divmod(rank, tp_size)
+        head_sizes = HEAD_SIZES[:n_heads]
+        rows = sum(head_sizes)
+        config = SimpleNamespace(
+            hidden_size=DIM,
+            hc_mult=2,
+            rms_norm_eps=1e-6,
+            engram_layer_ids=[0],
+            engram_num_embeddings=[rows],
+            engram_max_ngram_size=2,
+            engram_n_heads=n_heads,
+            engram_head_dim=DIM,
+            engram_compressed_vocab_size=32,
+            engram_pad_token_id=0,
+            engram_vocab_size=HEAD_SIZES[0],
+        )
         vllm_config = VllmConfig(
             parallel_config=ParallelConfig(
                 tensor_parallel_size=tp_size,
                 data_parallel_size=dp_size,
                 data_parallel_rank=dp_rank,
             ),
-        )
-        vllm_config.engram_config = EngramConfig(
-            enable_engram_shared_memory=shared_memory
+            scheduler_config=SchedulerConfig(
+                max_model_len=8,
+                is_encoder_decoder=False,
+                max_num_batched_tokens=8,
+                max_num_seqs=8,
+            ),
         )
         init_distributed_environment()
         with set_current_vllm_config(vllm_config):
@@ -134,18 +151,31 @@ def _worker(
             # Head shards run TP-major, so the DP gather brings in neighbours.
             assert engram_head_shard_rank() == tp_rank * dp_size + dp_rank
 
-            head_sizes = HEAD_SIZES[:n_heads]
-            rows = sum(head_sizes)
             weight, scale_inv = _full_table(rows)
-            with torch.device("cuda"):
-                layer = ParallelEngramEmbedding(
-                    rows,
-                    DIM,
-                    head_sizes,
-                    block_size=BLOCK,
+            layout = EngramLayout(config)
+            # Stub configuration inputs, not Engram's initialization or execution.
+            component_config = SimpleNamespace(
+                engram_config=EngramConfig(
                     cpu_offload=cpu_offload,
-                    shared_memory=shared_memory,
+                    enable_engram_shared_memory=shared_memory,
+                ),
+                parallel_config=ParallelConfig(ubatch_size=2 if shared_memory else 1),
+                scheduler_config=vllm_config.scheduler_config,
+                load_config=vllm_config.load_config,
+            )
+            with m.context() as init_patch, torch.device("cuda"):
+                init_patch.setattr(
+                    engram_ops, "get_current_vllm_config", lambda: component_config
                 )
+                engram = Engram(
+                    config,
+                    quant_config=None,
+                    layout=layout,
+                    layer_hash_index=0,
+                    use_sequence_parallel=sequence_parallel,
+                    prefix="model.layers.0.engram",
+                )
+            layer = engram.embed_tokens
             # Only the leader has valid checkpoint payload in shared mode.
             loader_weight = weight if not shared_memory or dp_rank == 0 else None
             loader_scale = scale_inv if not shared_memory or dp_rank == 0 else None
@@ -161,19 +191,7 @@ def _worker(
 
                 m.setattr(get_engram_dp_group(), "all_gather", unexpected_collective)
 
-            engram = Engram.__new__(Engram)
-            nn.Module.__init__(engram)
-            engram.embed_tokens = layer
-            engram._prefetch_streams = (torch.cuda.Stream(),) if cpu_offload else ()
-            engram.use_sequence_parallel = sequence_parallel
             token_counts = _token_counts(dp_size)
-            engram.staged_rows = torch.empty(
-                max(max(counts) for counts in token_counts) * layer.dp_size,
-                layer.part_n_hash_cols,
-                DIM,
-                dtype=torch.bfloat16,
-                device="cuda",
-            )
 
         # Production forward runs after the construction-time config has exited.
         assert get_current_vllm_config_or_none() is None
@@ -211,18 +229,9 @@ def _worker(
 
 
 def _check_shared_prefetch_replay(engram, head_sizes, weight, scale_inv, patch):
-    from vllm import envs
-    from vllm.compilation.breakable_cudagraph import (
-        BreakableCUDAGraphCapture,
-        eager_break_during_capture,
-    )
+    """Check buffer isolation with controlled IDs, not the full DBO scheduler."""
+    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
 
-    patch.setattr(envs, "VLLM_USE_BREAKABLE_CUDAGRAPH", True)
-    for name in ("_start_prefetch", "_finish_prefetch"):
-        fn = eager_break_during_capture(inspect.unwrap(getattr(Engram, name)))
-        setattr(engram, name, fn.__get__(engram, Engram))
-    engram._prefetch_streams = (torch.cuda.Stream(), torch.cuda.Stream())
-    engram._extra_staged_rows = [torch.empty_like(engram.staged_rows)]
     ids = [_make_ids(head_sizes, 8, seed=seed) for seed in (501, 502)]
     tp_rank = engram_ops.get_tensor_model_parallel_rank()
     tp_size = engram.embed_tokens.tp_size
@@ -232,12 +241,10 @@ def _check_shared_prefetch_replay(engram, head_sizes, weight, scale_inv, patch):
         for _ in ids
     ]
 
-    def step(cap=None):
+    def step():
         for ubatch in (0, 1):
             patch.setattr(engram_ops, "dbo_current_ubatch_id", lambda i=ubatch: i)
             engram.prepare_embeddings(ids[ubatch].clone())
-        if cap is not None:
-            cap.add_eager(lambda: None)
         for ubatch in (1, 0):
             patch.setattr(engram_ops, "dbo_current_ubatch_id", lambda i=ubatch: i)
             outputs[ubatch].copy_(engram.embed(ids[ubatch]))
@@ -249,8 +256,9 @@ def _check_shared_prefetch_replay(engram, head_sizes, weight, scale_inv, patch):
     torch.cuda.current_stream().wait_stream(warmup)
     graph = BreakableCUDAGraphCapture()
     with torch.cuda.stream(warmup), graph:
-        step(graph)
+        step()
     torch.cuda.current_stream().wait_stream(warmup)
+    assert graph.num_eager_breaks == 4  # Two prefetch starts and two waits.
     for iteration in range(3):
         for ubatch in (0, 1):
             ids[ubatch].copy_(
@@ -307,11 +315,17 @@ def test_engram_table_shared_across_dp_replicas(
     [(1, 4, False), (2, 2, False), (2, 2, True)],
 )
 def test_engram_shared_host_memory_prefetch(
-    tp_size: int, dp_size: int, sequence_parallel: bool, n_heads: int
+    tp_size: int,
+    dp_size: int,
+    sequence_parallel: bool,
+    n_heads: int,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """All DP readers prefetch leader-loaded pages without exchanging tokens/rows."""
     if torch.accelerator.device_count() < WORLD_SIZE:
         pytest.skip(f"Need {WORLD_SIZE} GPUs to run the test.")
+    # Spawned workers must import Engram with its production decorators enabled.
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "1")
     mp.spawn(
         _worker,
         args=(

--- a/tests/distributed/test_engram_dp_shard.py
+++ b/tests/distributed/test_engram_dp_shard.py
@@ -7,8 +7,12 @@ Four GPUs on one node split the hash heads four ways, whether as DEP
 the right rows if the ids of every replica are gathered, each rank looks up
 its own heads, and each replica trades those tokens back for the heads its
 peers own.
+
+With shared host storage, DP replicas instead map the same TP slice and
+prefetch only their own tokens without DP gathers.
 """
 
+import inspect
 from types import SimpleNamespace
 
 import pytest
@@ -16,7 +20,12 @@ import torch
 import torch.multiprocessing as mp
 from torch import nn
 
-from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.config import (
+    EngramConfig,
+    VllmConfig,
+    get_current_vllm_config_or_none,
+    set_current_vllm_config,
+)
 from vllm.config.parallel import ParallelConfig
 from vllm.distributed import cleanup_dist_env_and_memory, parallel_state
 from vllm.distributed.parallel_state import (
@@ -86,6 +95,7 @@ def _worker(
     n_heads: int,
     sequence_parallel: bool,
     port: int,
+    shared_memory: bool = False,
 ) -> None:
     monkeypatch = pytest.MonkeyPatch()
     with monkeypatch.context() as m:
@@ -107,7 +117,10 @@ def _worker(
                 tensor_parallel_size=tp_size,
                 data_parallel_size=dp_size,
                 data_parallel_rank=dp_rank,
-            )
+            ),
+        )
+        vllm_config.engram_config = EngramConfig(
+            enable_engram_shared_memory=shared_memory
         )
         init_distributed_environment()
         with set_current_vllm_config(vllm_config):
@@ -126,51 +139,130 @@ def _worker(
             weight, scale_inv = _full_table(rows)
             with torch.device("cuda"):
                 layer = ParallelEngramEmbedding(
-                    rows, DIM, head_sizes, block_size=BLOCK, cpu_offload=cpu_offload
+                    rows,
+                    DIM,
+                    head_sizes,
+                    block_size=BLOCK,
+                    cpu_offload=cpu_offload,
+                    shared_memory=shared_memory,
                 )
-            layer.weight.weight_loader(layer.weight, weight)
-            layer.weight_scale_inv.weight_loader(layer.weight_scale_inv, scale_inv)
+            # Only the leader has valid checkpoint payload in shared mode.
+            loader_weight = weight if not shared_memory or dp_rank == 0 else None
+            loader_scale = scale_inv if not shared_memory or dp_rank == 0 else None
+            layer.weight.weight_loader(layer.weight, loader_weight)
+            layer.weight_scale_inv.weight_loader(layer.weight_scale_inv, loader_scale)
+            if shared_memory:
+                assert layer.dp_size == 1
+                assert layer.head_start == tp_rank * layer.part_n_hash_cols
+                assert layer.weight.is_pinned() and layer.weight_scale_inv.is_pinned()
+
+                def unexpected_collective(*args, **kwargs):
+                    raise AssertionError("shared lookup must not use DP collectives")
+
+                m.setattr(get_engram_dp_group(), "all_gather", unexpected_collective)
 
             engram = Engram.__new__(Engram)
             nn.Module.__init__(engram)
             engram.embed_tokens = layer
+            engram._prefetch_streams = (torch.cuda.Stream(),) if cpu_offload else ()
             engram.use_sequence_parallel = sequence_parallel
             token_counts = _token_counts(dp_size)
             engram.staged_rows = torch.empty(
-                max(max(counts) for counts in token_counts) * dp_size,
+                max(max(counts) for counts in token_counts) * layer.dp_size,
                 layer.part_n_hash_cols,
                 DIM,
                 dtype=torch.bfloat16,
                 device="cuda",
             )
 
-            for batch_idx, counts in enumerate(token_counts):
-                num_tokens = counts[dp_rank]
-                # Ids differ per replica but must agree across its TP ranks.
-                ids = _make_ids(head_sizes, num_tokens, seed=100 + dp_rank)
-                if batch_idx == 2 and dp_rank == 1:
-                    ids.fill_(engram_ops.DEAD_ID)
-                with set_forward_context(
-                    None,
-                    vllm_config,
-                    num_tokens=num_tokens,
-                    num_tokens_across_dp=torch.tensor(counts, dtype=torch.int32),
-                ):
-                    gathered = gather_engram_hashes(ids)
-                    assert gathered.shape[0] == max(counts) * dp_size
-                    engram.prepare_embeddings(gathered)
-                    looked_up = engram.embed(ids)
-                    standalone = layer(ids)
-                expected = _reference(weight.cuda(), scale_inv.cuda(), ids)
-                torch.testing.assert_close(standalone, expected, atol=0, rtol=0)
-                if sequence_parallel:
-                    # SP hands back only this rank's token shard, zero-padded.
-                    chunk = -(-num_tokens // tp_size)
-                    expected = torch.nn.functional.pad(
-                        expected, (0, 0, 0, 0, 0, chunk * tp_size - num_tokens)
-                    )
-                    expected = expected[tp_rank * chunk : (tp_rank + 1) * chunk]
-                torch.testing.assert_close(looked_up, expected, atol=0, rtol=0)
+        # Production forward runs after the construction-time config has exited.
+        assert get_current_vllm_config_or_none() is None
+        for batch_idx, counts in enumerate(token_counts):
+            num_tokens = counts[dp_rank]
+            # Ids differ per replica but must agree across its TP ranks.
+            ids = _make_ids(head_sizes, num_tokens, seed=100 + dp_rank)
+            if batch_idx == 2 and dp_rank == 1:
+                ids.fill_(engram_ops.DEAD_ID)
+            with set_forward_context(
+                None,
+                vllm_config,
+                num_tokens=num_tokens,
+                num_tokens_across_dp=torch.tensor(counts, dtype=torch.int32),
+            ):
+                gathered = gather_engram_hashes(ids, shared_memory=layer.shared_memory)
+                expected_tokens = num_tokens if shared_memory else max(counts) * dp_size
+                assert gathered.shape[0] == expected_tokens
+                engram.prepare_embeddings(gathered)
+                looked_up = engram.embed(ids)
+                standalone = layer(ids)
+            expected = _reference(weight.cuda(), scale_inv.cuda(), ids)
+            torch.testing.assert_close(standalone, expected, atol=0, rtol=0)
+            if sequence_parallel:
+                # SP hands back only this rank's token shard, zero-padded.
+                chunk = -(-num_tokens // tp_size)
+                expected = torch.nn.functional.pad(
+                    expected, (0, 0, 0, 0, 0, chunk * tp_size - num_tokens)
+                )
+                expected = expected[tp_rank * chunk : (tp_rank + 1) * chunk]
+            torch.testing.assert_close(looked_up, expected, atol=0, rtol=0)
+
+        if shared_memory:
+            _check_shared_prefetch_replay(engram, head_sizes, weight, scale_inv, m)
+
+
+def _check_shared_prefetch_replay(engram, head_sizes, weight, scale_inv, patch):
+    from vllm import envs
+    from vllm.compilation.breakable_cudagraph import (
+        BreakableCUDAGraphCapture,
+        eager_break_during_capture,
+    )
+
+    patch.setattr(envs, "VLLM_USE_BREAKABLE_CUDAGRAPH", True)
+    for name in ("_start_prefetch", "_finish_prefetch"):
+        fn = eager_break_during_capture(inspect.unwrap(getattr(Engram, name)))
+        setattr(engram, name, fn.__get__(engram, Engram))
+    engram._prefetch_streams = (torch.cuda.Stream(), torch.cuda.Stream())
+    engram._extra_staged_rows = [torch.empty_like(engram.staged_rows)]
+    ids = [_make_ids(head_sizes, 8, seed=seed) for seed in (501, 502)]
+    tp_rank = engram_ops.get_tensor_model_parallel_rank()
+    tp_size = engram.embed_tokens.tp_size
+    tokens = 8 // tp_size if engram.use_sequence_parallel else 8
+    outputs = [
+        torch.empty(tokens, len(head_sizes), DIM, device="cuda", dtype=torch.bfloat16)
+        for _ in ids
+    ]
+
+    def step(cap=None):
+        for ubatch in (0, 1):
+            patch.setattr(engram_ops, "dbo_current_ubatch_id", lambda i=ubatch: i)
+            engram.prepare_embeddings(ids[ubatch].clone())
+        if cap is not None:
+            cap.add_eager(lambda: None)
+        for ubatch in (1, 0):
+            patch.setattr(engram_ops, "dbo_current_ubatch_id", lambda i=ubatch: i)
+            outputs[ubatch].copy_(engram.embed(ids[ubatch]))
+
+    warmup = torch.cuda.Stream()
+    warmup.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup):
+        step()
+    torch.cuda.current_stream().wait_stream(warmup)
+    graph = BreakableCUDAGraphCapture()
+    with torch.cuda.stream(warmup), graph:
+        step(graph)
+    torch.cuda.current_stream().wait_stream(warmup)
+    for iteration in range(3):
+        for ubatch in (0, 1):
+            ids[ubatch].copy_(
+                _make_ids(head_sizes, 8, seed=600 + 2 * iteration + ubatch)
+            )
+        graph.replay()
+        for actual, indices in zip(outputs, ids):
+            expected = _reference(weight.cuda(), scale_inv.cuda(), indices)
+            if engram.use_sequence_parallel:
+                expected = expected[tp_rank * tokens : (tp_rank + 1) * tokens]
+            torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    torch.accelerator.synchronize()
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
@@ -206,6 +298,68 @@ def test_engram_table_shared_across_dp_replicas(
         nprocs=WORLD_SIZE,
     )
     cleanup_dist_env_and_memory()
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize("n_heads", [8, 7])
+@pytest.mark.parametrize(
+    "tp_size,dp_size,sequence_parallel",
+    [(1, 4, False), (2, 2, False), (2, 2, True)],
+)
+def test_engram_shared_host_memory_prefetch(
+    tp_size: int, dp_size: int, sequence_parallel: bool, n_heads: int
+) -> None:
+    """All DP readers prefetch leader-loaded pages without exchanging tokens/rows."""
+    if torch.accelerator.device_count() < WORLD_SIZE:
+        pytest.skip(f"Need {WORLD_SIZE} GPUs to run the test.")
+    mp.spawn(
+        _worker,
+        args=(
+            tp_size,
+            dp_size,
+            True,
+            n_heads,
+            sequence_parallel,
+            get_open_port(),
+            True,
+        ),
+        nprocs=WORLD_SIZE,
+    )
+    cleanup_dist_env_and_memory()
+
+
+def test_engram_shared_memory_requires_cpu_offload():
+    with pytest.raises(ValueError, match="requires cpu_offload"):
+        EngramConfig(cpu_offload=False, enable_engram_shared_memory=True)
+
+
+def test_engram_shared_memory_requires_dp_peers(monkeypatch):
+    monkeypatch.setattr(engram_ops, "get_engram_dp_size", lambda: 1)
+    monkeypatch.setattr(engram_ops, "get_tensor_model_parallel_world_size", lambda: 4)
+    with pytest.raises(AssertionError, match="requires co-located DP replicas"):
+        ParallelEngramEmbedding(
+            sum(HEAD_SIZES), DIM, HEAD_SIZES, cpu_offload=True, shared_memory=True
+        )
+
+
+@pytest.mark.parametrize("load_format,multithread", [("dummy", False), ("auto", True)])
+def test_engram_shared_memory_rejects_uncoordinated_loaders(
+    monkeypatch, load_format, multithread
+):
+    """Reject loaders that bypass the single writer or reorder collective loads."""
+    monkeypatch.setattr(engram_ops, "get_engram_dp_size", lambda: 4)
+    monkeypatch.setattr(engram_ops, "get_tensor_model_parallel_world_size", lambda: 1)
+    config = SimpleNamespace(
+        load_config=SimpleNamespace(
+            load_format=load_format,
+            model_loader_extra_config={"enable_multithread_load": multithread},
+        )
+    )
+    monkeypatch.setattr(engram_ops, "get_current_vllm_config", lambda: config)
+    with pytest.raises(AssertionError, match="Shared Engram"):
+        ParallelEngramEmbedding(
+            sum(HEAD_SIZES), DIM, HEAD_SIZES, cpu_offload=True, shared_memory=True
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/distributed/test_engram_dp_shard.py
+++ b/tests/distributed/test_engram_dp_shard.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Engram tables shared by co-located DP replicas.
+
+Four GPUs on one node split the hash heads four ways, whether as DEP
+(TP1 x DP4, the single-node MoE layout) or TP2 x DP2. A lookup only returns
+the right rows if the ids of every replica are gathered, each rank looks up
+its own heads, and each replica trades those tokens back for the heads its
+peers own.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+from torch import nn
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.config.parallel import ParallelConfig
+from vllm.distributed import cleanup_dist_env_and_memory, parallel_state
+from vllm.distributed.parallel_state import (
+    get_engram_dp_group,
+    get_engram_dp_size,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.forward_context import set_forward_context
+from vllm.models.deepseek_v4_1.common import engram as engram_ops
+from vllm.models.deepseek_v4_1.common.engram import (
+    Engram,
+    ParallelEngramEmbedding,
+    engram_head_shard_rank,
+    gather_engram_hashes,
+)
+from vllm.platforms import current_platform
+from vllm.utils.network_utils import get_open_port
+from vllm.utils.system_utils import update_environment_variables
+
+WORLD_SIZE = 4
+DIM, BLOCK = 64, 32
+# Prime-sized buckets, as the model's layout builds them.
+HEAD_SIZES = (97, 101, 103, 107, 109, 113, 127, 131)
+
+
+def _token_counts(dp_size: int) -> tuple[tuple[int, ...], ...]:
+    """Even loads, then uneven ones with an idle replica to pad around."""
+    return ((8,) * dp_size, (7, 0, 5, 1)[:dp_size], (7,) * dp_size)
+
+
+def _full_table(rows: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """The unsharded table, identical on every rank."""
+    torch.manual_seed(0)
+    weight = (torch.randn(rows, DIM) * 4).to(torch.float8_e4m3fn)
+    scale_inv = torch.randint(120, 134, (rows, DIM // BLOCK), dtype=torch.uint8)
+    return weight, scale_inv
+
+
+def _make_ids(head_sizes: tuple[int, ...], num_tokens: int, seed: int) -> torch.Tensor:
+    """Ids of each head, drawn from that head's own bucket range."""
+    torch.manual_seed(seed)
+    offset = 0
+    columns = []
+    for size in head_sizes:
+        columns.append(torch.randint(offset, offset + size, (num_tokens, 1)))
+        offset += size
+    return torch.cat(columns, dim=1).to(torch.int32).cuda()
+
+
+def _reference(weight, scale_inv, ids) -> torch.Tensor:
+    """Dequantized lookup against the whole table."""
+    valid = ids >= 0
+    safe_ids = ids.clamp_min(0).long()
+    values = torch.nn.functional.embedding(safe_ids, weight).float()
+    scales = torch.nn.functional.embedding(safe_ids, scale_inv)
+    scales = (scales.to(torch.int32) << 23).view(torch.float32)
+    values = values.unflatten(-1, (-1, BLOCK)) * scales.unsqueeze(-1)
+    return values.flatten(-2).to(torch.bfloat16).masked_fill(~valid.unsqueeze(-1), 0)
+
+
+def _worker(
+    rank: int,
+    tp_size: int,
+    dp_size: int,
+    cpu_offload: bool,
+    n_heads: int,
+    sequence_parallel: bool,
+    port: int,
+) -> None:
+    monkeypatch = pytest.MonkeyPatch()
+    with monkeypatch.context() as m:
+        # Any DeepSeek V4.1 config would do; only the answer matters here.
+        m.setattr("vllm.config.engram.model_has_engram_layers", lambda config: True)
+        torch.accelerator.set_device_index(torch.device(f"cuda:{rank}"))
+        update_environment_variables(
+            {
+                "RANK": str(rank),
+                "LOCAL_RANK": str(rank),
+                "WORLD_SIZE": str(WORLD_SIZE),
+                "MASTER_ADDR": "localhost",
+                "MASTER_PORT": str(port),
+            }
+        )
+        dp_rank, tp_rank = divmod(rank, tp_size)
+        vllm_config = VllmConfig(
+            parallel_config=ParallelConfig(
+                tensor_parallel_size=tp_size,
+                data_parallel_size=dp_size,
+                data_parallel_rank=dp_rank,
+            )
+        )
+        init_distributed_environment()
+        with set_current_vllm_config(vllm_config):
+            initialize_model_parallel(tensor_model_parallel_size=tp_size)
+
+            assert get_engram_dp_size() == dp_size
+            # Replicas group per TP rank: {0, 2} and {1, 3} at TP2 x DP2.
+            assert get_engram_dp_group().ranks == [
+                tp_rank + replica * tp_size for replica in range(dp_size)
+            ]
+            # Head shards run TP-major, so the DP gather brings in neighbours.
+            assert engram_head_shard_rank() == tp_rank * dp_size + dp_rank
+
+            head_sizes = HEAD_SIZES[:n_heads]
+            rows = sum(head_sizes)
+            weight, scale_inv = _full_table(rows)
+            with torch.device("cuda"):
+                layer = ParallelEngramEmbedding(
+                    rows, DIM, head_sizes, block_size=BLOCK, cpu_offload=cpu_offload
+                )
+            layer.weight.weight_loader(layer.weight, weight)
+            layer.weight_scale_inv.weight_loader(layer.weight_scale_inv, scale_inv)
+
+            engram = Engram.__new__(Engram)
+            nn.Module.__init__(engram)
+            engram.embed_tokens = layer
+            engram.use_sequence_parallel = sequence_parallel
+            token_counts = _token_counts(dp_size)
+            engram.staged_rows = torch.empty(
+                max(max(counts) for counts in token_counts) * dp_size,
+                layer.part_n_hash_cols,
+                DIM,
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+
+            for batch_idx, counts in enumerate(token_counts):
+                num_tokens = counts[dp_rank]
+                # Ids differ per replica but must agree across its TP ranks.
+                ids = _make_ids(head_sizes, num_tokens, seed=100 + dp_rank)
+                if batch_idx == 2 and dp_rank == 1:
+                    ids.fill_(engram_ops.DEAD_ID)
+                with set_forward_context(
+                    None,
+                    vllm_config,
+                    num_tokens=num_tokens,
+                    num_tokens_across_dp=torch.tensor(counts, dtype=torch.int32),
+                ):
+                    gathered = gather_engram_hashes(ids)
+                    assert gathered.shape[0] == max(counts) * dp_size
+                    engram.prepare_embeddings(gathered)
+                    looked_up = engram.embed(ids)
+                    standalone = layer(ids)
+                expected = _reference(weight.cuda(), scale_inv.cuda(), ids)
+                torch.testing.assert_close(standalone, expected, atol=0, rtol=0)
+                if sequence_parallel:
+                    # SP hands back only this rank's token shard, zero-padded.
+                    chunk = -(-num_tokens // tp_size)
+                    expected = torch.nn.functional.pad(
+                        expected, (0, 0, 0, 0, 0, chunk * tp_size - num_tokens)
+                    )
+                    expected = expected[tp_rank * chunk : (tp_rank + 1) * chunk]
+                torch.testing.assert_close(looked_up, expected, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize("cpu_offload", [False, True])
+# 8 heads split evenly; 7 leave one padded column on the last shard.
+@pytest.mark.parametrize("n_heads", [8, 7])
+# DEP first: expert parallel over the node keeps the dense layers at TP1.
+# Sequence parallelism only exists above TP1, where it replaces the head
+# gather with a token gather.
+@pytest.mark.parametrize(
+    "tp_size,dp_size,sequence_parallel",
+    [(1, 4, False), (2, 2, False), (2, 2, True)],
+)
+def test_engram_table_shared_across_dp_replicas(
+    tp_size: int,
+    dp_size: int,
+    sequence_parallel: bool,
+    cpu_offload: bool,
+    n_heads: int,
+) -> None:
+    if torch.accelerator.device_count() < WORLD_SIZE:
+        pytest.skip(f"Need {WORLD_SIZE} GPUs to run the test.")
+    mp.spawn(
+        _worker,
+        args=(
+            tp_size,
+            dp_size,
+            cpu_offload,
+            n_heads,
+            sequence_parallel,
+            get_open_port(),
+        ),
+        nprocs=WORLD_SIZE,
+    )
+    cleanup_dist_env_and_memory()
+
+
+@pytest.mark.parametrize(
+    "node_ids,dp_size,replica_size,expected",
+    [
+        ([0] * 4, 4, 1, 4),
+        ([0] * 4, 2, 2, 2),
+        ([0] * 8 + [1] * 8, 8, 2, 4),
+        ([0] * 8 + [1] * 8 + [2] * 8, 8, 3, 1),
+        ([0, 1] * 4, 4, 2, 1),
+        ([0] * 3 + [1] * 5, 4, 2, 1),
+    ],
+)
+def test_engram_dp_shard_size_respects_node_boundaries(
+    node_ids, dp_size, replica_size, expected, monkeypatch
+):
+    """Sharing must fall back when replicas or node rank ranges do not align."""
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architecture="DeepseekV41ForCausalLM",
+            hf_text_config=SimpleNamespace(engram_layer_ids=[1, 14]),
+        )
+    )
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(parallel_state, "get_node_count", lambda: len(set(node_ids)))
+    monkeypatch.setattr(
+        parallel_state, "get_world_group", lambda: SimpleNamespace(cpu_group=None)
+    )
+    monkeypatch.setattr(
+        parallel_state,
+        "in_the_same_node_as",
+        lambda group, src: [node == node_ids[src] for node in node_ids],
+    )
+    assert (
+        parallel_state._engram_dp_shard_size(
+            config, len(node_ids), dp_size, replica_size, False
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [0, 2, 4, 5])
+def test_engram_hash_padding_has_no_valid_rows(num_tokens, monkeypatch):
+    """Idle/padded slots must not query row zero; oversized batches are rejected."""
+    monkeypatch.setattr(engram_ops, "engram_gathered_num_tokens", lambda: 4)
+    monkeypatch.setattr(
+        engram_ops,
+        "get_engram_dp_group",
+        lambda: SimpleNamespace(all_gather=lambda ids, dim: torch.cat([ids, ids], dim)),
+    )
+    ids = torch.full((num_tokens, 2, 3), 17, dtype=torch.int32)
+    if num_tokens > 4:
+        with pytest.raises(ValueError, match="exceeds the DP token slot"):
+            gather_engram_hashes(ids)
+        return
+    gathered = gather_engram_hashes(ids).reshape(2, 4, 2, 3)
+    for replica in gathered:
+        torch.testing.assert_close(replica[:num_tokens], ids)
+        assert torch.all(replica[num_tokens:] == engram_ops.DEAD_ID)

--- a/tests/kernels/test_engram.py
+++ b/tests/kernels/test_engram.py
@@ -116,7 +116,7 @@ def test_fused_engram_post_wkv_matches_reference(
     module.use_sequence_parallel = use_sequence_parallel
     module.embed_tokens = torch.nn.Identity()
     # `forward` reads rows staged by `prepare_embeddings`, so inject kv there.
-    module.embed_tokens.tp_size = 1
+    module.embed_tokens.tp_size = module.embed_tokens.dp_size = 1
     module.staged_rows = kv.unsqueeze(1)
     if use_sequence_parallel:
         padded = torch.nn.functional.pad(kv, (0, 0, 0, (-num_kv_tokens) % tp_size))
@@ -149,6 +149,51 @@ def _hash_state(use_slot_cache: bool) -> NgramHashState:
     state.swa_cache_module = torch.nn.Module()
     state.swa_cache_module.kv_cache = torch.empty(0)
     return state
+
+
+@pytest.mark.parametrize("num_tokens", [0, 7])
+def test_engram_dummy_hashes_leave_history_untouched(num_tokens):
+    """Dummy forwards have no valid table IDs and do not alter cached history."""
+    state = _hash_state(use_slot_cache=True)
+    state.multipliers = torch.empty(2, 4, dtype=torch.int64)
+    state.primes = torch.empty(2, 3, 8, dtype=torch.int64)
+    state._cache = torch.arange(16, dtype=torch.int32)
+    history = state._cache.clone()
+
+    hashes, keep = state.dummy_hashes(torch.arange(num_tokens))
+
+    assert hashes.shape == (num_tokens, 2, 24)
+    assert hashes.dtype == torch.int32
+    assert torch.all(hashes == engram_ops.DEAD_ID)
+    assert keep.shape == (num_tokens,) and keep.dtype == torch.bool
+    assert not keep.any()
+    torch.testing.assert_close(state._cache, history)
+
+
+def test_engram_staging_preserves_interleaved_microbatches(monkeypatch):
+    """A second microbatch must not overwrite rows awaiting a later layer."""
+    module = Engram.__new__(Engram)
+    torch.nn.Module.__init__(module)
+    module.embed_tokens = torch.nn.Identity()
+    module.embed_tokens.tp_size = module.embed_tokens.dp_size = 1
+    module.embed_tokens.lookup = lambda ids, out: out.copy_(ids.unsqueeze(-1))
+    module.use_sequence_parallel = False
+    module.staged_rows = torch.empty(3, 2, 1)
+    module._extra_staged_rows = [torch.empty_like(module.staged_rows)]
+    ids = [torch.full((3, 2), 11), torch.full((2, 2), 22)]
+
+    for ubatch_id in range(2):
+        monkeypatch.setattr(
+            engram_ops, "dbo_current_ubatch_id", lambda ubatch_id=ubatch_id: ubatch_id
+        )
+        module.prepare_embeddings(ids[ubatch_id])
+    for ubatch_id in range(2):
+        monkeypatch.setattr(
+            engram_ops, "dbo_current_ubatch_id", lambda ubatch_id=ubatch_id: ubatch_id
+        )
+        torch.testing.assert_close(
+            module.embed(ids[ubatch_id]), ids[ubatch_id].unsqueeze(-1).float()
+        )
 
 
 @pytest.mark.parametrize("num_blocks", [4, 100])
@@ -533,6 +578,7 @@ def _make_embedding(cpu_offload, rows=4096, dim=256, block=32):
     layer = ParallelEngramEmbedding.__new__(ParallelEngramEmbedding)
     torch.nn.Module.__init__(layer)
     layer.dim, layer.block_size, layer.tp_size = dim, block, 1
+    layer.dp_size = 1
     layer.n_hash_cols = layer.part_n_hash_cols = 24
     layer.head_start = 0
     layer.cpu_offload = cpu_offload
@@ -559,12 +605,25 @@ def _make_embedding(cpu_offload, rows=4096, dim=256, block=32):
     return layer
 
 
+@pytest.mark.parametrize(
+    "tp_size,dp_size,n_heads", [(1, 4, 5), (2, 2, 5), (4, 1, 6), (8, 1, 6)]
+)
+def test_engram_rejects_empty_head_shards(tp_size, dp_size, n_heads, monkeypatch):
+    """Reject empty owners before allocating weights or accessing CUDA."""
+    monkeypatch.setattr(
+        engram_ops, "get_tensor_model_parallel_world_size", lambda: tp_size
+    )
+    monkeypatch.setattr(engram_ops, "get_engram_dp_size", lambda: dp_size)
+    with pytest.raises(AssertionError, match="ranks without hash heads"):
+        ParallelEngramEmbedding(n_heads * 17, 64, (17,) * n_heads)
+
+
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
 @pytest.mark.parametrize("cpu_offload", [False, True])
 @pytest.mark.parametrize("tp_size", [1, 2, 4, 8])
 def test_engram_head_shards_reconstruct_checkpoint(cpu_offload, tp_size, monkeypatch):
     """Keep complete buckets and reconstruct head order, including TP padding."""
-    head_sizes = (17, 19, 23, 29, 31, 37)
+    head_sizes = (17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73)
     num_rows, dim = sum(head_sizes), 64
     torch.manual_seed(0)
     weight = torch.randn(num_rows + 7, dim).to(torch.float8_e4m3fn)
@@ -623,7 +682,7 @@ def test_engram_head_shards_reconstruct_checkpoint(cpu_offload, tp_size, monkeyp
     module.staged_rows = torch.empty_like(shards[0])
     module.prepare_embeddings(ids)
     torch.testing.assert_close(module.embed(ids), expected, rtol=0, atol=0)
-    # Slicing before head reordering must preserve padded heads and empty owners.
+    # Slicing before head reordering must preserve padded heads and tokens.
     module.use_sequence_parallel = True
     chunk = (len(ids) + tp_size - 1) // tp_size
     padded = torch.nn.functional.pad(expected, (0, 0, 0, 0, 0, (-len(ids)) % tp_size))

--- a/tests/kernels/test_engram.py
+++ b/tests/kernels/test_engram.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import bisect
+import inspect
 from types import SimpleNamespace
 
 import pytest
@@ -170,24 +171,43 @@ def test_engram_dummy_hashes_leave_history_untouched(num_tokens):
     torch.testing.assert_close(state._cache, history)
 
 
-def test_engram_staging_preserves_interleaved_microbatches(monkeypatch):
+@pytest.mark.parametrize("prefetch", [False, True])
+@pytest.mark.parametrize("consume_order", [(0, 1), (1, 0)])
+def test_engram_staging_preserves_interleaved_microbatches(
+    monkeypatch, prefetch, consume_order
+):
     """A second microbatch must not overwrite rows awaiting a later layer."""
+    if prefetch and not current_platform.is_cuda():
+        pytest.skip("CUDA required for async prefetch")
+    device = "cuda" if prefetch else "cpu"
     module = Engram.__new__(Engram)
     torch.nn.Module.__init__(module)
     module.embed_tokens = torch.nn.Identity()
     module.embed_tokens.tp_size = module.embed_tokens.dp_size = 1
-    module.embed_tokens.lookup = lambda ids, out: out.copy_(ids.unsqueeze(-1))
+
+    def lookup(ids, out, background=False):
+        if background:
+            torch.cuda._sleep(2_000_000)
+        out.copy_(ids.unsqueeze(-1))
+
+    module.embed_tokens.lookup = lookup
     module.use_sequence_parallel = False
-    module.staged_rows = torch.empty(3, 2, 1)
+    module._prefetch_streams = (
+        tuple(torch.cuda.Stream() for _ in range(2)) if prefetch else ()
+    )
+    module.staged_rows = torch.empty(3, 2, 1, device=device)
     module._extra_staged_rows = [torch.empty_like(module.staged_rows)]
-    ids = [torch.full((3, 2), 11), torch.full((2, 2), 22)]
+    ids = [
+        torch.full((3, 2), 11, device=device),
+        torch.full((2, 2), 22, device=device),
+    ]
 
     for ubatch_id in range(2):
         monkeypatch.setattr(
             engram_ops, "dbo_current_ubatch_id", lambda ubatch_id=ubatch_id: ubatch_id
         )
         module.prepare_embeddings(ids[ubatch_id])
-    for ubatch_id in range(2):
+    for ubatch_id in consume_order:
         monkeypatch.setattr(
             engram_ops, "dbo_current_ubatch_id", lambda ubatch_id=ubatch_id: ubatch_id
         )
@@ -582,6 +602,7 @@ def _make_embedding(cpu_offload, rows=4096, dim=256, block=32):
     layer.n_hash_cols = layer.part_n_hash_cols = 24
     layer.head_start = 0
     layer.cpu_offload = cpu_offload
+    layer.shared_memory = False
     layer.part_num_embeddings = rows
     # A window strictly inside the table, so unowned rows are exercised too.
     layer.vocab_start_idx, layer.vocab_end_idx = rows // 4, rows // 4 + rows // 2
@@ -719,19 +740,130 @@ def test_engram_lookup_matches_torch(cpu_offload, background, num_tokens):
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
-@pytest.mark.parametrize("cpu_offload", [False, True])
+@pytest.mark.parametrize("ubatch_size,enable_dbo", [(0, False), (2, False), (0, True)])
+def test_engram_constructor_prefetches_without_ubatching(
+    monkeypatch, ubatch_size, enable_dbo
+):
+    """Default num_ubatches=0 must still launch lookup on a side stream."""
+    from vllm.config import ParallelConfig
+
+    parallel = ParallelConfig(ubatch_size=ubatch_size, enable_dbo=enable_dbo)
+    config = SimpleNamespace(hidden_size=16, hc_mult=1, rms_norm_eps=1e-6)
+    layout = SimpleNamespace(
+        num_embeddings=(4096,),
+        head_dim=256,
+        max_ngram_size=2,
+        n_heads=24,
+        primes=(((3,) * 24,),),
+    )
+    vllm_config = SimpleNamespace(
+        engram_config=None,
+        parallel_config=parallel,
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
+    )
+    layer = _make_embedding(True)
+    streams = []
+    lookup = layer.lookup
+
+    def track_lookup(ids, out, background=False):
+        streams.append(torch.cuda.current_stream())
+        lookup(ids, out, background=background)
+
+    layer.lookup = track_lookup
+    monkeypatch.setattr(engram_ops, "get_current_vllm_config", lambda: vllm_config)
+    monkeypatch.setattr(engram_ops, "ParallelEngramEmbedding", lambda *a, **k: layer)
+    monkeypatch.setattr(
+        engram_ops, "ReplicatedLinear", lambda *a, **k: torch.nn.Identity()
+    )
+    with torch.device("cuda"):
+        module = Engram(config, None, layout, 0, False, "engram")
+    main = torch.cuda.current_stream()
+    ids = torch.randint(
+        layer.vocab_start_idx,
+        layer.vocab_end_idx,
+        (8, 24),
+        device="cuda",
+        dtype=torch.int32,
+    )
+    for ubatch in range(max(1, parallel.num_ubatches)):
+        monkeypatch.setattr(engram_ops, "dbo_current_ubatch_id", lambda u=ubatch: u)
+        module.prepare_embeddings(ids)
+        expected = _reference_lookup(
+            layer.weight.cuda(),
+            layer.weight_scale_inv.cuda(),
+            ids,
+            layer.vocab_start_idx,
+            layer.vocab_end_idx,
+        )
+        torch.testing.assert_close(module.embed(ids), expected, atol=0, rtol=0)
+    assert all(stream != main for stream in streams)
+    assert len(set(streams)) == max(1, parallel.num_ubatches)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "cpu_offload,delay",
+    [(False, None), (True, None), (True, "producer"), (True, "lookup")],
+)
 @pytest.mark.parametrize("capture", ["eager", "full", "breakable"])
-def test_engram_prepared_rows_survive_graph_breaks(cpu_offload, capture):
-    """Consume early lookup results after a break, with fresh IDs each replay."""
-    _run_engram_prepared_rows(cpu_offload, capture)
+def test_engram_prepared_rows_survive_graph_breaks(cpu_offload, capture, delay):
+    """Temporary lookup IDs survive allocator reuse and graph replay."""
+    _run_engram_prepared_rows(cpu_offload, capture, delay=delay)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "missing_dependency", ["record_stream", "producer_wait", "consumer_wait"]
+)
+def test_engram_prefetch_detects_missing_dependency(monkeypatch, missing_dependency):
+    """Negative controls must expose incorrect rows when a dependency is removed."""
+    if (
+        missing_dependency == "record_stream"
+        and torch.cuda.memory.get_allocator_backend() != "native"
+    ):
+        pytest.skip(
+            "The allocator reuse negative control requires the native allocator"
+        )
+
+    def start(self, hash_ids, rows, stream):
+        if missing_dependency != "producer_wait":
+            stream.wait_stream(torch.cuda.current_stream())
+        if missing_dependency != "record_stream":
+            hash_ids.record_stream(stream)
+        with torch.cuda.stream(stream):
+            self.embed_tokens.lookup(hash_ids, rows, background=True)
+
+    def finish(self, stream):
+        pass
+
+    monkeypatch.setattr(Engram, "_start_prefetch", start)
+    if missing_dependency == "consumer_wait":
+        monkeypatch.setattr(Engram, "_finish_prefetch", finish)
+    delay = "producer" if missing_dependency == "producer_wait" else "lookup"
+    try:
+        with pytest.raises(AssertionError, match="Tensor-likes are not equal"):
+            _run_engram_prepared_rows(True, "eager", delay=delay)
+    finally:
+        torch.accelerator.synchronize()
 
 
 def _run_engram_prepared_rows(
-    cpu_offload, capture, tp_size=1, rank=0, use_sequence_parallel=False
+    cpu_offload, capture, tp_size=1, rank=0, use_sequence_parallel=False, delay=None
 ):
-    from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
+    from vllm.compilation.breakable_cudagraph import (
+        BreakableCUDAGraphCapture,
+        eager_break_during_capture,
+    )
 
     layer = _make_embedding(cpu_offload)
+    if delay == "lookup":
+        lookup = layer.lookup
+
+        def delayed_lookup(indices, out, background=False):
+            torch.cuda._sleep(2_000_000)
+            lookup(indices, out, background=background)
+
+        layer.lookup = delayed_lookup
     cols, num_tokens = (23, 65) if use_sequence_parallel else (24, 64)
     layer.n_hash_cols = cols
     layer.tp_size = tp_size
@@ -740,6 +872,17 @@ def _run_engram_prepared_rows(
     engram = Engram.__new__(Engram)
     torch.nn.Module.__init__(engram)
     engram.embed_tokens = layer
+    engram._prefetch_streams = (torch.cuda.Stream(),) if cpu_offload else ()
+    # Exercise the production eager boundaries even when the test process
+    # imported Engram before breakable graphs were enabled.
+    if capture == "breakable":
+        import vllm.envs as envs
+
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(envs, "VLLM_USE_BREAKABLE_CUDAGRAPH", True)
+            for name in ("_start_prefetch", "_finish_prefetch"):
+                fn = eager_break_during_capture(inspect.unwrap(getattr(Engram, name)))
+                setattr(engram, name, fn.__get__(engram, Engram))
     engram.use_sequence_parallel = use_sequence_parallel
     engram.staged_rows = torch.empty(
         num_tokens,
@@ -768,7 +911,12 @@ def _run_engram_prepared_rows(
         embed = torch.compile(embed, backend="eager", fullgraph=True, dynamic=True)
 
     def step(cap=None):
-        engram.prepare_embeddings(src)
+        if delay == "producer":
+            torch.cuda._sleep(2_000_000)
+        # Drop the last reference to a non-contiguous input after launching lookup.
+        engram.prepare_embeddings(hashes.clone()[:, 1])
+        # Exercise same-size allocator reuse before consuming the prefetched rows.
+        torch.empty_like(hashes).fill_(layer.part_num_embeddings - 1)
         if cap is not None:
             cap.add_eager(lambda: None)
         out.copy_(embed(src))
@@ -789,9 +937,12 @@ def _run_engram_prepared_rows(
         with torch.cuda.stream(warmup), graph:
             step(graph)
         torch.cuda.current_stream().wait_stream(warmup)
-        assert graph.num_graphs == 2
+        assert graph.num_eager_breaks == (3 if cpu_offload else 1)
 
     for _ in range(3):
+        # Eager prefill can overwrite staging rows between decode replays.
+        hashes.random_(0, layer.part_num_embeddings)
+        step()
         hashes.random_(0, layer.part_num_embeddings)
         if graph is None:
             step()

--- a/vllm/config/engram.py
+++ b/vllm/config/engram.py
@@ -3,7 +3,8 @@
 
 from typing import TYPE_CHECKING
 
-from pydantic import Field
+from pydantic import Field, model_validator
+from typing_extensions import Self
 
 import vllm.envs as envs
 from vllm.config.utils import config, get_hash_factors, hash_factors
@@ -56,6 +57,20 @@ class EngramConfig:
     embedding_across_dp: bool = False
     """Shard embeddings across TP and all DP ranks when enabled.
     Otherwise, each DP rank has a separate TP-sharded embedding replica."""
+
+    enable_engram_shared_memory: bool = False
+    """Share host weights across co-located DP replicas, retaining TP sharding.
+    One DP rank loads each TP slice; every reader registers its shared mmap
+    with CUDA. Bypasses Engram DP gathers and supports asynchronous prefetch.
+    Requires CPU offload, a node-local Engram DP group, sufficient /dev/shm
+    capacity, and a shared IPC namespace on each node. Supported load formats
+    are auto, safetensors and pt, without multithreaded loading."""
+
+    @model_validator(mode="after")
+    def _validate_shared_memory(self) -> Self:
+        if self.enable_engram_shared_memory and not self.cpu_offload:
+            raise ValueError("enable_engram_shared_memory requires cpu_offload=True")
+        return self
 
     def verify_model_config(self, model_config: "ModelConfig | None") -> None:
         """Reject Engram configuration for models without n-gram embeddings."""

--- a/vllm/config/engram.py
+++ b/vllm/config/engram.py
@@ -34,6 +34,16 @@ def _default_cpu_offload() -> bool:
     return envs.VLLM_PLE_CPU_OFFLOAD
 
 
+def model_has_engram_layers(model_config: "ModelConfig | None") -> bool:
+    """Whether the model carries n-gram embedding layers."""
+    if model_config is None:
+        return False
+    field = _NGRAM_LAYER_FIELDS.get(model_config.architecture)
+    if field is None:
+        return False
+    return bool(getattr(model_config.hf_text_config, field, None))
+
+
 @config
 class EngramConfig:
     """Configuration for Engram embedding storage and sharding."""

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -32,6 +32,7 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from dataclasses import dataclass
 from datetime import timedelta
+from math import gcd
 from multiprocessing import shared_memory
 from typing import TYPE_CHECKING, Any, Protocol
 from unittest.mock import patch
@@ -59,6 +60,7 @@ from vllm.utils.torch_utils import (
 )
 
 if TYPE_CHECKING:
+    from vllm.config import VllmConfig
     from vllm.distributed.stateless_coordinator import StatelessGroupCoordinator
 
 
@@ -1560,6 +1562,23 @@ def get_etp_group() -> GroupCoordinator:
     return _ETP
 
 
+_ENGRAM_DP: GroupCoordinator | None = None
+
+
+def get_engram_dp_group() -> GroupCoordinator | None:
+    """Return the DP replicas that share one engram embedding table.
+
+    None when every replica holds a full (TP-sharded) copy, which is the case
+    for models without engram layers and for replicas that span nodes.
+    """
+    return _ENGRAM_DP
+
+
+def get_engram_dp_size() -> int:
+    """Number of DP replicas one engram embedding table is sharded over."""
+    return _ENGRAM_DP.world_size if _ENGRAM_DP is not None else 1
+
+
 _DCP: GroupCoordinator | None = None
 
 
@@ -1917,6 +1936,48 @@ def init_distributed_environment(
             _INNER_DP_WORLD = _WORLD
 
 
+def _engram_dp_shard_size(
+    config: "VllmConfig",
+    world_size: int,
+    data_parallel_size: int,
+    replica_size: int,
+    enable_elastic_ep: bool,
+) -> int:
+    """DP replicas that can share one engram table: those co-located on a node.
+
+    The tables run to ~100GB per layer, so a node holding one copy instead of
+    one per replica is a large win. Replicas on different nodes are left
+    alone: their per-step row exchange would land on the slow link.
+    """
+    from vllm.config.engram import model_has_engram_layers
+    from vllm.platforms import current_platform
+
+    if (
+        data_parallel_size == 1
+        or enable_elastic_ep
+        or not current_platform.is_cuda()
+        or not model_has_engram_layers(config.model_config)
+    ):
+        return 1
+    node_count = get_node_count()
+    if world_size % node_count:
+        return 1
+    ranks_per_node = world_size // node_count
+    if ranks_per_node % replica_size:
+        return 1
+    shard_size = gcd(data_parallel_size, ranks_per_node // replica_size)
+    if shard_size > 1 and node_count > 1:
+        # The arithmetic assumes uniform nodes with contiguous global ranks.
+        for start in range(0, world_size, ranks_per_node):
+            same_node = in_the_same_node_as(get_world_group().cpu_group, start)
+            if any(
+                bool(local) != (start <= rank < start + ranks_per_node)
+                for rank, local in enumerate(same_node)
+            ):
+                return 1
+    return shard_size
+
+
 def initialize_model_parallel(
     tensor_model_parallel_size: int = 1,
     pipeline_model_parallel_size: int = 1,
@@ -2037,6 +2098,37 @@ def initialize_model_parallel(
             get_world_group().local_rank,
             backend,
             group_name="etp",
+        )
+
+    # Build the engram embedding group: the DP replicas that shard one n-gram
+    # table between them. Hash IDs and lookup results are gathered over
+    # it every step, so it never spans nodes.
+    global _ENGRAM_DP
+    assert _ENGRAM_DP is None, "engram data parallel group is already initialized"
+    engram_dp_size = _engram_dp_shard_size(
+        config,
+        world_size,
+        data_parallel_size,
+        tensor_model_parallel_size
+        * pipeline_model_parallel_size
+        * prefill_context_model_parallel_size,
+        enable_elastic_ep,
+    )
+    if engram_dp_size > 1:
+        group_ranks = (
+            all_ranks.permute(0, 2, 3, 4, 1).reshape(-1, engram_dp_size).unbind(0)
+        )
+        _ENGRAM_DP = init_model_parallel_group(
+            [x.tolist() for x in group_ranks],
+            get_world_group().local_rank,
+            backend,
+            group_name="edp",
+        )
+        logger.info_once(
+            "Engram tables are sharded over %d ranks (TP=%d x DP=%d)",
+            engram_dp_size * tensor_model_parallel_size,
+            tensor_model_parallel_size,
+            engram_dp_size,
         )
 
     # Build the DCP model-parallel groups.
@@ -2284,6 +2376,11 @@ def destroy_model_parallel():
     if _TP:
         _TP.destroy()
     _TP = None
+
+    global _ENGRAM_DP
+    if _ENGRAM_DP:
+        _ENGRAM_DP.destroy()
+    _ENGRAM_DP = None
 
     global _DCP
     if _DCP:

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -34,12 +34,16 @@ chunk-by-chunk while an n-gram at position ``p`` needs the token ids at
   cache for the rest.
 """
 
+import mmap
+import tempfile
 import weakref
+from contextlib import ExitStack
 
 import numpy as np
 import torch
 from torch import nn
 
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_engram_dp_group,
@@ -585,14 +589,16 @@ def engram_gathered_num_tokens() -> int:
     return int(dp_metadata.num_tokens_across_dp_cpu.max())
 
 
-def gather_engram_hashes(hash_ids: torch.Tensor) -> torch.Tensor:
+def gather_engram_hashes(
+    hash_ids: torch.Tensor, *, shared_memory: bool = False
+) -> torch.Tensor:
     """Collect the n-gram ids of every DP replica sharing one table.
 
     Replicas are padded to a common token slot, so the gathered shape is
     static under CUDA graph capture (where DP already pads alike).
     """
     dp_group = get_engram_dp_group()
-    if dp_group is None:
+    if dp_group is None or shared_memory:
         return hash_ids
     slot = engram_gathered_num_tokens()
     if hash_ids.shape[0] > slot:
@@ -603,6 +609,60 @@ def gather_engram_hashes(hash_ids: torch.Tensor) -> torch.Tensor:
         )
         hash_ids = torch.cat((hash_ids, pad))
     return dp_group.all_gather(hash_ids, dim=0)
+
+
+def _unregister_engram_mapping(mapping: mmap.mmap, pointer: int) -> None:
+    # Torch storage retains the numpy owner, including through cached UVA views.
+    # Keep its mmap alive until CUDA has released the registration.
+    result = torch.cuda.cudart().cudaHostUnregister(pointer)
+    if result.value != 0:
+        logger.warning("Engram cudaHostUnregister failed: %s", result)
+
+
+def _allocate_shared_engram(num_bytes: int) -> torch.Tensor:
+    """Map and register one physical allocation across a node-local DP group."""
+    from vllm.distributed.device_communicators.shm_broadcast import (
+        check_shm_free_space,
+    )
+
+    group = get_engram_dp_group()
+    assert group is not None
+    with ExitStack() as stack:
+        path = None
+        if group.rank_in_group == 0:
+            check_shm_free_space(num_bytes)
+            backing_file = stack.enter_context(
+                tempfile.NamedTemporaryFile(prefix="vllm_engram_", dir="/dev/shm")
+            )
+            backing_file.truncate(num_bytes)
+            path = backing_file.name
+        path = group.broadcast_object(path)
+        with open(path, "r+b") as file:
+            mapping = mmap.mmap(file.fileno(), num_bytes, flags=mmap.MAP_SHARED)
+        # Unlink only after every peer has mapped the file.
+        torch.distributed.barrier(group=group.cpu_group)
+
+    owner = np.frombuffer(mapping, dtype=np.uint8)
+    pointer = owner.ctypes.data
+    tensor = torch.from_numpy(owner)
+    result = torch.cuda.cudart().cudaHostRegister(pointer, num_bytes, 0)
+    if result.value != 0:
+        raise RuntimeError(f"Engram cudaHostRegister failed: {result}")
+    finalizer = weakref.finalize(owner, _unregister_engram_mapping, mapping, pointer)
+    finalizer.atexit = False  # type: ignore[misc]
+    # The UVA helper otherwise silently allocates a private pinned copy.
+    assert tensor.is_pinned(), "CUDA did not recognize the shared Engram registration"
+    return tensor
+
+
+def _shared_engram_weight_loader(
+    param: torch.nn.Parameter, loaded_weight: torch.Tensor
+) -> None:
+    group = get_engram_dp_group()
+    assert group is not None
+    if group.rank_in_group == 0:
+        _engram_head_shard_weight_loader(param, loaded_weight)
+    torch.distributed.barrier(group=group.cpu_group)
 
 
 def _engram_head_shard_weight_loader(
@@ -688,7 +748,8 @@ class ParallelEngramEmbedding(nn.Module):
     trades those tokens back for the heads the peers own.
 
     With `cpu_offload` the shard lives in pinned host memory and is read over
-    UVA instead of HBM; the sharding is unchanged either way.
+    UVA instead of HBM. With `enable_engram_shared_memory`, DP replicas map
+    the same TP slice and look up their own tokens without DP collectives.
     """
 
     def __init__(
@@ -698,10 +759,21 @@ class ParallelEngramEmbedding(nn.Module):
         head_sizes: tuple[int, ...],
         block_size: int = 32,
         cpu_offload: bool = False,
+        shared_memory: bool = False,
     ):
         super().__init__()
         tp_size = get_tensor_model_parallel_world_size()
         dp_size = get_engram_dp_size()
+        if shared_memory:
+            assert cpu_offload and dp_size > 1, (
+                "enable_engram_shared_memory requires co-located DP replicas "
+                "and CPU offload"
+            )
+            load_config = get_current_vllm_config().load_config
+            assert load_config.load_format in ("auto", "safetensors", "pt") and (
+                not load_config.model_loader_extra_config.get("enable_multithread_load")
+            ), "Shared Engram requires the default loader without multithreaded loading"
+            dp_size = 1
         assert head_sizes and all(size > 0 for size in head_sizes)
         assert sum(head_sizes) <= num_embeddings
         if cpu_offload and not is_uva_available():
@@ -716,7 +788,12 @@ class ParallelEngramEmbedding(nn.Module):
             f"Engram sharding leaves ranks without hash heads: "
             f"{self.n_hash_cols} heads over TP={tp_size} x DP={dp_size}"
         )
-        self.head_start = engram_head_shard_rank() * self.part_n_hash_cols
+        head_rank = (
+            get_tensor_model_parallel_rank()
+            if shared_memory
+            else engram_head_shard_rank()
+        )
+        self.head_start = head_rank * self.part_n_hash_cols
         head_end = self.head_start + self.part_n_hash_cols
         self.vocab_start_idx = sum(head_sizes[: self.head_start])
         self.vocab_end_idx = sum(head_sizes[:head_end])
@@ -724,6 +801,7 @@ class ParallelEngramEmbedding(nn.Module):
         self.tp_size = tp_size
         self.dp_size = dp_size
         self.cpu_offload = cpu_offload
+        self.shared_memory = shared_memory
         self._views: tuple[torch.Tensor, torch.Tensor] | None = None
         self._view_src: tuple[int, int] | None = None
         self._num_sms = torch.cuda.get_device_properties(
@@ -733,47 +811,60 @@ class ParallelEngramEmbedding(nn.Module):
         # Explicit device: model init runs under a `torch.device("cuda")`
         # context, which would otherwise put the shard in HBM.
         kwargs = {"device": "cpu", "pin_memory": True} if cpu_offload else {}
-        self.weight = nn.Parameter(
-            torch.empty(
+        if shared_memory:
+            weight_bytes = self.part_num_embeddings * dim
+            storage = _allocate_shared_engram(weight_bytes + weight_bytes // block_size)
+            weight = storage[:weight_bytes].view(torch.float8_e4m3fn).view(-1, dim)
+            scales = storage[weight_bytes:].view(-1, dim // block_size)
+        else:
+            weight = torch.empty(
                 self.part_num_embeddings, dim, dtype=torch.float8_e4m3fn, **kwargs
-            ),
-            requires_grad=False,
-        )
-        self.weight_scale_inv = nn.Parameter(
-            torch.empty(
+            )
+            scales = torch.empty(
                 self.part_num_embeddings,
                 dim // block_size,
                 dtype=torch.uint8,
                 **kwargs,
-            ),
-            requires_grad=False,
-        )
+            )
+        self.weight = nn.Parameter(weight, requires_grad=False)
+        self.weight_scale_inv = nn.Parameter(scales, requires_grad=False)
         for param in (self.weight, self.weight_scale_inv):
             set_weight_attrs(
                 param,
                 {
-                    "weight_loader": _engram_head_shard_weight_loader,
+                    "weight_loader": (
+                        _shared_engram_weight_loader
+                        if shared_memory
+                        else _engram_head_shard_weight_loader
+                    ),
                     "engram_vocab_start": self.vocab_start_idx,
+                    "engram_shared_ptr": param.data_ptr() if shared_memory else None,
                 },
             )
         if cpu_offload:
             logger.info(
                 "Engram table offloaded to pinned host memory: %d rows x %d, "
-                "%.2f GiB per rank",
+                "%.2f GiB %s",
                 self.part_num_embeddings,
                 dim,
                 self.part_num_embeddings * (dim + dim // block_size) / 1024**3,
+                "shared across DP replicas" if shared_memory else "per rank",
             )
 
     def _storage(self) -> tuple[torch.Tensor, torch.Tensor]:
         """Parameters when resident, else cached UVA views of the pinned shard.
 
-        Rebuilt if anything swaps `.data`, so a stale device pointer cannot
-        survive silently.
+        Private views are rebuilt after `.data` swaps; shared storage must
+        retain its registered address.
         """
         if not self.cpu_offload:
             return self.weight.data, self.weight_scale_inv.data
         src = (self.weight.data_ptr(), self.weight_scale_inv.data_ptr())
+        if self.shared_memory:
+            assert src == (
+                self.weight.engram_shared_ptr,
+                self.weight_scale_inv.engram_shared_ptr,
+            ), "Shared Engram parameter storage must not be replaced"
         if self._view_src != src:
             self._views = (
                 get_accelerator_view_from_cpu_tensor(self.weight.data),
@@ -1005,6 +1096,8 @@ class Engram(nn.Module):
     training kernel).
     """
 
+    _prefetch_streams: tuple[torch.cuda.Stream, ...] = ()
+
     def __init__(
         self,
         config,
@@ -1031,6 +1124,9 @@ class Engram(nn.Module):
             layout.head_dim,
             tuple(size for order in layout.primes[layer_hash_index] for size in order),
             cpu_offload=engram_config.cpu_offload if engram_config else True,
+            shared_memory=(
+                engram_config.enable_engram_shared_memory if engram_config else False
+            ),
         )
         n_hash_cols = (layout.max_ngram_size - 1) * layout.n_heads
         self.wkv = ReplicatedLinear(
@@ -1052,8 +1148,8 @@ class Engram(nn.Module):
 
         vllm_config = get_current_vllm_config()
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        # Keep lookup results alive across breakable graph segments. A table
-        # shared by DP replicas stages every replica's tokens at once.
+        # Keep lookup results alive across breakable graph segments. DP-sharded
+        # storage stages every replica's tokens; shared host storage stages ours.
         self.staged_rows = torch.empty(
             max_tokens * self.embed_tokens.dp_size,
             self.embed_tokens.part_n_hash_cols,
@@ -1061,10 +1157,16 @@ class Engram(nn.Module):
             dtype=torch.bfloat16,
         )
 
+        num_ubatches = max(1, vllm_config.parallel_config.num_ubatches)
         self._extra_staged_rows = [
-            torch.empty_like(self.staged_rows)
-            for _ in range(vllm_config.parallel_config.num_ubatches - 1)
+            torch.empty_like(self.staged_rows) for _ in range(num_ubatches - 1)
         ]
+
+        if self.embed_tokens.cpu_offload:
+            self._prefetch_streams = tuple(
+                torch.cuda.Stream(device=self.staged_rows.device)
+                for _ in range(num_ubatches)
+            )
 
     def _staged_rows_for_ubatch(self) -> torch.Tensor:
         ubatch_id = dbo_current_ubatch_id()
@@ -1073,14 +1175,40 @@ class Engram(nn.Module):
         return self._extra_staged_rows[ubatch_id - 1]
 
     def prepare_embeddings(self, hash_ids: torch.Tensor) -> None:
-        """Gather this layer's rows on the main stream before decoder layers.
+        """Prefetch offloaded rows while the decoder runs; gather resident rows inline.
 
-        `hash_ids` covers every DP replica sharing the table (see
-        `gather_engram_hashes`), so only `embed` narrows back to this one.
+        `hash_ids` is local with shared host storage. DP-sharded storage uses
+        `gather_engram_hashes`, and `embed` narrows back to this replica.
         """
         rows = self._staged_rows_for_ubatch()[: hash_ids.shape[0]]
         assert rows.shape[0] == hash_ids.shape[0], "engram staging buffer too small"
-        self.embed_tokens.lookup(hash_ids, rows)
+        if self._prefetch_streams:
+            self._start_prefetch(
+                hash_ids, rows, self._prefetch_streams[dbo_current_ubatch_id()]
+            )
+        else:
+            self.embed_tokens.lookup(hash_ids, rows)
+
+    @eager_break_during_capture
+    def _start_prefetch(
+        self, hash_ids: torch.Tensor, rows: torch.Tensor, stream: torch.cuda.Stream
+    ) -> None:
+        # Eager boundaries let the lookup span piecewise graph segments.
+        stream.wait_stream(torch.cuda.current_stream())
+        # Keep temporary hash storage alive until lookup finishes reading it.
+        hash_ids.record_stream(stream)
+        with torch.cuda.stream(stream):
+            self.embed_tokens.lookup(hash_ids, rows, background=True)
+
+    @eager_break_during_capture
+    def _finish_prefetch(self, stream: torch.cuda.Stream) -> None:
+        torch.cuda.current_stream().wait_stream(stream)
+
+    def _ready_rows(self, num_tokens: int) -> torch.Tensor:
+        if self._prefetch_streams:
+            self._finish_prefetch(self._prefetch_streams[dbo_current_ubatch_id()])
+        # Persistent per-ubatch storage has a stable address across graph replays.
+        return self._staged_rows_for_ubatch()[:num_tokens]
 
     def _trade_dp_tokens_for_heads(self, num_tokens: int) -> torch.Tensor:
         """Keep this replica's tokens, take the heads its DP peers own.
@@ -1091,7 +1219,7 @@ class Engram(nn.Module):
         dp_group = get_engram_dp_group()
         assert dp_group is not None
         slot = engram_gathered_num_tokens()
-        staged = self._staged_rows_for_ubatch()[: slot * dp_group.world_size]
+        staged = self._ready_rows(slot * dp_group.world_size)
         return _gather_engram_rows(staged, num_tokens)
 
     def embed(self, hash_ids: torch.Tensor) -> torch.Tensor:
@@ -1102,7 +1230,7 @@ class Engram(nn.Module):
                 # No TP gather follows to drop the padded heads.
                 return rows[:, : self.embed_tokens.n_hash_cols]
         else:
-            rows = self._staged_rows_for_ubatch()[: hash_ids.shape[0]]
+            rows = self._ready_rows(hash_ids.shape[0])
             if self.embed_tokens.tp_size == 1:
                 return rows
         if self.use_sequence_parallel:

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -42,10 +42,13 @@ from torch import nn
 
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
+    get_engram_dp_group,
+    get_engram_dp_size,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
 )
+from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.quantization import QuantizationConfig
@@ -53,6 +56,7 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.triton_utils import tl, triton
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
+from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 logger = init_logger(__name__)
 
@@ -462,6 +466,21 @@ class NgramHashState(nn.Module):
         self._kv_cache_ref = weakref.ref(kv_cache)
         return True
 
+    def dummy_hashes(
+        self, input_ids: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Participate in DP lookups without valid rows or hash-cache updates."""
+        num_tokens = input_ids.shape[0]
+        num_layers, max_ngram = self.multipliers.shape
+        num_heads = self.primes.shape[-1]
+        hashes = input_ids.new_full(
+            (num_tokens, num_layers, (max_ngram - 1) * num_heads),
+            DEAD_ID,
+            dtype=torch.int32,
+        )
+        keep = torch.zeros(num_tokens, dtype=torch.bool, device=input_ids.device)
+        return hashes, keep
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -546,6 +565,46 @@ class NgramHashState(nn.Module):
         return output
 
 
+def engram_head_shard_rank() -> int:
+    """This rank's slot among the hash-head shards of one engram table.
+
+    TP-major, so the shards a DP gather brings in are contiguous heads and
+    the following TP gather completes the head order.
+    """
+    dp_group = get_engram_dp_group()
+    dp_size = dp_group.world_size if dp_group is not None else 1
+    dp_rank = dp_group.rank_in_group if dp_group is not None else 0
+    return get_tensor_model_parallel_rank() * dp_size + dp_rank
+
+
+def engram_gathered_num_tokens() -> int:
+    """Per-replica token slot of the DP-gathered n-gram id stream."""
+    dp_metadata = get_forward_context().dp_metadata
+    if dp_metadata is None:
+        raise RuntimeError("a DP-shared engram table needs DP token metadata")
+    return int(dp_metadata.num_tokens_across_dp_cpu.max())
+
+
+def gather_engram_hashes(hash_ids: torch.Tensor) -> torch.Tensor:
+    """Collect the n-gram ids of every DP replica sharing one table.
+
+    Replicas are padded to a common token slot, so the gathered shape is
+    static under CUDA graph capture (where DP already pads alike).
+    """
+    dp_group = get_engram_dp_group()
+    if dp_group is None:
+        return hash_ids
+    slot = engram_gathered_num_tokens()
+    if hash_ids.shape[0] > slot:
+        raise ValueError("Engram token count exceeds the DP token slot")
+    if hash_ids.shape[0] < slot:
+        pad = hash_ids.new_full(
+            (slot - hash_ids.shape[0], *hash_ids.shape[1:]), DEAD_ID
+        )
+        hash_ids = torch.cat((hash_ids, pad))
+    return dp_group.all_gather(hash_ids, dim=0)
+
+
 def _engram_head_shard_weight_loader(
     param: torch.nn.Parameter, loaded_weight: torch.Tensor
 ) -> None:
@@ -623,8 +682,13 @@ class ParallelEngramEmbedding(nn.Module):
     """The n-gram hash table, sharded by complete hash heads over TP ranks.
     Rows stay fp8 and are dequantized with ue8m0 per-32 scales on lookup.
 
+    DP replicas that sit on the same node split the heads further
+    (`get_engram_dp_size()`), so a node holds one table instead of a copy per
+    replica; the lookup then covers every replica's tokens and `Engram.embed`
+    trades those tokens back for the heads the peers own.
+
     With `cpu_offload` the shard lives in pinned host memory and is read over
-    UVA instead of HBM; the TP sharding is unchanged either way.
+    UVA instead of HBM; the sharding is unchanged either way.
     """
 
     def __init__(
@@ -637,7 +701,7 @@ class ParallelEngramEmbedding(nn.Module):
     ):
         super().__init__()
         tp_size = get_tensor_model_parallel_world_size()
-        tp_rank = get_tensor_model_parallel_rank()
+        dp_size = get_engram_dp_size()
         assert head_sizes and all(size > 0 for size in head_sizes)
         assert sum(head_sizes) <= num_embeddings
         if cpu_offload and not is_uva_available():
@@ -646,13 +710,19 @@ class ParallelEngramEmbedding(nn.Module):
         self.dim = dim
         self.block_size = block_size
         self.n_hash_cols = len(head_sizes)
-        self.part_n_hash_cols = triton.cdiv(self.n_hash_cols, tp_size)
-        self.head_start = tp_rank * self.part_n_hash_cols
+        num_shards = tp_size * dp_size
+        self.part_n_hash_cols = triton.cdiv(self.n_hash_cols, num_shards)
+        assert (num_shards - 1) * self.part_n_hash_cols < self.n_hash_cols, (
+            f"Engram sharding leaves ranks without hash heads: "
+            f"{self.n_hash_cols} heads over TP={tp_size} x DP={dp_size}"
+        )
+        self.head_start = engram_head_shard_rank() * self.part_n_hash_cols
         head_end = self.head_start + self.part_n_hash_cols
         self.vocab_start_idx = sum(head_sizes[: self.head_start])
         self.vocab_end_idx = sum(head_sizes[:head_end])
         self.part_num_embeddings = self.vocab_end_idx - self.vocab_start_idx
         self.tp_size = tp_size
+        self.dp_size = dp_size
         self.cpu_offload = cpu_offload
         self._views: tuple[torch.Tensor, torch.Tensor] | None = None
         self._view_src: tuple[int, int] | None = None
@@ -749,17 +819,21 @@ class ParallelEngramEmbedding(nn.Module):
 
     def forward(self, indices: torch.Tensor) -> torch.Tensor:
         """indices: [num_tokens, n_hash_cols] -> [num_tokens, n_hash_cols, dim]
-        bf16, gathered from all TP shards."""
+        bf16, gathered from all shards for this replica's tokens."""
+        num_tokens = indices.shape[0]
+        if self.dp_size > 1:
+            indices = gather_engram_hashes(indices)
         out = torch.empty(
             (indices.shape[0], self.part_n_hash_cols, self.dim),
             dtype=torch.bfloat16,
             device=indices.device,
         )
         self.lookup(indices, out)
+        if self.dp_size > 1:
+            out = _gather_engram_rows(out, num_tokens)
         if self.tp_size > 1:
             out = tensor_model_parallel_all_gather(out, dim=1)
-            out = out[:, : self.n_hash_cols]
-        return out
+        return out[:, : self.n_hash_cols]
 
 
 @triton.jit(do_not_specialize=["num_kv_tokens"])
@@ -855,7 +929,7 @@ def _fused_engram_post_wkv_kernel(
 
 
 @triton.jit(do_not_specialize=["num_tokens", "token_start", "num_elements"])
-def _engram_sp_rows_kernel(
+def _engram_select_rows_kernel(
     gathered,
     output,
     num_tokens,
@@ -874,6 +948,51 @@ def _engram_sp_rows_kernel(
         gathered + source, (offsets < num_elements) & (tokens < num_tokens), other=0
     )
     tl.store(output + offsets, values, offsets < num_elements)
+
+
+def _engram_select_rows(
+    gathered: torch.Tensor,
+    output: torch.Tensor,
+    source_tokens: int,
+    token_start: int,
+    local_width: int,
+) -> None:
+    """Copy one token window out of a rank-major gathered buffer.
+
+    Both gathers land rank-major ([rank][token][local width]); this walks the
+    window the rank keeps and lays its ranks out side by side as width.
+    """
+    if output.numel() == 0:
+        return
+    _engram_select_rows_kernel[(triton.cdiv(output.numel(), 1024),)](
+        gathered,
+        output,
+        source_tokens,
+        token_start,
+        output.numel(),
+        local_width,
+        output.shape[1] * output.shape[2],
+        BLOCK_SIZE=1024,
+    )
+
+
+def _gather_engram_rows(staged: torch.Tensor, num_tokens: int) -> torch.Tensor:
+    """Exchange DP tokens for heads, retaining only this replica's tokens."""
+    dp_group = get_engram_dp_group()
+    assert dp_group is not None
+    slot, remainder = divmod(staged.shape[0], dp_group.world_size)
+    assert remainder == 0 and 0 <= num_tokens <= slot
+    gathered = dp_group.all_gather(staged, dim=0)
+    local_heads, dim = staged.shape[1:]
+    rows = staged.new_empty((num_tokens, dp_group.world_size * local_heads, dim))
+    _engram_select_rows(
+        gathered,
+        rows,
+        staged.shape[0],
+        dp_group.rank_in_group * slot,
+        local_heads * dim,
+    )
+    return rows
 
 
 class Engram(nn.Module):
@@ -931,41 +1050,75 @@ class Engram(nn.Module):
             requires_grad=False,
         )
 
-        max_tokens = get_current_vllm_config().scheduler_config.max_num_batched_tokens
-        # Keep lookup results alive across breakable graph segments.
+        vllm_config = get_current_vllm_config()
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        # Keep lookup results alive across breakable graph segments. A table
+        # shared by DP replicas stages every replica's tokens at once.
         self.staged_rows = torch.empty(
-            max_tokens,
+            max_tokens * self.embed_tokens.dp_size,
             self.embed_tokens.part_n_hash_cols,
             layout.head_dim,
             dtype=torch.bfloat16,
         )
 
+        self._extra_staged_rows = [
+            torch.empty_like(self.staged_rows)
+            for _ in range(vllm_config.parallel_config.num_ubatches - 1)
+        ]
+
+    def _staged_rows_for_ubatch(self) -> torch.Tensor:
+        ubatch_id = dbo_current_ubatch_id()
+        if ubatch_id == 0:
+            return self.staged_rows
+        return self._extra_staged_rows[ubatch_id - 1]
+
     def prepare_embeddings(self, hash_ids: torch.Tensor) -> None:
-        """Gather this layer's rows on the main stream before decoder layers."""
-        self.embed_tokens.lookup(hash_ids, self.staged_rows[: hash_ids.shape[0]])
+        """Gather this layer's rows on the main stream before decoder layers.
+
+        `hash_ids` covers every DP replica sharing the table (see
+        `gather_engram_hashes`), so only `embed` narrows back to this one.
+        """
+        rows = self._staged_rows_for_ubatch()[: hash_ids.shape[0]]
+        assert rows.shape[0] == hash_ids.shape[0], "engram staging buffer too small"
+        self.embed_tokens.lookup(hash_ids, rows)
+
+    def _trade_dp_tokens_for_heads(self, num_tokens: int) -> torch.Tensor:
+        """Keep this replica's tokens, take the heads its DP peers own.
+
+        An all-to-all would move `dp_size` times less, but the gather stays on
+        vLLM's own collective path and so survives graph capture.
+        """
+        dp_group = get_engram_dp_group()
+        assert dp_group is not None
+        slot = engram_gathered_num_tokens()
+        staged = self._staged_rows_for_ubatch()[: slot * dp_group.world_size]
+        return _gather_engram_rows(staged, num_tokens)
 
     def embed(self, hash_ids: torch.Tensor) -> torch.Tensor:
         """Gather heads, returning only local tokens when SP is enabled."""
-        rows = self.staged_rows[: hash_ids.shape[0]]
-        if self.embed_tokens.tp_size == 1:
-            return rows
+        if self.embed_tokens.dp_size > 1:
+            rows = self._trade_dp_tokens_for_heads(hash_ids.shape[0])
+            if self.embed_tokens.tp_size == 1:
+                # No TP gather follows to drop the padded heads.
+                return rows[:, : self.embed_tokens.n_hash_cols]
+        else:
+            rows = self._staged_rows_for_ubatch()[: hash_ids.shape[0]]
+            if self.embed_tokens.tp_size == 1:
+                return rows
         if self.use_sequence_parallel:
             tp_size = self.embed_tokens.tp_size
             num_tokens, local_heads, dim = rows.shape
             gathered = tensor_model_parallel_all_gather(rows, dim=0)
             chunk = (num_tokens + tp_size - 1) // tp_size
-            rows = rows.new_empty((chunk, self.embed_tokens.n_hash_cols, dim))
-            _engram_sp_rows_kernel[(triton.cdiv(rows.numel(), 1024),)](
+            out = rows.new_empty((chunk, self.embed_tokens.n_hash_cols, dim))
+            _engram_select_rows(
                 gathered,
-                rows,
+                out,
                 num_tokens,
                 get_tensor_model_parallel_rank() * chunk,
-                rows.numel(),
                 local_heads * dim,
-                self.embed_tokens.n_hash_cols * dim,
-                BLOCK_SIZE=1024,
             )
-            return rows
+            return out
         rows = tensor_model_parallel_all_gather(rows, dim=1)
         return rows[:, : self.embed_tokens.n_hash_cols]
 

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -12,6 +12,7 @@ import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.config.kernel import MEGA_MOE_BACKENDS
 from vllm.distributed import (
+    get_engram_dp_size,
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -74,7 +75,12 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
-from ..common.engram import Engram, EngramLayout, NgramHashState
+from ..common.engram import (
+    Engram,
+    EngramLayout,
+    NgramHashState,
+    gather_engram_hashes,
+)
 from ..common.mm_preprocess import IMAGE_SENTINEL_BASE_ID, image_sentinel_mask
 
 if typing.TYPE_CHECKING:
@@ -594,12 +600,19 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                     swa_metadata.slot_mapping,
                     swa_metadata.block_table,
                 )
+            elif get_engram_dp_size() > 1:
+                # The lookup is collective once DP replicas share a table, so
+                # a replica skipping the hash still has to reach it.
+                engram_hashes, engram_mask = self.engram_hash.dummy_hashes(input_ids)
+            if engram_hashes is not None:
                 # Gather all Engram rows before entering the decoder layers.
+                # One gather feeds every layer sharing the DP-split table.
+                gathered_hashes = gather_engram_hashes(engram_hashes)
                 for layer in islice(self.layers, self.start_layer, self.end_layer):
                     engram = getattr(layer, "engram", None)
                     if engram is not None:
                         engram.prepare_embeddings(
-                            engram_hashes[:, engram.layer_hash_index]
+                            gathered_hashes[:, engram.layer_hash_index]
                         )
 
         full_num_tokens = positions.shape[0]

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -472,6 +472,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # layer's sliding-window KV cache. Only PP ranks owning an engram
         # layer need it.
         self.engram_hash: NgramHashState | None = None
+        self.engram_shared_memory = bool(
+            vllm_config.engram_config
+            and vllm_config.engram_config.enable_engram_shared_memory
+        )
         self.engram_swa_prefix: str | None = None
         if self.engram_layout is not None:
             local_engram = any(
@@ -607,7 +611,9 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             if engram_hashes is not None:
                 # Gather all Engram rows before entering the decoder layers.
                 # One gather feeds every layer sharing the DP-split table.
-                gathered_hashes = gather_engram_hashes(engram_hashes)
+                gathered_hashes = gather_engram_hashes(
+                    engram_hashes, shared_memory=self.engram_shared_memory
+                )
                 for layer in islice(self.layers, self.start_layer, self.end_layer):
                     engram = getattr(layer, "engram", None)
                     if engram is not None:


### PR DESCRIPTION
Stacked on #56230 ([Model][EDP][Engram] Support DP sharding for Engram
tables) — this PR adds the performance optimizations on top of it.

## What‘s New

Two engram embedding I/O improvements for DeepSeek V4.1: 

**1. Asynchronous lookup prefetch (cpu_offload path).** With
`cpu_offload`, engram table rows live in pinned host memory and are read
over UVA. The lookup used to run inline on the main stream when each
engram layer executes; `prepare_embeddings()` now starts it on a
per-ubatch side stream at forward entry — the n-gram hash ids for all
engram layers are known before the decoder layers run — with a halved
grid to leave SMs for the main stream. `embed()` only waits on the
stream. `@eager_break_during_capture` keeps the side-stream work out of
captured graphs, and persistent per-ubatch staging buffers keep
addresses stable across replays. DBO microbatches get independent
streams and buffers.

**2. Shared host tables (`EngramConfig.enable_engram_shared_memory`,
requires `cpu_offload`).** Engram hashes are deterministic and
replica-independent (tokenizer-derived token map, layer-seeded
multipliers), so DP replicas on one node can share one physical copy of
each TP slice instead of pinning private shards and trading tokens for
heads with two per-step all_gathers. edp rank 0 creates a /dev/shm
backing file; every replica maps it `MAP_SHARED` and
`cudaHostRegister`s the pages; lookups read the shared pages over UVA
with no kernel changes. Only edp rank 0 writes weights (single-writer
barrier per shard; load formats auto/safetensors/pt, no multithreaded
loading). Registered pointers are guarded by `engram_shared_ptr` and
released with `cudaHostUnregister` at teardown. Shared mode skips both
DP all_gathers, slot padding, and the rows-select kernel while keeping
per-rank and per-node host-link read bytes identical to the DP-shard
path; TP sharding/all_gather are unchanged.

Requirements, validated at init: `cpu_offload`, a node-local engram DP
group, sufficient /dev/shm capacity, and a shared IPC namespace per node.

## Why not a duplicate

`gh pr list --repo vllm-project/vllm --state open --search "engram"` —
no open PR covers this. This PR builds on the engram DP-shard
implementation from #56230, adding prefetch and mmap shared storage
behind flags; default behavior is unchanged.

## Benchmarks/Tests

Real DeepSeek V4.1, 4xGB200, TP4, 512 output tokens, sync lookup vs
prefetch, 2 rounds each (ms):

| input / concurrency | TTFT sync → prefetch | Δ | decode/tok sync → prefetch |
|---|---|---|---|
| 512 / 1    | 44.66 → 45.11     | ~0     | 7.452 → 7.451 |
| 4096 / 1   | 168.16 → 167.38   | ~0     | 7.461 → 7.463 |
| 4096 / 8   | 680.98 → 677.45   | -0.52% | 13.006 → 12.969 |
| 8192 / 1   | 304.97 → 303.72   | -0.41% | 7.491 → 7.486 |
| 8192 / 8   | 1447.05 → 1440.92 | -0.42% | 10.703 → 10.683 |
| 16384 / 1  | 573.26 → 568.04   | -0.91% | 7.511 → 7.500 |
| 16384 / 8  | 2636.92 → 2613.28 | -0.90% | 11.849 → 11.882  |


Prefetch recovers exactly the lookup-bytes / host-link time on the
critical path (two engram layers, ~50 MB/layer at 8k tokens ≈ 1.2 ms ≈
0.4%), and is neutral in decode where lookups are us-scale — no
regression anywhere.


Local Tests:

- `.venv/bin/python -m pytest tests/kernels/test_engram.py -v`  → All passed
- `.venv/bin/python -m pytest tests/distributed/test_engram_dp_shard.py -v` → All passed


Eval (GSM8K, DeepSeek V4.1, two runs each):
| config | accuracy |
|---|---|
| TP1xDP4 + `enable_engram_shared_memory` (zero DP comm) | 0.9318 / 0.9318 |
| TP4xDP1, prefetch (default) | 0.9363 / 0.9363 |


## Cross Nodes EDP

Both DP modes work cross-node. The EDP group is a separate process group
created only for the engram tables — the general DP group is untouched
and still spans all 8 ranks across both nodes for everything else. EDP is
built from node-local DP replicas only (`_engram_dp_shard_size` =
gcd(dp_size, ranks_per_node / replica_size)), so this TP1xDP8 run forms
two independent EDP groups of 4, one per node, each sharing one full
table copy; cross-node replicas therefore see zero engram communication,
and table storage scales with node count, not replica count. The two
modes differ only intra-node: DP shard pays two all_gathers per step in
the node's EDP group, while shm eliminates them via the /dev/shm mmap.

Cross-node (2 nodes, TP1xDP8 — DP spans both nodes,
so this also validates the cross-node topology for both modes):

| mode | engram group | table storage | per-step DP comm | GSM8K flex / strict |
|---|---|---|---|---|
| DP shard | per-node Engram EDP=4 | 8 × 23.60 GiB = 188.8 GiB | yes (gather + token/head exchange) | 0.9265 / 0.9272 |
| shm | per-node Engram EDP=4 | 2 × 94.42 GiB = 188.8 GiB (each mmap'd 4×) | none | 0.9257 / 0.9257 |
