### PR TITLE
[Bugfix] Disable sequence parallelism / async TP under batch invariance and add a TP regression test

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -144,7 +144,7 @@ When batch invariance is enabled, vLLM:
 
 1. Uses deterministic kernel implementations for attention and other operations
 2. Ensures consistent numerical behavior across different batch sizes
-3. Disables certain optimizations that may introduce non-determinism (such as custom all-reduce operations in tensor parallel mode)
+3. Disables certain optimizations that may introduce non-determinism (such as custom all-reduce operations in tensor parallel mode, and sequence parallelism / async TP, whose reduce-scatter path is not batch-invariant)
 
 !!! note
     Enabling batch invariance may impact performance compared to the default non-deterministic mode. This trade-off is intentional to guarantee reproducibility.

--- a/tests/v1/determinism/test_batch_invariance.py
+++ b/tests/v1/determinism/test_batch_invariance.py
@@ -16,6 +16,7 @@ from utils import (
 )
 
 import vllm.envs as envs
+from tests.utils import multi_gpu_test
 from vllm import LLM, SamplingParams
 
 
@@ -387,6 +388,69 @@ def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(
             f"{len(prompts)} prompts. See output above for details."
         )
         pytest.fail(msg)
+
+
+@multi_gpu_test(num_gpus=4)
+@pytest.mark.timeout(1500)
+@pytest.mark.parametrize("backend", ["TRITON_ATTN"])
+def test_logprobs_bitwise_batch_invariance_with_sequence_parallelism(backend):
+    """Guard against batch-dependent SP reductions (vllm-project/vllm#56370).
+
+    Removing the config gate should fail this test: SP makes the reduction
+    order depend on the batch composition.
+    """
+    llm = LLM(
+        model=TEST_MODEL,
+        tensor_parallel_size=4,
+        max_num_seqs=64,
+        max_model_len=512,
+        gpu_memory_utilization=0.5,
+        seed=0,
+        attention_config={"backend": backend},
+        compilation_config={"pass_config": {"enable_sp": True, "sp_min_token_num": 64}},
+    )
+
+    try:
+        pass_config = llm.llm_engine.vllm_config.compilation_config.pass_config
+        assert pass_config.enable_sp is False
+        assert pass_config.fuse_gemm_comms is False
+
+        random.seed(0)
+        prompts = [_random_prompt(10, 50) for _ in range(64)]
+        sampling_params = SamplingParams(
+            temperature=0.0, max_tokens=24, logprobs=5, seed=1234
+        )
+
+        bs1_results = []
+        for i, prompt in enumerate(prompts):
+            outputs = llm.generate([prompt], sampling_params, use_tqdm=False)
+            assert len(outputs) == 1, f"Prompt {i}: expected one output"
+            bs1_results.append(_extract_step_logprobs(outputs[0]))
+
+        outputs_batched = llm.generate(prompts, sampling_params, use_tqdm=False)
+        assert len(outputs_batched) == len(prompts)
+        for i, ((logprobs_bs1, tokens_bs1), output) in enumerate(
+            zip(bs1_results, outputs_batched)
+        ):
+            logprobs_bsN, tokens_bsN = _extract_step_logprobs(output)
+            assert logprobs_bs1 is not None, f"Prompt {i}: missing BS=1 logprobs"
+            assert logprobs_bsN is not None, f"Prompt {i}: missing BS=64 logprobs"
+            assert logprobs_bs1.shape == logprobs_bsN.shape, (
+                f"Prompt {i}: different number of steps: "
+                f"{len(logprobs_bs1)} (BS=1) vs {len(logprobs_bsN)} (BS=64)"
+            )
+            for step, (a, b) in enumerate(zip(logprobs_bs1, logprobs_bsN)):
+                assert tokens_bs1[step] == tokens_bsN[step], (
+                    f"Prompt {i}, step {step}: different tokens: "
+                    f"{tokens_bs1[step]} (BS=1) vs {tokens_bsN[step]} (BS=64)"
+                )
+                assert torch.equal(a, b), (
+                    f"Prompt {i}, step {step}: bitwise logprob mismatch: "
+                    f"{a.item()} (BS=1) vs {b.item()} (BS=64)"
+                )
+    finally:
+        with contextlib.suppress(Exception):
+            llm.shutdown()
 
 
 @skip_unsupported

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1556,6 +1556,17 @@ class VllmConfig:
 
         # async tp is built on top of sequence parallelism and requires it.
         pass_config = self.compilation_config.pass_config
