### PR TITLE
[Proposal][HiSparse] Simplify cache initialization and block-size resolution

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -89,31 +89,21 @@ from vllm.v1.request import Request
 pytestmark = pytest.mark.cpu_test
 
 
-@pytest.mark.parametrize(
-    ("block_size", "main_sizes", "indexer_sizes", "gpu_block_size"),
-    [
-        (256, (64,), (64,), 64),
-        (64, (32, 64), (16, 32), 32),
-    ],
-)
-def test_hisparse_hma_uses_backend_gpu_block_size(
-    monkeypatch, block_size, main_sizes, indexer_sizes, gpu_block_size
-):
+@pytest.mark.parametrize("gpu_block_size", [32, 64])
+def test_hisparse_hma_uses_resolved_gpu_block_size(monkeypatch, gpu_block_size):
     specs = {
         "model.layers.0.self_attn": MLAAttentionSpec(
-            block_size=block_size,
+            block_size=gpu_block_size,
             num_kv_heads=1,
             head_size=576,
             dtype=torch.bfloat16,
-            supported_kernel_block_sizes=main_sizes,
             is_index_group_leader=True,
         ),
         "model.layers.0.self_attn.indexer": MLAAttentionSpec(
-            block_size=block_size,
+            block_size=gpu_block_size,
             num_kv_heads=1,
             head_size=128,
             dtype=torch.bfloat16,
-            supported_kernel_block_sizes=indexer_sizes,
             cache_role=SparseCacheRole.INDEXER,
         ),
     }
@@ -124,7 +114,7 @@ def test_hisparse_hma_uses_backend_gpu_block_size(
         attention_config=SimpleNamespace(hisparse_config=HiSparseConfig()),
         model_config=SimpleNamespace(
             hf_config=SimpleNamespace(index_topk=128),
-            max_model_len=block_size,
+            max_model_len=gpu_block_size,
         ),
         parallel_config=SimpleNamespace(decode_context_parallel_size=1),
         cache_config=SimpleNamespace(

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -13,7 +13,7 @@ import pytest
 import torch
 
 from tests.v1.attention.utils import dense_kv_cache_views
-from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.attention.backend import AttentionBackend, AttentionCGSupport, MultipleOf
 from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -23,6 +23,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheLayout,
     KVCacheTensor,
     MLAAttentionSpec,
+    SparseCacheRole,
     compute_layout_strides,
 )
 from vllm.v1.worker.gpu import attn_utils
@@ -35,6 +36,60 @@ from vllm.v1.worker.utils import (
     allocate_kv_cache,
     copy_kv_cache_blocks_inplace,
 )
+
+
+@pytest.mark.parametrize(
+    ("enabled", "block_size", "main_sizes", "indexer_sizes", "expected"),
+    [
+        (True, 256, [64], [64], 64),
+        (True, 64, [32, 64], [16, 32], 32),
+        (True, 64, [MultipleOf(16)], [32], 32),
+        (True, 64, [64], [32], None),
+        (False, 256, [64], [64], 256),
+    ],
+)
+def test_get_kv_cache_spec_resolves_hisparse_block_size(
+    monkeypatch, enabled, block_size, main_sizes, indexer_sizes, expected
+):
+    """Resolve shared MLA geometry before planning; leave other specs alone."""
+    specs = {
+        "main": MLAAttentionSpec(
+            block_size=block_size, num_kv_heads=1, head_size=576, dtype=torch.bfloat16
+        ),
+        "indexer": MLAAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            cache_role=SparseCacheRole.INDEXER,
+        ),
+        "dense": FullAttentionSpec(
+            block_size=block_size, num_kv_heads=1, head_size=128, dtype=torch.bfloat16
+        ),
+    }
+    layers = {}
+    for name, sizes in zip(specs, [main_sizes, indexer_sizes, [block_size]]):
+        backend = SimpleNamespace(
+            customize_spec=AttentionBackend.customize_spec,
+            get_supported_kernel_block_sizes=lambda sizes=sizes: sizes,
+        )
+        layers[name] = SimpleNamespace(
+            get_kv_cache_spec=lambda _, spec=specs[name]: spec,
+            get_attn_backend=lambda backend=backend: backend,
+        )
+    monkeypatch.setattr(attn_utils, "get_layers_from_vllm_config", lambda *_: layers)
+    config = SimpleNamespace(
+        attention_config=SimpleNamespace(hisparse_config=object() if enabled else None)
+    )
+    if expected is None:
+        with pytest.raises(ValueError, match="supported by every sparse"):
+            attn_utils.get_kv_cache_spec(config)
+        return
+
+    resolved = attn_utils.get_kv_cache_spec(config)
+    assert resolved["main"].block_size == resolved["indexer"].block_size == expected
+    assert resolved["dense"] is specs["dense"]
+    assert all(spec.block_size == block_size for spec in specs.values())
 
 
 class _FakeMetadataBuilder:

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -15,6 +15,7 @@ import torch
 from tests.v1.attention.utils import dense_kv_cache_views
 from vllm.v1.attention.backend import AttentionBackend, AttentionCGSupport, MultipleOf
 from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
