### PR TITLE
[Bugfix][Pooling] Restore token limits for offline Jina scoring

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
+++ b/tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
@@ -1,15 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for JinaRankingIOProcessor online request building."""
+"""Unit tests for JinaRankingIOProcessor request building."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from tokenizers import Tokenizer, models, pre_tokenizers
+from transformers import PreTrainedTokenizerFast
 
+from vllm import PoolingParams
 from vllm.entrypoints.pooling.base.io_processor import PoolingIOProcessor
 from vllm.entrypoints.pooling.scoring.io_processor import JinaRankingIOProcessor
 from vllm.entrypoints.pooling.scoring.protocol import RerankRequest
 from vllm.entrypoints.pooling.scoring.typing import ScoringData
+from vllm.entrypoints.pooling.typing import OfflineScoringInputsContext
+from vllm.renderers import TokenizeParams
 
 pytestmark = pytest.mark.skip_global_cleanup
 
@@ -57,3 +63,82 @@ def test_online_forwards_truncate_prompt_tokens_to_proxy(monkeypatch):
     assert captured["truncation_side"] == "left"
     # The real request is restored after delegating.
     assert ctx.request is request
+
+
+@pytest.fixture
+def offline_processor_and_context():
+    backend = Tokenizer(models.WordLevel({"[UNK]": 0}, unk_token="[UNK]"))
+    backend.pre_tokenizer = pre_tokenizers.WhitespaceSplit()
+    proc = JinaRankingIOProcessor.__new__(JinaRankingIOProcessor)
+    proc.tokenizer = PreTrainedTokenizerFast(tokenizer_object=backend)
+    proc.model_config = SimpleNamespace(max_model_len=1024, is_encoder_decoder=False)
+    proc.renderer = SimpleNamespace(
+        default_cmpl_tok_params=TokenizeParams(max_total_tokens=1024)
+    )
+    ctx = OfflineScoringInputsContext(
+        pooling_task="token_embed",
+        scoring_data=ScoringData(
+            data_1=["query alpha beta", "query gamma delta"],
+            data_2=["document one two", "document three four"],
+        ),
+        pooling_params=PoolingParams(
+            extra_kwargs={
+                "chat_template_kwargs": {"instruction": "Keep this instruction"}
+            }
+        ),
+        tokenization_kwargs=None,
+        chat_template=None,
+        lora_request=None,
+        priorities=None,
+    )
+    return proc, ctx
+
+
+@pytest.mark.parametrize(
+    ("query_limit", "doc_limit", "n_queries"),
+    [(None, None, 1), (0, 0, 2), (1, None, 1), (None, 2, 1), (1, 2, 1), (1, 2, 2)],
+    ids=["unset", "zero", "query", "doc", "both-1-to-n", "both-n-to-n"],
+)
+def test_offline_truncates_text_before_formatting(
+    offline_processor_and_context, query_limit, doc_limit, n_queries
+):
+    proc, ctx = offline_processor_and_context
+    queries = ctx.scoring_data.data_1[:n_queries]
+    docs = ctx.scoring_data.data_2
+    ctx.scoring_data = ScoringData(data_1=queries, data_2=docs)
+    ctx.pooling_params.extra_kwargs.update(
+        {
+            name: limit
+            for name, limit in (
+                ("max_tokens_per_query", query_limit),
+                ("max_tokens_per_doc", doc_limit),
+            )
+            if limit is not None
+        }
+    )
+
+    factory, num_requests = proc.get_request_factory_offline(ctx)
+    requests = list(factory())
+    assert len(requests) == num_requests == n_queries
+    for i, request in enumerate(requests):
+        prompt = request["prompts"]["prompt"]
+        query = " ".join(queries[i].split()[: query_limit or None])
+        assert f"<query>\n{query}<|rerank_token|>\n</query>" in prompt
+        prompt_docs = docs if n_queries == 1 else [docs[i]]
+        for j, doc in enumerate(prompt_docs):
+            doc = " ".join(doc.split()[: doc_limit or None])
+            assert f'<passage id="{j}">\n{doc}<|embed_token|>\n</passage>' in prompt
+        assert prompt.count("<|embed_token|>") == len(prompt_docs)
+        assert prompt.count("<|rerank_token|>") == 1
+        assert "<instruct>\nKeep this instruction\n</instruct>" in prompt
+
+
+@pytest.mark.parametrize("name", ["max_tokens_per_query", "max_tokens_per_doc"])
+@pytest.mark.parametrize("limit", [-1, 1024])
+def test_offline_rejects_invalid_token_limits(
+    offline_processor_and_context, name, limit
+):
+    proc, ctx = offline_processor_and_context
+    ctx.pooling_params.extra_kwargs[name] = limit
+    with pytest.raises(ValueError, match=name):
+        proc.get_request_factory_offline(ctx)

