### PR TITLE
[Frontend] Use XGrammar schema constraints for DeepSeek V4.1

### DIFF
--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from xgrammar import Grammar, StructuralTag
+from xgrammar import Grammar, StructuralTag, builtin_structural_tag
 from xgrammar.testing import _is_grammar_accept_string
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -81,10 +81,14 @@ def test_supported_structural_tag_models_include_vllm_builtins():
 
 
 @pytest.mark.parametrize("choice", ["auto", "required", "get_weather"])
-def test_deepseek_v41_format_constraints_ignore_parameter_schema(
+def test_deepseek_v41_older_xgrammar_keeps_format_constraints(
     choice,
     sample_tools_strict,
+    monkeypatch,
 ):
+    monkeypatch.setattr(
+        builtin_structural_tag, "get_deepseek_v4_1_structural_tag", None, raising=False
+    )
     tool_choice = (
         ChatCompletionNamedToolChoiceParam(
             function=ChatCompletionNamedFunction(name=choice)
@@ -128,7 +132,11 @@ def test_deepseek_v41_named_choice_emits_one_call(sample_tools):
         reasoning=False,
     )
     grammar = Grammar.from_structural_tag(tag)
-    call = '<｜DSML｜ invoke name="get_weather">\n</｜DSML｜ invoke>\n'
+    call = (
+        '<｜DSML｜ invoke name="get_weather">\n'
+        '<｜DSML｜ parameter name="city" string="true">Paris</｜DSML｜ parameter>\n'
+        "</｜DSML｜ invoke>\n"
+    )
     assert _is_grammar_accept_string(
         grammar, "\n\n<｜DSML｜ calls>\n" + call + "</｜DSML｜ calls>"
     )
@@ -138,6 +146,72 @@ def test_deepseek_v41_named_choice_emits_one_call(sample_tools):
     assert (
         get_model_structural_tag("deepseek_v41", sample_tools, "auto", reasoning=False)
         is None
+    )
+
+
+@pytest.mark.skipif(
+    not hasattr(builtin_structural_tag, "get_deepseek_v4_1_structural_tag"),
+    reason="Requires XGrammar's DeepSeek V4.1 builtin",
+)
+@pytest.mark.parametrize("choice", ["auto", "required", "get_weather"])
+@pytest.mark.parametrize("reasoning", [False, True])
+def test_deepseek_v41_constrains_parameters_after_reasoning(
+    sample_tools_strict, choice, reasoning
+):
+    """Strict calls must enforce the schema without requiring another think close."""
+    tool_choice = (
+        ChatCompletionNamedToolChoiceParam(
+            function=ChatCompletionNamedFunction(name=choice)
+        )
+        if choice == "get_weather"
+        else choice
+    )
+    sample_tools_strict[0].function.parameters["additionalProperties"] = False
+    tag = get_model_structural_tag(
+        "deepseek_v41", sample_tools_strict, tool_choice, reasoning=reasoning
+    )
+    grammar = Grammar.from_structural_tag(tag)
+    begin = '\n\n<｜DSML｜ calls>\n<｜DSML｜ invoke name="get_weather">\n'
+    end = "</｜DSML｜ invoke>\n</｜DSML｜ calls>"
+    parameter = (
+        '<｜DSML｜ parameter name="city" string="true">Paris</｜DSML｜ parameter>\n'
+    )
+    assert _is_grammar_accept_string(grammar, begin + parameter + end)
+    for invalid in (
+        "",  # missing required city
+        parameter * 2,
+        parameter.replace('name="city"', 'name="unknown"'),
+        parameter.replace('string="true">Paris', 'string="false">42'),
+        parameter.replace("｜ parameter", "｜parameter"),
+        '{"city":"Paris"}',  # the encoder emits DSML parameters, not a JSON body
+    ):
+        assert not _is_grammar_accept_string(grammar, begin + invalid + end)
+    assert not _is_grammar_accept_string(
+        grammar, "reason</think>" + begin + parameter + end
+    )
+    assert _is_grammar_accept_string(grammar, "Hello") == (choice == "auto")
+
+
+@pytest.mark.skipif(
+    not hasattr(builtin_structural_tag, "get_deepseek_v4_1_structural_tag"),
+    reason="Requires XGrammar's DeepSeek V4.1 builtin",
+)
+def test_deepseek_v41_non_strict_parallel_calls_keep_typed_dsml(sample_tools):
+    sample_tools[0].function.strict = False
+    tag = get_model_structural_tag(
+        "deepseek_v41", sample_tools, "required", reasoning=False
+    )
+    grammar = Grammar.from_structural_tag(tag)
+    call = (
+        '<｜DSML｜ invoke name="get_weather">\n'
+        '<｜DSML｜ parameter name="extra" string="false">'
+        '{"nested":[true,null,1.5]}</｜DSML｜ parameter>\n'
+        "</｜DSML｜ invoke>\n"
+    )
+    output = "\n\n<｜DSML｜ calls>\n" + call * 2 + "</｜DSML｜ calls>"
+    assert _is_grammar_accept_string(grammar, output)
+    assert not _is_grammar_accept_string(
+        grammar, output.replace('{"nested":[true,null,1.5]}', "invalid")
     )
 
 

--- a/vllm/tool_parsers/structural_tag_registry.py
+++ b/vllm/tool_parsers/structural_tag_registry.py
@@ -10,6 +10,7 @@ from openai.types.responses.tool import Tool as ResponsesTool
 from openai.types.responses.tool_choice_allowed import ToolChoiceAllowed
 from openai.types.responses.tool_choice_function import ToolChoiceFunction
 from xgrammar import StructuralTag, normalize_tool_choice
+from xgrammar import builtin_structural_tag as xgrammar_builtin_structural_tag
 from xgrammar import get_model_structural_tag as get_xgrammar_model_structural_tag
 from xgrammar.openai_tool_call_schema import (
     BuiltinToolParam,
@@ -242,9 +243,20 @@ def get_deepseek_v41_structural_tag(
     token_suffix: str = "",
 ) -> StructuralTag:
     # Serving enables this visible-text grammar after the reasoning boundary.
+    builder = getattr(
+        xgrammar_builtin_structural_tag, "get_deepseek_v4_1_structural_tag", None
+    )
+    if builder is not None:
+        return builder(
+            tools=tools,
+            builtin_tools=builtin_tools,
+            tool_choice=tool_choice,
+            reasoning="disabled",
+        )
+
     del builtin_tools, reasoning, token_suffix
 
-    # TODO: lower parameter schemas into DSML constraints. This builder constrains
+    # Compatibility with xgrammar releases without the V4.1 builtin. This constrains
     # tool names and DSML/value syntax only. Parameter names, presence, uniqueness
     # and value schemas remain unconstrained, including for strict=true. The request
     # layer still uses strict to decide whether auto tool choice activates a grammar.


### PR DESCRIPTION
## Purpose

The Python DeepSeek V4.1 builder currently accepts missing, repeated, undeclared, and incorrectly typed parameters even with `strict=true`. Prefer XGrammar's new V4.1 builtin to enforce parameter schemas and the `string="true|false"` wire types. Serving already owns the reasoning boundary, so the delegated grammar uses `reasoning="disabled"`.

Requires the next XGrammar release. The existing format-only builder remains available for older versions. Human review of this AI-assisted draft is pending.

Duplicate-work check: #56235 changes only the Rust frontend and explicitly leaves the Python builder unchanged. This PR changes only Python's structural-tag registry and its existing tests, complementing that work. Also checked #56400 and open DeepSeek V4.1 PRs.

AI assistance: Codex implemented the change, ran local validation, and prepared this PR. Human line-by-line review and independent test execution are still pending.

## Test Plan

Tested with a development build for the next XGrammar release in an isolated environment:

```bash
.venv/bin/python -m pytest -q tests/tool_parsers/test_structural_tag_registry.py \
  tests/parser/engine/test_deepseek_v41.py --tb=short
.venv/bin/pre-commit run --files vllm/tool_parsers/structural_tag_registry.py \
  tests/tool_parsers/test_structural_tag_registry.py
```

Also installed the actual XGrammar 0.2.1 wheel into a separate target and ran the DeepSeek V4.1 registry cases with that target on `PYTHONPATH`. Native-only tests skip on older releases; the fallback tests compile real grammars and check accepted/rejected output.

## Test Result

- **110 passed** with the development build; pre-commit passed.
- XGrammar 0.2.1 compatibility: **4 passed, 7 skipped** (native-only cases), 79 deselected.
- Supplemental protocol replay: **10 passed**, **1266 next-token masks checked**, using the official encoder and tokenizer pinned to `deepseek-ai/DeepSeek-V4.1-Flash@dba1be0a40aa45a94ad051997016db3960a90277`. It covers reasoning on/off, auto/required/named choice, parallel calls, union/null/string values, nested JSON, `strict=False`, no premature EOS, and parser round-trip equality.

These are CPU protocol and parser evaluations, without model weights or inference accuracy/throughput measurements. The precompiled installation attempt could not resolve `wheels.vllm.ai`; local tests imported the current checkout with the existing extensions, Torch 2.11.0+cu130 and Transformers 5.16.1. This PR does not change kernels or model execution.

CI status after submission: upstream `pre-run-check` requires a `verified`/`ready`/`ready-run-all-tests` label or at least four merged contributions by the author. This PR has not passed that authorization gate, so upstream pre-commit has not run. DCO passed; local pre-commit passed. The gate explicitly tells AI agents not to request authorization labels.
