### PR TITLE
[Bugfix][Frontend] Preserve namespace functions in constrained tool calling

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -100,6 +100,8 @@ vLLM supports the `tool_choice='required'` option in the chat completion API. Si
 
 When tool_choice='required' is set, the model is guaranteed to generate one or more tool calls based on the specified tool list in the `tools` parameter. The number of tool calls depends on the user's query. The output format strictly follows the schema defined in the `tools` parameter.
 
+In the JSON-guided tool-calling path (for example, with `VLLM_ENFORCE_STRICT_TOOL_CALLING=0`), Responses API namespace functions support local `$ref` references to `$defs` with `tool_choice='required'`, just like top-level function tools. Definitions are shared across the combined tool schema, so a definition name used by multiple tools must have the same schema.
+
 ## None Function Calling
 
 vLLM supports the `tool_choice='none'` option in the chat completion API. When this option is set, the model will not generate any tool calls and will respond with regular text content only, even if tools are defined in the request.
@@ -121,6 +123,8 @@ Whether vLLM enforces the tool parameter schema during generation depends on the
 ### Strict Mode
 
 For `tool_choice="required"` or named function calling, structural-tag constraints are always applied regardless of the `strict` field. For `tool_choice="auto"`, setting `strict: true` on at least one tool opts in to structural-tag constraints; without it, the model generates freely and tool calls are extracted from raw text. The `strict` field is supported across all three API surfaces: Chat Completion, Responses, and Anthropic Messages.
+
+In the Responses API, these rules also apply to function tools inside a `namespace` tool. Set `strict` on the nested function, not on the namespace. Structural-tag constraints use the same `namespace__function` names as the model's tool prompt, while Responses output items report the original function `name` and `namespace` separately.
 
 For best compatibility with strict schema enforcement, define tool parameter schemas in the OpenAI strict-schema style:
 

--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -5,6 +5,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from openai.types.responses import (
+    FunctionTool,
+    NamespaceTool,
+    ToolChoiceAllowed,
+    ToolChoiceFunction,
+)
 from xgrammar import Grammar, StructuralTag
 from xgrammar.testing import _is_grammar_accept_string
 
@@ -226,6 +232,100 @@ def test_hermes_required_tool_calls_use_empty_separator():
 
     assert tag is not None
     assert tag.format.separator == ""
