### PR TITLE
[Bugfix][ROCm] Match MLA block tables to storage page size

### DIFF
--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -492,6 +492,16 @@ def prepare_kernel_block_sizes(
             selected_kernel_size = select_common_block_size(
                 kv_manager_block_size, group_backends
             )
+            if (
+                current_platform.is_rocm()
+                and isinstance(kv_cache_spec, MLAAttentionSpec)
+                and kv_cache_spec.storage_block_size is not None
+            ):
+                # allocate_kv_cache views the physical cache at
+                # storage_block_size granularity; the block table must use the
+                # same granularity or pool-page consumers (indexer K gather,
+                # paged MQA logits) index past the table.
+                selected_kernel_size = kv_cache_spec.storage_block_size
             kernel_block_sizes.append(selected_kernel_size)
         elif isinstance(kv_cache_spec, MambaSpec):
             # This is likely Mamba or other non-attention cache, no splitting.


### PR DESCRIPTION
## Purpose

Addresses the block-table mismatch in #56380. This PR does **not** fix the separate kpool-tail slot-mapping fault in that issue.

For the GLM-5.3-Flash indexer on gfx942, `allocate_kv_cache` uses 128-token storage pages, while `prepare_kernel_block_sizes` selects the 640-token manager block size. Block-table entries then name manager blocks rather than the physical pages consumed by the indexer.

Honor `MLAAttentionSpec.storage_block_size` on ROCm, matching allocation. The existing `append_block_ids` logic then expands manager block `b` into pages `5*b + [0, 1, 2, 3, 4]`. This preserves token-granular slot addresses for the tested 640/128 layout.

Related: #55219 replaces this layout and removes `storage_block_size`. This PR is a smaller fix for the existing layout, not that refactor; it may be superseded by #55219.

## Test Plan

Tested on 8x MI308X (gfx942), ROCm 7.2.3, TP8, bf16 KV, with vLLM `0.28.1rc1.dev628+g2a02f6efe.rocm723` plus local patches.

- Compare block-table dimensions and page IDs before/after with `max_model_len=262144`.
- Separately exercise long prompts with `max_model_len=524288`.
- Historical local probe commands (scripts are not included in this PR):

```bash
SEAL_WHICH=byCC,byAA python3 /tmp/flash-seal.py 26000
ECHO_CTK='{"enable_thinking": false}' python3 /tmp/flash-echo2.py 30000x-1
```

## Test Result

- At the **same 262144-token setting**, the block table changed from `(1, 410)` to `(1, 2050)`, with page IDs expanded as expected. Before the fix, one 160K prefill sample had `last_pos=160639` but `sel_max=52479`.
- At **524288 tokens**, a later sample reached `last_pos=475935, sel_max=475935`. The commands above completed with 516417 and 519040 prompt tokens, respectively.
- These are diagnostic results, **not exact-answer accuracy scores**. SEAL accepted a matching code in either final or reasoning text; ECHO checked only a 24-character substring.

The model runs also used separate local fixes for FlyDSL integer shifts, FP8 pack conversion, and kpool-tail slot mapping. They are not evidence that this PR alone fixes a stock deployment.

No automated regression test or standardized model evaluation is included yet. Before merge, add coverage for storage-page selection and unchanged non-ROCm/no-override behavior in `tests/v1/worker/test_attn_utils.py`, then run the relevant suite on a supported environment.

AI assistance was used for investigation, implementation, and this description.
