### PR TITLE
[Feature] Add opt-in fixed-order tensor-parallel reduction

### DIFF
--- a/tests/distributed/test_fixed_order_all_reduce.py
+++ b/tests/distributed/test_fixed_order_all_reduce.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from vllm.distributed import communication_op, parallel_state
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def test_fixed_order_all_reduce_dispatches_custom_op(monkeypatch):
+    monkeypatch.setenv("VLLM_TP_FIXED_ORDER_ALLREDUCE", "1")
+    group = SimpleNamespace(
+        world_size=3,
+        unique_name="tp:test",
+        all_reduce=Mock(),
+    )
+    communication_op._fixed_order_notice_printed = True
+    with (
+        patch.object(communication_op, "get_tp_group", return_value=group),
+        patch.object(
+            torch.ops.vllm,
+            "fixed_order_all_reduce_",
+        ) as fixed_order,
+    ):
+        input_ = torch.tensor([0.0, 0.0])
+        result = communication_op.tensor_model_parallel_all_reduce(input_)
+
+    assert result is input_
+    fixed_order.assert_called_once()
+    assert fixed_order.call_args.kwargs == {"group_name": "tp:test"}
+    group.all_reduce.assert_not_called()
+
+
+def test_fixed_order_all_reduce_gathers_then_sums_by_rank():
+    rank_values = (
+        torch.tensor([1.0, 2.0]),
+        torch.tensor([10.0, 20.0]),
+        torch.tensor([100.0, 200.0]),
+    )
+    gathered_inputs = []
+
+    def gather(input_, dim):
+        gathered_inputs.append((input_.clone(), dim))
+        return torch.stack(rank_values)
+
+    group = SimpleNamespace(
+        world_size=3,
+        _all_gather_out_place=Mock(side_effect=gather),
+    )
+
+    with patch.dict(parallel_state._groups, {"tp:test": lambda: group}):
+        result = torch.tensor([0.0, 0.0])
+        parallel_state.fixed_order_all_reduce_(result, "tp:test")
+
+    torch.testing.assert_close(result, torch.tensor([111.0, 222.0]))
+    (gathered_input, dim) = gathered_inputs[0]
+    torch.testing.assert_close(gathered_input, torch.tensor([[0.0, 0.0]]))
+    assert dim == 0
+
+
+def test_fixed_order_all_reduce_is_opt_in(monkeypatch):
+    monkeypatch.delenv("VLLM_TP_FIXED_ORDER_ALLREDUCE", raising=False)
+    expected = torch.tensor([3.0])
+    group = SimpleNamespace(
+        world_size=2,
+        unique_name="tp:test",
+        all_reduce=Mock(return_value=expected),
+    )
+
+    with patch.object(communication_op, "get_tp_group", return_value=group):
+        result = communication_op.tensor_model_parallel_all_reduce(torch.tensor([1.0]))
+
+    assert result is expected
+    group.all_reduce.assert_called_once()

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from typing import Any
 
 import torch
@@ -8,10 +9,25 @@ import torch.distributed
 
 from .parallel_state import get_tp_group
 
+_fixed_order_notice_printed = False
+
 
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
-    return get_tp_group().all_reduce(input_)
+    group = get_tp_group()
+    if os.environ.get("VLLM_TP_FIXED_ORDER_ALLREDUCE") == "1" and group.world_size > 1:
+        global _fixed_order_notice_printed
+        if not _fixed_order_notice_printed:
+            print(
+                "[BI_TP_ALLREDUCE] all_gather + fixed rank-order local sum enabled",
+                flush=True,
+            )
+            _fixed_order_notice_printed = True
+
+        torch.ops.vllm.fixed_order_all_reduce_(input_, group_name=group.unique_name)
+        return input_
+
+    return group.all_reduce(input_)
 
 
 def tensor_model_parallel_all_gather(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -238,6 +238,24 @@ def all_gather_fake(
     return torch.empty(new_shape, dtype=tensor.dtype, device=tensor.device)
 
 
+def fixed_order_all_reduce_(tensor: torch.Tensor, group_name: str) -> None:
+    """Gather every rank, then overwrite tensor with the rank-ordered sum."""
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+
+    gathered = group._all_gather_out_place(tensor.contiguous().unsqueeze(0), 0)
+    parts = gathered.unbind(0)
+    tensor.copy_(parts[0])
+    for rank in range(1, group.world_size):
+        tensor.add_(parts[rank])
+
+
+def fixed_order_all_reduce_fake_(tensor: torch.Tensor, group_name: str) -> None:
+    return
+
+
 def patched_fused_scaled_matmul_reduce_scatter_fake(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -406,6 +424,13 @@ direct_register_custom_op(
     op_name="all_gather",
     op_func=all_gather,
     fake_impl=all_gather_fake,
+)
+
+direct_register_custom_op(
+    op_name="fixed_order_all_reduce_",
+    op_func=fixed_order_all_reduce_,
+    mutates_args=["tensor"],
+    fake_impl=fixed_order_all_reduce_fake_,
 )
 
 # TODO: Remove this once the pytorch fix


### PR DESCRIPTION
## Summary
- add an opt-in tensor-parallel reduction that gathers rank outputs and sums them in fixed rank order
- expose the reduction as a graph-visible mutating custom operator
- preserve the existing all-reduce path unless `VLLM_TP_FIXED_ORDER_ALLREDUCE=1`

The in-place contract keeps the input address stable across PIECEWISE graph replay while making the reduction order independent of collective scheduling.

## Validation
- 3 focused unit tests passed on the validated integration branch
- Qwen3-30B-A3B MXFP8 non-eager PIECEWISE TP8 gates passed at real B1/B8/B16/B32 through 2,048 generated tokens
- B1 and B8 fresh-process repeats matched all token IDs and top-20 logprobs exactly
- patch applies cleanly to current upstream `main`; `git diff --check` passes

This behavior is opt-in and does not change the default collective path.