### PR TITLE
[Bugfix][MM] Fix OpenPangu video backend crash on num_frames=-1

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -24,6 +24,7 @@ from vllm.multimodal.video import (
     GLM46VVideoBackend,
     GLMGAVideoBackend,
     Molmo2VideoBackend,
+    OpenCVDynamicOpenPanguVideoBackend,
     Qwen2VLVideoBackend,
     Qwen3VLVideoBackend,
     VideoBackend,
@@ -1435,6 +1436,27 @@ def test_glm46v_dynamic_fps_thresholds(
 
     # Indices must be sorted and deduplicated
     assert indices == sorted(set(indices)), "Indices must be sorted and deduplicated"
+
+
+@pytest.mark.parametrize("fps", [2, -1])
+def test_openpangu_num_frames_sentinel(fps):
+    """`num_frames=-1` (the default / "no cap" sentinel) must sample frames
+    instead of raising `ValueError` from `np.linspace(..., -1)`."""
+    source = VideoSourceMetadata(
+        total_frames_num=100, original_fps=30, duration=100 / 30
+    )
+    target = VideoTargetMetadata(num_frames=-1, fps=fps, max_duration=300)
+
+    indices = OpenCVDynamicOpenPanguVideoBackend.compute_frames_index_to_sample(
+        source, target
+    )
+
+    assert len(indices) > 0
+    assert indices == sorted(indices)
+    assert all(0 <= idx < source.total_frames_num for idx in indices)
+    # fps=-1 means "no fps limit" -> sample every frame.
+    if fps == -1:
+        assert len(indices) == source.total_frames_num
 
 
 def test_glm46v_even_frame_count_enforcement():

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -1220,14 +1220,20 @@ class OpenCVDynamicOpenPanguVideoBackend(VideoLoader):
         # `fps` is the FPS parameter passed in for sampling,
         # -1 indicates that sampling can be performed directly without FPS limitation.
         if fps > 0:
-            # Num_frames is the maximum number of frames to sample.
+            # Num_frames is the maximum number of frames to sample; `num_frames < 0`
+            # means "no cap" and defers entirely to the fps-derived count.
             # If fewer frames are sampled at this sample_fps, the update duration will be longer. # noqa: E501
-            if num_frames >= int(total_duration * fps) + 1:
-                num_frames = int(total_duration * fps) + 1
+            max_num_frames = int(total_duration * fps) + 1
+            if num_frames < 0 or num_frames >= max_num_frames:
+                num_frames = max_num_frames
                 # Under the new maximum frame rate, the video duration of the rightmost frame, # noqa: E501
                 # cannot be calculated for frame 0.
                 total_duration = min(total_duration, (num_frames - 1) / fps)
-        elif fps != -1:
+        elif fps == -1:
+            # No fps limit: `num_frames < 0` means sample every frame.
+            if num_frames < 0:
+                num_frames = total_frames_num
+        else:
             raise ValueError(
                 f"requires dataset fps is -1 or greater than 0 but got {fps}"
             )


### PR DESCRIPTION
## Purpose

`OpenCVDynamicOpenPanguVideoBackend.compute_frames_index_to_sample` never normalizes the `num_frames = -1` ("no cap / all frames") sentinel that every other video backend honors via `if num_frames > 0`. The backend's own `load_bytes` default is `num_frames=-1`, so with the default the `fps > 0` cap branch condition `num_frames >= int(total_duration * fps) + 1` evaluates to `-1 >= (>=1)` → `False`, leaving `num_frames == -1`, which then hits:

```python
np.linspace(0, total_duration, num_frames, dtype=float)  # num_frames == -1
```

→ `ValueError: Number of samples, -1, must be non-negative`. The `fps == -1` ("no fps limit") path crashes the same way.

## Fix

Treat `num_frames < 0` as "no cap":
- `fps > 0`: use the fps-derived count (`int(total_duration * fps) + 1`).
- `fps == -1`: sample every frame (`total_frames_num`).

Positive `num_frames` (within or above the fps cap) and the invalid-fps `ValueError` are unchanged.

## Reproduction (from the real code)

**Before** (`origin/main`):
```
>>> OpenCVDynamicOpenPanguVideoBackend.compute_frames_index_to_sample(
...     VideoSourceMetadata(total_frames_num=100, original_fps=30, duration=100/30),
...     VideoTargetMetadata(num_frames=-1, fps=2, max_duration=300))
ValueError: Number of samples, -1, must be non-negative.
```

**After:**
```
num_frames=-1, fps=2   -> 7 indices,  range=[0,90], sorted, in-range   (was CRASH)
num_frames=-1, fps=-1  -> 100 indices, range=[0,99], sorted, in-range  (was CRASH)
num_frames=8,  fps=2   -> capped to fps count (unchanged)
num_frames=10000, fps=2-> capped to fps count (unchanged)
fps=0                  -> ValueError: requires dataset fps is -1 or greater than 0 (unchanged)
```

## Test Plan / Result

- Added `test_openpangu_num_frames_sentinel` (parametrized `fps=2` and `fps=-1`) to `tests/multimodal/test_video.py`.
- `pytest tests/multimodal/test_video.py -k openpangu_num_frames_sentinel` → **2 passed**.
- `pre-commit run ruff-check --files vllm/multimodal/video.py tests/multimodal/test_video.py` → Passed.

## Not a duplicate

Searched open PRs on `vllm-project/vllm` (`openpangu num_frames`, `OpenPangu video sampling`); none address this. This is distinct from the recent zero-fps guard PRs (#54390 Qwen3-VL, #54396 GLM-GA), which fix a different `ZeroDivisionError`, not the `num_frames=-1` sentinel.

## Notes

The `openpangu` backend is opt-in (registered without a `video_processor` auto-mapping), but its own default parameter value crashes it, so any explicit selection without also overriding `num_frames` hits this. AI assistance was used to locate, reproduce, fix, and test this bug; a human has reviewed the change.