### PR TITLE
[Kernel][GDN] Reuse preallocated prefill output

### DIFF
--- a/tests/kernels/mamba/test_gdn_prefill_flashinfer.py
+++ b/tests/kernels/mamba/test_gdn_prefill_flashinfer.py
@@ -19,13 +19,21 @@ from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
 )  # noqa: E402
 
 
-def test_flashinfer_gdn_prefill_uses_int64_cu_seqlens(monkeypatch):
+@pytest.mark.parametrize("output_final_state", [False, True])
+def test_flashinfer_gdn_prefill_reuses_output_and_uses_int64_cu_seqlens(
+    monkeypatch, output_final_state
+):
     captured_cu_seqlens = None
+    captured_output = None
+    expected_final_state = torch.ones(1, 1, 2, 2)
 
     def fake_chunk_gated_delta_rule(**kwargs):
-        nonlocal captured_cu_seqlens
+        nonlocal captured_cu_seqlens, captured_output
         captured_cu_seqlens = kwargs["cu_seqlens"]
-        return kwargs["q"]
+        captured_output = kwargs["output"]
+        if kwargs["output_final_state"]:
+            return kwargs["output"], expected_final_state
+        return kwargs["output"]
 
     monkeypatch.setattr(
         flashinfer.gdn_prefill,
@@ -33,6 +41,7 @@ def test_flashinfer_gdn_prefill_uses_int64_cu_seqlens(monkeypatch):
         fake_chunk_gated_delta_rule,
     )
     q = torch.zeros(1, 2, 1, 2)
+    core_attn_out = torch.empty(3, 1, 2)
     cu_seqlens = torch.tensor([0, 2], dtype=torch.int32)
 
     output, final_state = fi_chunk_gated_delta_rule(
@@ -42,12 +51,19 @@ def test_flashinfer_gdn_prefill_uses_int64_cu_seqlens(monkeypatch):
         g=torch.zeros(1, 2, 1),
         beta=torch.zeros(1, 2, 1),
         initial_state=torch.zeros(1, 1, 2, 2),
-        output_final_state=False,
+        output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         use_qk_l2norm_in_kernel=False,
+        core_attn_out=core_attn_out,
     )
 
     assert captured_cu_seqlens is not None
     assert captured_cu_seqlens.dtype == torch.int64
+    assert captured_output.shape == (2, 1, 2)
+    assert captured_output.data_ptr() == core_attn_out.data_ptr()
+    assert output.data_ptr() == core_attn_out.data_ptr()
     assert output.shape == q.shape
