### PR TITLE
[Bugfix][Offload] Avoid duplicate host allocation for UVA weights

### DIFF
--- a/tests/model_executor/offloader/test_uva.py
+++ b/tests/model_executor/offloader/test_uva.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.offloader.uva import UVAOffloader
+
+
+class _FakeCpuData:
+    def __init__(self):
+        self.pin_memory_calls = 0
+
+    def to(self, *, device):
+        assert device == "cpu"
+        return self
+
+    def pin_memory(self):
+        self.pin_memory_calls += 1
+        return self
+
+    def numel(self):
+        return 1
+
+    def element_size(self):
+        return 4
+
+
+class _FakeParameter:
+    def __init__(self):
+        self.device = torch.device("cuda")
+        self.data = _FakeCpuData()
+
+
+class _FakeModule:
+    def __init__(self):
+        self.parameter = _FakeParameter()
+
+    def parameters(self):
+        yield self.parameter
+
+    def named_parameters(self):
+        yield "weight", self.parameter
+
+    def forward(self):
+        pass
+
+
+@pytest.mark.parametrize("uva_offloading, expected_pin_calls", [(True, 0), (False, 1)])
+def test_uva_offloader_only_pins_fallback_cpu_weights(
+    monkeypatch, uva_offloading, expected_pin_calls
+):
+    offloader = object.__new__(UVAOffloader)
+    offloader.cpu_offload_max_bytes = 1024
+    offloader.cpu_offload_bytes = 0
+    offloader.cpu_offload_params = set()
+    offloader.pin_memory = True
+    offloader.uva_offloading = uva_offloading
+
+    if uva_offloading:
+        monkeypatch.setattr(
+            "vllm.model_executor.offloader.uva.get_accelerator_view_from_cpu_tensor",
+            lambda tensor: tensor,
+        )
+
+    module = _FakeModule()
+    offloader._maybe_offload_to_cpu(module)
+
+    assert module.parameter.data.pin_memory_calls == expected_pin_calls

--- a/vllm/model_executor/offloader/uva.py
+++ b/vllm/model_executor/offloader/uva.py
@@ -83,8 +83,8 @@ class UVAOffloader(BaseOffloader):
         if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
             return module
 
-        # offload parameters to CPU
-        # use pin_memory if possible, which helps cudagraph capture speed
+        # Pin only the fallback path; the UVA helper allocates mapped host
+        # memory for unpinned tensors.
         offloaded_parameters = False
         for name, p in module.named_parameters():
             if self.cpu_offload_bytes >= self.cpu_offload_max_bytes:
@@ -111,7 +111,7 @@ class UVAOffloader(BaseOffloader):
                     continue
 
             cpu_data = p.data.to(device="cpu")
-            if self.pin_memory:
+            if self.pin_memory and not self.uva_offloading:
                 cpu_data = cpu_data.pin_memory()
 
             if not self.uva_offloading:


### PR DESCRIPTION
## Summary

- Avoid pinning CPU tensors before the UVA helper allocates its mapped host buffer.
- Preserve pinned memory for the non-UVA fallback, where it enables asynchronous host-to-device copies.
- Add a CPU-only regression test covering both paths.

Fixes #56410

## Why this is not duplicate work

Issue #56410 is open and unassigned. Its reporter provided a reproduction showing that `--cpu-offload-gb` can consume about 1.9x the requested host memory when UVA is enabled, and explicitly stated that they are not planning to open a PR. I checked the issue comments and searched all open PR titles/bodies for `56410`, `cpu-offload-gb`, `UVAOffloader`, and `uva_offloading`; no PR addresses this fix. The related offload PRs found by keyword concern different functionality.

## Validation

- `uvx ruff check vllm/model_executor/offloader/uva.py tests/model_executor/offloader/test_uva.py`
- `uvx ruff format --check vllm/model_executor/offloader/uva.py tests/model_executor/offloader/test_uva.py`
- `uv run --no-sync python -m pytest tests/model_executor/offloader/test_uva.py tests/model_executor/offloader/test_prefetch.py -q --confcutdir=tests/model_executor/offloader` — 8 passed
- `git diff --check`

The test host has no CUDA runtime, so I did not run a GPU memory measurement. The change does not affect model outputs, so no model evaluation is applicable.

## AI assistance

AI assistance was used to inspect the repository, audit duplicate work, implement the focused change, and run the checks above. The human submitter will review and understand every changed line and the behavior before responding to review.