### PR TITLE
[Bugfix][KV Offload] Unregister pinned staging buffers on disk backend teardown

### DIFF
--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -561,6 +561,7 @@ def test_disk_backend_teardown_releases_pins_for_reinit(tmp_path):
         backend.shutdown()
     assert backend._fd == -1
     assert not backend._store_buffer_caches and not backend._load_buffer_caches
+    assert not backend._store_slot_views and not backend._load_slot_views
     for thread in (backend._store_thread, backend._load_thread):
         assert thread is not None
         assert not thread.is_alive()
@@ -587,13 +588,38 @@ def test_disk_backend_init_pin_failure_unwinds_registrations(tmp_path, monkeypat
     backend.shutdown()  # must be safe after a failed init
 
 
-def test_disk_backend_live_after_failed_init_shutdown_reinit(tmp_path, monkeypatch):
-    """init fail -> shutdown -> re-init must leave a working backend.
+def test_disk_backend_init_failure_after_views_unwinds(tmp_path, monkeypatch):
+    """Failure after slot views are built must release buffers and views."""
 
-    shutdown() after a pre-thread init failure still queued None sentinels
-    once; without the thread-existence guard those stale sentinels are eaten
-    immediately by the re-init's fresh threads, silently killing them.
+    def fail_build_params(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("induced")
+
+    monkeypatch.setattr(
+        "vllm.v1.simple_kv_offload.disk_backend.build_params", fail_build_params
+    )
+    gpu = {"k": torch.zeros((4, 4096), dtype=torch.int8, device="cuda")}
+    backend = DiskBackend()
+    with pytest.raises(RuntimeError, match="induced"):
+        _init_disk_backend(backend, gpu, str(tmp_path / "kv-offload.bin"))
+    assert not backend._store_buffer_caches and not backend._load_buffer_caches
+    assert not backend._store_slot_views and not backend._load_slot_views
+    assert backend._fd == -1
+    backend.shutdown()
+
+
+def test_disk_backend_live_after_failed_init_shutdown_reinit(tmp_path, monkeypatch):
+    """Failed init after a clean cycle must not poison the next re-init.
+
+    A shutdown that follows a failed init sees leftover thread refs from the
+    earlier cycle; if it still queues stop sentinels for those dead threads,
+    the next re-init's fresh threads eat the stale sentinels and exit.
     """
+    gpu = {"k": torch.zeros((4, 4096), dtype=torch.int8, device="cuda")}
+    backend = DiskBackend()
+    disk_path = str(tmp_path / "kv-offload.bin")
+    _init_disk_backend(backend, gpu, disk_path)
+    backend.shutdown()
+
     pins = {"n": 0}
 
     def fail_second_pin(buf: torch.Tensor) -> None:
@@ -605,9 +631,6 @@ def test_disk_backend_live_after_failed_init_shutdown_reinit(tmp_path, monkeypat
     monkeypatch.setattr(
         "vllm.v1.simple_kv_offload.disk_backend.pin_tensor", fail_second_pin
     )
-    gpu = {"k": torch.zeros((4, 4096), dtype=torch.int8, device="cuda")}
-    backend = DiskBackend()
-    disk_path = str(tmp_path / "kv-offload.bin")
     with pytest.raises(RuntimeError, match="induced"):
         _init_disk_backend(backend, gpu, disk_path)
     backend.shutdown()
@@ -616,6 +639,37 @@ def test_disk_backend_live_after_failed_init_shutdown_reinit(tmp_path, monkeypat
     _init_disk_backend(backend, gpu, disk_path)
     events: list[tuple[int, torch.Event]] = []
     backend.launch_copy([], [], is_store=True, event_idx=0, events_list=events)
+    deadline = time.time() + 10.0
+    while not events and time.time() < deadline:
+        time.sleep(0.0005)
+    assert events, "store thread consumed a stale shutdown sentinel and exited"
+    backend.shutdown()
+
+
+def test_disk_backend_reinit_after_early_store_thread_exit(tmp_path, monkeypatch):
+    """A store thread that died before shutdown must not poison re-init.
+
+    init() starts each lifecycle with fresh queues, so a stop sentinel that a
+    dead thread never consumed cannot reach the re-init's fresh threads.
+    """
+
+    def stub_store_loop(*args: object, **kwargs: object) -> None:
+        return
+
+    monkeypatch.setattr(DiskBackend, "_store_loop", stub_store_loop)
+    gpu = {"k": torch.zeros((4, 4096), dtype=torch.int8, device="cuda")}
+    backend = DiskBackend()
+    disk_path = str(tmp_path / "kv-offload.bin")
+    _init_disk_backend(backend, gpu, disk_path)
+    assert backend._store_thread is not None
+    backend._store_thread.join(timeout=10.0)
+    assert not backend._store_thread.is_alive()
+    monkeypatch.undo()
+    backend.shutdown()
+
+    _init_disk_backend(backend, gpu, disk_path)
+    events: list[tuple[int, torch.Event]] = []
+    backend.launch_copy([], [], is_store=True, event_idx=1, events_list=events)
     deadline = time.time() + 10.0
     while not events and time.time() < deadline:
         time.sleep(0.0005)

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -42,7 +42,9 @@ from vllm.v1.simple_kv_offload.cuda_mem_ops import (
     CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
     build_params,
     pin_tensor,
+    unpin_tensor,
 )
+from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
 from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadMetadata
 from vllm.v1.simple_kv_offload.worker import SimpleCPUOffloadWorker
 from vllm.v1.worker.utils import allocate_kv_cache
@@ -69,6 +71,13 @@ def _make_backend() -> tuple[DmaCopyBackend, torch.Tensor, torch.Tensor]:
         torch.cuda.Stream(priority=low_pri),
     )
     return backend, gpu["k"], cpu["k"]
+
+
+def _teardown_backend(backend: DmaCopyBackend, cpu: torch.Tensor) -> None:
+    backend.shutdown()
+    # Freeing a still-registered tensor strands a VA registration that a later
+    # cudaHostRegister may land on; always unpin after shutdown.
+    unpin_tensor(cpu)
 
 
 def _drive_store(
@@ -140,7 +149,7 @@ def test_store_orders_after_compute_write():
         control = _drive_store(backend, gpu, cpu, with_barrier=False)
         fixed = _drive_store(backend, gpu, cpu, with_barrier=True)
     finally:
-        backend.shutdown()
+        _teardown_backend(backend, cpu)
 
     assert control > 0, (
         "no-barrier store did not race the compute write; the test no longer "
@@ -519,3 +528,116 @@ def test_mixed_page_byte_placement_is_dcp_invariant():
         )
 
     assert placements[0] == placements[1]
+
+
+def _init_disk_backend(
+    backend: DiskBackend, gpu: dict[str, torch.Tensor], disk_path: str
+) -> None:
+    backend.init(
+        gpu,
+        gpu["k"].device,
+        torch.cuda.Stream(),
+        torch.cuda.Stream(),
+        disk_path,
+        4,
+        4096,
+        use_page_cache=True,
+    )
+
+
+def test_disk_backend_teardown_releases_pins_for_reinit(tmp_path):
+    """Two full init/shutdown cycles on one DiskBackend in one process.
+
+    shutdown() must unregister the pinned staging buffers, not just stop the
+    threads: a freed-but-still-registered VA range crashes the next
+    cudaHostRegister that lands on it (cudaErrorHostMemoryAlreadyRegistered),
+    so re-init only works if teardown released the first cycle's pins.
+    """
+    gpu = {"k": torch.zeros((4, 4096), dtype=torch.int8, device="cuda")}
+    backend = DiskBackend()
+    disk_path = str(tmp_path / "kv-offload.bin")
+    for _ in range(2):
+        _init_disk_backend(backend, gpu, disk_path)
+        backend.shutdown()
+    assert backend._fd == -1
+    assert not backend._store_buffer_caches and not backend._load_buffer_caches
+    for thread in (backend._store_thread, backend._load_thread):
+        assert thread is not None
+        assert not thread.is_alive()
+
+
+def test_disk_backend_init_pin_failure_unwinds_registrations(tmp_path, monkeypatch):
+    """A mid-init pin failure must release registrations already taken."""
+    pins = {"n": 0}
+
+    def fail_second_pin(buf: torch.Tensor) -> None:
+        pins["n"] += 1
+        if pins["n"] == 2:
+            raise RuntimeError("cudaHostRegister failed: induced")
+        pin_tensor(buf)
+
+    monkeypatch.setattr(
+        "vllm.v1.simple_kv_offload.disk_backend.pin_tensor", fail_second_pin
+    )
+    gpu = {"k": torch.zeros((4, 4096), dtype=torch.int8, device="cuda")}
+    backend = DiskBackend()
+    with pytest.raises(RuntimeError, match="induced"):
+        _init_disk_backend(backend, gpu, str(tmp_path / "kv-offload.bin"))
+    assert not backend._store_buffer_caches and not backend._load_buffer_caches
+    backend.shutdown()  # must be safe after a failed init
+
+
+def test_disk_backend_live_after_failed_init_shutdown_reinit(tmp_path, monkeypatch):
+    """init fail -> shutdown -> re-init must leave a working backend.
+
+    shutdown() after a pre-thread init failure still queued None sentinels
+    once; without the thread-existence guard those stale sentinels are eaten
+    immediately by the re-init's fresh threads, silently killing them.
+    """
+    pins = {"n": 0}
+
+    def fail_second_pin(buf: torch.Tensor) -> None:
+        pins["n"] += 1
+        if pins["n"] == 2:
+            raise RuntimeError("cudaHostRegister failed: induced")
+        pin_tensor(buf)
+
+    monkeypatch.setattr(
+        "vllm.v1.simple_kv_offload.disk_backend.pin_tensor", fail_second_pin
+    )
+    gpu = {"k": torch.zeros((4, 4096), dtype=torch.int8, device="cuda")}
+    backend = DiskBackend()
+    disk_path = str(tmp_path / "kv-offload.bin")
+    with pytest.raises(RuntimeError, match="induced"):
+        _init_disk_backend(backend, gpu, disk_path)
+    backend.shutdown()
+    monkeypatch.undo()
+
+    _init_disk_backend(backend, gpu, disk_path)
+    events: list[tuple[int, torch.Event]] = []
+    backend.launch_copy([], [], is_store=True, event_idx=0, events_list=events)
+    deadline = time.time() + 10.0
+    while not events and time.time() < deadline:
+        time.sleep(0.0005)
+    assert events, "store thread consumed a stale shutdown sentinel and exited"
+    backend.shutdown()
+
+
+def test_pin_tensor_double_register_cuda_errors_without_poisoning():
+    """Re-registering a pinned range errors on CUDA and stays contained.
+
+    pin_tensor must drain the per-thread last error on failure so the next
+    CUDA call in this thread does not die with the previous call's error.
+    """
+    buf = torch.zeros(4096, dtype=torch.int8, device="cpu")
+    pin_tensor(buf)
+    try:
+        if not current_platform.is_rocm():
+            # HIP silently allows re-registering the same range; CUDA errors.
+            with pytest.raises(RuntimeError, match="cudaHostRegister failed"):
+                pin_tensor(buf)
+            torch.zeros(1, device="cuda")
+    finally:
+        unpin_tensor(buf)
+    pin_tensor(buf)  # a properly unregistered range registers again
+    unpin_tensor(buf)

--- a/vllm/v1/simple_kv_offload/cuda_mem_ops.py
+++ b/vllm/v1/simple_kv_offload/cuda_mem_ops.py
@@ -30,7 +30,29 @@ def pin_tensor(tensor: torch.Tensor) -> None:
     """
     err = torch.cuda.cudart().cudaHostRegister(tensor.data_ptr(), tensor.nbytes, 0)
     if err.value != 0:
-        raise RuntimeError(f"cudaHostRegister failed: {err}")
+        # The runtime latches the failure as the per-thread last error; drain
+        # it so it cannot ambush an unrelated CUDA call later in this thread.
+        last = torch.cuda.cudart().cudaGetLastError()
+        raise RuntimeError(
+            f"cudaHostRegister failed: {err} (pending last-error: {last})"
+        )
+
+
+def unpin_tensor(tensor: torch.Tensor) -> None:
+    """Release a previous ``pin_tensor`` registration (cudaHostUnregister).
+
+    Cleanup sits on shutdown/failure paths where raising would mask the real
+    problem, so a failed unregister only logs (matching
+    SharedOffloadRegion.cleanup).
+    """
+    err = torch.cuda.cudart().cudaHostUnregister(tensor.data_ptr())
+    if err.value != 0:
+        # Same latching hazard as a failed cudaHostRegister: drain so it cannot
+        # surface later as an unrelated call's error.
+        last = torch.cuda.cudart().cudaGetLastError()
+        logger.warning(
+            "cudaHostUnregister failed: %s (pending last-error: %s)", err, last
+        )
 
 
 class _CUmemLocation(ctypes.Structure):

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -25,6 +25,7 @@ from vllm.v1.simple_kv_offload.cuda_mem_ops import (
     build_params,
     copy_blocks,
     pin_tensor,
+    unpin_tensor,
 )
 
 logger = init_logger(__name__)
@@ -90,6 +91,12 @@ class DiskBackend:
         num_buffer_slots: int = 2,
         use_page_cache: bool = False,
     ) -> None:
