### PR TITLE
[Bugfix][Multimodal] Fix Qwen3-VL modality-scoped mm_processor_kwargs handling (images_kwargs/videos_kwargs)

### DIFF
--- a/tests/models/multimodal/processing/test_qwen3_vl.py
+++ b/tests/models/multimodal/processing/test_qwen3_vl.py
@@ -187,6 +187,66 @@ def test_processor_kwargs_videos_kwargs_does_not_leak_into_image_budget(
 
 
 @pytest.mark.parametrize("model_id", [MODEL_ID])
+def test_processor_kwargs_videos_kwargs_partial_size_runtime(
+    model_id: str,
+) -> None:
+    """A partial ``videos_kwargs.size`` must work in the runtime path.
+
+    The scoped size is resolved against the video processor defaults and
+    forwarded to Transformers without also passing the same kwarg flat.
+    """
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 0, "video": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+
+    mm_data = _build_video_mm_data(num_frames=8)
+    hf_mm_kwargs = {
+        "videos_kwargs": {
+            "size": {
+                "longest_edge": _LONG_VIDEO_SIZE["longest_edge"],
+            }
+        }
+    }
+
+    processed = processor._apply_hf_processor_main(
+        processor.info.parse_mm_data(mm_data),
+        hf_mm_kwargs,
+    )
+
+    assert len(processed["video_grid_thw"]) == 1
+
+
+@pytest.mark.parametrize("model_id", [MODEL_ID])
+def test_processor_kwargs_images_kwargs_partial_size_runtime(
+    model_id: str,
+) -> None:
+    """A partial ``images_kwargs.size`` must work in the runtime path."""
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 1, "video": 0},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+
+    image = np.zeros((128, 128, 3), dtype=np.uint8)
+    hf_mm_kwargs = {
+        "images_kwargs": {
+            "size": {
+                "longest_edge": 16_777_216,
+            }
+        }
+    }
+
+    processed = processor._apply_hf_processor_main(
+        processor.info.parse_mm_data({"image": [image]}),
+        hf_mm_kwargs,
+    )
+
+    assert len(processed["image_grid_thw"]) == 1
+
+
+@pytest.mark.parametrize("model_id", [MODEL_ID])
 @pytest.mark.parametrize(
     "hf_mm_kwargs",
     [{"num_frames": [8, 16]}, {"fps": [2.0, 4.0]}],

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -967,6 +967,31 @@ def test_hf_processor_call_kwargs(
     assert result == expected_kwargs
 
 
+@pytest.mark.parametrize("model_id", ["Qwen/Qwen2-VL-2B-Instruct"])  # Dummy
+def test_hf_processor_call_kwargs_does_not_remerge_merged_kwargs(model_id):
+    ctx = InputProcessingContext(
+        model_config=ModelConfig(
+            model_id,
+            mm_processor_kwargs={"c": 1},
+        ),
+        tokenizer=None,
+    )
+
+    processor = ctx.get_hf_processor(DummyProcessor)  # type: ignore[arg-type]
+
+    merged_kwargs = ctx.get_merged_mm_kwargs({"a": 2})
+    merged_kwargs.pop("c")
+
+    result = ctx.call_hf_processor(
+        processor,
+        {},
+        merged_kwargs,
+        mm_kwargs_are_merged=True,
+    )
+
+    assert result == {"a": 2, "c": 0}
+
+
 def test_apply_matches_no_match_exits_quickly():
     """
     Test that _apply_matches exits quickly when no matches are found.

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1316,6 +1316,25 @@ def _replace_video_token_placeholders(
 
 class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo]):
     @staticmethod
+    def _resolve_vision_size(
+        processor: Qwen2VLImageProcessor | Qwen3VLVideoProcessor,
+        mm_kwargs: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Resolve vision size overrides against the processor defaults.
+
+        The returned `size` is complete: `size` is applied first, followed by
+        `min_pixels` and `max_pixels` for the corresponding edges.
+        """
+        size = dict(processor.size)
+        if (override_size := mm_kwargs.get("size")) is not None:
+            size = size | override_size
+        if (min_pixels := mm_kwargs.get("min_pixels")) is not None:
+            size["shortest_edge"] = min_pixels
+        if (max_pixels := mm_kwargs.get("max_pixels")) is not None:
+            size["longest_edge"] = max_pixels
+        return size
+
+    @staticmethod
     def _expands_only_video_token(hf_processor: ProcessorMixin) -> bool:
         """Transformers>=5.10 processors override `replace_video_token`
         to expand only the bare video token, keeping the prompt's outer
@@ -1365,24 +1384,26 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
                 # used to calculate the timestamps. Make sure that
                 # do_sample_frames in mm_kwargs is false for presampled videos.
 
-                # NOTE: a copy of is created to update do_sample_frames,
-                # otherwise mm_hash for the object will be incorrect.
-                video_mm_kwargs = dict(**hf_processor_mm_kwargs)
-                merged = self.info.ctx.get_merged_mm_kwargs(
+                # Use fresh merged kwargs for each item because sampling options are
+                # updated below; `hf_processor_mm_kwargs` must remain unchanged for
+                # `mm_hash`.
+                video_mm_kwargs = self.info.ctx.get_merged_mm_kwargs(
                     hf_processor_mm_kwargs, modality="video"
                 )
-                if merged.keys() & {"size", "min_pixels", "max_pixels"}:
-                    video_size = dict(self.info.get_video_processor().size)
-                    size_override = merged.get("size")
-                    if size_override is not None:
-                        video_size = video_size | size_override
-                    min_pixels = merged.get("min_pixels")
-                    if min_pixels is not None:
-                        video_size["shortest_edge"] = min_pixels
-                    max_pixels = merged.get("max_pixels")
-                    if max_pixels is not None:
-                        video_size["longest_edge"] = max_pixels
-                    video_mm_kwargs["size"] = video_size
+                video_scoped_kwargs = dict(video_mm_kwargs.get("videos_kwargs", {}))
+
+                # Resolve video sizing overrides against the processor defaults and
+                # keep the complete size under videos_kwargs. Transformers rejects a
+                # processor kwarg when provided both as a flat kwarg and under its
+                # modality-specific kwargs.
+                if video_mm_kwargs.keys() & {"size", "min_pixels", "max_pixels"}:
+                    video_scoped_kwargs["size"] = self._resolve_vision_size(
+                        self.info.get_video_processor(), video_mm_kwargs
+                    )
+                    video_scoped_kwargs.pop("min_pixels", None)
+                    video_scoped_kwargs.pop("max_pixels", None)
+
+                # Resolve per-item sampling options before computing timestamps.
                 sampled_fps = video_mm_kwargs.get("fps")
                 if is_list_of(sampled_fps, float):
                     video_mm_kwargs["fps"] = sampled_fps[item_idx]
@@ -1420,6 +1441,22 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
                 if "num_frames" in video_mm_kwargs and "fps" not in video_mm_kwargs:
                     video_mm_kwargs["fps"] = None
 
+                # Keep the final per-item sampling values under videos_kwargs.
+                for key in ("fps", "num_frames", "do_sample_frames"):
+                    if key in video_mm_kwargs:
+                        video_scoped_kwargs[key] = video_mm_kwargs[key]
+
+                # Before the HF call, remove flat copies of the video-scoped kwargs.
+                # min_pixels/max_pixels are already reflected in videos_kwargs["size"],
+                # and images_kwargs does not apply to this video-only call.
+                for key in video_scoped_kwargs.keys() | {
+                    "min_pixels",
+                    "max_pixels",
+                }:
+                    video_mm_kwargs.pop(key, None)
+                video_mm_kwargs.pop("images_kwargs", None)
+                video_mm_kwargs["videos_kwargs"] = video_scoped_kwargs
+
                 video_outputs = self.info.ctx.call_hf_processor(
                     self.info.get_hf_processor(**video_mm_kwargs),
                     dict(
@@ -1427,6 +1464,7 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
                         **video_mm_data,
                     ),
                     video_mm_kwargs,
+                    mm_kwargs_are_merged=True,
                 )
 
                 # Discard HF output input_ids — we use get_video_repl below
@@ -1479,17 +1517,41 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
         else:
             video_outputs = dict()
 
-        # fps/num_frames are video-only kwargs already consumed by the loop;
-        # exclude them so the text/image processor call below never gets a list.
-        non_video_mm_kwargs = {
-            k: v
-            for k, v in hf_processor_mm_kwargs.items()
-            if k not in ("fps", "num_frames")
-        }
+        image_mm_kwargs = self.info.ctx.get_merged_mm_kwargs(
+            hf_processor_mm_kwargs, modality="image"
+        )
+        image_scoped_kwargs = dict(image_mm_kwargs.get("images_kwargs", {}))
+
+        # Resolve image sizing overrides against the processor defaults and keep
+        # the complete size under images_kwargs. Transformers rejects a processor
+        # kwarg when provided both as a flat kwarg and under its modality-specific
+        # kwargs.
+        if image_mm_kwargs.keys() & {"size", "min_pixels", "max_pixels"}:
+            image_scoped_kwargs["size"] = self._resolve_vision_size(
+                self.info.get_image_processor(), image_mm_kwargs
+            )
+            image_scoped_kwargs.pop("min_pixels", None)
+            image_scoped_kwargs.pop("max_pixels", None)
+
+        # Before the HF call, remove flat copies of the image-scoped kwargs.
+        # min_pixels/max_pixels are already reflected in images_kwargs["size"].
+        for key in image_scoped_kwargs.keys() | {"min_pixels", "max_pixels"}:
+            image_mm_kwargs.pop(key, None)
+
+        # Videos are processed separately above, so remove video-specific kwargs
+        # from the text/image call.
+        for key in ("fps", "num_frames", "do_sample_frames"):
+            image_mm_kwargs.pop(key, None)
+        image_mm_kwargs.pop("videos_kwargs", None)
+
+        if image_scoped_kwargs:
+            image_mm_kwargs["images_kwargs"] = image_scoped_kwargs
+
         processed_data = self.info.ctx.call_hf_processor(
-            self.info.get_hf_processor(**non_video_mm_kwargs),
+            self.info.get_hf_processor(**image_mm_kwargs),
             dict(text=prompt_text, **mm_data),
-            non_video_mm_kwargs,
+            image_mm_kwargs,
+            mm_kwargs_are_merged=True,
         )
 
         # Replace each placeholder with pre-computed video tokens.

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -316,14 +316,24 @@ class InputProcessingContext:
         hf_processor: Callable[..., BatchFeature] | ProcessorMixin,
         data: Mapping[str, object],
         kwargs: Mapping[str, object] = {},
+        *,
+        mm_kwargs_are_merged: bool = False,
     ) -> BatchFeature:
         """
         Call `hf_processor` on the prompt `data`
         (text, image, audio...) with configurable options `kwargs`.
+
+        When `mm_kwargs_are_merged` is set, `kwargs` must already include the
+        engine-level `mm_processor_kwargs`; they are used without another merge.
         """
         assert callable(hf_processor)
 
-        merged_kwargs = self.get_merged_mm_kwargs(kwargs)
+        # Some callers merge the engine-level mm_processor_kwargs before preparing
+        # modality-specific kwargs. Merging them again here could reintroduce values
+        # intentionally removed from `kwargs`.
+        merged_kwargs = (
+            dict(kwargs) if mm_kwargs_are_merged else self.get_merged_mm_kwargs(kwargs)
+        )
 
         # vLLM needs the full untruncated sequence to keep multi-modal
         # placeholder tokens aligned; note that the text inputs in


### PR DESCRIPTION
## Purpose

Fixes #56363.

Qwen3-VL currently mishandles modality-scoped vision processor kwargs at the boundary between vLLM's modality-resolved view and the kwargs forwarded to Hugging Face processors.

For video inputs, a `size` override under `videos_kwargs` can be resolved by vLLM and materialized as a flat `size` while the original nested value is still present, causing Transformers to reject the duplicated kwarg. For image inputs, a partial `size` override under `images_kwargs` can reach the image processor without being completed from the processor defaults.

This PR keeps the modality-resolved view for vLLM-side processing while normalizing values modified by vLLM back into the corresponding HF-style scoped kwargs before the final processor call. It also allows callers that have already merged engine-level `mm_processor_kwargs` to avoid merging them a second time.

Regression tests cover partial `size` overrides under `images_kwargs` and `videos_kwargs`, as well as preserving already merged multimodal processor kwargs without merging engine-level settings again.

## Related issues / PRs

- #52834 reported the original mismatch between HF modality-scoped kwargs and vLLM-side sizing/profiling.
- #53808 fixed the sizing/profiling side by introducing modality-aware overlays. The video failure fixed here is a runtime regression exposed by that change.
- #54527 is a related follow-up extending modality-scoped vLLM-side reads to additional models, but it does not modify the affected Qwen3-VL runtime path or `InputProcessingContext.call_hf_processor()`.

### AI assistance

This PR was prepared with AI assistance from ChatGPT. I reviewed every changed line, ran the tests above, and am responsible for the final implementation.

## Test Plan

```bash
pytest -v \
  tests/models/multimodal/processing/test_qwen3_vl.py::test_processor_kwargs_videos_kwargs_partial_size_runtime \
  tests/models/multimodal/processing/test_qwen3_vl.py::test_processor_kwargs_images_kwargs_partial_size_runtime \
  tests/multimodal/test_processing.py::test_hf_processor_call_kwargs_does_not_remerge_merged_kwargs
```

```bash
pre-commit run --files \
  vllm/model_executor/models/qwen3_vl.py \
  vllm/multimodal/processing/context.py \
  tests/models/multimodal/processing/test_qwen3_vl.py \
  tests/multimodal/test_processing.py
```

## Test Result

Before the fix:

- A `size` override under `videos_kwargs` containing only `longest_edge` fails because Transformers receives `size` both as a flat kwarg and inside `videos_kwargs`:

  ```text
  ValueError: Keyword argument size was passed two times: in a dictionary for videos_kwargs and as a **kwarg.
  ```

- A `size` override under `images_kwargs` containing only `longest_edge` reaches the image processor without being completed from its defaults:

  ```text
  ValueError: `size` dict must contain 'shortest_edge' and 'longest_edge' keys but got SizeDict(height=None, width=None, longest_edge=16777216, shortest_edge=None, max_height=None, max_width=None, min_pixels=None, max_pixels=None).
  ```

After the fix:

```text
test_processor_kwargs_videos_kwargs_partial_size_runtime PASSED
test_processor_kwargs_images_kwargs_partial_size_runtime PASSED
test_hf_processor_call_kwargs_does_not_remerge_merged_kwargs PASSED
```

All applicable pre-commit hooks pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>