### PR TITLE
Revert "[CI][XPU] Disable model runner V2 for XPU quantization test for some partially pre-quantized models"

### DIFF
--- a/.buildkite/intel_jobs/test-intel.yaml
+++ b/.buildkite/intel_jobs/test-intel.yaml
@@ -145,16 +145,10 @@ steps:
     source_file_dependencies:
       - vllm/
       - .buildkite/intel_jobs/test-intel.yaml 
-    # TODO: XPU fused MoE + model runner V2 currently hangs on some
-    # pre-quantized models, e.g.
-    # quantization/test_online.py::test_online_quantization_loads_real_weights[nm-testing/tinysmokeqwen3moe-W4A16-first-only-CTstable]
-    # Remove the VLLM_USE_V2_MODEL_RUNNER=0 override below once the hang is
-    # root-caused and fixed.
     commands:
       - >-
         bash .buildkite/scripts/hardware_ci/run-intel-test.sh
         'cd tests &&
-        export VLLM_USE_V2_MODEL_RUNNER=0 &&
         pytest -v -s quantization/test_auto_round.py &&
         pytest -v -s quantization/test_online.py'
   - label: "XPU compressed tensors FP8 test"


### PR DESCRIPTION
This reverts #56179.

**The problem**

`test_online_quantization_loads_real_weights[...tinysmokeqwen3moe-W4A16...]` hangs on XPU CI. `CompressedTensorsWNA16MoEMethod.create_weights()` (pre-#54809) always registers 4 g_idx-related `nn.Parameter`s, even for checkpoints (like this one) with no actorder/g_idx data — leaving them uninitialized.

**Verified on real XPU hardware**

Re-registering just these 4 parameters reproduces the hang; removing them fixes it. On XPU, `_process_weights_xpu()` never touches g_idx at all, so these parameters stay untouched throughout loading.

**Why not on CUDA**

On CUDA (Marlin backend), `process_weights_after_loading()` reads and replaces the g_idx parameter even for non-actorder checkpoints, so it doesn't stay untouched the way it does on XPU.

**Fixing PR**

#54809 removes GPTQ actorder support and, as part of that, deletes this unconditional registration. 

**Why this revert**

#54809 already fixes this on `main`, so #56179's `VLLM_USE_V2_MODEL_RUNNER=0` workaround is no longer needed.
