### PR TITLE
[Bugfix][V1] Fail pending utility RPCs when the output receiver stops

### DIFF
--- a/tests/v1/engine/test_core_client_utility.py
+++ b/tests/v1/engine/test_core_client_utility.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Exercise utility RPC lifecycles without starting a model or EngineCore."""
+
+import asyncio
+import weakref
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import msgspec
+import pytest
+import pytest_asyncio
+import zmq
+import zmq.asyncio
+
+from vllm.v1.engine import (
+    EEP_NOTIFICATION_CALL_ID,
+    EngineCoreOutputs,
+    UtilityOutput,
+    UtilityResult,
+)
+from vllm.v1.engine.core_client import (
+    AsyncMPClient,
+    BackgroundResources,
+    DPLBAsyncMPClient,
+    MPClient,
+    SyncMPClient,
+)
+from vllm.v1.engine.exceptions import EngineDeadError
+from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
+
+
+@pytest_asyncio.fixture
+async def utility_client(monkeypatch):
+    clients = []
+
+    def init(self, asyncio_mode, vllm_config, *args, **kwargs):
+        ctx = zmq.Context()
+        self.ctx = zmq.asyncio.Context(ctx) if asyncio_mode else ctx
+        self.vllm_config = vllm_config
+        self.resources = BackgroundResources(ctx=ctx)
+        self._finalizer = weakref.finalize(self, self.resources)
+        self.input_socket = self.resources.input_socket = self.ctx.socket(zmq.ROUTER)
+        self.resources.output_socket = self.ctx.socket(zmq.PULL)
+        self.input_socket.bind("inproc://utility-input")
+        self.resources.output_socket.bind("inproc://utility-output")
+        self.encoder = MsgpackEncoder()
+        self.decoder = MsgpackDecoder(EngineCoreOutputs)
+        self.core_engine = b"\x00\x00"
+        self.utility_results = {}
+
+        peer_input, peer_output = ctx.socket(zmq.DEALER), ctx.socket(zmq.PUSH)
+        peer_input.setsockopt(zmq.IDENTITY, self.core_engine)
+        peer_input.setsockopt(zmq.RCVTIMEO, 5000)
+        peer_input.connect("inproc://utility-input")
+        peer_output.connect("inproc://utility-output")
+        peer_input.send(b"ready")
+        assert zmq.Socket.shadow(self.input_socket).recv_multipart() == [
+            self.core_engine,
+            b"ready",
+        ]
+        clients.append((self, peer_input, peer_output))
+
+    monkeypatch.setattr(MPClient, "__init__", init)
+
+    def create(asyncio_mode):
+        config = SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                data_parallel_size=1, enable_fault_tolerance=False
+            )
+        )
+        client_cls = AsyncMPClient if asyncio_mode else SyncMPClient
+        client_cls(config, None, False)
+        return clients[-1]
+
+    yield create
+
+    for client, peer_input, peer_output in clients:
+        # Release waiters even when testing the broken implementation.
+        for future in list(client.utility_results.values()):
+            if not future.done():
+                future.cancel()
+        if isinstance(client, SyncMPClient):
+            if not client.output_queue_thread.is_alive():
+                client.resources.shutdown_path = None
+            client.shutdown()
+            await asyncio.to_thread(client.output_queue_thread.join, 5)
+            assert not client.output_queue_thread.is_alive()
+        else:
+            client.shutdown()
+            await asyncio.gather(
+                client.resources.output_queue_task, return_exceptions=True
+            )
+        peer_input.close(linger=0)
+        peer_output.close(linger=0)
+        client.resources.ctx.term()
+
+
+async def _receive_call(peer_input):
+    frames = await asyncio.to_thread(peer_input.recv_multipart)
+    return msgspec.msgpack.decode(frames[1])[1]
+
+
+def _reply(peer_output, call_id):
+    output = EngineCoreOutputs(
+        utility_output=UtilityOutput(call_id=call_id, result=UtilityResult("ok"))
+    )
+    peer_output.send_multipart(MsgpackEncoder().encode(output))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asyncio_mode", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize("stop", ["shutdown", "engine_dead", "decode_error"])
+async def test_receiver_stop_fails_pending_utility(utility_client, asyncio_mode, stop):
+    client, peer_input, peer_output = utility_client(asyncio_mode)
+
+    async def call():
+        if asyncio_mode:
+            return await client.call_utility_async("echo")
+        return await asyncio.to_thread(client.call_utility, "echo")
+
+    completed = asyncio.create_task(call())
+    _reply(peer_output, await _receive_call(peer_input))
+    assert await asyncio.wait_for(completed, 5) == "ok"
+
+    pending = asyncio.create_task(call())
+    await _receive_call(peer_input)
+    error = EngineDeadError
+    if stop == "shutdown":
+        client.shutdown()
+    else:
+        peer_output.send(b"ENGINE_CORE_DEAD" if stop == "engine_dead" else b"\xc1")
+        if stop == "decode_error":
+            error = msgspec.DecodeError
+    try:
+        with pytest.raises(error):
+            await asyncio.wait_for(asyncio.shield(pending), 5)
+        assert not client.utility_results
+    finally:
+        for future in list(client.utility_results.values()):
+            if not future.done():
+                future.cancel()
+        await asyncio.gather(pending, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_receiver_cancelled_before_start_fails_pending_utility(utility_client):
+    client, _, _ = utility_client(True)
+    pending = asyncio.get_running_loop().create_future()
+    client.utility_results[1] = pending
+    client.resources.output_queue_task.cancel()
+
+    with pytest.raises(EngineDeadError):
+        await asyncio.wait_for(asyncio.shield(pending), 5)
+    assert not client.utility_results
+
+
+@pytest.mark.asyncio
+async def test_cancelled_utility_late_response_keeps_receiver_alive(utility_client):
+    client, peer_input, peer_output = utility_client(True)
+    cancelled = asyncio.create_task(client.call_utility_async("echo"))
+    call_id = await _receive_call(peer_input)
+    cancelled.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled
+    _reply(peer_output, call_id)
+
+    completed = asyncio.create_task(client.call_utility_async("echo"))
+    _reply(peer_output, await _receive_call(peer_input))
+    assert await asyncio.wait_for(completed, 5) == "ok"
+    assert not client.resources.output_queue_task.done()
+    assert not client.utility_results
+
+
+@pytest.mark.asyncio
+async def test_send_error_after_receiver_failure_cleans_pending_utility(
+    utility_client, monkeypatch
+):
+    client, _, peer_output = utility_client(True)
+    sending, release = asyncio.Event(), asyncio.Event()
+
+    async def send(*args):
+        sending.set()
+        await release.wait()
+        raise RuntimeError("send failed")
+
+    monkeypatch.setattr(client, "_send_input_message", send)
+    pending = asyncio.create_task(client.call_utility_async("echo"))
+    await asyncio.wait_for(sending.wait(), 5)
+    peer_output.send(b"ENGINE_CORE_DEAD")
+    await asyncio.wait_for(client.resources.output_queue_task, 5)
+    release.set()
+    with pytest.raises(RuntimeError, match="send failed"):
+        await pending
+    assert not client.utility_results
+
+
+@pytest.mark.asyncio
+async def test_cancelled_eep_commit_cancels_notification_waiter(monkeypatch):
+    client = DPLBAsyncMPClient.__new__(DPLBAsyncMPClient)
+    client.core_engines = [b"\x00\x00"]
+    client.utility_results = {}
+    monkeypatch.setattr(client, "_ensure_output_queue_task", lambda: None)
+    monkeypatch.setattr(client, "pause_scheduler_async", AsyncMock())
+    committing = asyncio.Event()
+
+    async def commit(*args, **kwargs):
+        committing.set()
+        await asyncio.get_running_loop().create_future()
+
+    monkeypatch.setattr(client, "_call_utility_async", commit)
+    pending = asyncio.create_task(client._commit_scale_up_elastic_ep(2))
+    await asyncio.wait_for(committing.wait(), 5)
+    notification = client.utility_results[EEP_NOTIFICATION_CALL_ID]
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    assert notification.cancelled()

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from collections.abc import Awaitable, Callable, Sequence
 from concurrent.futures import Future
+from concurrent.futures import InvalidStateError as FutureInvalidStateError
 from dataclasses import dataclass
 from multiprocessing.connection import Connection
 from multiprocessing.queues import Queue
@@ -844,11 +845,27 @@ class MPClient(EngineCoreClient):
                 assert response.dp_stats_address == self.stats_update_address
 
 
+def _fail_pending_utility_calls(
+    utility_results: dict[int, AnyFuture], error: Exception
+) -> None:
+    while True:
+        try:
+            _, future = utility_results.popitem()
+        except KeyError:
+            return
+        # A caller may have cancelled or already completed its future.
+        with contextlib.suppress(asyncio.InvalidStateError, FutureInvalidStateError):
+            future.set_exception(error)
+
+
 def _process_utility_output(
     output: UtilityOutput, utility_results: dict[int, AnyFuture]
 ):
     """Set the result from a utility method in the waiting future."""
-    future = utility_results.pop(output.call_id)
+    future = utility_results.pop(output.call_id, None)
+    if future is None:
+        # The call may have been cancelled or failed during receiver cleanup.
+        return
     failure_message = output.failure_message
     try:
         if failure_message is not None:
@@ -903,6 +920,7 @@ class SyncMPClient(MPClient):
         def process_outputs_socket():
             assert isinstance(out_socket, zmq.Socket)
             shutdown_socket = ctx.socket(zmq.PAIR)
+            error: Exception = EngineDeadError()
             try:
                 shutdown_socket.bind(shutdown_path)
                 poller = zmq.Poller()
@@ -924,8 +942,11 @@ class SyncMPClient(MPClient):
                     else:
                         outputs_queue.put_nowait(outputs)
             except Exception as e:
+                error = e
                 outputs_queue.put_nowait(e)
             finally:
+                resources.engine_dead = True
+                _fail_pending_utility_calls(utility_results, error)
                 # Close sockets.
                 shutdown_socket.close(linger=0)
                 out_socket.close(linger=0)
@@ -966,9 +987,11 @@ class SyncMPClient(MPClient):
         call_id = uuid.uuid1().int >> 64
         future: Future[Any] = Future()
         self.utility_results[call_id] = future
-        self._send_input(EngineCoreRequestType.UTILITY, (0, call_id, method, args))
-
-        return future.result()
+        try:
+            self._send_input(EngineCoreRequestType.UTILITY, (0, call_id, method, args))
+            return future.result()
+        finally:
+            self.utility_results.pop(call_id, None)
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         return self.call_utility("get_supported_tasks")
@@ -1109,6 +1132,7 @@ class AsyncMPClient(MPClient):
         ) = getattr(self.__class__, "eep_process_engine_core_notification", None)
 
         async def process_outputs_socket():
+            error: Exception = EngineDeadError()
             try:
                 while True:
                     frames = await output_socket.recv_multipart(copy=False)
@@ -1156,13 +1180,26 @@ class AsyncMPClient(MPClient):
                     if outputs.outputs or outputs.scheduler_stats:
                         outputs_queue.put_nowait(outputs)
             except Exception as e:
+                error = e
                 outputs_queue.put_nowait(e)
             except asyncio.CancelledError:
-                outputs_queue.put_nowait(EngineDeadError())
+                outputs_queue.put_nowait(error)
+            finally:
+                resources.engine_dead = True
+                _fail_pending_utility_calls(utility_results, error)
+
+        def on_output_queue_done(task: asyncio.Task) -> None:
+            # A task cancelled before its first step never enters the finally block.
+            if task.cancelled():
+                resources.engine_dead = True
+                error = EngineDeadError()
+                outputs_queue.put_nowait(error)
+                _fail_pending_utility_calls(utility_results, error)
 
         resources.output_queue_task = asyncio.create_task(
             process_outputs_socket(), name="EngineCoreOutputQueueTask"
         )
+        resources.output_queue_task.add_done_callback(on_output_queue_done)
 
     async def get_output_async(self) -> EngineCoreOutputs:
         self._ensure_output_queue_task()
@@ -1205,13 +1242,17 @@ class AsyncMPClient(MPClient):
         call_id = uuid.uuid1().int >> 64
         future = asyncio.get_running_loop().create_future()
         self.utility_results[call_id] = future
-        message = (
-            EngineCoreRequestType.UTILITY.value,
-            *self.encoder.encode((self.client_index, call_id, method, args)),
-        )
-        await self._send_input_message(message, engine)
-        self._ensure_output_queue_task()
-        return await future
+        try:
+            message = (
+                EngineCoreRequestType.UTILITY.value,
+                *self.encoder.encode((self.client_index, call_id, method, args)),
+            )
+            await self._send_input_message(message, engine)
+            self._ensure_output_queue_task()
+            return await future
+        finally:
+            self.utility_results.pop(call_id, None)
+            future.cancel()
 
     async def get_supported_tasks_async(self) -> tuple[SupportedTask, ...]:
         return await self.call_utility_async("get_supported_tasks")
@@ -1859,9 +1900,8 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             await asyncio.gather(*finish_futures)
             await wait_future
             self._wait_for_new_engine_ready(new_core_engines)
-        except Exception:
+        finally:
             wait_future.cancel()
-            raise
 
         self.core_engines.extend(new_core_engines)
         # Update the parallel config
@@ -1953,9 +1993,8 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             await self.first_req_send_socket.send(scale_down_marker)
             await wait_future
             await self.resume_scheduler_async()
-        except Exception:
+        finally:
             wait_future.cancel()
-            raise
 
         logger.info(
             "[Elastic EP] Scale down completed, new data parallel size: %s",


### PR DESCRIPTION
## Purpose

If EngineCore dies before replying to a utility call, operations such as pause, reset, or sleep can remain blocked after the output receiver has stopped. Receiver errors are forwarded to the output queue, but these callers wait on separate futures that never receive the failure. Both sync and async clients are affected.

Fail pending utility futures when the receiver exits, including shutdown and cancellation before the async receiver starts. Also clean up calls that fail or are cancelled while sending, tolerate late responses, and cancel EEP notification waiters when reconfiguration is cancelled.

## Test Plan

Add CPU regressions using real ZMQ sockets and the production client methods, covering receiver shutdown/errors, cancellation, late responses, send failure, and EEP waiter cleanup.

```bash
VLLM_TARGET_DEVICE=cpu PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$PWD" \
  .venv/bin/python -m pytest tests/v1/engine/test_core_client_utility.py \
  -q -p no:cacheprovider

.venv/bin/pre-commit run --files \
  vllm/v1/engine/core_client.py tests/v1/engine/test_core_client_utility.py

.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files \
  vllm/v1/engine/core_client.py tests/v1/engine/test_core_client_utility.py
```

## Test Result

- Before the fix: **9 failed, 1 passed** with the same test suite on `4b839c3378`.
- After the fix: **10 passed** on macOS with CPU dependencies.
- All applicable pre-commit checks and the separate mypy 3.12 check passed.

Also ran before/after EngineCore integration smoke tests on a single A10 with `Qwen/Qwen3.5-0.8B`. A deferred test utility confirms that the call has reached the real EngineCore without completing its response; the test then sends SIGKILL to that EngineCore.

- Before the fix, both sync and async utility calls were still pending two seconds after their receivers exited.
- After the fix, both calls raised `EngineDeadError` and the pending-call maps were empty.
- Normal generation produced identical token IDs across all four runs, and pause/resume controls passed.

Also reported in [this CodeRabbit review comment on #55274](https://github.com/vllm-project/vllm/pull/55274#discussion_r3930659253). Checked related open, closed, and merged PRs on September 11, 2026; no equivalent fix was found. The health-probe timeout in [#36451](https://github.com/vllm-project/vllm/pull/36451) addresses an engine that remains alive but unresponsive; this change propagates failure once the receiver has stopped.

AI assistance: Codex helped with the investigation, implementation, and tests.