+
+
+@pytest.mark.parametrize("model", ["hermes", "qwen_3"])
+@pytest.mark.parametrize(
+    "choice", ["auto", "required", "named", "flat_named", "allowed"]
+)
+def test_namespace_structural_tag_enforces_local_schema(model, choice):
+    """Namespace functions retain their schema root and native call framing."""
+    namespace = NamespaceTool(
+        type="namespace",
+        name="weather",
+        description="Weather tools",
+        tools=[
+            {
+                "type": "function",
+                "name": "forecast",
+                "strict": True,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"$ref": "#/$defs/City"}},
+                    "required": ["city"],
+                    "additionalProperties": False,
+                    "$defs": {"City": {"type": "string", "enum": ["Vienna"]}},
+                },
+            }
+        ],
+    )
+    top_level = FunctionTool(
+        type="function",
+        name="get_time",
+        strict=True,
+        parameters={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    )
+    if choice == "named":
+        tool_choice = ToolChoiceFunction.model_validate(
+            {"type": "function", "name": "forecast", "namespace": "weather"}
+        )
+    elif choice == "flat_named":
+        tool_choice = ToolChoiceFunction(type="function", name="weather__forecast")
+    elif choice == "allowed":
+        tool_choice = ToolChoiceAllowed(
+            type="allowed_tools",
+            mode="required",
+            tools=[{"type": "function", "name": "forecast", "namespace": "weather"}],
+        )
+    else:
+        tool_choice = choice
+    tag = get_model_structural_tag(
+        model, [namespace, top_level], tool_choice, reasoning=False
+    )
+    grammar = Grammar.from_structural_tag(tag)
+    call = (
+        '<tool_call>\n{"name": "weather__forecast", '
+        '"arguments": {"city": "Vienna"}}\n</tool_call>'
+    )
+    assert _is_grammar_accept_string(grammar, call)
+    assert not _is_grammar_accept_string(grammar, call.replace("Vienna", "Oslo"))
+    assert not _is_grammar_accept_string(
+        grammar, call.replace('"city": "Vienna"', '"city": 1')
+    )
+    assert not _is_grammar_accept_string(
+        grammar, call.replace("weather__forecast", "forecast")
+    )
+    assert _is_grammar_accept_string(
+        grammar, '<tool_call>\n{"name": "get_time", "arguments": {}}\n</tool_call>'
+    ) == (choice in ("auto", "required"))
+
+
+def test_namespace_strict_function_enables_auto_structural_tag():
+    namespace = NamespaceTool(
+        type="namespace",
+        name="weather",
+        description="Weather tools",
+        tools=[{"type": "function", "name": "forecast", "strict": False}],
+    )
+    assert (
+        get_model_structural_tag("hermes", [namespace], "auto", reasoning=False) is None
+    )
+    namespace.tools[0].strict = True
+    tag = get_model_structural_tag("hermes", [namespace], "auto", reasoning=False)
+    grammar = Grammar.from_structural_tag(tag)
+    assert _is_grammar_accept_string(grammar, "No tool call needed.")
+    assert _is_grammar_accept_string(
+        grammar,
+        '<tool_call>\n{"name": "weather__forecast", "arguments": {}}\n</tool_call>',
+    )
+    assert not _is_grammar_accept_string(
+        grammar,
+        '<tool_call>\n{"name": "forecast", "arguments": {}}\n</tool_call>',
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tool_use/test_tool_choice_required.py
+++ b/tests/tool_use/test_tool_choice_required.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import pytest
 import regex as re
-from openai.types.responses import FunctionTool, WebSearchTool
+from openai.types.responses import FunctionTool, NamespaceTool, WebSearchTool
 from pydantic import TypeAdapter
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -13,6 +13,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.tool_parsers.streaming import extract_required_tool_call_streaming
 from vllm.tool_parsers.utils import (
+    Tool,
     find_tool_properties,
     get_json_schema_from_tools,
 )
@@ -67,13 +68,8 @@ EXAMPLE_TOOLS = [
 ]
 
 
-def _compile_and_check(
-    tools: list[ChatCompletionToolsParam], sample_output, should_match: bool
-):
-    # self = MagicMock(tool_choice="required", tools=tools)
-    # schema = ChatCompletionRequest._get_json_schema_from_tool(self)
+def _compile_and_check(tools: list[Tool], sample_output, should_match: bool):
     schema = get_json_schema_from_tools(tools=tools, tool_choice="required")
-    assert isinstance(schema, dict)
 
     # use build_regex_from_schema used in JSONLogitsProcessor to create Guide
     from outlines_core.json_schema import build_regex_from_schema
@@ -389,8 +385,40 @@ class TestNonFunctionToolsSkipped:
 
     def test_get_json_schema_with_mixed_tools(self):
         tools = [WEB_SEARCH_TOOL, FUNCTION_TOOL]
-        schema = get_json_schema_from_tools(tools=tools, tool_choice="required")
-        assert isinstance(schema, dict)
-        any_of = schema["items"]["anyOf"]
-        assert len(any_of) == 1
-        assert any_of[0]["properties"]["name"]["enum"] == ["get_weather"]
+        _compile_and_check(
+            tools,
+            [{"name": "get_weather", "parameters": {"city": "Vienna"}}],
+            True,
+        )
+        _compile_and_check(
+            tools,
+            [{"name": "web_search", "parameters": {"city": "Vienna"}}],
+            False,
+        )
+
+
+@pytest.mark.parametrize("city, should_match", [("Vienna", True), (42, False)])
+def test_required_namespace_tool_resolves_parameter_definitions(city, should_match):
+    tool = NamespaceTool(
+        type="namespace",
+        name="weather",
+        description="Weather tools",
+        tools=[
+            {
+                "type": "function",
+                "name": "forecast",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"$ref": "#/$defs/City"}},
+                    "required": ["city"],
+                    "additionalProperties": False,
+                    "$defs": {"City": {"type": "string"}},
+                },
+            }
+        ],
+    )
+    _compile_and_check(
+        [tool],
+        [{"name": "weather__forecast", "parameters": {"city": city}}],
+        should_match,
+    )

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -4,7 +4,7 @@
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, TypeAlias
 
-from openai.types.responses import FunctionTool
+from openai.types.responses import FunctionTool, NamespaceTool
 from openai.types.responses.response import ToolChoice as ResponsesToolChoice
 from openai.types.responses.tool import Tool as ResponsesTool
 from openai.types.responses.tool_choice_allowed import ToolChoiceAllowed
