### PR TITLE
[Perf] Vectorize DeepSeek V4.1 Triton K-cache gather

### DIFF
--- a/tests/kernels/test_compressor_kv_cache.py
+++ b/tests/kernels/test_compressor_kv_cache.py
@@ -838,6 +838,7 @@ def _dequantize_and_gather_k_cache_reference(
             out[req_id, offset + i, fp8_dim:] = bf16_tail
 
 
+@pytest.mark.parametrize("implementation", ["dispatch", "v41_triton"])
 @pytest.mark.parametrize(
     ("seq_lens_host", "gather_lens_host", "offset"),
     [
@@ -846,6 +847,7 @@ def _dequantize_and_gather_k_cache_reference(
     ],
 )
 def test_dequantize_and_gather_k_cache(
+    implementation: str,
     seq_lens_host: list[int],
     gather_lens_host: list[int] | None,
     offset: int,
@@ -897,8 +899,8 @@ def test_dequantize_and_gather_k_cache(
     quantize_and_insert_k_cache(compressed_kv, k_cache_2d, slot_mapping, block_size)
 
     out_shape = (num_reqs, offset + max_gather_len + 3, head_dim)
-    ref_out = torch.empty(out_shape, dtype=torch.bfloat16, device=device)
-    actual_out = torch.empty_like(ref_out)
+    ref_out = torch.full(out_shape, -123.0, dtype=torch.bfloat16, device=device)
+    actual_out = torch.full_like(ref_out, -123.0)
     seq_lens = torch.tensor(seq_lens_host, dtype=torch.int32, device=device)
     gather_lens = (
         torch.tensor(gather_lens_host, dtype=torch.int32, device=device)
@@ -906,23 +908,22 @@ def test_dequantize_and_gather_k_cache(
         else None
     )
 
-    # Compare production gather against a PyTorch reference for valid output rows.
+    # Force the V4.1 Triton path even when CuTeDSL is installed.
+    gather = dequantize_and_gather_k_cache
+    if implementation == "v41_triton":
+        from vllm.models.deepseek_v4_1.common.ops.cache_utils import (
+            dequantize_and_gather_k_cache_triton,
+        )
+
+        gather = dequantize_and_gather_k_cache_triton
     _dequantize_and_gather_k_cache_reference(
         ref_out, k_cache, seq_lens, gather_lens, block_table, block_size, offset
     )
-    dequantize_and_gather_k_cache(
-        actual_out, k_cache, seq_lens, gather_lens, block_table, block_size, offset
-    )
+    gather(actual_out, k_cache, seq_lens, gather_lens, block_table, block_size, offset)
     torch.accelerator.synchronize()
 
-    # only check non-padded content
-    for req_id, seq_len in enumerate(seq_lens_host):
-        gather_len = (
-            gather_lens_host[req_id] if gather_lens_host is not None else seq_len
-        )
-        actual = actual_out[req_id, offset : offset + gather_len]
-        expected = ref_out[req_id, offset : offset + gather_len]
-        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    # Include untouched rows before and after each gathered window.
+    torch.testing.assert_close(actual_out, ref_out, rtol=0, atol=0)
 
 
 # ── Test C: Indexer path ────────────────────────────────────────────────────

--- a/vllm/models/deepseek_v4_1/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4_1/common/ops/cache_utils.py
@@ -298,49 +298,24 @@ def _dequantize_and_gather_k_kernel(
         # Output pointer for this token (flattened)
         output_row_ptr = out_ptr + batch_idx * out_stride0 + (offset + i) * out_stride1
 
-        # ========== Dequantize FP8 portion using UE8M0 ==========
-        for qblock_idx in tl.static_range(n_quant_blocks):
-            qblock_start = qblock_idx * quant_block
+        qblocks = tl.arange(0, triton.next_power_of_2(n_quant_blocks))
+        offsets = qblocks[:, None] * quant_block + tl.arange(0, quant_block)[None, :]
+        mask = (qblocks[:, None] < n_quant_blocks) & (offsets < fp8_dim)
+        x_uint8 = tl.load(token_fp8_ptr + offsets, mask=mask, other=0)
+        fp8_dtype = tl.float8e4b8 if use_fnuz else tl.float8e4nv
+        x = x_uint8.to(fp8_dtype, bitcast=True).to(tl.float32)
+        encoded_scales = tl.load(
+            token_scale_ptr + qblocks, mask=qblocks < n_quant_blocks, other=127
+        )
+        scales = tl.exp2(encoded_scales.to(tl.float32) - 127.0)
+        tl.store(
+            output_row_ptr + offsets, (x * scales[:, None]).to(tl.bfloat16), mask=mask
+        )
 
-            if qblock_start < fp8_dim:
-                offsets = qblock_start + tl.arange(0, quant_block)
-                mask = offsets < fp8_dim
-
-                # Load quantized fp8 values (stored as uint8)
-                x_uint8 = tl.load(token_fp8_ptr + offsets, mask=mask, other=0)
-
-                # Bitcast uint8 back to fp8 (FNUZ on gfx942, OCP elsewhere).
-                if use_fnuz:
-                    x_fp8 = x_uint8.to(tl.float8e4b8, bitcast=True)
-                else:
-                    x_fp8 = x_uint8.to(tl.float8e4nv, bitcast=True)
-
-                # Convert fp8 to float32 for computation
-                x_float = x_fp8.to(tl.float32)
-
-                # Load and decode UE8M0 scale
-                # UE8M0: scale = 2^(stored_value - 127)
-                encoded_scale = tl.load(token_scale_ptr + qblock_idx)
-                exponent = encoded_scale.to(tl.float32) - 127.0
-                scale = tl.exp2(exponent)
-
-                # Dequantize: bf16_value = fp8_value * scale
-                x_dequant = x_float * scale
-
-                # Store as bf16
-                tl.store(output_row_ptr + offsets, x_dequant.to(tl.bfloat16), mask=mask)
-
-        # ========== Copy BF16 portion directly ==========
-        bf16_output_offset = fp8_dim  # After 448 elements in output
-
-        # Read bf16 from cache
         bf16_cache_ptr = token_bf16_ptr.to(tl.pointer_type(tl.bfloat16))
-
-        # Process in chunks of 16
-        for j in tl.static_range(bf16_dim // 16):
-            chunk_offsets = j * 16 + tl.arange(0, 16)
-            bf16_vals = tl.load(bf16_cache_ptr + chunk_offsets)
-            tl.store(output_row_ptr + bf16_output_offset + chunk_offsets, bf16_vals)
+        rope_offsets = tl.arange(0, bf16_dim)
+        rope = tl.load(bf16_cache_ptr + rope_offsets)
+        tl.store(output_row_ptr + fp8_dim + rope_offsets, rope)
 
 
 def dequantize_and_gather_k_cache_triton(


### PR DESCRIPTION
Ports merged [Inferact/sra#77](https://github.com/Inferact/sra/pull/77) to `vllm-project/vllm:dsv41-feat` (base `c9d909e802a39292f54101bff8a36096761ea605`). Cherry-picked `fffe975387eba8c8de14b4e390ea3e35a0313bbe` without conflicts; the patch ID matches and both changed files are byte-identical to the source PR.

## Port validation

Run on this port:

```sh
/Users/daole/git/sra/.venv/bin/pre-commit run --files vllm/models/deepseek_v4_1/common/ops/cache_utils.py tests/kernels/test_compressor_kv_cache.py
git diff --check upstream/dsv41-feat...HEAD
```

All applicable hooks and whitespace checks passed. GPU pytest, benchmarks, and model evaluations were not rerun for this port on the local macOS arm64 host. The GPU measurements below are the results reported by the original SRA PR, not new measurements against this branch.

Duplicate-work checks were refreshed: inspected the source PR and its comments, searched open SRA/upstream PRs by source URL and gather/vectorization keywords, and inspected all open PRs targeting `dsv41-feat`. No open PR implements this same V4.1 gather vectorization. The source PR is already merged into `sra-tracking`; this PR ports it to a different repository and target branch. No associated issue is being closed.

## Purpose

Vectorize the DeepSeek V4.1 Triton K-cache gather fallback. It currently expresses each token's seven FP8 quantization groups and BF16 tail as separate unrolled chunks. Load/dequantize/store the FP8 groups as one masked `[8, 64]` tile and copy the BF16 tail as one 64-element vector. The eighth FP8 row is masked, preserving the BF16 tail and excluding the padded scale byte.

The existing gather reference test now explicitly exercises the V4.1 Triton wrapper even when CuTeDSL is installed, and checks that output rows outside each gather window remain untouched.

Duplicate-work checks: searched open PRs in `Inferact/sra` and `vllm-project/vllm`. SRA #76 adds cache-format dispatch and sparse-index sentinel handling; it does not vectorize this kernel. Upstream [#49156](https://github.com/vllm-project/vllm/pull/49156) changes worker counts/warp configuration, and [#42504](https://github.com/vllm-project/vllm/pull/42504) adds a separate sparse-slot gather API. This change preserves the existing dense gather scheduling and interface. No associated issue is being closed.

## Original SRA test plan

Commands run:

```sh
.venv/bin/pre-commit run --files vllm/models/deepseek_v4_1/common/ops/cache_utils.py tests/kernels/test_compressor_kv_cache.py
git diff --check

# On gb200-rack1-05; standalone source copies bypass CuTeDSL dispatch.
cd /home/daole/benchmarks/dsv41-gather-bench.PQUxwZ
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=/home/daole/benchmarks/dsv41-gather-bench.PQUxwZ/deps /home/daole/vllm-internal/.venv/bin/python -u bench.py --rounds 4 --iterations 100
```

The remote directory contains `bench.py`, verbatim baseline/candidate kernel and wrapper copies, `source_metadata.json` with source hashes, `change.diff`, `environment.json`, raw samples in `results.json`, and `REPORT.md`. The baseline is `0a5cb4e592a4a35a92f15b445cd3cc5340635f6e`. CUPTI dependencies were installed into that directory without modifying the existing environment.

Still to run in a full matching vLLM GPU environment:

```sh
.venv/bin/python -m pytest tests/kernels/test_compressor_kv_cache.py -k test_dequantize_and_gather_k_cache -v
```

## Original SRA test results

- All applicable pre-commit checks and whitespace checks passed.
- Both implementations exactly matched the independent PyTorch reference (`atol=rtol=0`) for 24 timed cases and four additional boundary cases. Coverage includes 64/128-token pages, shuffled physical pages, empty requests, partial gathers, output offsets, padded physical pages, the BF16 tail, and untouched output rows.
- On GPU 0 of `gb200-rack1-05` (NVIDIA GB200), the modified Triton kernel was **1.80–3.39x faster** across all 24 timed cases. Timings use CUPTI, CUDA graphs, cold L2, four alternating rounds of 100 samples, and the median of round medians. Setup, compilation, and cache flushing are outside kernel timing. Clocks were not locked; kernels were warmed before measurement, and no competing GPU workloads were observed.

Representative 64-token-page results:

| Requests x gathered tokens | Original us | Modified us | Speedup | Useful bandwidth, original -> modified GB/s |
|---|---:|---:|---:|---:|
| 1 x 1 | 5.360 | 2.912 | 1.84x | 0.30 -> 0.55 |
| 1 x 512 | 17.496 | 6.528 | 2.68x | 47.0 -> 126.0 |
| 1 x 8192 | 217.457 | 66.305 | 3.28x | 60.5 -> 198.5 |
| 8 x 8192 | 240.825 | 71.240 | 3.38x | 437.3 -> 1478.3 |
| 32 x 2048 | 123.849 | 40.736 | 3.04x | 850.4 -> 2585.3 |

Environment: PyTorch 2.11.0+cu130, CUDA 13.0, Triton 3.6.0, FlashInfer 0.6.13, CUPTI 13.4.0. Format: OCP FP8 E4M3 with UE8M0 scales and BF16 tail/output. Useful bandwidth assumes 1,607 bytes per gathered token (583 input/scale bytes + 1,024 output bytes), excluding metadata and transaction overhead; the peak measured case reached 2.62 TB/s with 128-token pages.

Limitations: the full repository pytest command and model evaluations have **not** been run. These are standalone kernel correctness/performance results, not serving throughput or accuracy results. FNUZ was excluded because the unchanged baseline cannot compile `fp8e4b8` on GB200 with this Triton version. CuTeDSL dispatch is unchanged, so these results only establish an improvement for the Triton fallback.

AI assistance: OpenAI Codex implemented the change, extended the test, and ran the reported checks and benchmark. This is a draft for human review; the submitting human must review every changed line and run relevant tests before marking it ready.