-    assert final_state is None
+    if output_final_state:
+        assert final_state is expected_final_state
+    else:
+        assert final_state is None

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -196,6 +196,7 @@ def fi_chunk_gated_delta_rule(
     output_final_state: bool,
     cu_seqlens: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = True,
+    core_attn_out: torch.Tensor | None = None,
 ):
     from flashinfer.gdn_prefill import (
         chunk_gated_delta_rule as chunk_gated_delta_rule_fi,
@@ -217,6 +218,12 @@ def fi_chunk_gated_delta_rule(
     fi_beta = beta.to(torch.float32)
     if cu_seqlens is not None:
         cu_seqlens = cu_seqlens.to(torch.int64)
+    fi_output = None
+    if core_attn_out is not None:
+        assert core_attn_out.numel() >= v.numel(), (
+            f"core_attn_out too small: {core_attn_out.numel()} < {v.numel()}"
+        )
+        fi_output = core_attn_out.reshape(-1)[: v.numel()].view_as(v)
     result = chunk_gated_delta_rule_fi(
         q=q,
         k=k,
@@ -226,6 +233,7 @@ def fi_chunk_gated_delta_rule(
         initial_state=fi_state,
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
+        output=fi_output,
     )
     # FlashInfer returns (output, state) when output_final_state=True,
     # or just output when output_final_state=False.
@@ -285,11 +293,8 @@ class ChunkGatedDeltaRule(CustomOp):
             output_final_state=output_final_state,
             cu_seqlens=cu_seqlens,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            core_attn_out=core_attn_out,
         )
-        if core_attn_out is not None:
-            o_flat = o.squeeze(0).reshape(-1)
-            co_flat = core_attn_out.reshape(-1)
-            co_flat[: o_flat.numel()].copy_(o_flat)
         return o, final_state
 
     def forward_native(
@@ -1514,6 +1519,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             core_attn_out_decode = None
 
         # 2.3: Process the remaining part (prefill chunk, or non-spec decode-only)
+        reused_core_attn_out = False
         if attn_metadata.num_prefills > 0:
             # State indices, initial-state mask and cu_seqlens for the chunk
             # kernel are precomputed by the metadata builder (the prefill tail
@@ -1523,6 +1529,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefill_has_initial_state = attn_metadata.prefill_has_initial_state
             assert prefill_state_indices is not None
             assert prefill_has_initial_state is not None
+            reused_core_attn_out = spec_sequence_masks is None and not split_non_spec
             initial_state = ssm_state[prefill_state_indices]
             initial_state[~prefill_has_initial_state, ...] = 0
             (
@@ -1540,6 +1547,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 chunk_indices=attn_metadata.chunk_indices,
                 chunk_offsets=attn_metadata.chunk_offsets,
                 use_qk_l2norm_in_kernel=False,
+                core_attn_out=(
+                    core_attn_out[: query_non_spec.shape[1]]
+                    if reused_core_attn_out
+                    else None
+                ),
             )
             # Init cache
             ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
@@ -1586,7 +1598,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         elif spec_sequence_masks is not None:
             core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
         else:
-            core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
+            assert core_attn_out_non_spec is not None
+            if not reused_core_attn_out:
+                core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
 
     def _forward_core_decode_aiter(
         self,


### PR DESCRIPTION
## Purpose

Reuse the output buffer already allocated by `QwenGatedDeltaNetAttention`
during pure GDN prefill. The wrapper now passes that destination to
FlashInfer instead of allocating a second output and copying it back.

Mixed decode/prefill and speculative merge paths are unchanged. This is a
focused memory/copy optimization related to #53787; it does **not** claim an
end-to-end latency improvement or a complete fix for long-prefill regressions.

For Qwen3.6-35B-A3B at TP=2, each rank has 16 BF16 value heads of width 128.
At 32K tokens, the redundant output is 128 MiB per rank. Across 30
linear-attention layers, the old path also copies 3.75 GiB of output payload
per rank per request.

## Test Plan

- run the focused wrapper test for output aliasing, oversized destination
  slicing, int64 `cu_seqlens`, and both final-state return modes
- compare allocator peaks for the real FlashInfer shape `[32768, 16, 128]`
- compare real Qwen3.6-35B-A3B-FP8 TP2 compiled prefills at 4K/16K/32K
  contexts in fresh processes
- rerun a fresh-process 32K pair from exact upstream `b5d4186300`

## Test Result

- RTX 5090 SM120, CUDA 13.0, Torch 2.13, FlashInfer 0.6.18
- focused repository test: 2 passed
- Ruff and Python compile checks passed on the changed files
- focused allocator comparison, four alternating repeats:
  - old-path temporary peak: 135,266,304 bytes
  - reused-path temporary peak: 1,048,576 bytes
  - net reduction: 134,217,728 bytes (128 MiB)
  - outputs are bitwise identical and the returned tensor aliases the supplied
    output buffer
- real Qwen3.6-35B-A3B-FP8, TP=2, compiled vLLM, 4K/16K/32K contexts,
  two fresh-process paired repeats:
  - token IDs and selected logprobs: 24/24 identical
  - paired speedups: 0.9985x and 1.0019x
  - pooled speedup: 1.0002x (latency neutral)
- exact upstream `b5d4186300`, fresh-process 32K confirmation:
  - token IDs and selected logprobs: 4/4 identical
  - control: 1328.90 ms; candidate: 1331.19 ms; 0.9983x (latency neutral)

The whole-engine activation peak remains 1.42 GiB because another operator
dominates it. The claim here is limited to removing this redundant GDN
allocation and copy.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose and claim boundary are stated; related issue: #53787.
- [x] The test plan is provided.
- [x] Focused and real-model test results are provided.
- [x] No documentation update is required for this internal memory optimization.

</details>

