### PR TITLE
[CI] Spawn isolated Maverick distributed tests

### DIFF
--- a/tests/models/multimodal/generation/test_maverick.py
+++ b/tests/models/multimodal/generation/test_maverick.py
@@ -24,7 +24,7 @@ from vllm import LLM, SamplingParams
 from vllm.v1.executor.abstract import Executor
 from vllm.v1.kv_cache_interface import ChunkedLocalAttentionSpec, FullAttentionSpec
 
-from ....utils import multi_gpu_test
+from ....utils import create_new_process_for_each_test, multi_gpu_marks
 
 # Sample prompts for testing
 PROMPTS: list[str] = [
@@ -593,13 +593,15 @@ def run_reduced_model(llm: LLM, should_profile: bool = False) -> None:
         print("-" * 40)
 
 
-@multi_gpu_test(num_gpus=2)
+@create_new_process_for_each_test("spawn")
 @pytest.mark.parametrize(
     "original_model_name,text_layers,num_experts,vision_layers,",
     [("meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", 4, 4, 2)],
 )
 @pytest.mark.parametrize("enforce_eager", [True, False])
-@pytest.mark.parametrize("tp,ep", [(2, True)])
+@pytest.mark.parametrize(
+    "tp,ep", [pytest.param(2, True, marks=multi_gpu_marks(num_gpus=2))]
+)
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_dummy_maverick(
     monkeypatch,
@@ -616,6 +618,7 @@ def test_dummy_maverick(
 ) -> None:
     # Disable multiprocessing allows us to access model executor from LLM engine
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
 
     model_path = create_reduced_maverick_model(
         original_model_name=original_model_name,


### PR DESCRIPTION
Both `test_dummy_maverick` variants fail in [main CI build 88260](https://buildkite.com/vllm/ci/builds/88260#01a08f27-1486-4c40-9985-6bdf9c69bbfe) before generation: the tensor-parallel workers raise `Cannot re-initialize CUDA in forked subprocess`. The test uses `multi_gpu_test`, which forks the pytest process on CUDA and can inherit CUDA state initialized during collection or preceding tests.

Run Maverick in a fresh interpreter with the existing spawn helper, and explicitly spawn its TP workers. Preserve the two-GPU distributed selector, hardware skip, eager/compiled cases, and in-process engine inspection.

Validation:
- `pre-commit run --files tests/models/multimodal/generation/test_maverick.py` — passed, including mypy.
- GPU validation will run on the L4 Distributed Models shards; it has not passed yet. This development machine has no CUDA GPUs.
- No model implementation or expected outputs changed; the existing Maverick generation test is the runtime validation.

Duplicate check: searched open PRs and issues for Maverick with fork/spawn; no existing PR addresses this test isolation failure. #52231 is broader ROCm batch invariance work.

AI assistance: OpenAI Codex helped investigate logs and implement this change. Human review of the changed lines is still required before merge.

Targeted GPU CI: https://buildkite.com/vllm/ci/builds/88281 (exact PR head; bootstrap passed, image build/test shards pending).