--- a/vllm/entrypoints/pooling/scoring/io_processor.py
+++ b/vllm/entrypoints/pooling/scoring/io_processor.py
@@ -845,7 +845,14 @@ class JinaRankingIOProcessor(LateInteractionIOProcessor, JinaRankingIOProcessorM
     ) -> tuple[RequestFactory, int]:
         assert isinstance(ctx, OfflineScoringInputsContext)
 
+        max_tokens_per_query, max_tokens_per_doc = self._get_token_limits(
+            pooling_params=ctx.pooling_params
+        )
         scoring_data = ctx.scoring_data
+        if max_tokens_per_query > 0 or max_tokens_per_doc > 0:
+            scoring_data = self._truncate_scoring_data(
+                scoring_data, max_tokens_per_query, max_tokens_per_doc
+            )
         prompt_extras = ctx.pooling_params.extra_kwargs
 
         queries = self.ensure_str(scoring_data.data_1)


### PR DESCRIPTION
## Purpose

`LLM.score()` with `jinaai/jina-reranker-v3` silently ignores `max_tokens_per_query` and `max_tokens_per_doc` passed through `PoolingParams.extra_kwargs`. Long inputs remain untruncated and can fail the model's input-length check even when these limits are set.

Jina previously inherited this truncation from the bi-encoder's offline preprocessing. It was omitted when [#47699](https://github.com/vllm-project/vllm/pull/47699) moved that path to request factories. Restore it by reusing the existing token-limit validation and truncation helpers before formatting the query and documents, matching Jina's online path. Unset or zero limits retain the current behavior, and custom instructions are preserved.

## Test Plan

Extend the existing Jina unit tests to cover query-only, document-only, and combined limits, unset and zero limits, 1:N and N:N inputs, and invalid limits. Check the resulting prompts, including document order, ranking markers, and the instruction.

Run the focused CPU suite with the repository's parent conftest excluded:

```bash
VLLM_TARGET_DEVICE=cpu PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$PWD" \
  .venv/bin/python -m pytest --confcutdir=tests/entrypoints/pooling/scoring \
  tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py \
  -q -p no:cacheprovider

PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --files \
  vllm/entrypoints/pooling/scoring/io_processor.py \
  tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py

PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run mypy-3.12 \
  --hook-stage manual --files \
  vllm/entrypoints/pooling/scoring/io_processor.py \
  tests/entrypoints/pooling/scoring/test_jina_ranking_io_processor_unit.py
```

## Test Result

- Before the fix: **8 failed, 3 passed** with the same test suite.
- After the fix: **11 passed** on macOS with CPU dependencies.
- All applicable pre-commit checks and the separate mypy 3.12 check passed.

Also ran before/after offline end-to-end tests on a single A10 with `jinaai/jina-reranker-v3`, using the real `LLM.score()` path and model weights:

- Covered 12 combinations: 1:1, 1:N, and N:N inputs, each with no limits, query-only, document-only, and both limits. Before the fix, setting limits had no effect. After the fix, prompt token IDs and scores matched a control that manually truncated the input text with the model's tokenizer; the observed score difference was zero. Unrestricted inputs produced identical tokens and scores before and after the fix.
- For the long 1:1 input, setting both limits to 10 reduced the full prompt from 567 to 177 tokens. With `max_model_len=256`, the baseline raised an input-length error; the fixed version completed scoring.
- Custom-instruction checks also passed.

Checked related open, closed, and merged PRs on September 11, 2026; no equivalent fix was found. [#55200](https://github.com/vllm-project/vllm/pull/55200) checks for ranking markers lost during whole-prompt truncation; this change restores query/document truncation before prompt formatting. The changes can be merged independently.

AI assistance: Codex helped with the investigation, implementation, and tests.