@@ -33,6 +33,10 @@ from xgrammar.structural_tag import (
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolsParam,
+)
+from vllm.tool_parsers.utils import (
+    flat_namespace_tool_name,
+    iter_response_function_tool_dicts,
 )
 
 ToolChoice: TypeAlias = (
@@ -101,6 +105,10 @@ def _any_tool_strict(
             return True
         if isinstance(tool, ChatCompletionToolsParam) and tool.function.strict is True:
             return True
+        if isinstance(tool, NamespaceTool) and any(
+            child.type == "function" and child.strict is True for child in tool.tools
+        ):
+            return True
     return False
 
 
@@ -119,7 +127,15 @@ def get_model_structural_tag(
     if tool_choice == "auto" and not _any_tool_strict(tools):
         return None
 
-    dumped_tools = [_dump_tool_for_xgrammar(tool) for tool in tools]
+    dumped_tools: list[dict[str, Any]] = []
+    for tool in tools:
+        if isinstance(tool, NamespaceTool):
+            dumped_tools.extend(
+                {"type": "function", "function": function}
+                for function in iter_response_function_tool_dicts([tool])
+            )
+        else:
+            dumped_tools.append(_dump_tool_for_xgrammar(tool))
     dumped_tool_choice = _dump_tool_choice_for_xgrammar(tool_choice)
 
     if model in _VLLM_STRUCTURAL_TAG_REGISTRY:
@@ -188,10 +204,9 @@ def _dump_tool_choice_for_xgrammar(
         return tool_choice.model_dump(mode="json", exclude_none=True)
 
     if isinstance(tool_choice, ToolChoiceFunction):
-        return {
-            "type": "function",
-            "function": {"name": tool_choice.name},
-        }
+        return _dump_allowed_tool_ref_for_xgrammar(
+            tool_choice.model_dump(mode="json", exclude_none=True)
+        )
 
     if isinstance(tool_choice, ToolChoiceAllowed):
         return {
@@ -214,9 +229,13 @@ def _dump_allowed_tool_ref_for_xgrammar(tool_ref: AllowedToolRef) -> AllowedTool
         and "function" not in tool_ref
         and "name" in tool_ref
     ):
+        name = tool_ref["name"]
+        namespace = tool_ref.get("namespace")
+        if isinstance(namespace, str) and isinstance(name, str):
+            name = flat_namespace_tool_name(namespace, name)
         return {
             "type": "function",
-            "function": {"name": tool_ref["name"]},
+            "function": {"name": name},
         }
     return tool_ref
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -330,13 +330,11 @@ def _get_tool_schema_from_tool(tool: Tool) -> dict:
 
 
 def _get_tool_schema_defs(
-    tools: list[Tool],
+    tool_schemas: list[dict[str, Any]],
 ) -> dict:
     all_defs: dict[str, dict[str, Any]] = {}
-    for tool in tools:
-        _, params = _extract_tool_info(tool)
-        if params is None:
-            continue
+    for tool_schema in tool_schemas:
+        params = tool_schema["properties"]["parameters"]
         defs = params.pop("$defs", {})
         for def_name, def_schema in defs.items():
             if def_name in all_defs and all_defs[def_name] != def_schema:
@@ -352,18 +350,14 @@ def _get_json_schema_from_tools(
     tools: list[Tool],
 ) -> dict:
     fn_tool_schemas: list[dict[str, Any]] = []
-    fn_tools: list[Tool] = []
     for tool in tools:
         if isinstance(tool, (FunctionTool, NamespaceTool)):
             fn_tool_schemas.extend(
                 _get_tool_schema_from_name_and_params(name, params)
                 for name, params in iter_response_function_tool_info(tool)
             )
-            if isinstance(tool, FunctionTool):
-                fn_tools.append(tool)
         elif _is_function_tool(tool):
             fn_tool_schemas.append(_get_tool_schema_from_tool(tool))
-            fn_tools.append(tool)
     json_schema = {
         "type": "array",
         "minItems": 1,
@@ -372,7 +366,7 @@ def _get_json_schema_from_tools(
             "anyOf": fn_tool_schemas,
         },
     }
-    json_schema_defs = _get_tool_schema_defs(fn_tools)
+    json_schema_defs = _get_tool_schema_defs(fn_tool_schemas)
     if json_schema_defs:
         json_schema["$defs"] = json_schema_defs
     return json_schema


### PR DESCRIPTION
## Purpose

I fixed constrained tool calling for Responses API namespace functions. The structural-tag registry treated a namespace as a builtin instead of expanding its functions. Required calls could therefore produce an empty grammar; nested `strict: true` did not enable automatic-call constraints, and named selectors lost their namespace.

I reuse the existing qualified-name and function-iteration helpers before grammar normalization, preserve each function's parameter-schema root, and collect namespace `$defs` in the JSON-guided path as well.

This is distinct from #55153's guidance-format handling, #56285's custom-tool shims, and #50933's schema coercion/non-destructive cleanup. Those paths are unchanged.

## Test Plan

```bash
pytest -q tests/tool_parsers/test_structural_tag_registry.py tests/tool_use/test_tool_choice_required.py
pre-commit run --files vllm/tool_parsers/structural_tag_registry.py vllm/tool_parsers/utils.py tests/tool_parsers/test_structural_tag_registry.py tests/tool_use/test_tool_choice_required.py docs/features/tool_calling.md
```

I also exercised `/v1/responses` with Qwen/Qwen2.5-0.5B-Instruct on CPU using the Hermes parser, both with default strict mode and with `VLLM_ENFORCE_STRICT_TOOL_CALLING=0`.

## Test Result

- All 13 new namespace regression cases fail on the original source.
- Both affected suites pass: 259 passed. Applicable pre-commit hooks, including mypy, pass.
- Default-mode required, named, automatic, and streamed calls return `weather.forecast` with `{"city":"Vienna"}`. The original required request returned HTTP 400.
- The JSON-guided request also returns HTTP 200 instead of the original unresolved `/$defs/City` error.
- Native grammar checks reject invalid argument types/enums and unqualified function names.

This does not add general `allowed_tools` HTTP dispatch support: a top-level control still returns raw tool markup on both versions. Registry-level selector normalization is covered separately. The CPU serving checks are not accuracy or performance benchmarks.

I used AI assistance for the implementation and regression coverage. I reviewed every changed line, understand the patch, and ran the relevant tests.