+        if envs.VLLM_BATCH_INVARIANT and (
+            pass_config.enable_sp or pass_config.fuse_gemm_comms
+        ):
+            logger.warning_once(
+                "Disabling sequence parallelism and async TP "
+                "(pass_config.enable_sp / fuse_gemm_comms) when "
+                "VLLM_BATCH_INVARIANT is enabled: the reduce-scatter path "
+                "is not batch-invariant (see vllm-project/vllm#56370)."
+            )
+            pass_config.enable_sp = False
+            pass_config.fuse_gemm_comms = False
         if pass_config.fuse_gemm_comms:
             pass_config.enable_sp = True
         if pass_config.enable_sp:


### PR DESCRIPTION
## Purpose

Fixes #56370.

`VLLM_BATCH_INVARIANT=1` did not prevent `pass_config.enable_sp` / `fuse_gemm_comms` from being enabled. The `SequenceParallelismPass` rewrites `all_reduce + rms_norm` into `reduce_scatter + rms_norm + all_gather` for compile ranges above `sp_min_token_num`; the reduce-scatter goes through the plain PyNccl path whose reduction order depends on which rank owns a token's chunk, i.e. on the batch composition. Measured on 4x RTX PRO 6000 with Qwen3-1.7B: with SP on, 1522/1536 sampled-token logprobs differ between `bs=1` and `bs=64` and greedy outputs change; with SP off all 1536 match.

This PR:
- forces `enable_sp = fuse_gemm_comms = False` with a `warning_once` when `VLLM_BATCH_INVARIANT=1`, next to the existing batch-invariance guards in `vllm/config/vllm.py`;
- adds a multi-GPU regression test (`TP=4`, prompts on both sides of `sp_min_token_num`) under `tests/v1/determinism/` that fails on main without the guard and passes with it;
- documents the limitation in `docs/features/batch_invariance.md`.

Making the SP reduce-scatter itself batch-invariant (owner-independent reduction order, as `reduce_scatterv` already does for the MoE combine) is left as a follow-up so that SP can be re-enabled under batch invariance later.

## Test Plan

- `VLLM_BATCH_INVARIANT=1 pytest tests/v1/determinism/test_batch_invariance.py -k sp -x -q` on 4 GPUs (new test), before and after the change
- `VLLM_BATCH_INVARIANT=1 VLLM_TEST_TP_SIZE=4 pytest tests/v1/determinism/test_batch_invariance.py -k bs1_vs_bsN` (existing test, unchanged)
- Manual: the repro script from #56370 with `--compilation-config '{"pass_config":{"enable_sp":true,"sp_min_token_num":64}}'` now logs the warning, keeps SP off, and reports 0 mismatches

## Test Result

Note: with `enable_sp` set, `VllmConfig` currently falls back to the V1 model runner (MRV2 does not support SP yet), so every SP-on measurement above ran on V1; SP-off arms on V2. A forced-V1 SP-off control is bitwise stable (see #56370), so the effect is specific to the SP path. The gate is config-level and runner-agnostic; the SP/batch-invariance interaction should be re-measured once SP lands in MRV2.

Hardware: 4x NVIDIA RTX PRO 6000 Blackwell (sm_120, PCIe), vLLM main @ 7470082f5 + this patch, torch 2.13.0+cu130, `TEST_MODEL=Qwen/Qwen3-1.7B`, attention backend `TRITON_ATTN`.

New regression test (batch invariance with SP requested; the guard forces SP off, bs=1 vs bs=64 logprobs bitwise equal):

```
$ pytest -v -s v1/determinism/test_batch_invariance.py -k with_sequence_parallelism
WARNING [vllm.py:1562] Disabling sequence parallelism and async TP (pass_config.enable_sp / fuse_gemm_comms) when VLLM_BATCH_INVARIANT is enabled: the reduce-scatter path is not batch-invariant (see vllm-project/vllm#56370).
PASSED
========== 1 passed, 19 deselected, 14 warnings in 144.62s (0:02:24) ===========
```

Same configuration on main without the guard (from #56370, `enable_sp=True, sp_min_token_num=64`, TP=4): 1522/1536 sampled-token logprobs differ and 17/64 greedy outputs change. With the guard, the standalone repro script from #56370 reports `enable_sp=False`, `logprob_mismatch_tokens=0`, `max_abs_logprob_diff=0.0`.

Existing TP regression (unchanged test):

```
$ VLLM_TEST_TP_SIZE=4 pytest -v -s v1/determinism/test_batch_invariance.py -k "bs1_vs_bsN and TRITON_ATTN and 16-16"
PASSED
=========== 1 passed, 19 deselected, 14 warnings in 95.76s (0:01:35) ===========
```

Lint: `ruff check` / `ruff format --check` clean on the two Python files.