+        # A second init on a live backend would orphan the registrations in
+        # the caches dicts.
+        assert not (self._store_buffer_caches or self._load_buffer_caches), (
+            "DiskBackend.init() called on a live backend; call shutdown() first"
+        )
+        self._shutdown = False
         self._load_stream = load_stream
         self._store_stream = store_stream
         self._total_block_bytes = total_block_bytes
@@ -103,61 +110,71 @@ class DiskBackend:
             f"total_block_bytes={total_block_bytes} not aligned to {_ALIGNMENT}"
         )
 
-        # Separate buffer pools for store and load threads
-        self._store_buffer_caches = {}
-        self._load_buffer_caches = {}
-        for name, gpu_t in gpu_caches.items():
-            bpb = gpu_t.stride(0) * gpu_t.element_size()
-            store_buf = _alloc_aligned(num_buffer_slots, bpb)
-            pin_tensor(store_buf)
-            self._store_buffer_caches[name] = store_buf
-            load_buf = _alloc_aligned(num_buffer_slots, bpb)
-            pin_tensor(load_buf)
-            self._load_buffer_caches[name] = load_buf
+        # Release registrations taken so far if anything fails after a pin;
+        # the buffers are about to be freed while the driver still holds them.
+        try:
+            # Separate buffer pools for store and load threads
+            for name, gpu_t in gpu_caches.items():
+                bpb = gpu_t.stride(0) * gpu_t.element_size()
+                store_buf = _alloc_aligned(num_buffer_slots, bpb)
+                pin_tensor(store_buf)
+                self._store_buffer_caches[name] = store_buf
+                load_buf = _alloc_aligned(num_buffer_slots, bpb)
+                pin_tensor(load_buf)
+                self._load_buffer_caches[name] = load_buf
 
