### PR TITLE
[ROCm] Match sparse indexer call to registered schema

### DIFF
--- a/tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
+++ b/tests/kernels/attention/test_rocm_aiter_mla_op_registration.py
@@ -8,6 +8,8 @@ support for torch.compile tracing and ``mutates_args=["o"]`` in-place output
 aliasing.
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -31,6 +33,45 @@ def _require_aiter():
 
     if not is_aiter_found_and_supported():
         pytest.skip("aiter is required on supported ROCm hardware for this test")
+
+
+@pytest.mark.parametrize("candidate_blocks", [False, True])
+def test_sparse_indexer_forward_hip_schema(monkeypatch, candidate_blocks):
+    """The ROCm caller must match the registered op and reject CUDA-only features."""
+    _require_aiter()
+    from torch._subclasses.fake_tensor import FakeTensorMode
+
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: True)
+    with FakeTensorMode():
+        tensor = torch.empty(1, device="cuda")
+        indices = torch.empty((1, 1), dtype=torch.int32, device="cuda")
+        indexer = SimpleNamespace(
+            use_fp4_cache=False,
+            candidate_blocks=indices if candidate_blocks else None,
+            candidate_block_size=128 if candidate_blocks else 0,
+            candidate_write=False,
+            k_cache=SimpleNamespace(prefix="model.layers.0.indexer", kv_cache=tensor),
+            quant_block_size=128,
+            scale_fmt="ue8m0",
+            topk_tokens=1,
+            head_dim=128,
+            max_model_len=128,
+            max_total_seq_len=128,
+            topk_indices_buffer=indices,
+            skip_k_cache_insert=False,
+            compress_ratio=1,
+        )
+        if candidate_blocks:
+            with pytest.raises(NotImplementedError, match="candidate blocks"):
+                SparseAttnIndexer.forward_hip(indexer, tensor, tensor, None, tensor)
+        else:
+            output = SparseAttnIndexer.forward_hip(
+                indexer, tensor, tensor, None, tensor
+            )
+            assert output is indices
 
 
 @torch.inference_mode()

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -980,6 +980,10 @@ class SparseAttnIndexer(CustomOp):
         assert isinstance(q_quant, torch.Tensor), (
             "AMD sparse_attn_indexer expects a single FP8 q_quant tensor"
         )
+        if self.candidate_blocks is not None:
+            raise NotImplementedError(
+                "ROCm sparse attention indexer does not support candidate blocks"
+            )
         from vllm.platforms.rocm import on_gfx11, on_gfx950
 
         if (
@@ -1007,9 +1011,6 @@ class SparseAttnIndexer(CustomOp):
                 self.topk_indices_buffer,
                 skip_k_cache_insert=self.skip_k_cache_insert,
                 compress_ratio=self.compress_ratio,
-                candidate_blocks=self.candidate_blocks,
-                candidate_block_size=self.candidate_block_size,
-                candidate_write=self.candidate_write,
             )
         raise RuntimeError(
             "Sparse attention indexer ROCm path requires AITER or a supported "


### PR DESCRIPTION
[MI355 LM Eval Spec Decode on main build 88259](https://buildkite.com/vllm/ci/builds/88259#01a08f2e-259f-4ad7-bb68-b8e94c0bd3af) fails before evaluation because `rocm_aiter_sparse_attn_indexer` receives 18 arguments while its registered schema accepts 15. #56228 added CUDA candidate-block arguments to `forward_hip` without adding a ROCm implementation.

Remove these three arguments from the ROCm dispatch. Explicitly reject non-None candidate blocks so unsupported two-level selection cannot silently produce unfiltered results. Existing models with no candidate blocks use the unchanged ROCm operator.

Extend the existing ROCm MLA registration suite to exercise `forward_hip` against the real registered schema under FakeTensorMode, and check that unsupported candidate blocks fail clearly.

Validation:
- `pre-commit run --files vllm/model_executor/layers/sparse_attn_indexer.py tests/kernels/attention/test_rocm_aiter_mla_op_registration.py` — passed, including mypy.
- ROCm regression and MI355 model evaluation have not run yet; GPU CI will be linked here. This development machine has no ROCm GPU. No accuracy result is claimed.

Duplicate check: searched open PRs for ROCm candidate_blocks, sparse indexer and the operator name; no existing PR addresses this caller/schema regression. This does not add ROCm candidate-block support.

AI assistance: OpenAI Codex helped investigate logs and implement this change. Human review of the changed lines is still required before merge.

Targeted ROCm CI: https://buildkite.com/vllm/ci/builds/88282 (exact PR head; bootstrap passed and generated MI300 attention shards plus MI355 LM Eval Spec Decode; image prerequisites/tests pending).
