### PR TITLE
[Bugfix][MM] Fix swapped H/W in dummy video profiling inputs

### DIFF
--- a/vllm/multimodal/processing/dummy_inputs.py
+++ b/vllm/multimodal/processing/dummy_inputs.py
@@ -193,5 +193,5 @@ class BaseDummyInputsBuilder(ABC, Generic[_I]):
                         height,
                     )
                 height = min(height, overrides.height)
-        video = np.full((num_frames, width, height, 3), 255, dtype=np.uint8)
+        video = np.full((num_frames, height, width, 3), 255, dtype=np.uint8)
         return [video] * num_videos


### PR DESCRIPTION
## Purpose

`BaseDummyInputsBuilder._get_dummy_videos` builds the dummy profiling video with **width and height swapped**:

```python
# vllm/multimodal/processing/dummy_inputs.py (before)
video = np.full((num_frames, width, height, 3), 255, dtype=np.uint8)
```

Every other video code path in `vllm/multimodal/` uses the `(T, H, W, C)` layout, e.g. `rescale_video_size`:

```python
# vllm/multimodal/video.py
_, height, width, _ = frames.shape
```

So for any **non-square** dummy size, the profiling video has H and W transposed, feeding memory profiling / max-token estimation the wrong aspect ratio. Square sizes hide the bug. The sibling `_get_dummy_images` already uses the correct order (`Image.new("RGB", (width, height))`).

Fix is one line:

```python
video = np.full((num_frames, height, width, 3), 255, dtype=np.uint8)
```

## Reproduction (from the real code)

**Before:**
```
requested width=1920 height=1080 num_frames=4
dummy video shape   = (4, 1920, 1080, 3)   (expected (4, 1080, 1920, 3))
downstream height   = 1920 (should be 1080),  width = 1080 (should be 1920)
rescaled 0.5x shape = (4, 960, 540, 3)     (expected (4, 540, 960, 3))
```

**After:**
```
dummy video shape   = (4, 1080, 1920, 3)   (expected (4, 1080, 1920, 3))
downstream height   = 1080 (want 1080),  width = 1920 (want 1920)
rescaled 0.5x shape = (4, 540, 960, 3)     (expected (4, 540, 960, 3))
```

Repro script (uses the real code path):
```python
from vllm.multimodal.processing.dummy_inputs import BaseDummyInputsBuilder
from vllm.multimodal.video import rescale_video_size

class _B(BaseDummyInputsBuilder):
    def get_dummy_text(self, mm_counts): return ""
    def get_dummy_mm_data(self, seq_len, mm_counts, mm_options=None): return {}

b = _B.__new__(_B)
v = b._get_dummy_videos(width=1920, height=1080, num_frames=4, num_videos=1)[0]
assert v.shape == (4, 1080, 1920, 3)  # fails before, passes after
```

## Test Plan / Result

- Repro script above: fails on `main`, passes with this fix.
- `pre-commit run ruff-check --files vllm/multimodal/processing/dummy_inputs.py` → Passed.

## Not a duplicate

Searched open PRs on `vllm-project/vllm` (`dummy video width height`, MM cleanup PRs); none touch the `_get_dummy_videos` shape.

## Notes

AI assistance was used to locate, reproduce, and fix this bug; a human has reviewed the change.