### PR TITLE
[Bugfix][Spec Decode] Fix arange capacity at token boundary

### DIFF
--- a/tests/v1/spec_decode/test_llm_base_proposer.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for SpecDecodeBaseProposer.initialize_attn_backend.
+"""Tests for SpecDecodeBaseProposer.
 
 Block tables are stored at kernel-block granularity, so the proposer's
 ``block_size`` (used for slot-mapping math) must be the kernel block size,
@@ -20,6 +20,23 @@ from vllm.v1.spec_decode.eagle import EagleProposer
 
 SCHEDULER_BLOCK_SIZE = 256
 KERNEL_BLOCK_SIZE = 64
+
+
+@pytest.mark.parametrize(
+    ("max_batch_size", "max_num_tokens", "expected_size"),
+    [
+        pytest.param(60, 240, 241, id="token-bound"),
+        pytest.param(256, 128, 257, id="batch-bound"),
+        pytest.param(128, 128, 129, id="equal-bounds"),
+    ],
+)
+def test_arange_buffer_includes_boundary(
+    max_batch_size: int, max_num_tokens: int, expected_size: int
+):
+    assert (
+        llm_base_proposer._get_arange_buffer_size(max_batch_size, max_num_tokens)
+        == expected_size
+    )
 
 
 class _FakeAttentionGroup:

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -68,6 +68,11 @@ from vllm.v1.worker.utils import AttentionGroup
 logger = init_logger(__name__)
 
 
+def _get_arange_buffer_size(max_batch_size: int, max_num_tokens: int) -> int:
+    """Return the capacity needed for token and query boundary indices."""
+    return max(max_batch_size, max_num_tokens) + 1
+
+
 class SpecDecodeBaseProposer:
     def __init__(
         self,
@@ -202,8 +207,10 @@ class SpecDecodeBaseProposer:
         self.block_size: int = -1
 
         # We need +1 here because the arange is used to set query_start_loc,
-        # which has one more element than batch_size.
-        max_num_slots_for_arange = max(self.max_batch_size + 1, self.max_num_tokens)
+        # which has one more element than the corresponding item count.
+        max_num_slots_for_arange = _get_arange_buffer_size(
+            self.max_batch_size, self.max_num_tokens
+        )
         self.arange = torch.arange(
             max_num_slots_for_arange, device=device, dtype=torch.int32
         )


### PR DESCRIPTION
## Purpose

Fix an off-by-one allocation in the speculative decoding proposer when
`max_num_batched_tokens` is larger than `max_num_seqs`.

The shared `arange` buffer is also sliced as `query_start_loc`, a boundary
array with one more element than the corresponding item count. The previous
expression only added that extra element on the batch-size branch. For
example, `max_num_seqs=60` and `max_num_batched_tokens=240` allocated 240
elements even though the token-boundary case requires 241.

This PR expresses the invariant symmetrically as
`max(max_batch_size, max_num_tokens) + 1` and adds focused regression coverage
for token-bound, batch-bound, and equal-bound configurations.

The issue was observed in the
[DeepSeek-V4 Flash weekly run](https://github.com/vllm-project/vllm-ascend/actions/runs/34332823330/job/102406795191).
I searched open vLLM issues and PRs for `llm_base_proposer`, `arange`,
`query_start_loc`, `240/239`, and speculative-decode boundary failures and did
not find an existing fix for this allocation.

AI assistance was used to inspect the code and test surface, draft the focused
change and PR text, and run the checks listed below. The author reviewed the
change and validation evidence.

## Test Plan

- Run lint and format checks on both changed files.
- Compile both changed Python files.
- Exercise the capacity helper at all three relative boundaries:
  `tokens > batch`, `batch > tokens`, and `tokens == batch`.
- Validate the change with a controlled two-node Ascend A/B using the same
  image, model, configuration, and workload, changing only the capacity
  expression.

Commands:

```bash
ruff check vllm/v1/spec_decode/llm_base_proposer.py tests/v1/spec_decode/test_llm_base_proposer.py
ruff format --check vllm/v1/spec_decode/llm_base_proposer.py tests/v1/spec_decode/test_llm_base_proposer.py
python -m compileall -q vllm/v1/spec_decode/llm_base_proposer.py tests/v1/spec_decode/test_llm_base_proposer.py
pytest -q tests/v1/spec_decode/test_llm_base_proposer.py
```

The pytest command is included for Linux CI. It was not run on the Windows
development host because the repository's test environment requires the Linux
PyTorch runtime.

## Test Result

- `ruff check`: passed.
- `ruff format --check`: passed.
- `python -m compileall`: passed.
- Targeted pytest: pending Linux CI.
- Controlled Ascend baseline, 1200 requests: reproduced 29 occurrences of
  `The size of tensor a (240) must match the size of tensor b (239)` after a
  decode engine reached 60 active requests.
- Patched, same 1200-request workload: 1200/1200 completed, 0 failed.
- Patched saturation workload: 1600/1600 completed, 0 failed; all 16 decode
  engines reached 60 active requests; 0 occurrences of the 240/239 signature
  and 0 worker-process failures.

The full 4096-request weekly performance gate was not rerun, so this PR makes
no performance-regression or throughput-acceptance claim.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. No documentation update is needed for this internal capacity fix.
</details>

