### PR TITLE
[EC] Automatically enable embedding inputs on EC/KV consumers

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2523,11 +2523,8 @@ class VllmConfig:
             return
 
         if not mm_config.enable_mm_embeds:
-            # A consumer is sent the media as an `*_embeds` reference, which
-            # the frontend rejects outright unless embedding inputs are
-            # enabled at all. Letting the tensor be omitted decides nothing
-            # if the request never gets that far, so enabling one without the
-            # other fails every multimodal request rather than some of them.
+            # Allowing missing tensors still requires enabling embedding inputs
+            # for the frontend to accept metadata-only requests.
             mm_config.enable_mm_embeds = True
             logger.info_once(
                 "EC/KV consumer: accepting pre-computed-embedding inputs, "

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1716,7 +1716,7 @@ class VllmConfig:
             )
         current_platform.check_and_update_config(self)
 
-        self._resolve_allow_missing_mm_embeddings()
+        self._resolve_mm_embedding_inputs()
         self._resolve_mm_processor_device()
         self._validate_mm_processor_device()
 
@@ -2497,8 +2497,8 @@ class VllmConfig:
             f"kernel_config={self.kernel_config!r}"
         )
 
-    def _resolve_allow_missing_mm_embeddings(self) -> None:
-        """Allow `*_embeds` tensors to be omitted on disaggregated consumers.
+    def _resolve_mm_embedding_inputs(self) -> None:
+        """Accept embedding inputs, tensor optional, on disaggregated consumers.
 
         An EC consumer loads embeddings from its connector. A KV consumer
         receives the prompt KV produced from those embeddings, so it does not
@@ -2519,11 +2519,24 @@ class VllmConfig:
         mm_config.allow_missing_mm_embeddings = (
             ec_config is not None and ec_config.is_ec_consumer
         ) or (kv_config is not None and kv_config.is_kv_consumer)
-        if mm_config.allow_missing_mm_embeddings:
+        if not mm_config.allow_missing_mm_embeddings:
+            return
+
+        if not mm_config.enable_mm_embeds:
+            # A consumer is sent the media as an `*_embeds` reference, which
+            # the frontend rejects outright unless embedding inputs are
+            # enabled at all. Letting the tensor be omitted decides nothing
+            # if the request never gets that far, so enabling one without the
+            # other fails every multimodal request rather than some of them.
+            mm_config.enable_mm_embeds = True
             logger.info_once(
-                "EC/KV consumer: pre-computed-embedding inputs may "
-                "omit the embedding tensor."
+                "EC/KV consumer: accepting pre-computed-embedding inputs, "
+                "which this role is sent by definition."
             )
+        logger.info_once(
+            "EC/KV consumer: pre-computed-embedding inputs may "
+            "omit the embedding tensor."
+        )
 
     def _resolve_mm_encoder_only(self) -> None:
         """Enable encoder-only mode for a dedicated EC producer."""


### PR DESCRIPTION
## Summary

Automatically enable `enable_mm_embeds` for EC/KV consumers alongside `allow_missing_mm_embeddings`, so EPD rewrite requests are accepted without an explicit `--enable-mm-embeds`. Other roles are unchanged.

Consumer endpoints must remain trusted, as with explicitly enabling embedding inputs.

Extracted from #54176; the configuration change has been removed there. No other matching open PR was found.

## Validation

- `.venv/bin/python -m pytest tests/config/test_multimodal_config.py -q`: 46 passed.
- Commit pre-commit hooks passed. No new tests added.
- Model evaluation/E2E not rerun for this extraction; pending before marking ready.

AI assistance was used. Draft pending human review and validation.