### PR TITLE
[Qwen4Exp] Pass raw bytes to the PLE UVA lookup kernel for FP8 tables

### DIFF
--- a/vllm/models/qwen4_exp/nvidia/ngram_embedding.py
+++ b/vllm/models/qwen4_exp/nvidia/ngram_embedding.py
@@ -467,10 +467,21 @@ class Qwen4ExpPLEPinnedHostEmbedding(Qwen4ExpPLEEmbedding):
 
         flat_ids = input_ids.reshape(-1).long()
         if flat_ids.numel():
+            # Triton refuses an fp8e4nv pointer on SM 8.x, so the kernel fails
+            # to compile on Ampere even though it does no arithmetic. The
+            # lookup is a masked gather, so pass the raw bytes instead. FP8 is
+            # one byte wide, so a uint8 view keeps the shape and the strides,
+            # and the copy is byte identical. _reduce_etp_embeddings below
+            # views FP8 as int8 for the same reason.
+            weight_arg = self._uva_weight
+            output_arg = output
+            if weight_arg.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+                weight_arg = weight_arg.view(torch.uint8)
+                output_arg = output_arg.view(torch.uint8)
             _lookup_ple_embedding_from_pinned_kernel[(flat_ids.numel(),)](
-                self._uva_weight,
+                weight_arg,
                 flat_ids,
-                output,
+                output_arg,
                 self.embedding_dim,
                 self.shard_indices.org_vocab_start_index,
                 self.shard_indices.org_vocab_end_index,


### PR DESCRIPTION
## Purpose

The UVA PLE offload path from #54371 does not start on NVIDIA Ampere GPUs. This
change makes it start.

## The problem

Triton refuses an `fp8e4nv` pointer on SM 8.x. When the PLE table is FP8,
`_lookup_ple_embedding_from_pinned_kernel` fails to compile on every rank:

```
triton.compiler.errors.CompilationError: at 1:0:
def _lookup_ple_embedding_from_pinned_kernel(
^
ValueError("type fp8e4nv not supported in this architecture.
           The supported fp8 dtypes are ('fp8e4b15', 'fp8e5')")
```

The failure happens during `profile_run`, so the server never becomes ready.

## Why a byte view is correct

The kernel does no arithmetic on the values. It is a masked gather:

1. It reads one row index.
2. It does one `tl.load` with a mask.
3. It does one `tl.store` with a mask.

The element type is therefore not important to the operation. FP8 is one byte
wide, so a `uint8` view keeps the shape and the strides. The copy is byte
identical.

This file already uses the same technique. `_reduce_etp_embeddings`, 15 lines
below the changed code, views FP8 as `int8` before the all-reduce:

```python
if embeddings.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
    # Each vocabulary row has one owner, so reduce the raw FP8 bytes.
    reduced = self.parallel_group.all_reduce(embeddings.view(torch.int8))
    return reduced.view(embeddings.dtype)
```

This change applies the same idea at the kernel launch site, and it uses the
same dtype test.

Tables that are not FP8 are not affected. The view happens only inside the
dtype test.

## Test

Hardware: 8x NVIDIA RTX A5000, 24 GB, SM 8.6, no NVLink.
Model: Qwen3.8-Flash-Next W4A16 with an FP8 E4M3 PLE table.
Configuration: tensor parallel size 8, expert parallelism on,
`--engram-config '{"cpu_offload":true}'`.

The measurement counts the error string in the server log.

| Build | Occurrences of `fp8e4nv not supported` | Server result |
| --- | ---: | --- |
| Before the change | 18 | The server never becomes ready |
| After the change | 0 | Healthy, GPU KV cache size 737,866 tokens |

Both counts come from the same log file. The log is append-only, so I recorded
its length in bytes before the second start and counted only the bytes after
that point. This makes sure that the second count does not read the first
failure.

## Risk

The change is 13 added lines and 2 changed lines in one file. It has no effect
when the PLE table is not FP8. It has no effect on any architecture where the
kernel already compiles, because the gather result is the same bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
