### PR TITLE
[Bugfix][Frontend] Preserve structured content when consolidating system messages

### DIFF
--- a/tests/renderers/test_hf.py
+++ b/tests/renderers/test_hf.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from copy import deepcopy
+from typing import Any
+
 import jinja2
 import pytest
 
 from vllm.config import ModelConfig
-from vllm.entrypoints.chat_utils import load_chat_template
+from vllm.entrypoints.chat_utils import load_chat_template, parse_chat_messages
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.exceptions import VLLMValidationError
 from vllm.renderers.hf import (
@@ -750,6 +753,21 @@ STRICT_ROLE_TEMPLATE = (
 )
 
 
+# From HuggingFaceTB/SmolVLM2-2.2B-Instruct/tokenizer_config.json.
+# This template requires structured content for every role.
+SMOLVLM_TEMPLATE = (
+    "<|im_start|>{% for message in messages %}"
+    "{{message['role'] | capitalize}}"
+    "{% if message['content'][0]['type'] == 'image' %}{{':'}}"
+    "{% else %}{{': '}}{% endif %}"
+    "{% for line in message['content'] %}"
+    "{% if line['type'] == 'text' %}{{line['text']}}"
+    "{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}"
+    "{% endfor %}<end_of_utterance>\n{% endfor %}"
+    "{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}"
+)
+
+
 class TestDetectDeveloperRoleSupport:
     def test_absent_in_chatml(self):
         assert _detect_developer_role_support(CHATML_TEMPLATE) is False
@@ -886,6 +904,46 @@ class TestSafeApplyChatTemplateDeveloperRole:
         )
         assert "<|im_start|>system" in result
         assert "Be concise." in result
