### PR TITLE
[Bugfix] Keep null stop fields in non-streaming /v1/messages responses

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -26,7 +26,10 @@ from pydantic import BaseModel, Field, ValidationError
 
 from vllm.entrypoints.anthropic.api_router import attach_router
 from vllm.entrypoints.anthropic.protocol import (
+    AnthropicContentBlock,
     AnthropicMessagesRequest,
+    AnthropicMessagesResponse,
+    AnthropicUsage,
 )
 from vllm.entrypoints.anthropic.serving import (
     AnthropicServingMessages,
@@ -1635,6 +1638,89 @@ class TestStopSequenceReason:
         assert msg_deltas[0]["delta"]["stop_reason"] == "end_turn"
         assert "stop_sequence" in msg_deltas[0]["delta"]
         assert msg_deltas[0]["delta"]["stop_sequence"] is None
+
+
+# ======================================================================
+# Non-streaming /v1/messages keeps null stop fields on the wire
+# ======================================================================
+
+
+class TestNonStreamingNullableStopFields:
+    """The Anthropic Message schema lists ``stop_reason`` and
+    ``stop_sequence`` as required, nullable fields. The non-streaming
+    ``/v1/messages`` route serializes with ``exclude_none=True``, which drops
+    them when null; the route must add them back as explicit nulls, matching
+    the streaming ``message_delta`` contract from #55324.
+    """
+
+    @staticmethod
+    def _make_api_app(response: AnthropicMessagesResponse) -> FastAPI:
+        app = FastAPI()
+        attach_router(app)
+        app.state.args = Namespace(log_error_stack=False)
+        handler = MagicMock(spec=AnthropicServingMessages)
+        handler.create_messages.return_value = response
+        app.state.anthropic_serving_messages = handler
+        return app
+
+    @classmethod
+    def _post_messages(cls, response: AnthropicMessagesResponse) -> dict:
+        with TestClient(cls._make_api_app(response)) as client:
+            http_response = client.post(
+                "/v1/messages",
+                json={
+                    "model": "test-model",
+                    "max_tokens": 8,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+        assert http_response.status_code == HTTPStatus.OK
+        return http_response.json()
+
+    @staticmethod
+    def _make_response(**stop_fields) -> AnthropicMessagesResponse:
+        # Extension fields are set explicitly, as messages_full_converter does,
+        # so the omission test would catch a switch to exclude_unset.
+        return AnthropicMessagesResponse(
+            id="msg_test",
+            content=[AnthropicContentBlock(type="text", text="hi")],
+            model="test-model",
+            usage=AnthropicUsage(input_tokens=5, output_tokens=3),
+            kv_transfer_params=None,
+            ec_transfer_params=None,
+            **stop_fields,
+        )
+
+    def test_end_turn_emits_explicit_null_stop_sequence(self):
+        body = self._post_messages(self._make_response(stop_reason="end_turn"))
+
+        assert body["stop_reason"] == "end_turn"
+        assert "stop_sequence" in body
+        assert body["stop_sequence"] is None
+
+    def test_null_stop_reason_is_kept(self):
+        body = self._post_messages(self._make_response())
+
+        assert body["stop_reason"] is None
+        assert body["stop_sequence"] is None
+
+    def test_populated_stop_sequence_is_not_overwritten(self):
+        body = self._post_messages(
+            self._make_response(stop_reason="stop_sequence", stop_sequence="</tool>")
+        )
+
+        assert body["stop_reason"] == "stop_sequence"
+        assert body["stop_sequence"] == "</tool>"
+
+    def test_other_null_fields_are_still_omitted(self):
+        """exclude_none keeps pruning optional fields outside the contract."""
+        body = self._post_messages(self._make_response(stop_reason="end_turn"))
+
+        assert body["type"] == "message"
+        assert body["role"] == "assistant"
+        assert "kv_transfer_params" not in body
+        assert "ec_transfer_params" not in body
+        assert body["content"] == [{"type": "text", "text": "hi"}]
 
 
 # ======================================================================

--- a/vllm/entrypoints/anthropic/api_router.py
+++ b/vllm/entrypoints/anthropic/api_router.py
@@ -80,6 +80,10 @@ async def create_messages(request: AnthropicMessagesRequest, raw_request: Reques
 
     elif isinstance(generator, AnthropicMessagesResponse):
         resp = generator.model_dump(exclude_none=True)
+        # Required-nullable in the Anthropic Message schema; exclude_none drops
+        # an explicit None (unlike the stream's exclude_unset, see #55324).
+        for key in ("stop_reason", "stop_sequence"):
+            resp.setdefault(key, None)
         logger.debug("Anthropic Messages Response: %s", resp)
         return JSONResponse(content=resp)
 


### PR DESCRIPTION
## Purpose

Fix #56371: the non-streaming `/v1/messages` route serializes the response with
`model_dump(exclude_none=True)`, which drops `stop_reason` and `stop_sequence` whenever they
are null. Both are required, nullable members of the Anthropic `Message` schema, so a
schema-validating client sees a missing field on every `end_turn`, `max_tokens` and `tool_use`
response. This is the non-streaming twin of #55324 / #55325, which fixed the same omission on
the streaming `message_delta` under `exclude_unset`.

`exclude_none` stays: it keeps the defaulted `type`/`role` (which `exclude_unset` would drop,
the #45367 bug) and omits `kv_transfer_params`/`ec_transfer_params`, which the converter passes
as `None`. Inapplicable content-block members stay off the wire because they are unset. The
route restores the two schema keys as explicit nulls after the dump, preserving existing
values. No change to `serving.py` or the protocol models.

## Test Plan

New `TestNonStreamingNullableStopFields` in
`tests/entrypoints/anthropic/test_anthropic_messages_conversion.py`, built on the file's
existing `attach_router` + `TestClient` pattern with a mocked handler, asserting on the HTTP
body rather than the model object:

- `end_turn` response carries an explicit `"stop_sequence": null`
- a response with neither stop field set carries both as explicit nulls
- an already-populated `stop_sequence` survives the fixup untouched
- `type`/`role` stay; `kv_transfer_params`, `ec_transfer_params` and inapplicable
  content-block fields stay omitted (the fixture sets the extension fields explicitly, as
  `messages_full_converter` does, so a switch to `exclude_unset` would fail this test)

```
.venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q
# router change reverted, tests kept
.venv/bin/python -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -q -k TestNonStreamingNullableStopFields
```

## Test Result

```
# with fix
66 passed, 15 warnings in 11.68s

# router change reverted, tests kept
2 failed, 2 passed, 62 deselected, 15 warnings in 0.86s
```

Wire before/after on the same object (`stop_reason="max_tokens"`, content elided):

```
BEFORE: {"id":"...","type":"message","role":"assistant","content":[...],"model":"...","stop_reason":"max_tokens","usage":{...}}
AFTER : {"id":"...","type":"message","role":"assistant","content":[...],"model":"...","stop_reason":"max_tokens","usage":{...},"stop_sequence":null}
```

`pre-commit run --all-files` (31 hooks) and `pre-commit run mypy-3.12 --all-files --hook-stage manual`
both pass.

No model evaluation: the change restores missing stop keys as explicit nulls in the JSON
envelope, preserving existing values, and does not touch model execution, sampling or
generation.

## Duplicate check

```
$ gh issue list --repo vllm-project/vllm --state open --search "anthropic exclude_none"
53349  [Feature]: Opt-in omission of unset vLLM-specific extension fields from /v1/chat/completions responses

$ gh issue list --repo vllm-project/vllm --state closed --search "anthropic exclude_none"
55324  [Bug]: /v1/messages streaming omits stop_sequence from message_delta (exclude_unset)
45367  [Bug] /v1/messages streaming: message_start drops type/role (exclude_unset)

$ gh pr list --repo vllm-project/vllm --state open --search "messages stop_sequence non-streaming"
55440  fix(anthropic): explicitly set stop_sequence in message_delta on stream end
47598  [Bugfix][Frontend] Report named Anthropic tool calls as tool_use
52896  [Rust Frontend] Add Anthropic Messages API request surface and count_tokens (PR 1/3)

$ gh pr list --repo vllm-project/vllm --state closed --search "messages stop_sequence non-streaming"
55325  [Bugfix] Set stop_sequence explicitly in streaming message_delta event
45807  fix: report stop_sequence stop_reason in Anthropic Messages API

$ gh issue view 56371 --comments
(no comments)

$ gh pr list --state open --search "56371 in:body"
(none)
```

#55324 / #55325 cover the streaming `message_delta` only. #48273 (open) is about the
`stop_sequence` value on a matched stop string, delivered by #45807, and a `json.loads` crash in
the converter; neither touches the null case on the route. #55440 (open) duplicates #55325.

This change was developed with assistance from a mixture of AI models. The diff and tests were
reviewed and run locally by the submitter.
