### PR TITLE
[Bugfix] Run post-load processing for TensorizerLoader

### DIFF
--- a/vllm/model_executor/model_loader/tensorizer_loader.py
+++ b/vllm/model_executor/model_loader/tensorizer_loader.py
@@ -10,7 +10,10 @@ from torch import nn
 from vllm.config import ModelConfig, ParallelConfig, VllmConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
-from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+from vllm.model_executor.model_loader.base_loader import (
+    BaseModelLoader,
+    _has_online_quant,
+)
 from vllm.model_executor.model_loader.tensorizer import (
     TensorizerConfig,
     deserialize_tensorizer_model,
@@ -22,7 +25,9 @@ from vllm.model_executor.model_loader.tensorizer import (
 from vllm.model_executor.model_loader.utils import (
     get_model_architecture,
     initialize_model,
+    process_weights_after_loading,
 )
+from vllm.model_executor.model_loader.reload import finalize_layerwise_processing
 from vllm.utils.torch_utils import set_default_torch_dtype
 
 logger = init_logger(__name__)
@@ -84,6 +89,10 @@ class TensorizerLoader(BaseModelLoader):
                 model = initialize_model(vllm_config=vllm_config, prefix=prefix)
 
             model.load_weights(self._get_weights_iterator())
+        target_device = torch.device(device_config.device)
+        if _has_online_quant(model):
+            finalize_layerwise_processing(model, model_config)
+        process_weights_after_loading(model, model_config, target_device)
         return model.eval()
 
     def download_model(self, model_config: ModelConfig) -> None:
@@ -135,7 +144,11 @@ class TensorizerLoader(BaseModelLoader):
                         tensorizer_config=tensorizer_config, vllm_config=vllm_config
                     )
             self.load_weights(model, model_config)
-            return model
+            target_device = torch.device(device_config.device)
+            if _has_online_quant(model):
+                finalize_layerwise_processing(model, model_config)
+            process_weights_after_loading(model, model_config, target_device)
+            return model.eval()
         return self._load_model_serialized_cpu(vllm_config=vllm_config, prefix=prefix)
 
     @staticmethod


### PR DESCRIPTION
## Resolves Issue #55198

## Problem

`TensorizerLoader.load_model` bypasses the common `BaseModelLoader.load_model` post-load steps. Both Tensorizer paths load weights but skip `process_weights_after_loading`; the vLLM-tensorized path also returns the model without calling `.eval()`. This can leave quantized checkpoints without required derived state and can return a model in training mode.

## Reproduction

A CPU-only source inspection of the loader call paths reproduced the issue: neither `TensorizerLoader.load_model` nor `_load_model_serialized_cpu` called `process_weights_after_loading` or `finalize_layerwise_processing`, while the base loader did. The vLLM-tensorized branch also lacked an `eval()` call.

## Fix

Run the same online-quantization finalization and `process_weights_after_loading` steps in both Tensorizer branches, then return the model in evaluation mode. The target device is passed to the post-load processing helper, matching the base loader behavior.

## Testing

- CPU-only AST call-path reproduction now finds `finalize_layerwise_processing` and `process_weights_after_loading` in both Tensorizer branches.
- `python3 -m compileall -q vllm/model_executor/model_loader/tensorizer_loader.py` passes.
- `git diff --check` passes.

Closes #55198.