+from vllm.v1.hisparse.binding import allocate_hisparse_kv_caches
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     HiSparseResidentSpec,
@@ -448,7 +449,7 @@ def test_copy_kv_cache_blocks_with_virtual_block_splitting(
             )
 
 
-def test_allocate_kv_cache_host_pool_and_view_less_specs():
+def test_allocate_hisparse_kv_caches_host_pool_and_view_less_specs():
     """Host tensors get their own backing; view-less specs keep the raw one."""
     spec = FullAttentionSpec(
         block_size=2, num_kv_heads=1, head_size=4, dtype=torch.float32
@@ -492,9 +493,14 @@ def test_allocate_kv_cache_host_pool_and_view_less_specs():
         host_buffers.append(torch.zeros(size, dtype=torch.int8))
         return host_buffers[-1]
 
-    caches = allocate_kv_cache(
-        config, torch.device("cpu"), KVCacheLayout.LBHNC, host_allocator=host_allocator
+    caches = allocate_hisparse_kv_caches(
+        config,
+        torch.device("cpu"),
+        KVCacheLayout.LBHNC,
+        [2, 2, 2],
+        SimpleNamespace(allocate=host_allocator),
     )
+    assert len(config.kv_cache_tensors) == 3
 
     assert [buf.numel() for buf in host_buffers] == [3 * page]
     assert caches["source"].shape[0] == 3

--- a/tests/v1/worker/test_kv_cache_allocation_scope.py
+++ b/tests/v1/worker/test_kv_cache_allocation_scope.py
@@ -46,13 +46,13 @@ def test_mrv2_kv_pool_only_wraps_backing_allocation(monkeypatch, hisparse) -> No
 
     hisparse_bindings = []
     if hisparse:
-        host_allocator = SimpleNamespace(registered_pools={})
+        host_pool = SimpleNamespace()
 
         def bind_hisparse(**kwargs):
             hisparse_bindings.append(kwargs)
             assert scope.active
             assert kwargs["kv_caches"] is kv_caches
-            assert kwargs["pinned_host_pools"] is host_allocator.registered_pools
+            assert kwargs["host_pool"] is host_pool
             return [
                 SimpleNamespace(
                     view=SimpleNamespace(cache=torch.empty(1, 1, 1), block_size=1),
@@ -60,10 +60,8 @@ def test_mrv2_kv_pool_only_wraps_backing_allocation(monkeypatch, hisparse) -> No
                 )
             ]
 
-        monkeypatch.setattr(
-            hisparse_binding, "HiSparseHostAllocator", lambda config: host_allocator
-        )
-        monkeypatch.setattr(hisparse_binding, "allocate_kv_cache", allocate)
+        monkeypatch.setattr(hisparse_binding, "HiSparseHostPool", lambda: host_pool)
+        monkeypatch.setattr(hisparse_binding, "allocate_hisparse_kv_caches", allocate)
         monkeypatch.setattr(hisparse_binding, "bind_hisparse_kv_caches", bind_hisparse)
 
     config = SimpleNamespace(

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeVar
@@ -25,13 +24,14 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
     from vllm.platforms.interface import DeviceCapability
     from vllm.v1.hisparse.runtime import HiSparseCacheHandle
-    from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheSpec, KVQuantMode
+    from vllm.v1.kv_cache_interface import (
+        AttentionSpec,
+        KVCacheLayout,
+        KVCacheSpec,
+        KVQuantMode,
+    )
 
-from vllm.v1.kv_cache_interface import (
-    KVCacheLayout,
-    MLAAttentionSpec,
-    get_kv_quant_mode,
-)
+from vllm.v1.kv_cache_interface import KVCacheLayout, get_kv_quant_mode
 
 
 class AttentionType(str, Enum):
@@ -50,45 +50,11 @@ class AttentionType(str, Enum):
     """Attention between dec. Q and enc. K/V for encoder-decoder."""
 
 
-@dataclass(frozen=True)
 class MultipleOf:
     base: int
 
-
-def select_common_block_size_from_constraints(
-    kv_manager_block_size: int,
-    constraints: Sequence[Sequence[int | MultipleOf]],
-) -> int:
-    """Select the largest manager-block divisor supported by every constraint."""
-
-    def is_supported(block_size: int) -> bool:
-        return all(
-            any(
-                block_size == supported
-                if isinstance(supported, int)
-                else block_size % supported.base == 0
-                for supported in sizes
-            )
-            for sizes in constraints
-        )
-
-    if not constraints or any(not sizes for sizes in constraints):
-        raise ValueError("Kernel block-size constraints must not be empty.")
-
-    if is_supported(kv_manager_block_size):
-        return kv_manager_block_size
-
-    exact_sizes = {
-        supported
-        for sizes in constraints
-        for supported in sizes
-        if isinstance(supported, int)
-    }
-    for block_size in sorted(exact_sizes, reverse=True):
-        if kv_manager_block_size % block_size == 0 and is_supported(block_size):
-            return block_size
-
-    raise ValueError(f"No common block size for {kv_manager_block_size}.")
+    def __init__(self, base: int):
+        self.base = base
 
 
 class AttentionBackend(ABC):
@@ -179,13 +145,6 @@ class AttentionBackend(ABC):
 
         (see: https://github.com/vllm-project/vllm/issues/42449)
         """
-        if isinstance(spec, MLAAttentionSpec):
-            return replace(
-                spec,
-                supported_kernel_block_sizes=tuple(
-                    cls.get_supported_kernel_block_sizes()
-                ),
-            )
         return spec
 
     @classmethod

--- a/vllm/v1/hisparse/binding.py
+++ b/vllm/v1/hisparse/binding.py
@@ -3,6 +3,7 @@
 """Worker-side wiring of HiSparse caches to attention layers."""
 
 from collections.abc import Mapping
+from copy import copy
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -22,8 +23,11 @@ from vllm.v1.kv_cache_interface import (
     HiSparseHotSpec,
     HiSparseResidentSpec,
     KVCacheConfig,
+    KVCacheLayout,
     KVCacheSpec,
     MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
+    create_kv_cache_views,
 )
 from vllm.v1.worker.utils import allocate_kv_cache, select_common_block_size
 
@@ -64,6 +68,49 @@ def resolve_hisparse_block_size(
     )
 
 
+def allocate_hisparse_kv_caches(
+    kv_cache_config: KVCacheConfig,
+    device: torch.device,
+    layout: KVCacheLayout,
+    kernel_block_sizes: list[int],
+    host_pool: HiSparseHostPool,
+) -> dict[str, torch.Tensor]:
+    """Allocate the host pool separately from the shared device backing."""
+    device_config = copy(kv_cache_config)
+    device_config.kv_cache_tensors = [
+        tensor
+        for tensor in kv_cache_config.kv_cache_tensors
+        if not tensor.host_resident
+    ]
+    kv_caches = allocate_kv_cache(device_config, device, layout, kernel_block_sizes)
+    host_tensors = [
+        tensor for tensor in kv_cache_config.kv_cache_tensors if tensor.host_resident
+    ]
+    (host_size,) = {tensor.size for tensor in host_tensors}
+    backing = host_pool.allocate(host_size)
+    (host_group_id,) = kv_cache_config.host_group_ids
+    host_spec = kv_cache_config.kv_cache_groups[host_group_id].kv_cache_spec
+    for tensor in host_tensors:
+        spec = (
+            host_spec.kv_cache_specs[tensor.layers[0]]
+            if isinstance(host_spec, UniformTypeKVCacheSpecs)
+            else host_spec
+        )
+        kernel_block_size = kernel_block_sizes[host_group_id]
+        if isinstance(spec, MLAAttentionSpec) and spec.storage_block_size is not None:
+            kernel_block_size = spec.storage_block_size
+        views = create_kv_cache_views(
+            backing,
+            spec,
+            kv_cache_config.num_blocks_of(tensor),
+            layout,
+            tensor,
+            kernel_block_size=kernel_block_size,
+        )
+        kv_caches.update(zip(tensor.layers, views))
+    return kv_caches
+
+
 def init_hisparse_kv_cache(
     kv_cache_config: KVCacheConfig,
     device: torch.device,
@@ -74,12 +121,12 @@ def init_hisparse_kv_cache(
 ) -> dict[str, torch.Tensor]:
     """Allocate and bind HiSparse caches within the caller's allocation context."""
     host_pool = HiSparseHostPool()
-    kv_caches = allocate_kv_cache(
+    kv_caches = allocate_hisparse_kv_caches(
         kv_cache_config,
         device,
         vllm_config.cache_config.get_resolved_kv_cache_layout(),
         kernel_block_sizes,
-        host_allocator=host_pool.allocate,
+        host_pool,
     )
     cache_handles = bind_hisparse_kv_caches(
         forward_context=forward_context,

--- a/vllm/v1/hisparse/binding.py
+++ b/vllm/v1/hisparse/binding.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Worker-side wiring of HiSparse caches to attention layers."""
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -13,19 +14,54 @@ from vllm.v1.hisparse.layout import (
 )
 from vllm.v1.hisparse.runtime import (
     HiSparseCacheHandle,
-    allocate_pinned_host_pool,
-    check_hisparse_host_memory,
+    HiSparseHostPool,
+    initialize_hisparse_runtime_buffers,
     release_pinned_state,
 )
 from vllm.v1.kv_cache_interface import (
     HiSparseHotSpec,
     HiSparseResidentSpec,
     KVCacheConfig,
+    KVCacheSpec,
+    MLAAttentionSpec,
 )
-from vllm.v1.worker.utils import allocate_kv_cache
+from vllm.v1.worker.utils import allocate_kv_cache, select_common_block_size
 
 if TYPE_CHECKING:
+    from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
     from vllm.v1.worker.gpu.block_table import BlockTables
+
+
+def resolve_hisparse_block_size(
+    vllm_config: VllmConfig,
+    kv_cache_spec: dict[str, KVCacheSpec],
+    attn_layers: Mapping[str, "AttentionLayerBase"],
+) -> None:
+    """Resolve a common kernel block size in-place for HiSparse MLA specs."""
+    if vllm_config.attention_config.hisparse_config is None:
+        return
+    mla_specs = {
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if isinstance(spec, MLAAttentionSpec)
+    }
+    if not mla_specs:
+        return
+    block_sizes = {spec.block_size for spec in mla_specs.values()}
+    if len(block_sizes) != 1:
+        raise ValueError("HiSparse requires one scheduler block size.")
+    backends = [attn_layers[name].get_attn_backend() for name in mla_specs]
+    try:
+        block_size = select_common_block_size(block_sizes.pop(), backends)
+    except ValueError as error:
+        raise ValueError(
+            "HiSparse requires a GPU block size supported by every sparse "
+            f"attention and indexer backend: {error}"
+        ) from error
+    kv_cache_spec.update(
+        (name, spec.copy_with_new_block_size(block_size))
+        for name, spec in mla_specs.items()
+    )
 
 
 def init_hisparse_kv_cache(
@@ -37,46 +73,27 @@ def init_hisparse_kv_cache(
     block_tables: "BlockTables",
 ) -> dict[str, torch.Tensor]:
     """Allocate and bind HiSparse caches within the caller's allocation context."""
-    host_allocator = HiSparseHostAllocator(kv_cache_config)
+    host_pool = HiSparseHostPool()
     kv_caches = allocate_kv_cache(
         kv_cache_config,
         device,
         vllm_config.cache_config.get_resolved_kv_cache_layout(),
         kernel_block_sizes,
-        host_allocator=host_allocator,
+        host_allocator=host_pool.allocate,
     )
     cache_handles = bind_hisparse_kv_caches(
         forward_context=forward_context,
         kv_cache_config=kv_cache_config,
         kv_caches=kv_caches,
         block_tables=block_tables,
-        pinned_host_pools=host_allocator.registered_pools,
+        host_pool=host_pool,
     )
-    _init_runtime_buffers(
+    initialize_hisparse_runtime_buffers(
         cache_handles,
         max_num_reqs=vllm_config.scheduler_config.max_num_seqs,
         max_num_batched_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
     )
     return kv_caches
-
-
-class HiSparseHostAllocator:
-    """Allocate the registered pinned host pool and remember it by storage."""
-
-    def __init__(self, kv_cache_config: KVCacheConfig) -> None:
-        host_sizes = {
-            tensor.size
-            for tensor in kv_cache_config.kv_cache_tensors
-            if tensor.host_resident
-        }
-        assert len(host_sizes) <= 1
-        check_hisparse_host_memory(sum(host_sizes))
-        self.registered_pools: dict[int, torch.Tensor] = {}
-
-    def __call__(self, size: int) -> torch.Tensor:
-        backing, registered = allocate_pinned_host_pool(size)
-        self.registered_pools[registered.untyped_storage().data_ptr()] = registered
-        return backing
 
 
 def _get_hisparse_cache(
@@ -120,9 +137,10 @@ def bind_hisparse_kv_caches(
     kv_cache_config: KVCacheConfig,
     kv_caches: dict[str, torch.Tensor],
     block_tables: "BlockTables",
-    pinned_host_pools: dict[int, torch.Tensor],
+    host_pool: HiSparseHostPool,
 ) -> list[HiSparseCacheHandle]:
     """Bind existing cache storage and block tables; return the bound handles."""
+    assert host_pool.registered is not None
     tensor_configs = {
         name: tensor_config
         for tensor_config in kv_cache_config.kv_cache_tensors
@@ -189,11 +207,12 @@ def bind_hisparse_kv_caches(
             ):
                 raise RuntimeError("HiSparse resident and hot layouts must match.")
             source_cache = kv_caches[layer_name]
+            assert source_cache.untyped_storage().data_ptr() == (
+                host_pool.registered.untyped_storage().data_ptr()
+            )
             cache_handle.runtime.bind_source_cache(
                 source_cache,
-                registered_host_pool=pinned_host_pools[
-                    source_cache.untyped_storage().data_ptr()
-                ],
+                registered_host_pool=host_pool.registered,
             )
             cache_handles.append(cache_handle)
             # The hot slab is raw storage owned by the runtime, not a layer
@@ -209,38 +228,3 @@ def bind_hisparse_kv_caches(
         ]
         cache_handle.mirror_slot_mapping = block_tables.slot_mappings[source_group_id]
     return cache_handles
-
-
-def _init_runtime_buffers(
-    cache_handles: list[HiSparseCacheHandle],
-    *,
-    max_num_reqs: int,
-    max_num_batched_tokens: int,
-) -> None:
-    """Allocate shared request indices and per-layer mirror staging buffers."""
-    resident = cache_handles[0].view
-    assert resident is not None
-    request_state_indices = torch.full(
-        (max_num_reqs,), -1, dtype=torch.int32, device=resident.cache.device
-    )
-    for cache_handle in cache_handles:
-        cache_handle.runtime.request_state_indices = request_state_indices
-    staging_blocks = (
-        max_num_batched_tokens + resident.block_size - 1
-    ) // resident.block_size
-    mirror_staging_caches = torch.empty(
-        (
-            len(cache_handles),
-            staging_blocks,
-            resident.block_size,
-            resident.cache.shape[-1],
-        ),
-        dtype=resident.cache.dtype,
-        device=resident.cache.device,
-    )
-    mirror_staging_slots = torch.arange(
-        max_num_batched_tokens, dtype=torch.int64, device=resident.cache.device
-    )
-    for layer_index, cache_handle in enumerate(cache_handles):
-        cache_handle.mirror_staging_cache = mirror_staging_caches[layer_index]
-        cache_handle.mirror_staging_slots = mirror_staging_slots

--- a/vllm/v1/hisparse/layout.py
+++ b/vllm/v1/hisparse/layout.py
@@ -9,7 +9,6 @@ from vllm.config import VllmConfig
 from vllm.config.kv_transfer import hisparse_host_pool_gib
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
-from vllm.v1.attention.backend import select_common_block_size_from_constraints
 from vllm.v1.hisparse.runtime import ResolvedHiSparseConfig
 from vllm.v1.kv_cache_interface import (
     HiSparseHotSpec,
@@ -126,24 +125,12 @@ def create_hisparse_layout(
     host_budget: int,
 ) -> HiSparseLayout:
     source_specs, indexer_specs = _partition_hisparse_specs(groups)
-    scheduler_block_sizes = {spec.block_size for spec in source_specs.values()}
-    scheduler_block_sizes.update(spec.block_size for spec in indexer_specs.values())
-    if len(scheduler_block_sizes) != 1:
-        raise ValueError("HiSparse requires one scheduler block size.")
-    scheduler_block_size = scheduler_block_sizes.pop()
-    constraints = [
-        spec.supported_kernel_block_sizes
-        for spec in (*source_specs.values(), *indexer_specs.values())
-    ]
-    try:
-        gpu_block_size = select_common_block_size_from_constraints(
-            scheduler_block_size, constraints
-        )
-    except ValueError as error:
-        raise ValueError(
-            "HiSparse requires a GPU block size supported by every sparse "
-            f"attention and indexer backend: {error}"
-        ) from error
+    block_sizes = {
+        spec.block_size for spec in (*source_specs.values(), *indexer_specs.values())
+    }
+    if len(block_sizes) != 1:
+        raise ValueError("HiSparse requires one resolved GPU block size.")
+    gpu_block_size = block_sizes.pop()
 
     config = ResolvedHiSparseConfig.from_vllm_config(
         vllm_config,
@@ -151,15 +138,6 @@ def create_hisparse_layout(
         gpu_block_size,
     )
     assert config is not None
-    source_specs = {
-        name: spec.copy_with_new_block_size(gpu_block_size)
-        for name, spec in source_specs.items()
-    }
-    indexer_specs = {
-        name: spec.copy_with_new_block_size(gpu_block_size)
-        for name, spec in indexer_specs.items()
-    }
-
     indexer_group_spec = UniformTypeKVCacheSpecs.from_specs(
         cast(dict[str, KVCacheSpec], indexer_specs)
     )

--- a/vllm/v1/hisparse/runtime.py
+++ b/vllm/v1/hisparse/runtime.py
@@ -182,6 +182,20 @@ def allocate_pinned_host_pool(size: int) -> tuple[torch.Tensor, torch.Tensor]:
     return registered[:size], registered
 
 
+class HiSparseHostPool:
+    """Keep the single host backing and its exact CUDA registration range."""
+
+    def __init__(self) -> None:
+        self.backing: torch.Tensor | None = None
+        self.registered: torch.Tensor | None = None
+
+    def allocate(self, size: int) -> torch.Tensor:
+        assert self.backing is None, "HiSparse host pool is already allocated."
+        check_hisparse_host_memory(size)
+        self.backing, self.registered = allocate_pinned_host_pool(size)
+        return self.backing
+
+
 def release_pinned_state(
     runtimes: list[HiSparseRuntime], pinned_host_pools: list[torch.Tensor]
 ) -> None:
@@ -987,6 +1001,42 @@ class HiSparseCacheHandle:
             attention_indices_out=attention_indices_out,
             valid_counts_out=valid_counts_out,
         )
+
+
+def initialize_hisparse_runtime_buffers(
+    cache_handles: list[HiSparseCacheHandle],
+    *,
+    max_num_reqs: int,
+    max_num_batched_tokens: int,
+) -> None:
+    """Allocate shared request state and per-layer prefill staging buffers."""
+    assert cache_handles
+    resident = cache_handles[0].view
+    assert resident is not None
+    device = resident.cache.device
+    request_state_indices = torch.full(
+        (max_num_reqs,), -1, dtype=torch.int32, device=device
+    )
+    staging_blocks = (
+        max_num_batched_tokens + resident.block_size - 1
+    ) // resident.block_size
+    mirror_staging_caches = torch.empty(
+        (
+            len(cache_handles),
+            staging_blocks,
+            resident.block_size,
+            resident.cache.shape[-1],
+        ),
+        dtype=resident.cache.dtype,
+        device=device,
+    )
+    mirror_staging_slots = torch.arange(
+        max_num_batched_tokens, dtype=torch.int64, device=device
+    )
+    for layer_index, cache_handle in enumerate(cache_handles):
+        cache_handle.runtime.request_state_indices = request_state_indices
+        cache_handle.mirror_staging_cache = mirror_staging_caches[layer_index]
+        cache_handle.mirror_staging_slots = mirror_staging_slots
 
 
 def create_hisparse_cache_handle(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -25,7 +25,6 @@ from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
-    from vllm.v1.attention.backend import MultipleOf
 
 logger = init_logger(__name__)
 
@@ -645,7 +644,6 @@ def _apply_alignment_padding(spec: MLAAttentionSpec | SlidingWindowMLASpec):
 
 @dataclass(frozen=True, kw_only=True)
 class MLAAttentionSpec(FullAttentionSpec):
-    supported_kernel_block_sizes: tuple[int | MultipleOf, ...] = ()
     # TODO(Lucas/Chen): less hacky way to do this
     cache_dtype_str: str | None = None
     # DeepseekV4 only fields. Non-DeepseekV4 MLA models leave these at defaults.
@@ -697,7 +695,6 @@ class MLAAttentionSpec(FullAttentionSpec):
             page_size_padded=specs[0].page_size_padded,
             num_head_slots=specs[0].num_head_slots,
             state_content_bytes=specs[0].state_content_bytes,
-            supported_kernel_block_sizes=specs[0].supported_kernel_block_sizes,
             cache_dtype_str=cache_dtype_str_set.pop(),
             tokens_per_state=tokens_per_state_set.pop(),
             model_version=model_version_set.pop(),

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -18,7 +18,10 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
 )
 from vllm.v1.attention.backends.utils import create_fast_prefill_custom_backend
-from vllm.v1.hisparse.binding import init_hisparse_kv_cache
+from vllm.v1.hisparse.binding import (
+    init_hisparse_kv_cache,
+    resolve_hisparse_block_size,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheConfig,
@@ -134,6 +137,7 @@ def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
             if isinstance(spec, AttentionSpec):
                 spec = attn_module.get_attn_backend().customize_spec(spec)
             kv_cache_spec[layer_name] = spec
+    resolve_hisparse_block_size(vllm_config, kv_cache_spec, attn_layers)
     return kv_cache_spec
 
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -24,7 +24,7 @@ from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionMetadataBuilder,
-    select_common_block_size_from_constraints,
+    MultipleOf,
 )
 from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
 from vllm.v1.kv_cache_interface import (
@@ -349,13 +349,51 @@ def select_common_block_size(
         ValueError: If no valid block size found.
     """
 
-    if not backends:
+    def block_size_is_supported(
+        backends: list[type[AttentionBackend]], block_size: int
+    ) -> bool:
+        """Check if the block size is supported by all backends."""
+        for backend in backends:
+            is_supported = False
+            for supported_size in backend.get_supported_kernel_block_sizes():
+                if isinstance(supported_size, int):
+                    if block_size == supported_size:
+                        is_supported = True
+                elif isinstance(supported_size, MultipleOf):
+                    if block_size % supported_size.base == 0:
+                        is_supported = True
+                else:
+                    raise ValueError(f"Unknown supported size: {supported_size}")
+            if not is_supported:
+                return False
+        return True
+
+    # Case 1: if the block_size of kv cache manager is supported by all backends,
+    # return it directly.
+    if block_size_is_supported(backends, kv_manager_block_size):
         return kv_manager_block_size
 
-    return select_common_block_size_from_constraints(
-        kv_manager_block_size,
-        [backend.get_supported_kernel_block_sizes() for backend in backends],
+    # Case 2: otherwise, the block_size must be an `int`-format supported size of
+    # at least one backend. Iterate over all `int`-format supported sizes in
+    # descending order and return the first one that is supported by all backends.
+    # Simple proof:
+    # If the supported size b is in MultipleOf(x_i) format for all attention
+    # backends i, and b a factor of kv_manager_block_size, then
+    # kv_manager_block_size also satisfies MultipleOf(x_i) for all i. We will
+    # return kv_manager_block_size in case 1.
+    all_int_supported_sizes = set(
+        supported_size
+        for backend in backends
+        for supported_size in backend.get_supported_kernel_block_sizes()
+        if isinstance(supported_size, int)
     )
+
+    for supported_size in sorted(all_int_supported_sizes, reverse=True):
+        if kv_manager_block_size % supported_size != 0:
+            continue
+        if block_size_is_supported(backends, supported_size):
+            return supported_size
+    raise ValueError(f"No common block size for {kv_manager_block_size}. ")
 
 
 def allocate_kv_cache(

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -368,32 +368,22 @@ def select_common_block_size(
                 return False
         return True
 
-    # Case 1: if the block_size of kv cache manager is supported by all backends,
-    # return it directly.
     if block_size_is_supported(backends, kv_manager_block_size):
         return kv_manager_block_size
 
-    # Case 2: otherwise, the block_size must be an `int`-format supported size of
-    # at least one backend. Iterate over all `int`-format supported sizes in
-    # descending order and return the first one that is supported by all backends.
-    # Simple proof:
-    # If the supported size b is in MultipleOf(x_i) format for all attention
-    # backends i, and b a factor of kv_manager_block_size, then
-    # kv_manager_block_size also satisfies MultipleOf(x_i) for all i. We will
-    # return kv_manager_block_size in case 1.
-    all_int_supported_sizes = set(
-        supported_size
+    # MultipleOf constraints also accept the manager size if they accept a divisor.
+    # Any remaining candidate must therefore be an explicit size from a backend.
+    candidates = {
+        size
         for backend in backends
-        for supported_size in backend.get_supported_kernel_block_sizes()
-        if isinstance(supported_size, int)
-    )
+        for size in backend.get_supported_kernel_block_sizes()
+        if isinstance(size, int) and kv_manager_block_size % size == 0
+    }
 
-    for supported_size in sorted(all_int_supported_sizes, reverse=True):
-        if kv_manager_block_size % supported_size != 0:
-            continue
-        if block_size_is_supported(backends, supported_size):
-            return supported_size
-    raise ValueError(f"No common block size for {kv_manager_block_size}. ")
+    for size in sorted(candidates, reverse=True):
+        if block_size_is_supported(backends, size):
+            return size
+    raise ValueError(f"No common block size for {kv_manager_block_size}.")
 
 
 def allocate_kv_cache(

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import math
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import product as iprod
 from typing import Any
@@ -401,21 +401,17 @@ def allocate_kv_cache(
     device: torch.device,
     layout: KVCacheLayout,
     kernel_block_sizes: list[int] | None = None,
-    host_allocator: Callable[[int], torch.Tensor] | None = None,
 ) -> dict[str, torch.Tensor]:
     """Allocate the KV cache and view it as ``[B, H, N, C]`` per layer.
 
     Every KVCacheTensor places its layers in the same backing allocation: layer ``l`` of
     block ``b`` starts at ``offset + l * layer_stride + b * block_stride``. Cache
-    groups overlay each other, so tensors may address the same bytes. Host-resident
-    tensors share a second backing, taken from ``host_allocator`` when given.
-    Layers whose spec has no per-layer view map to their backing tensor instead.
+    groups overlay each other, so tensors may address the same bytes.
     """
-    tensors = kv_cache_config.kv_cache_tensors
-    if not tensors:
+    if not kv_cache_config.kv_cache_tensors:
         return {}
 
-    sizes = {tensor.size for tensor in tensors if not tensor.host_resident}
+    sizes = {tensor.size for tensor in kv_cache_config.kv_cache_tensors}
     assert len(sizes) == 1, "KV cache tensors must share one backing allocation."
     raw_size = sizes.pop()
     # wvSplitKrc's process-lifetime static workspaces (csrc/rocm/skinny_gemms.cu)
@@ -432,21 +428,10 @@ def allocate_kv_cache(
         buf_size = ((raw_size + page_size - 1) // page_size) * page_size
     else:
         buf_size = raw_size
-    backings = {False: torch.zeros(buf_size, dtype=torch.int8, device=device)}
-
-    host_sizes = {tensor.size for tensor in tensors if tensor.host_resident}
-    assert len(host_sizes) <= 1, "Host KV cache tensors must share one backing."
-    if host_sizes:
-        host_size = host_sizes.pop()
-        backings[True] = (
-            host_allocator(host_size)
-            if host_allocator is not None
-            else torch.zeros(host_size, dtype=torch.int8, device="cpu")
-        )
+    buf = torch.zeros(buf_size, dtype=torch.int8, device=device)
 
     kv_caches: dict[str, torch.Tensor] = {}
-    for tensor in tensors:
-        buf = backings[tensor.host_resident]
+    for tensor in kv_cache_config.kv_cache_tensors:
         layer_name = tensor.layers[0]
         group_id, group = next(
             (group_id, group)
@@ -456,6 +441,7 @@ def allocate_kv_cache(
         spec = group.kv_cache_spec
         if isinstance(spec, UniformTypeKVCacheSpecs):
             spec = spec.kv_cache_specs[layer_name]
+
         if not spec.has_layer_views:
             kv_caches.update((name, buf) for name in tensor.layers)
             continue


### PR DESCRIPTION
Proposal against #53781, targeting `feat/hisparse-mla-decode-main` at e995b60e3f.

HiSparse currently carries backend block-size capabilities through `MLAAttentionSpec` so the scheduler-side layout planner can resolve cache geometry. Resolve that geometry while the worker still has the selected attention and indexer backends instead. For example, a configured 256-token block with 64-token-only kernels produces 64-token specs before layout planning.

- Remove `supported_kernel_block_sizes` from the spec and its `customize_spec` plumbing. Keep `get_kv_cache_spec` to one HiSparse helper call.
- Reuse main's existing `select_common_block_size`, removing the extra constraints helper and reverting the `MultipleOf` dataclass change. Condense its candidate selection and proof comment while preserving the preference for the manager size, then the largest compatible divisor.
- Replace the allocator's storage-pointer dictionary with a single `HiSparseHostPool`, preserving explicit CUDA registration and the existing cleanup path.
- Keep host allocation and view construction in HiSparse, passing only device tensors to the shared allocator. This removes the shared allocator's host callback and placement branching. Including the selector simplification, `worker/utils.py` against main is +36/-25.
- Move shared request-state and prefill-staging allocation into runtime initialization so cache binding only wires existing storage and block tables.

The common-size compatibility check remains. Non-HiSparse specs retain their existing block sizes.

### Relationship to other work

Checked #53781's discussion, open PRs mentioning `53781`, open HiSparse block-size PRs, and PRs targeting this base. #56008 proposes block-pool placement metadata and #56109 proposes evictable resident pages; this proposal instead addresses worker initialization and removes backend capability data from cache specs. It is intended to be merged or cherry-picked into #53781, not to replace it.

### Validation

```bash
CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest \
  tests/v1/worker/test_attn_utils.py \
  tests/v1/core/test_kv_cache_utils.py \
  tests/v1/worker/test_gpu_model_runner.py \
  tests/v1/kv_connector/unit/test_hisparse_connector.py \
  -q -k 'hisparse or allocate or (select_common_block_size and not rocm)'
```

23 passed (the invocation also included `tests/v1/worker/test_kv_cache_allocation_scope.py`, whose scope tests were deselected). Separately, `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest tests/v1/worker/test_kv_cache_allocation_scope.py -q`: 4 passed. Covers common-size selection, mixed exact/multiple constraints, incompatible backends, non-HiSparse behavior, layout geometry, and connector behavior. All applicable pre-commit hooks passed on the changed files; `git diff --check` passed.

An earlier broader CPU-only run of `test_attn_utils.py` and `test_kv_cache_utils.py` had 121 passes and 11 failures: nine copy tests require CUDA-backed pinned memory and two pipeline-parallel configuration tests require visible GPUs. That run used `CUDA_VISIBLE_DEVICES=''`.

GPU/model evaluation: not run. This is an initialization refactor with no intended output change, but end-to-end HiSparse validation remains pending.

AI assistance: OpenAI Codex assisted with implementation and validation at the submitter's direction. This is a draft proposal; the submitter's full line-by-line review and independent test run remain pending.