+
+    @pytest.mark.parametrize("structured_input", [False, True])
+    @pytest.mark.parametrize("has_system", [False, True])
+    def test_developer_instructions_preserved_in_openai_template(
+        self, model_config, tokenizer, structured_input, has_system
+    ):
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": "Hello"},
+            {"role": "developer", "content": "Be concise."},
+            {"role": "user", "content": "What is 2+2?"},
+        ]
+        if has_system:
+            messages[0] = {"role": "system", "content": "You are helpful."}
+        if structured_input:
+            for message in messages:
+                message["content"] = [{"type": "text", "text": message["content"]}]
+
+        request = ChatCompletionRequest(messages=messages)
+        content_format = resolve_chat_template_content_format(
+            SMOLVLM_TEMPLATE, None, "auto", tokenizer, model_config=model_config
+        )
+        conversation, _, _ = parse_chat_messages(
+            request.messages, model_config, content_format
+        )
+        result = safe_apply_chat_template(
+            model_config,
+            tokenizer,
+            conversation,
+            chat_template=SMOLVLM_TEMPLATE,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        system_text = "You are helpful.\n\nBe concise." if has_system else "Be concise."
+        first_user = "" if has_system else "User: Hello<end_of_utterance>\n"
+        assert result == (
+            f"<|im_start|>System: {system_text}<end_of_utterance>\n"
+            f"{first_user}"
+            "User: What is 2+2?<end_of_utterance>\n"
+            "Assistant:"
+        )
 
 
 SYSTEM_FIRST_TEMPLATE = (
@@ -1048,21 +1106,41 @@ class TestConsolidateSystemMessages:
         assert result[0]["content"] == "You are helpful.\n\nBe concise."
         assert result[1]["role"] == "user"
 
-    def test_list_content_handled(self):
+    def test_list_content_preserved(self):
+        content = [
+            {"type": "text", "text": "Rule 1."},
+            {"type": "text", "text": "Rule 2."},
+        ]
         conversation = [
             {"role": "user", "content": "Hello"},
-            {
-                "role": "system",
-                "content": [
-                    {"type": "text", "text": "Rule 1."},
-                    {"type": "text", "text": "Rule 2."},
-                ],
-            },
+            {"role": "system", "content": content},
         ]
         result = _consolidate_system_messages(conversation)
         assert result[0]["role"] == "system"
-        assert result[0]["content"] == "Rule 1.\nRule 2."
+        assert result[0]["content"] == content
         assert result[1]["role"] == "user"
+
+    @pytest.mark.parametrize(
+        "first_content", ["Rule 1.", [{"type": "text", "text": "Rule 1."}]]
+    )
+    def test_merging_lists_preserves_parts_and_input(self, first_content):
+        conversation = [
+            {"role": "system", "content": first_content},
+            {"role": "system", "content": []},
+            {
+                "role": "system",
+                "content": [{"type": "image"}, {"type": "text", "text": "Rule 2."}],
+            },
+        ]
+        original = deepcopy(conversation)
+        result = _consolidate_system_messages(conversation)
+        assert result[0]["content"] == [
+            {"type": "text", "text": "Rule 1."},
+            {"type": "text", "text": "\n\n"},
+            {"type": "image"},
+            {"type": "text", "text": "Rule 2."},
+        ]
+        assert conversation == original
 
     def test_does_not_mutate_original(self):
         conversation = [

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -531,7 +531,7 @@ def _consolidate_system_messages(
     very first message.  After developer-to-system conversion, system messages
     may appear at non-first positions; this merges them into a single message.
     """
-    system_contents: list[str] = []
+    system_contents: list[str | list[dict[str, str]]] = []
     non_system: list[ConversationMessage] = []
     needs_consolidation = False
     for i, msg in enumerate(conversation):
@@ -539,15 +539,7 @@ def _consolidate_system_messages(
             if i > 0 or system_contents:
                 needs_consolidation = True
             content = msg.get("content", "")
-            if isinstance(content, list):
-                parts = []
-                for part in content:
-                    if isinstance(part, dict) and "text" in part:
-                        parts.append(part["text"])
-                    elif isinstance(part, str):
-                        parts.append(part)
-                content = "\n".join(parts)
-            if content:
+            if isinstance(content, list) or content:
                 system_contents.append(content)
         else:
             non_system.append(msg)
@@ -555,10 +547,23 @@ def _consolidate_system_messages(
     if not needs_consolidation:
         return conversation
 
-    merged: ConversationMessage = {
-        "role": "system",
-        "content": "\n\n".join(system_contents),
-    }
+    merged_content: str | list[dict[str, str]]
+    if any(isinstance(content, list) for content in system_contents):
+        merged_parts: list[dict[str, str]] = []
+        for content in system_contents:
+            if not content:
+                continue
+            if merged_parts:
+                merged_parts.append({"type": "text", "text": "\n\n"})
+            if isinstance(content, list):
+                merged_parts.extend(content)
+            else:
+                merged_parts.append({"type": "text", "text": content})
+        merged_content = merged_parts
+    else:
+        merged_content = "\n\n".join(cast(list[str], system_contents))
+
+    merged: ConversationMessage = {"role": "system", "content": merged_content}
     return [merged, *non_system]
 
 


### PR DESCRIPTION
## Problem

When a chat template does not support the `developer` role, the HF renderer
converts developer messages to `system` and consolidates system messages.

For templates using the OpenAI content format, message content is represented
as a list of structured parts. The consolidation logic currently converts these
lists to plain strings. Templates that require structured content can then
silently drop the system instructions during rendering.

This is reproducible with the official
`HuggingFaceTB/SmolVLM2-2.2B-Instruct` chat template, even when the request uses
plain strings:

```json
[
  {"role": "system", "content": "You are helpful."},
  {"role": "developer", "content": "Be concise."},
  {"role": "user", "content": "What is 2+2?"}
]
```

Before the fix, the rendered system block is empty:

```text
<|im_start|>System: <end_of_utterance>
```

After the fix, it contains both instructions:

```text
<|im_start|>System: You are helpful.

Be concise.<end_of_utterance>
```

## Complete reproduction

The following Chat Completions request reproduces the issue before model
generation; model weights are not required:

```json
{
  "model": "HuggingFaceTB/SmolVLM2-2.2B-Instruct",
  "messages": [
    {"role": "system", "content": "You are helpful."},
    {"role": "developer", "content": "Be concise."},
    {"role": "user", "content": "What is 2+2?"}
  ]
}
```

With the official tokenizer revision
`482adb537c021c86670beed01cd58990d01e72e4`, vLLM detects the template's
content format as `openai` and parses all three messages as structured content
lists. SmolVLM does not declare a `developer` role, so the existing
developer-to-system fallback runs before rendering. On the parent commit, that
fallback converts the merged content list to a string; SmolVLM then iterates
over the string as if it were a list of content parts and silently renders an
empty system block. With this PR, the structured parts remain intact and both
instructions are rendered.

The same renderer path is used after Responses API input is converted to chat
messages, so this is independent of native `developer` support in models such
as DeepSeek V3.2.

## Fix

- Preserve structured content parts when consolidating system messages.
- Insert the existing separator as a text content part.
- Wrap plain string content as a text part when mixed with structured content.
- Preserve non-text parts instead of silently discarding them.
- Keep the existing behavior for conversations containing only plain strings.

This change only fixes content preservation during consolidation. It does not
change the existing developer-role conversion or system-message ordering policy.

## Validation

- Added regression coverage for plain-string and structured content.
- Added coverage for mixed content, empty lists, non-text parts, and input preservation.
- The seven new or updated regression cases fail on the original implementation.
- Developer-role and system-consolidation test classes: `18 passed` after the fix.
- Renderer tests available locally: `42 passed, 37 deselected`.
- Verified the official SmolVLM2 model configuration and tokenizer: the rendered
  prompt and all 28 token IDs match the manually consolidated prompt.
- Ruff, formatting, typos, repository checks, and mypy for Python 3.10 and 3.12 pass.

Commands:

```bash
VLLM_TARGET_DEVICE=cpu HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
VLLM_NO_USAGE_STATS=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
.venv/bin/python -m pytest tests/renderers/test_hf.py -q \
  -k 'TestSafeApplyChatTemplateDeveloperRole or TestConsolidateSystemMessages'

VLLM_TARGET_DEVICE=cpu HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
VLLM_NO_USAGE_STATS=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
.venv/bin/python -m pytest tests/renderers/test_hf.py -q \
  -k 'not test_resolve_chat_template and not test_resolve_content_format_hf_defined and not test_resolve_content_format_fallbacks and not test_resolve_content_format_examples'

SKIP=actionlint .venv/bin/python -m pre_commit run \
  --files vllm/renderers/hf.py tests/renderers/test_hf.py

.venv/bin/python -m pre_commit run mypy-3.12 --hook-stage manual \
  --files vllm/renderers/hf.py tests/renderers/test_hf.py
```

The full renderer test file could not finish locally because other model
configurations were not cached. `actionlint` was skipped after its Go dependency
downloads timed out; this PR changes only Python files.

No GPU serving or model generation evaluation was run. Validation covers request
parsing, chat-template rendering, and tokenization.

## Related work

I checked related PRs and did not find another fix for this content-preservation issue.
This is separate from:

- #43590, which introduced developer-to-system conversion.
- #44505 and #47681, which focus on system-message ordering and consolidation policy.
- #52392, which handles message-level tool declarations.
- #53148, which adds Kimi K3-specific developer-role compatibility.

AI assistance was used, and I reviewed all changes and tests.