-        # Pre-built iovec views per slot (avoid per-transfer .numpy() calls)
-        self._store_slot_views = [
-            [
-                memoryview(self._store_buffer_caches[name][slot].numpy())
-                for name in self._tensor_names
+            # Pre-built iovec views per slot (avoid per-transfer .numpy() calls)
+            self._store_slot_views = [
+                [
+                    memoryview(self._store_buffer_caches[name][slot].numpy())
+                    for name in self._tensor_names
+                ]
+                for slot in range(num_buffer_slots)
             ]
-            for slot in range(num_buffer_slots)
-        ]
-        self._load_slot_views = [
-            [
-                memoryview(self._load_buffer_caches[name][slot].numpy())
-                for name in self._tensor_names
+            self._load_slot_views = [
+                [
+                    memoryview(self._load_buffer_caches[name][slot].numpy())
+                    for name in self._tensor_names
+                ]
+                for slot in range(num_buffer_slots)
             ]
-            for slot in range(num_buffer_slots)
-        ]
 
-        self._store_params = build_params(
-            gpu_caches,
-            self._store_buffer_caches,
-            store_stream,
-            src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
-        )
-        self._load_params = build_params(
-            self._load_buffer_caches,
-            gpu_caches,
-            load_stream,
-            src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
-        )
+            self._store_params = build_params(
+                gpu_caches,
+                self._store_buffer_caches,
+                store_stream,
+                src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
+            )
+            self._load_params = build_params(
+                self._load_buffer_caches,
+                gpu_caches,
+                load_stream,
+                src_access_order=CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
+            )
 
-        os.makedirs(os.path.dirname(disk_path) or ".", exist_ok=True)
-        # Slot contents never outlive the process, so unlink then O_EXCL rather
-        # than reopening: a pre-existing file would otherwise keep its own
-        # (possibly world-readable) mode, and blocks may encode user prompts.
-        with contextlib.suppress(FileNotFoundError):
-            os.unlink(disk_path)
-        # O_DIRECT by default: page cache would consume the very host DRAM this
-        # backend exists to conserve, and doubles the copy on the store path.
-        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
-        if not use_page_cache:
-            flags |= O_DIRECT
-        self._fd = os.open(disk_path, flags, 0o600)
-        self._disk_path = disk_path
-        os.ftruncate(self._fd, num_disk_slots * total_block_bytes)
+            os.makedirs(os.path.dirname(disk_path) or ".", exist_ok=True)
+            # Slot contents never outlive the process, so unlink then O_EXCL
+            # rather than reopening: a pre-existing file would otherwise keep
+            # its own (possibly world-readable) mode, and blocks may encode
+            # user prompts.
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(disk_path)
+            # O_DIRECT by default: page cache would consume the very host DRAM
+            # this backend exists to conserve, and doubles the store-path copy.
+            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+            if not use_page_cache:
+                flags |= O_DIRECT
+            self._fd = os.open(disk_path, flags, 0o600)
+            self._disk_path = disk_path
+            os.ftruncate(self._fd, num_disk_slots * total_block_bytes)
+        except Exception:
+            self._unpin_staging_buffers()
+            if self._fd >= 0:
+                with contextlib.suppress(OSError):
+                    os.unlink(self._disk_path)
+                os.close(self._fd)
+                self._fd = -1
+            raise
 
         logger.info(
             "DiskBackend: path=%s, slots=%d, total=%.2f GB, buf=%dx%d bytes"
@@ -195,37 +212,57 @@ class DiskBackend:
         q = self._store_queue if is_store else self._load_queue
         q.put((src_blocks, dst_blocks, event_idx, events_list, wait_event))
 
+    def _unpin_staging_buffers(self) -> None:
+        """Unregister the buffers pinned by init(). Idempotent.
+
+        Unregisters the same aligned views that were pinned (their data_ptr,
+        not the raw allocation's base, is what cudaHostRegister recorded). On
+        the partial-init failure path only the successfully pinned buffers are
+        in the dicts, which is exactly the set to release.
+        """
+        for caches in (self._store_buffer_caches, self._load_buffer_caches):
+            for buf in caches.values():
+                unpin_tensor(buf)
+            caches.clear()
+
     def shutdown(self) -> None:
         if self._shutdown:
             return
         self._shutdown = True
-        self._store_queue.put(None)
-        self._load_queue.put(None)
+        # Signal only threads that exist: a queued sentinel with no consumer
+        # (init failed before thread creation) would be eaten by a later
+        # re-init's fresh threads, killing them on arrival.
+        if self._store_thread is not None:
+            self._store_queue.put(None)
+        if self._load_thread is not None:
+            self._load_queue.put(None)
         if self._store_thread is not None:
             self._store_thread.join(timeout=10.0)
         if self._load_thread is not None:
             self._load_thread.join(timeout=10.0)
-        if self._fd < 0:
-            return
-        # Slot contents can encode user prompts, so drop the name now rather
-        # than leaving them readable until the next run overwrites the file.
-        # Unlinking only removes the directory entry: any thread still holding
-        # the fd keeps writing to the (now anonymous) inode, which the kernel
-        # frees once the last fd goes away.
+        # Slot contents can encode user prompts, so drop the name even when
+        # the rest of teardown must bail out. Unlinking only removes the
+        # directory entry: any thread still holding the fd keeps writing to
+        # the (now anonymous) inode until the last fd goes away.
         with contextlib.suppress(OSError):
             os.unlink(self._disk_path)
-        # Closing under a still-running IO thread would let the fd number be
-        # reused by an unrelated open(), turning its next pwritev into a write
-        # into that file. Leaking one fd for the remaining process lifetime is
-        # the cheaper failure.
         if any(
             t is not None and t.is_alive()
             for t in (self._store_thread, self._load_thread)
         ):
+            # A still-running IO thread may DMA through the staging buffers or
+            # pwritev through self._fd (whose number a later open() could then
+            # reuse for an unrelated file). Leaking the registrations and the
+            # fd for the thread's remaining lifetime is the cheaper failure.
             logger.warning(
-                "IO thread still running after shutdown timeout; leaking fd %d",
+                "IO thread still running after shutdown timeout; leaking fd %d"
+                " and %d pinned staging buffers",
                 self._fd,
+                len(self._store_buffer_caches) + len(self._load_buffer_caches),
             )
+            return
+        self._unpin_staging_buffers()
+        if self._fd < 0:
             return
         os.close(self._fd)
         self._fd = -1

--- a/vllm/v1/simple_kv_offload/disk_backend.py
+++ b/vllm/v1/simple_kv_offload/disk_backend.py
@@ -97,6 +97,11 @@ class DiskBackend:
             "DiskBackend.init() called on a live backend; call shutdown() first"
         )
         self._shutdown = False
+        # Fresh queues per lifecycle: a thread that died before shutdown can
+        # leave an unconsumed stop sentinel behind, which a re-init's fresh
+        # threads would otherwise eat on arrival.
+        self._store_queue = queue.SimpleQueue()
+        self._load_queue = queue.SimpleQueue()
         self._load_stream = load_stream
         self._store_stream = store_stream
         self._total_block_bytes = total_block_bytes
@@ -169,6 +174,8 @@ class DiskBackend:
             os.ftruncate(self._fd, num_disk_slots * total_block_bytes)
         except Exception:
             self._unpin_staging_buffers()
+            self._store_slot_views.clear()
+            self._load_slot_views.clear()
             if self._fd >= 0:
                 with contextlib.suppress(OSError):
                     os.unlink(self._disk_path)
@@ -229,13 +236,8 @@ class DiskBackend:
         if self._shutdown:
             return
         self._shutdown = True
-        # Signal only threads that exist: a queued sentinel with no consumer
-        # (init failed before thread creation) would be eaten by a later
-        # re-init's fresh threads, killing them on arrival.
-        if self._store_thread is not None:
-            self._store_queue.put(None)
-        if self._load_thread is not None:
-            self._load_queue.put(None)
+        self._store_queue.put(None)
+        self._load_queue.put(None)
         if self._store_thread is not None:
             self._store_thread.join(timeout=10.0)
         if self._load_thread is not None:
@@ -262,6 +264,8 @@ class DiskBackend:
             )
             return
         self._unpin_staging_buffers()
+        self._store_slot_views.clear()
+        self._load_slot_views.clear()
         if self._fd < 0:
             return
         os.close(self._fd)


### PR DESCRIPTION
## Purpose

`DiskBackend.init()` pins its NVMe staging buffers with `cudaHostRegister`, but nothing ever calls `cudaHostUnregister`: `shutdown()` joins the IO threads and closes the file while the registrations stay held by the driver. When PyTorch's caching allocator recycles those freed address ranges later, the next `cudaHostRegister` that lands on one fails with `cudaErrorHostMemoryAlreadyRegistered`. Worse, a failed register leaves the per-thread last error set, so it can come out of an unrelated CUDA call later in the same thread. (Observed on the NVIDIA `v1-kv-offload` CI shard: https://buildkite.com/vllm/ci/builds/88256. The ROCm shard doesn't hit it because HIP silently accepts registering the same range twice.)

What changes:

- `shutdown()` now unregisters each staging buffer after both IO threads have joined, using the same `data_ptr` that was registered, and drops the per-slot views so the buffers' storage is fully released at teardown. If a thread ignores the 10s join timeout, the registrations leak together with the fd on purpose, because a zombie thread can still be doing DMA through them.
- `init()` backs out cleanly if something fails after the first pin: registrations, slot views, and any opened fd and file are all released. A second `init()` on a live backend now fails an assert instead of orphaning its registrations; `init()` -> `shutdown()` -> `init()` on the same instance works.
- `init()` starts each lifecycle with fresh queues, so a stop sentinel left queued for a dead or never-started thread can't reach a later lifecycle's threads.
- `pin_tensor` drains the per-thread last error before raising, so a failed register can't poison whatever CUDA call runs next. New `unpin_tensor` sits next to it, matching the warn-not-raise style of `SharedOffloadRegion.cleanup`.

Out of scope: production doesn't call `DiskBackend.shutdown()` today (the connector's `shutdown()` is a no-op), so a running engine behaves the same as before. The CPU offload pool in `SimpleCPUOffloadWorker` has the same never-unpin problem; #54792 is covering that.

AI assistance disclosure: drafted with an AI assistant; I reviewed every line and validated the changes by hand.

## Test Plan

New tests in `tests/v1/simple_kv_offload/test_worker.py`, run by the `v1-kv-offload` jobs on NVIDIA and ROCm:

- Two full `init()`/`shutdown()` cycles on one `DiskBackend` instance. Passes only if teardown released the first cycle's registrations, slot views, threads, and fd.
- Forced `init()` failures at both stages that can leak state, mid-pinning and after the slot views are built: registrations, views, and any opened fd are all released, and a later `shutdown()` is safe.
- Liveness after the two lifecycle compositions that used to leave stale stop sentinels: a clean cycle followed by a failed init followed by re-init, and a store thread that exited before `shutdown()`. Both end with the re-initialized backend demonstrably processing a store.
- A pin, pin again (raises on CUDA), unpin, pin again probe: the failed register leaves no stale error behind, and re-pin works only if the unregister happened.
- The `_make_backend` helper used by the existing store-ordering test now unpins its CPU tensor in teardown, removing that leak from the same pytest process.
