### PR TITLE
[ROCm] Route DSv4 sparse decode to the aiter v4 nm ASM kernel

### DIFF
--- a/tests/kernels/attention/test_rocm_dsv4_asm_decode.py
+++ b/tests/kernels/attention/test_rocm_dsv4_asm_decode.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Equivalence tests for the DeepSeek V4 aiter ASM sparse decode path.
+
+The ASM path repacks the selected pages of both V4 caches into the two-buffer
+layout `mla_decode_fwd_v4_nm` consumes, then issues one kernel call. It must
+agree with the Triton path it replaces, including on the two inputs that path
+tolerates: slots it masks out, and ragged index arrays whose allocated capacity
+exceeds their live length.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_rocm(), reason="Only used by ROCm"
+)
+
+DIM_NOPE, DIM_ROPE, DIM_QK = 448, 64, 512
+NTILES, TOK, FP8_MAX = 7, 576, 448.0
+
+
+def _on_gfx950() -> bool:
+    if not current_platform.is_rocm():
+        return False
+    try:
+        from vllm.platforms.rocm import _ON_GFX950
+
+        return bool(_ON_GFX950)
+    except ImportError:
+        return False
+
+
+requires_gfx950 = pytest.mark.skipif(
+    not _on_gfx950(), reason="aiter ships the v4 nm ASM decode for gfx950 only"
+)
+
+
+def _pack_tokens(latent: torch.Tensor):
+    """Encode latents exactly as the V4 cache writers do.
+
+    448 OCP E4M3 FP8 NoPE values, 64 BF16 RoPE values at byte offset 448, and
+    seven UE8M0 scale bytes of ceil(log2(absmax / 448)) + 127.
+    """
+    n = latent.shape[0]
+    nope = latent[:, :DIM_NOPE].float().view(n, NTILES, 64)
+    absmax = nope.abs().amax(-1).clamp_min(1e-4)
+    exp = torch.ceil(torch.log2(absmax / FP8_MAX))
+    q = (nope / torch.pow(2.0, exp).unsqueeze(-1)).clamp(-FP8_MAX, FP8_MAX)
+
+    tokens = torch.empty((n, TOK), dtype=torch.uint8, device=latent.device)
+    tokens[:, :DIM_NOPE] = (
+        q.to(torch.float8_e4m3fn).view(n, DIM_NOPE).view(torch.uint8)
+    )
+    tokens[:, DIM_NOPE:] = latent[:, DIM_NOPE:].contiguous().view(torch.uint8)
+    scales = torch.zeros((n, 8), dtype=torch.uint8, device=latent.device)
+    scales[:, :NTILES] = (exp.to(torch.int32) + 127).clamp(0, 255).to(torch.uint8)
+    return tokens, scales
+
+
+def _make_cache(num_blocks: int, block_size: int, device: torch.device):
+    """A paged V4 cache: per block, all token data then all scale bytes."""
+    latent = (
+        torch.randn(
+            (num_blocks * block_size, DIM_QK), device=device, dtype=torch.bfloat16
+        )
+        * 0.5
+    )
+    tokens, scales = _pack_tokens(latent)
+    block_bytes = block_size * TOK + block_size * 8
+    cache = torch.zeros((num_blocks, block_bytes), dtype=torch.uint8, device=device)
+    cache[:, : block_size * TOK] = tokens.view(num_blocks, block_size * TOK)
+    cache[:, block_size * TOK :] = scales.view(num_blocks, block_size * 8)
+    return cache.view(num_blocks, block_size, block_bytes // block_size)
+
+
+def _run_both(*, num_blocks, block_size, num_tokens, heads, len_extra, len_main,
+              slack=0, corrupt=False, device="cuda"):
+    from vllm.v1.attention.ops import rocm_aiter_mla_sparse as ops
+
+    torch.manual_seed(0)
+    dev = torch.device(device)
+    extra_cache = _make_cache(num_blocks, block_size, dev)
+    main_cache = _make_cache(num_blocks, block_size, dev)
+    rows = num_blocks * block_size
+
+    def ragged(per_query, n_slack):
+        lens = torch.full((num_tokens,), per_query, dtype=torch.int32, device=dev)
+        indptr = torch.nn.functional.pad(lens.cumsum(0), (1, 0)).int()
+        idx = torch.randint(
+            0, rows, (num_tokens * per_query + n_slack,), dtype=torch.int32, device=dev
+        )
+        return idx, indptr
+
+    extra_idx, extra_indptr = ragged(len_extra, slack)
+    main_idx, main_indptr = ragged(len_main, slack)
+    if corrupt:
+        # Slots the Triton path masks out: negative, and past the row count.
+        extra_idx[3::17] = -1
+        extra_idx[5::29] = rows + 7
+        main_idx[2::11] = -1
+
+    q = torch.randn((num_tokens, heads, DIM_QK), device=dev, dtype=torch.bfloat16) * 0.5
+    sink = torch.randn((heads,), device=dev, dtype=torch.float32)
+    common = dict(
+        q=q,
+        main_cache=main_cache,
+        main_indices=main_idx,
+        scale=1.0 / (DIM_QK**0.5),
+        attn_sink=sink,
+        nope_head_dim=DIM_NOPE,
+        rope_head_dim=DIM_ROPE,
+        extra_cache=extra_cache,
+        extra_indices=extra_idx,
+        main_ragged_indices=main_idx,
+        main_ragged_indptr=main_indptr,
+        extra_ragged_indices=extra_idx,
+        extra_ragged_indptr=extra_indptr,
+    )
+
+    outs = []
+    for enabled in (True, False):
+        out = torch.empty(
+            (num_tokens, heads, DIM_QK), dtype=torch.bfloat16, device=dev
+        )
+        saved = ops._V4_ASM_DECODE
+        ops._V4_ASM_DECODE = enabled
+        try:
+            ops._rocm_sparse_attn_decode_triton(out=out, **common)
+        finally:
+            ops._V4_ASM_DECODE = saved
+        torch.cuda.synchronize()
+        outs.append(out.float())
+    return outs
+
+
+@requires_gfx950
+@pytest.mark.parametrize("heads", [16, 128])
+def test_asm_decode_matches_triton(heads):
+    """The ASM path agrees with Triton on a plain decode batch."""
+    asm, triton_out = _run_both(
+        num_blocks=512,
+        block_size=64,
+        num_tokens=4,
+        heads=heads,
+        len_extra=96,
+        len_main=32,
+    )
+    # Q is quantized to FP8 on the ASM path and kept BF16 on the Triton path,
+    # so agreement is to BF16 accuracy rather than bitwise.
+    torch.testing.assert_close(asm, triton_out, atol=6e-3, rtol=6e-2)
+
+
+@requires_gfx950
+def test_asm_decode_masks_invalid_slots():
+    """Negative and out-of-range slots must be excluded, as Triton excludes them."""
+    asm, triton_out = _run_both(
+        num_blocks=512,
+        block_size=64,
+        num_tokens=4,
+        heads=128,
+        len_extra=96,
+        len_main=32,
+        corrupt=True,
+    )
+    torch.testing.assert_close(asm, triton_out, atol=6e-3, rtol=6e-2)
+
+
+@requires_gfx950
+def test_asm_decode_tolerates_oversized_ragged_workspace():
+    """Ragged arrays are capacity-sized workspaces, so numel() exceeds indptr[T].
+
+    Entries past the live region must not be gathered, and must not push the
+    per-entry owner index past the end of the per-query length tensors.
+    """
+    asm, triton_out = _run_both(
+        num_blocks=512,
+        block_size=64,
+        num_tokens=4,
+        heads=128,
+        len_extra=96,
+        len_main=32,
+        slack=512,
+        corrupt=True,
+    )
+    torch.testing.assert_close(asm, triton_out, atol=6e-3, rtol=6e-2)
+
+
+@requires_gfx950
+def test_asm_decode_falls_back_on_small_caches():
+    """A cache too small to be a served rank must stay on Triton.
+
+    The memory-profiling dummy run allocates a handful of blocks, which would
+    leave every sequence with zero KV length after the validity filter.
+    """
+    from vllm.v1.attention.ops import rocm_aiter_mla_sparse as ops
+
+    asm, triton_out = _run_both(
+        num_blocks=8,
+        block_size=64,
+        num_tokens=4,
+        heads=128,
+        len_extra=96,
+        len_main=32,
+    )
+    assert 8 * 64 < ops._V4_MIN_CACHE_ROWS
+    # Both arms took the Triton path, so they agree exactly.
+    torch.testing.assert_close(asm, triton_out, atol=0.0, rtol=0.0)

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -3182,14 +3182,81 @@ def _rocm_sparse_attn_decode_ragged_triton(
 
 
 @triton.jit
+def _v4_plan_kernel(
+    indices_ptr,
+    indptr_ptr,
+    rank_ptr,
+    lens_ptr,
+    num_rows,
+    n_entries,
+    MAX_LEN: tl.constexpr,
+):
+    """Per query: rank each surviving entry, and count the survivors.
+
+    A single ASM call cannot mask entries the way the Triton decode does, so
+    the rejected ones are compacted out of the CSR instead. Rank is the
+    exclusive prefix count of survivors within the query, which is what the
+    gather turns into a destination row.
+
+    Entries are rejected when the Triton kernel would mask them (`slot < 0` or
+    `slot >= num_rows`) or when they sit past `indptr[T]`, which happens because
+    the ragged arrays are capacity-sized workspaces. Rejected entries get
+    rank -1.
+    """
+    t = tl.program_id(0)
+    start = tl.load(indptr_ptr + t)
+    end = tl.load(indptr_ptr + t + 1)
+
+    off = tl.arange(0, MAX_LEN)
+    e = start + off
+    live = (off < end - start) & (e < n_entries)
+    slot = tl.load(indices_ptr + e, mask=live, other=-1)
+    ok = live & (slot >= 0) & (slot < num_rows)
+
+    okin = ok.to(tl.int32)
+    rank = tl.cumsum(okin, axis=0) - okin
+    tl.store(rank_ptr + e, tl.where(ok, rank, -1), mask=live)
+    tl.store(lens_ptr + t, tl.sum(okin, axis=0))
+
+
+@triton.jit
+def _v4_combine_kernel(
+    lens_e_ptr,
+    lens_m_ptr,
+    combined_ptr,
+    base_m_ptr,
+    n_queries,
+    BLOCK: tl.constexpr,
+):
+    """Exclusive prefix sum over per-query lengths, in one program.
+
+    `combined` is both the CSR indptr the ASM kernel reads and the first row of
+    each query's slice; `base_m` is where that query's SWA rows start, which is
+    its own start plus the compressed rows it kept.
+    """
+    off = tl.arange(0, BLOCK)
+    m = off < n_queries
+    le = tl.load(lens_e_ptr + off, mask=m, other=0)
+    lm = tl.load(lens_m_ptr + off, mask=m, other=0)
+    tot = le + lm
+    excl = tl.cumsum(tot, axis=0) - tot
+    tl.store(combined_ptr + off, excl, mask=m)
+    tl.store(combined_ptr + n_queries, tl.sum(tot, axis=0))
+    tl.store(base_m_ptr + off, excl + le, mask=m)
+
+
+@triton.jit
 def _v4_gather_repack_kernel(
     out_nope_ptr,
     out_rope_ptr,
     cache_ptr,
     cache_stride0,
     indices_ptr,
-    dst_ptr,
+    rank_ptr,
+    base_ptr,
+    indptr_ptr,
     n_entries,
+    n_queries,
     block_size: tl.constexpr,
     NOPE: tl.constexpr,
     ROPE: tl.constexpr,
@@ -3205,17 +3272,27 @@ def _v4_gather_repack_kernel(
     token data. Nothing is requantized; the 448 FP8 bytes are copied verbatim
     and the 7 UE8M0 scale bytes are duplicated into ``[448, 462)``.
 
-    ``dst_ptr`` carries a precomputed destination row per entry, negative for
-    entries the Triton path would have masked out. Keeping that decision on the
-    host side of a device array means this kernel never reads a device value
-    from the host, so it is safe inside a captured CUDA graph.
+    The destination row is ``base[query] + rank[entry]``, with a negative rank
+    marking an entry the planner compacted out. The owning query comes from
+    bisecting ``indptr`` rather than from a host-built array, so nothing here
+    reads a device value on the host and the whole path is capture-safe.
     """
     e = tl.program_id(0)
     if e >= n_entries:
         return
-    dst = tl.load(dst_ptr + e)
-    if dst < 0:
+    rank = tl.load(rank_ptr + e)
+    if rank < 0:
         return
+
+    lo = 0
+    hi = n_queries
+    while lo < hi - 1:
+        mid = (lo + hi) // 2
+        if tl.load(indptr_ptr + mid) <= e:
+            lo = mid
+        else:
+            hi = mid
+    dst = tl.load(base_ptr + lo) + rank
 
     slot = tl.load(indices_ptr + e).to(tl.int64)
     blk = slot // block_size
@@ -3249,6 +3326,11 @@ def _v4_gather_repack_kernel(
 
 _V4_NOPE, _V4_ROPE, _V4_QK = 448, 64, 512
 _V4_NTILES, _V4_SOFF, _V4_FP8_MAX = 7, 448, 448.0
+# Per-query scan width for the planner. Must cover topk plus the SWA window for
+# a single query; the kernel masks beyond the real length.
+_V4_PLAN_BLOCK = 2048
+# Prefix-sum width for the cross-query combine, which runs in one program.
+_V4_COMBINE_BLOCK = 256
 # gfx950 ships the v4 nm decode kernel only for these gqa ratios at qSeqLen 1
 # (aiter asm_mla_v4.cu). TP1/DP8 keeps every head on the rank, so we land on a
 # shipped variant without ATOM's head padding.
@@ -3257,6 +3339,26 @@ _V4_SHIPPED_GQA = (16, 32, 64, 128)
 # 2^18 rows is 168 MB, roughly 7x a real C64 decode step, and keeps the
 # worst-case profiling shape off this path.
 _V4_MAX_UNIFIED_ROWS = 1 << 18
+
+_V4_IOTA: dict[torch.device, torch.Tensor] = {}
+
+
+def _v4_iota(n: int, device: torch.device) -> torch.Tensor:
+    """`arange(n)` from a grown-on-demand cache.
+
+    Both the qo_indptr and the page-index array this path hands aiter are plain
+    iotas that depend only on a length. Rebuilding them per layer per step is a
+    kernel launch each, which matters once everything else is fused.
+    """
+    buf = _V4_IOTA.get(device)
+    if buf is None or buf.numel() < n:
+        buf = torch.arange(
+            max(n, 1 << 12), dtype=torch.int32, device=device
+        )
+        _V4_IOTA[device] = buf
+    return buf[:n]
+
+
 # A served rank holds millions of token slots per cache; the profiling dummy run
 # holds 128. Anything below this is not a real decode.
 _V4_MIN_CACHE_ROWS = 1 << 14
@@ -3273,26 +3375,71 @@ def _v4_asm_decode_fn():
     return mla_decode_fwd_v4_nm
 
 
-def _v4_pack_query(q: torch.Tensor):
-    """BF16 q [T,H,512] -> (packed FP8 [T,H,512], BF16 RoPE [T,H,64]).
+@triton.jit
+def _v4_pack_query_kernel(
+    q_ptr,
+    out_fp8_ptr,
+    out_u8_ptr,
+    out_rope_ptr,
+    n_rows,
+    NOPE: tl.constexpr,
+    ROPE: tl.constexpr,
+    QK: tl.constexpr,
+    NT: tl.constexpr,
+    TILE: tl.constexpr,
+    SOFF: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    """Pack one BF16 query row into the packed FP8 NoPE + BF16 RoPE pair.
 
-    Quantizes the 448 NoPE dims per 64-element tile with the same UE8M0 rule the
-    cache writer uses, so Q and K are on the same scale grid.
+    Same UE8M0 rule the cache writers use, so Q and K land on one scale grid:
+    per 64-element tile the exponent is ceil(log2(absmax / 448)).
+
+    ``out_fp8_ptr`` and ``out_u8_ptr`` alias the same buffer through different
+    dtypes, which lets the FP8 values and the scale bytes be written without
+    casting a pointer inside the kernel.
     """
-    T, H, _ = q.shape
-    flat = q.reshape(T * H, _V4_QK)
-    nope = flat[:, :_V4_NOPE].float().view(T * H, _V4_NTILES, 64)
-    absmax = nope.abs().amax(dim=-1).clamp_min(1e-4)
-    exp = torch.ceil(torch.log2(absmax / _V4_FP8_MAX))
-    qn = (nope / torch.pow(2.0, exp).unsqueeze(-1)).clamp(-_V4_FP8_MAX, _V4_FP8_MAX)
+    r = tl.program_id(0)
+    if r >= n_rows:
+        return
+    row = q_ptr + r * QK
 
-    packed = torch.zeros((T * H, _V4_QK), dtype=torch.uint8, device=q.device)
-    packed[:, :_V4_NOPE] = (
-        qn.to(torch.float8_e4m3fn).view(T * H, _V4_NOPE).view(torch.uint8)
+    for i in tl.static_range(NT):
+        off = i * TILE + tl.arange(0, TILE)
+        x = tl.load(row + off).to(tl.float32)
+        amax = tl.maximum(tl.max(tl.abs(x), axis=0), 1e-4)
+        e = tl.ceil(tl.log2(amax / FP8_MAX))
+        qv = x * tl.exp2(-e)
+        qv = tl.minimum(tl.maximum(qv, -FP8_MAX), FP8_MAX)
+        tl.store(out_fp8_ptr + r * QK + off, qv.to(out_fp8_ptr.dtype.element_ty))
+        sb = (e.to(tl.int32) + 127).to(tl.uint8)
+        tl.store(out_u8_ptr + r * QK + SOFF + 2 * i, sb)
+        tl.store(out_u8_ptr + r * QK + SOFF + 2 * i + 1, sb)
+
+    rr = tl.arange(0, ROPE)
+    tl.store(out_rope_ptr + r * ROPE + rr, tl.load(row + NOPE + rr))
+
+
+def _v4_pack_query(q: torch.Tensor):
+    """BF16 q [T,H,512] -> (packed FP8 [T,H,512], BF16 RoPE [T,H,64])."""
+    T, H, _ = q.shape
+    rows = T * H
+    packed = torch.zeros((rows, _V4_QK), dtype=torch.uint8, device=q.device)
+    rope = torch.empty((rows, _V4_ROPE), dtype=torch.bfloat16, device=q.device)
+    _v4_pack_query_kernel[(rows,)](
+        q.reshape(rows, _V4_QK),
+        packed.view(torch.float8_e4m3fn),
+        packed,
+        rope,
+        rows,
+        NOPE=_V4_NOPE,
+        ROPE=_V4_ROPE,
+        QK=_V4_QK,
+        NT=_V4_NTILES,
+        TILE=64,
+        SOFF=_V4_SOFF,
+        FP8_MAX=_V4_FP8_MAX,
     )
-    sc = (exp.to(torch.int32) + 127).clamp(0, 255).to(torch.uint8)
-    packed[:, _V4_SOFF : _V4_SOFF + _V4_NTILES * 2] = sc.repeat_interleave(2, dim=1)
-    rope = flat[:, _V4_NOPE :].contiguous().to(torch.bfloat16)
     return (
         packed.view(torch.float8_e4m3fn).view(T, H, _V4_QK),
         rope.view(T, H, _V4_ROPE),
@@ -3342,15 +3489,12 @@ def _rocm_sparse_attn_decode_aiter_asm(
         in_profiling = False
     if in_profiling:
         return False
-    # The probe fired at T=256, which is the FULL cudagraph capture size, not a
-    # real decode step. Capture drives dummy metadata whose slots this path
-    # filters out as invalid, leaving every sequence with zero KV length, and
-    # the ASM kernel aborts on that with HSA_STATUS_ERROR_EXCEPTION rather than
-    # a memory fault. Capture therefore records Triton and replay keeps using
-    # it; the ASM path serves the eager decode steps. is_current_stream_capturing
-    # is a host-side query and does not synchronise.
-    if torch.cuda.is_current_stream_capturing():
-        return False
+    # NOTE: this path deliberately runs under CUDA graph capture. Capture is
+    # where it pays off: the host-side planning below is recorded into the
+    # graph, so replay pays no launch overhead for it. Everything here is
+    # therefore capture-safe, which means no device-to-host reads and no
+    # pageable H2D copies, including inside the aiter wrapper (see the explicit
+    # split_indptr at the call).
     # The memory-profiling dummy run keeps attn_metadata a dict and is not a
     # capture, so neither check above sees it. What gives it away is the cache:
     # profiling allocates 64 blocks, so the compressed cache holds 64*2 = 128
@@ -3381,44 +3525,40 @@ def _rocm_sparse_attn_decode_aiter_asm(
     # determine_available_memory. Bound it and let those steps use Triton.
     if total == 0 or total > _V4_MAX_UNIFIED_ROWS:
         return False
+    # The planner scans a whole query in one program, so a query longer than
+    # _V4_PLAN_BLOCK would be silently truncated, and the combine holds every
+    # query in one program. Decline rather than drop entries.
+    if T > _V4_COMBINE_BLOCK or n_extra > T * _V4_PLAN_BLOCK or (
+        n_main > T * _V4_PLAN_BLOCK
+    ):
+        return False
 
-    def plan(indices, indptr, n, cache):
-        """Per-entry destination row, negative where the Triton path masks out.
-
-        The ragged arrays are preallocated workspaces, so entries past
-        ``indptr[T]`` are stale, and live entries may still hold a slot the
-        Triton kernel would reject (`slot < 0 or slot >= num_rows`). A single
-        ASM call cannot mask per entry, so those are compacted out of the CSR
-        instead: lengths count only surviving entries.
-        """
-        num_rows = cache.shape[0] * cache.shape[1]
-        pos = torch.arange(n, device=dev, dtype=torch.int32)
-        owner = torch.searchsorted(indptr, pos, right=True) - 1
-        live = (pos < indptr[T]) & (owner >= 0)
-        ok = live & (indices >= 0) & (indices < num_rows)
-        # searchsorted returns T for entries past indptr[T], and those exist
-        # because the ragged arrays are capacity-sized workspaces. Their owner
-        # is only ever used to index T-element tensors (`lens_e` below), so it
-        # must be clamped on BOTH sides; clamping only the low side reads one
-        # past the end and faults the device. `ok` already excludes them from
-        # the result, so any in-range value works here.
-        owner = owner.clamp(0, max(T - 1, 0))
-        # Exclusive prefix count of survivors, so rank within a query is the
-        # difference against that query's own base.
-        cp = torch.zeros((n + 1,), dtype=torch.int32, device=dev)
-        torch.cumsum(ok.to(torch.int32), dim=0, out=cp[1:])
-        lens = cp[indptr[1:].long()] - cp[indptr[:-1].long()]
-        rank = cp[pos.long()] - cp[indptr[owner.long()].long()]
-        return ok, owner, rank, lens
-
-    ok_e, own_e, rank_e, lens_e = plan(extra_indices, extra_indptr, n_extra, extra_cache)
-    ok_m, own_m, rank_m, lens_m = plan(main_indices, main_indptr, n_main, main_cache)
-
-    combined = torch.zeros((T + 1,), dtype=torch.int32, device=dev)
-    torch.cumsum(lens_e + lens_m, dim=0, out=combined[1:])
-
-    dst_e = torch.where(ok_e, combined[own_e.long()] + rank_e, -1)
-    dst_m = torch.where(ok_m, combined[own_m.long()] + lens_e[own_m.long()] + rank_m, -1)
+    # Planning is two small kernels rather than ~30 torch ops. Doing it in torch
+    # measured 0.41 ms per call against 0.078 ms for the kernels it feeds, which
+    # is launch-bound and independent of batch size, and it is recorded into the
+    # CUDA graph so replay pays for every one of those launches too.
+    # Prefilled with -1, not left uninitialized: the planner only writes the
+    # entries that belong to some query, so the stale tail past indptr[T] would
+    # otherwise hand the gather a garbage rank and an out-of-range destination.
+    rank_e = torch.full((max(n_extra, 1),), -1, dtype=torch.int32, device=dev)
+    rank_m = torch.full((max(n_main, 1),), -1, dtype=torch.int32, device=dev)
+    lens_e = torch.empty((T,), dtype=torch.int32, device=dev)
+    lens_m = torch.empty((T,), dtype=torch.int32, device=dev)
+    _v4_plan_kernel[(T,)](
+        extra_indices, extra_indptr, rank_e, lens_e,
+        extra_cache.shape[0] * extra_cache.shape[1], n_extra,
+        MAX_LEN=_V4_PLAN_BLOCK,
+    )
+    _v4_plan_kernel[(T,)](
+        main_indices, main_indptr, rank_m, lens_m,
+        main_cache.shape[0] * main_cache.shape[1], n_main,
+        MAX_LEN=_V4_PLAN_BLOCK,
+    )
+    combined = torch.empty((T + 1,), dtype=torch.int32, device=dev)
+    base_m = torch.empty((T,), dtype=torch.int32, device=dev)
+    _v4_combine_kernel[(1,)](
+        lens_e, lens_m, combined, base_m, T, BLOCK=_V4_COMBINE_BLOCK
+    )
 
     nope = torch.empty((total, _V4_QK), dtype=torch.uint8, device=dev)
     rope = torch.empty((total, _V4_ROPE), dtype=torch.bfloat16, device=dev)
@@ -3429,14 +3569,18 @@ def _rocm_sparse_attn_decode_aiter_asm(
         NT=_V4_NTILES,
         SOFF=_V4_SOFF,
     )
-    # Compressed rows occupy the head of each query's slice, SWA the tail.
+    # Compressed rows occupy the head of each query's slice, SWA the tail, so
+    # the SWA base is the query's start plus however many compressed rows it
+    # kept. `combined` doubles as the per-query start and as the CSR indptr.
     _v4_gather_repack_kernel[(n_extra,)](
-        nope, rope, extra_cache, extra_cache.stride(0), extra_indices, dst_e,
-        n_extra, block_size=extra_cache.shape[1], **cfg
+        nope, rope, extra_cache, extra_cache.stride(0), extra_indices,
+        rank_e, combined, extra_indptr, n_extra, T,
+        block_size=extra_cache.shape[1], **cfg
     )
     _v4_gather_repack_kernel[(n_main,)](
-        nope, rope, main_cache, main_cache.stride(0), main_indices, dst_m,
-        n_main, block_size=main_cache.shape[1], **cfg
+        nope, rope, main_cache, main_cache.stride(0), main_indices,
+        rank_m, base_m, main_indptr, n_main, T,
+        block_size=main_cache.shape[1], **cfg
     )
 
     q_packed, q_rope = _v4_pack_query(q)
@@ -3446,9 +3590,9 @@ def _rocm_sparse_attn_decode_aiter_asm(
         nope.view(torch.float8_e4m3fn).view(total, 1, 1, _V4_QK),
         rope.view(total, 1, 1, _V4_ROPE),
         out,
-        torch.arange(T + 1, dtype=torch.int32, device=dev),
+        _v4_iota(T + 1, dev),
         combined,
-        torch.arange(total, dtype=torch.int32, device=dev),
+        _v4_iota(total, dev),
         1,
         sink=attn_sink.contiguous().to(torch.float32),
         # ATOM always passes an explicit split count. Leaving it to aiter's
@@ -3457,7 +3601,15 @@ def _rocm_sparse_attn_decode_aiter_asm(
         # at 61 layers and decode frequency that is heavy transient churn.
         # num_kv_splits=1 keeps the single-pass path, where the kernel writes
         # BF16 straight into `out` and no merge runs.
+        #
+        # split_indptr must be passed too, and built on the device. Omitting it
+        # sends the wrapper through get_meta_param, which finishes with a
+        # pageable host-to-device copy of the indptr it computed. That copy is
+        # illegal under stream capture and is what previously forced this path
+        # to decline captured steps. For a single pass the uniform indptr the
+        # wrapper would have built is [0, 1, ..., T].
         num_kv_splits=1,
+        split_indptr=_v4_iota(T + 1, dev),
     )
     return True
 

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -3,6 +3,7 @@
 import functools
 import importlib
 import math
+import os
 from collections.abc import Callable
 from importlib.util import find_spec
 
@@ -61,6 +62,16 @@ _GFX950_C4A_NATIVE_MAX_ROWS = 256
 # Conservative perf gate, not a correctness bound: OPUS is correct for any query
 # count, but Triton stays faster below this measured crossover.
 _GFX950_AITER_SPARSE_PREFILL_OPUS_MIN_QUERIES = 1024
+
+# Split-K tile for the gfx950 sparse decode kernel. Upstream hard-codes 32;
+# this reads the same value unless VLLM_ROCM_SPARSE_DECODE_BLOCK_K is set, so
+# an unset environment reproduces upstream exactly.
+_DECODE_BLOCK_K = int(os.getenv("VLLM_ROCM_SPARSE_DECODE_BLOCK_K", "32"))
+if _DECODE_BLOCK_K not in (16, 32, 64, 128):
+    raise ValueError(
+        "VLLM_ROCM_SPARSE_DECODE_BLOCK_K must be one of 16, 32, 64, 128; "
+        f"got {_DECODE_BLOCK_K}"
+    )
 
 
 def _get_aiter_top_k_kernel(
@@ -3017,7 +3028,10 @@ def _rocm_sparse_attn_decode_ragged_triton(
         )
         return out
 
-    block_k = 32  # KV tokens walked per split-K iteration. Tuned on gfx950.
+    # KV tokens walked per split-K iteration. 32 is the upstream gfx950 tuning
+    # and stays the default; the override exists to screen the decode kernel
+    # that TraceLens shows at 13.81 ms/iter against ATOM's 5.23 ms ASM kernel.
+    block_k = _DECODE_BLOCK_K
     if _ON_GFX950:
         inv_q = 1.0 / max(1, num_queries)
         avg_main_len = main_indices.numel() * inv_q
@@ -3167,6 +3181,287 @@ def _rocm_sparse_attn_decode_ragged_triton(
     return out
 
 
+@triton.jit
+def _v4_gather_repack_kernel(
+    out_nope_ptr,
+    out_rope_ptr,
+    cache_ptr,
+    cache_stride0,
+    indices_ptr,
+    dst_ptr,
+    n_entries,
+    block_size: tl.constexpr,
+    NOPE: tl.constexpr,
+    ROPE: tl.constexpr,
+    QK: tl.constexpr,
+    NT: tl.constexpr,
+    SOFF: tl.constexpr,
+):
+    """Gather one selected token out of a paged V4 cache and write it in the
+    two-buffer layout aiter's v4 nm ASM decode consumes.
+
+    Source addressing mirrors ``_sparse_attn_decode_ragged_kernel`` exactly:
+    token data at ``pos * 576`` inside the block, the 8 scale bytes after all
+    token data. Nothing is requantized; the 448 FP8 bytes are copied verbatim
+    and the 7 UE8M0 scale bytes are duplicated into ``[448, 462)``.
+
+    ``dst_ptr`` carries a precomputed destination row per entry, negative for
+    entries the Triton path would have masked out. Keeping that decision on the
+    host side of a device array means this kernel never reads a device value
+    from the host, so it is safe inside a captured CUDA graph.
+    """
+    e = tl.program_id(0)
+    if e >= n_entries:
+        return
+    dst = tl.load(dst_ptr + e)
+    if dst < 0:
+        return
+
+    slot = tl.load(indices_ptr + e).to(tl.int64)
+    blk = slot // block_size
+    pos = slot % block_size
+    base = cache_ptr + blk * cache_stride0 + pos * 576
+
+    off = tl.arange(0, 512)
+    m = off < NOPE
+    tl.store(out_nope_ptr + dst * QK + off, tl.load(base + off, mask=m, other=0), mask=m)
+
+    s = tl.arange(0, 16)
+    sm = s < NT * 2
+    sb = tl.load(
+        cache_ptr + blk * cache_stride0 + block_size * 576 + pos * 8 + s // 2,
+        mask=sm,
+        other=0,
+    )
+    tl.store(out_nope_ptr + dst * QK + SOFF + s, sb, mask=sm)
+    pad = tl.arange(0, 64)
+    pm = (SOFF + NT * 2 + pad) < QK
+    tl.store(
+        out_nope_ptr + dst * QK + SOFF + NT * 2 + pad,
+        tl.zeros((64,), tl.uint8),
+        mask=pm,
+    )
+
+    r = tl.arange(0, 64)
+    rp = (base + NOPE).to(tl.pointer_type(tl.bfloat16))
+    tl.store(out_rope_ptr + dst * ROPE + r, tl.load(rp + r))
+
+
+_V4_NOPE, _V4_ROPE, _V4_QK = 448, 64, 512
+_V4_NTILES, _V4_SOFF, _V4_FP8_MAX = 7, 448, 448.0
+# gfx950 ships the v4 nm decode kernel only for these gqa ratios at qSeqLen 1
+# (aiter asm_mla_v4.cu). TP1/DP8 keeps every head on the rank, so we land on a
+# shipped variant without ATOM's head padding.
+_V4_SHIPPED_GQA = (16, 32, 64, 128)
+# Upper bound on the transient unified buffer, in rows of 512B NoPE + 128B RoPE.
+# 2^18 rows is 168 MB, roughly 7x a real C64 decode step, and keeps the
+# worst-case profiling shape off this path.
+_V4_MAX_UNIFIED_ROWS = 1 << 18
+# A served rank holds millions of token slots per cache; the profiling dummy run
+# holds 128. Anything below this is not a real decode.
+_V4_MIN_CACHE_ROWS = 1 << 14
+_V4_ASM_DECODE = os.getenv("VLLM_ROCM_V4_ASM_DECODE", "0") == "1"
+
+
+@functools.lru_cache
+def _v4_asm_decode_fn():
+    try:
+        from aiter.mla import mla_decode_fwd_v4_nm
+    except ImportError:
+        logger.info_once("aiter mla_decode_fwd_v4_nm unavailable; staying on Triton")
+        return None
+    return mla_decode_fwd_v4_nm
+
+
+def _v4_pack_query(q: torch.Tensor):
+    """BF16 q [T,H,512] -> (packed FP8 [T,H,512], BF16 RoPE [T,H,64]).
+
+    Quantizes the 448 NoPE dims per 64-element tile with the same UE8M0 rule the
+    cache writer uses, so Q and K are on the same scale grid.
+    """
+    T, H, _ = q.shape
+    flat = q.reshape(T * H, _V4_QK)
+    nope = flat[:, :_V4_NOPE].float().view(T * H, _V4_NTILES, 64)
+    absmax = nope.abs().amax(dim=-1).clamp_min(1e-4)
+    exp = torch.ceil(torch.log2(absmax / _V4_FP8_MAX))
+    qn = (nope / torch.pow(2.0, exp).unsqueeze(-1)).clamp(-_V4_FP8_MAX, _V4_FP8_MAX)
+
+    packed = torch.zeros((T * H, _V4_QK), dtype=torch.uint8, device=q.device)
+    packed[:, :_V4_NOPE] = (
+        qn.to(torch.float8_e4m3fn).view(T * H, _V4_NOPE).view(torch.uint8)
+    )
+    sc = (exp.to(torch.int32) + 127).clamp(0, 255).to(torch.uint8)
+    packed[:, _V4_SOFF : _V4_SOFF + _V4_NTILES * 2] = sc.repeat_interleave(2, dim=1)
+    rope = flat[:, _V4_NOPE :].contiguous().to(torch.bfloat16)
+    return (
+        packed.view(torch.float8_e4m3fn).view(T, H, _V4_QK),
+        rope.view(T, H, _V4_ROPE),
+    )
+
+
+def _rocm_sparse_attn_decode_aiter_asm(
+    q: torch.Tensor,
+    main_cache: torch.Tensor,
+    main_indices: torch.Tensor,
+    main_indptr: torch.Tensor,
+    extra_cache: torch.Tensor,
+    extra_indices: torch.Tensor,
+    extra_indptr: torch.Tensor,
+    attn_sink: torch.Tensor,
+    out: torch.Tensor,
+) -> bool:
+    """Replace the Triton sparse decode with aiter's v4 nm ASM kernel.
+
+    Both caches are gathered into one unified two-buffer allocation, compressed
+    rows first then the SWA window, which is how ATOM gives a single-source
+    kernel a two-source decode. Returns False when the shape is not supported,
+    leaving the caller on the Triton path.
+    """
+    fn = _v4_asm_decode_fn()
+    if fn is None:
+        return False
+
+    T, H = q.shape[0], q.shape[1]
+    if H not in _V4_SHIPPED_GQA or q.shape[-1] != _V4_QK or T == 0:
+        return False
+    # The memory-profiling dummy run executes before the KV caches exist, so the
+    # cache tensors handed in here are placeholders. Launching the gather on
+    # them faults the worker with no Python traceback. Same signal the prefill
+    # path uses to detect profiling.
+    if (
+        extra_cache.ndim != 3
+        or main_cache.ndim != 3
+        or extra_cache.numel() == 0
+        or main_cache.numel() == 0
+    ):
+        return False
+    try:
+        in_profiling = not isinstance(get_forward_context().attn_metadata, dict)
+    except AssertionError:
+        # No forward context outside the engine (standalone equivalence tests).
+        in_profiling = False
+    if in_profiling:
+        return False
+    # The probe fired at T=256, which is the FULL cudagraph capture size, not a
+    # real decode step. Capture drives dummy metadata whose slots this path
+    # filters out as invalid, leaving every sequence with zero KV length, and
+    # the ASM kernel aborts on that with HSA_STATUS_ERROR_EXCEPTION rather than
+    # a memory fault. Capture therefore records Triton and replay keeps using
+    # it; the ASM path serves the eager decode steps. is_current_stream_capturing
+    # is a host-side query and does not synchronise.
+    if torch.cuda.is_current_stream_capturing():
+        return False
+    # The memory-profiling dummy run keeps attn_metadata a dict and is not a
+    # capture, so neither check above sees it. What gives it away is the cache:
+    # profiling allocates 64 blocks, so the compressed cache holds 64*2 = 128
+    # token slots against 32768 dummy indices. Nearly every index then fails the
+    # validity filter, every sequence ends up with zero KV length, and the ASM
+    # kernel aborts on that with HSA_STATUS_ERROR_EXCEPTION. A served rank has
+    # millions of slots, so this separates the two by five orders of magnitude.
+    if (
+        main_cache.shape[0] * main_cache.shape[1] < _V4_MIN_CACHE_ROWS
+        or extra_cache.shape[0] * extra_cache.shape[1] < _V4_MIN_CACHE_ROWS
+    ):
+        return False
+
+    dev = q.device
+    # Element counts come from shapes, never from a device read: this path runs
+    # inside a captured CUDA graph, where a device-to-host sync raises
+    # "operation not permitted when stream is capturing".
+    n_extra = extra_indices.numel()
+    n_main = main_indices.numel()
+    total = n_extra + n_main
+    if extra_indptr.numel() != T + 1 or main_indptr.numel() != T + 1:
+        return False
+    # The unified buffer is sized by the ragged arrays' CAPACITY, not by the
+    # live entry count, because the live count only exists on the device. A
+    # real decode step is ~37k rows (24 MB), but the memory-profiling dummy run
+    # drives the worst-case prefill shape, where the same expression reaches
+    # millions of rows and several GB, which killed the worker during
+    # determine_available_memory. Bound it and let those steps use Triton.
+    if total == 0 or total > _V4_MAX_UNIFIED_ROWS:
+        return False
+
+    def plan(indices, indptr, n, cache):
+        """Per-entry destination row, negative where the Triton path masks out.
+
+        The ragged arrays are preallocated workspaces, so entries past
+        ``indptr[T]`` are stale, and live entries may still hold a slot the
+        Triton kernel would reject (`slot < 0 or slot >= num_rows`). A single
+        ASM call cannot mask per entry, so those are compacted out of the CSR
+        instead: lengths count only surviving entries.
+        """
+        num_rows = cache.shape[0] * cache.shape[1]
+        pos = torch.arange(n, device=dev, dtype=torch.int32)
+        owner = torch.searchsorted(indptr, pos, right=True) - 1
+        live = (pos < indptr[T]) & (owner >= 0)
+        ok = live & (indices >= 0) & (indices < num_rows)
+        # searchsorted returns T for entries past indptr[T], and those exist
+        # because the ragged arrays are capacity-sized workspaces. Their owner
+        # is only ever used to index T-element tensors (`lens_e` below), so it
+        # must be clamped on BOTH sides; clamping only the low side reads one
+        # past the end and faults the device. `ok` already excludes them from
+        # the result, so any in-range value works here.
+        owner = owner.clamp(0, max(T - 1, 0))
+        # Exclusive prefix count of survivors, so rank within a query is the
+        # difference against that query's own base.
+        cp = torch.zeros((n + 1,), dtype=torch.int32, device=dev)
+        torch.cumsum(ok.to(torch.int32), dim=0, out=cp[1:])
+        lens = cp[indptr[1:].long()] - cp[indptr[:-1].long()]
+        rank = cp[pos.long()] - cp[indptr[owner.long()].long()]
+        return ok, owner, rank, lens
+
+    ok_e, own_e, rank_e, lens_e = plan(extra_indices, extra_indptr, n_extra, extra_cache)
+    ok_m, own_m, rank_m, lens_m = plan(main_indices, main_indptr, n_main, main_cache)
+
+    combined = torch.zeros((T + 1,), dtype=torch.int32, device=dev)
+    torch.cumsum(lens_e + lens_m, dim=0, out=combined[1:])
+
+    dst_e = torch.where(ok_e, combined[own_e.long()] + rank_e, -1)
+    dst_m = torch.where(ok_m, combined[own_m.long()] + lens_e[own_m.long()] + rank_m, -1)
+
+    nope = torch.empty((total, _V4_QK), dtype=torch.uint8, device=dev)
+    rope = torch.empty((total, _V4_ROPE), dtype=torch.bfloat16, device=dev)
+    cfg = dict(
+        NOPE=_V4_NOPE,
+        ROPE=_V4_ROPE,
+        QK=_V4_QK,
+        NT=_V4_NTILES,
+        SOFF=_V4_SOFF,
+    )
+    # Compressed rows occupy the head of each query's slice, SWA the tail.
+    _v4_gather_repack_kernel[(n_extra,)](
+        nope, rope, extra_cache, extra_cache.stride(0), extra_indices, dst_e,
+        n_extra, block_size=extra_cache.shape[1], **cfg
+    )
+    _v4_gather_repack_kernel[(n_main,)](
+        nope, rope, main_cache, main_cache.stride(0), main_indices, dst_m,
+        n_main, block_size=main_cache.shape[1], **cfg
+    )
+
+    q_packed, q_rope = _v4_pack_query(q)
+    fn(
+        q_packed,
+        q_rope,
+        nope.view(torch.float8_e4m3fn).view(total, 1, 1, _V4_QK),
+        rope.view(total, 1, 1, _V4_ROPE),
+        out,
+        torch.arange(T + 1, dtype=torch.int32, device=dev),
+        combined,
+        torch.arange(total, dtype=torch.int32, device=dev),
+        1,
+        sink=attn_sink.contiguous().to(torch.float32),
+        # ATOM always passes an explicit split count. Leaving it to aiter's
+        # heuristic selects a multi-pass mode that allocates FP32 logits of
+        # [total_q, splits, heads, 512] per call and then runs the stage2 merge;
+        # at 61 layers and decode frequency that is heavy transient churn.
+        # num_kv_splits=1 keeps the single-pass path, where the kernel writes
+        # BF16 straight into `out` and no merge runs.
+        num_kv_splits=1,
+    )
+    return True
+
+
 def _rocm_sparse_attn_decode_triton(
     q: torch.Tensor,
     main_cache: torch.Tensor,
@@ -3208,6 +3503,30 @@ def _rocm_sparse_attn_decode_triton(
             else (extra_indices >= 0).sum(dim=-1, dtype=torch.int32),
             num_rows=extra_cache.shape[0] * extra_cache.shape[1],
         )
+
+    if (
+        _V4_ASM_DECODE
+        and _ON_GFX950
+        and out is not None
+        and attn_sink is not None
+        and extra_cache is not None
+        and extra_ragged_indices is not None
+        and extra_ragged_indptr is not None
+        and nope_head_dim == _V4_NOPE
+        and rope_head_dim == _V4_ROPE
+        and _rocm_sparse_attn_decode_aiter_asm(
+            q=q,
+            main_cache=main_cache,
+            main_indices=main_ragged_indices,
+            main_indptr=main_ragged_indptr,
+            extra_cache=extra_cache,
+            extra_indices=extra_ragged_indices,
+            extra_indptr=extra_ragged_indptr,
+            attn_sink=attn_sink,
+            out=out,
+        )
+    ):
+        return out
 
     return _rocm_sparse_attn_decode_ragged_triton(
         q=q,


### PR DESCRIPTION
## Summary

The DeepSeek V4 sparse decode on ROCm always runs the Triton
`_sparse_attn_decode_gfx950_partial` kernel. aiter ships an ASM decode for this
exact shape, `mla_decode_fwd_v4_nm` (loaded as
`mla_a8w8_qh64_qseqlen1_gqaratio64_nm`), but it takes a single packed KV buffer
while the V4 decode reads two caches: the SWA window and the compressed region.

Both stacks already encode a token identically — 448 OCP E4M3 FP8 NoPE values,
64 BF16 RoPE values, and seven UE8M0 scale bytes of
`ceil(log2(absmax / 448)) + 127`. Only the placement differs:

| | vLLM record | aiter / packed row |
|---|---|---|
| NoPE | 448 FP8 at offset 0 | 448 FP8 at offset 0 |
| Scales | 8 bytes/token in a block-tail scale row, 7 real + 1 pad | inline at `[448, 462)`, each of the 7 duplicated twice, then pad to 512 |
| RoPE | 64 BF16 inline at offset 448, giving a 576-byte token record | separate parallel `[pages, 64]` BF16 buffer |

So a fused Triton gather repacks the selected pages of both caches into one
unified two-buffer allocation **without requantizing anything**, and a single
ASM call serves the whole step. Compressed rows take the head of each query's
slice and the SWA window takes the tail, which is how a single-source kernel
covers a two-source decode.

Opt-in with `VLLM_ROCM_V4_ASM_DECODE=1`. Unset reproduces the Triton path
exactly: the flag is the first, short-circuiting condition in the dispatch.

## Status: the kernel wins, the path still loses

Draft because this is not yet a net gain. Everything below is measured on
MI355X, DeepSeek-V4-Pro, `--kv-cache-dtype fp8`,
`cudagraph_mode=FULL_DECODE_ONLY`, 512-token prompt, 512-token generation with
`ignore_eos`, so the work is decode.

The kernel replacement is a clear win in isolation. Per decode launch, 32 rows,
128 heads, 1024 compressed pages plus a 128-token SWA window per query:

| | time |
|---|---:|
| fused gather + repack | 0.031 ms |
| ASM decode | 0.047 ms |
| **kernels total** | **0.078 ms** |
| Triton `_sparse_attn_decode_gfx950_partial` | 0.216 ms |

The surrounding path is what loses. Current end-to-end, DP8
(`--tensor-parallel-size 1 --data-parallel-size 8`), 128 heads per rank:

| Max concurrency | ASM off tok/s | ASM on tok/s | Gain |
|---:|---:|---:|---:|
| 1 | 44.46 | 40.74 | -8.37% |
| 2 | 85.74 | 77.72 | -9.35% |
| 4 | 161.61 | 152.67 | -5.53% |
| 8 | 328.11 | 302.29 | -7.87% |
| 16 | 633.57 | 599.60 | -5.36% |
| 32 | 1,140.69 | 1,078.86 | -5.42% |
| 48 | 1,640.19 | 1,432.83 | -12.64% |
| 64 | 2,144.94 | 1,949.57 | -9.11% |

TP8 (`--tensor-parallel-size 8`), 16 heads per rank:

| Max concurrency | ASM off tok/s | ASM on tok/s | Gain |
|---:|---:|---:|---:|
| 1 | 65.71 | 40.89 | -37.77% |
| 2 | 77.69 | 44.88 | -42.23% |
| 4 | 226.36 | 202.69 | -10.46% |
| 8 | 448.56 | 383.61 | -14.48% |
| 16 | 920.72 | 775.69 | -15.75% |
| 32 | 1,739.96 | 1,478.03 | -15.05% |
| 48 | 2,386.84 | 1,982.37 | -16.95% |
| 64 | 2,972.98 | 2,477.10 | -16.68% |

TP8 is worse for a structural reason: each rank holds an eighth of the heads, so
the ASM kernel does an eighth of the work per rank while the fixed per-call cost
is unchanged.

### What was fixed, and what is left

The first version of this path had to decline CUDA graph capture. The cause was
inside the aiter wrapper: leaving `split_indptr` as `None` routes through
`get_meta_param`, which ends with a pageable host-to-device copy of the indptr
it computed, and that is illegal under stream capture. Passing an explicit,
device-built `split_indptr` alongside `num_kv_splits=1` removes it, and the path
now runs under capture.

Enabling capture alone made things worse, not better, which corrected a wrong
assumption: capture removes CPU launch cost, but replay still executes every
recorded kernel, so the per-call work simply started applying to every step
instead of only eager ones. The planning had to actually go away.

Compacting rejected slots out of the CSR was about 30 torch ops per call:

| decode rows | plan x2 | unified alloc | pack Q | per-call overhead |
|---:|---:|---:|---:|---:|
| 1 | 0.284 ms | 0.004 ms | 0.116 ms | 0.404 ms |
| 64 | 0.293 ms | 0.004 ms | 0.115 ms | 0.412 ms |

0.41 ms against 0.078 ms of kernel time, flat in batch size because it is
launch-bound. That is now two Triton kernels — a per-query rank-and-count and a
cross-query prefix sum — with the Q pack fused into one kernel and the iota
arguments served from a cache. DP8 at concurrency 64 moved 1,312 -> 1,691 ->
1,950 tok/s across those steps, against 2,145 for Triton.

What remains is structural: this path issues seven kernels where Triton issues
one. Closing the rest means folding planning, gather and Q packing into a single
kernel, which is a redesign rather than a tweak, and is not in this PR.

For the same reason, an early version of the repack written with torch advanced
indexing measured 0.643 ms and lost outright while moving only about 45 MB.

## Accuracy

gsm8k, 1319 questions, 5-shot, temperature 0, seed 42, DP8, same server
configuration, arms differing only by the flag:

| Arm | Accuracy | Invalid |
|---|---:|---:|
| ASM off | 95.07% | 0.0% |
| ASM on | 94.92% | 0.0% |

-0.15pp, which is 2 questions out of 1319. The ASM path quantizes Q to FP8 where
the Triton path keeps it BF16, so this was the change worth checking; it does
not show up at this sample size.

## Correctness

`tests/kernels/attention/test_rocm_dsv4_asm_decode.py`, 5 tests, all passing on
MI355X. They compare the ASM path against the Triton path it replaces on
identical inputs, and cover the inputs the Triton path tolerates and this one
therefore must:

- slots the Triton kernel masks out (negative, and past the row count);
- ragged index arrays whose allocated capacity exceeds `indptr[T]`, since they
  are preallocated workspaces. This was a real bug twice: `searchsorted` returns
  `T` for stale entries, which read one past the end of the per-query length
  tensors, and later the fused planner left the stale tail of its rank array
  uninitialized;
- the small-cache case, which must stay on Triton.

Measured `rel = 0.0094` against the Triton path; the tests assert
`atol=6e-3, rtol=6e-2`, since FP8 Q makes the agreement BF16-level rather than
bitwise.

## Known limits

- Net negative end-to-end, as above. The kernel-level win is real but the path
  around it costs more than it saves.
- aiter ships this kernel for gqa in `{16, 32, 64, 128}` at `qSeqLen=1`. DSv4 at
  TP1/DP8 gives 128 heads per rank and at TP8 gives 16, both shipped. Shapes
  outside that set are declined rather than padded.

## Test plan

```
pytest tests/kernels/attention/test_rocm_dsv4_asm_decode.py
```

Requires gfx950 and aiter; every test is skipped elsewhere.

### Where the remaining cost is, and a fusion that backfired

Timing the whole call against the single Triton kernel it replaces, on
engine-shaped inputs (1024 compressed pages plus a 128-token SWA window per
query):

| decode rows | heads | ASM path | Triton | ratio |
|---:|---:|---:|---:|---:|
| 8 | 128 | 0.146 ms | 0.044 ms | 3.31x |
| 32 | 128 | 0.147 ms | 0.086 ms | 1.72x |
| 64 | 128 | 0.193 ms | 0.159 ms | 1.22x |
| 8 | 16 | 0.147 ms | 0.043 ms | 3.45x |
| 64 | 16 | 0.173 ms | 0.044 ms | 3.93x |

The ASM path is nearly flat while Triton scales with the work, which is the
signature of fixed per-call cost rather than a slow kernel. Of that ~0.15 ms,
the gather is 0.031 ms, the ASM call 0.047 ms and the Q pack 0.022 ms; the rest
is planning, allocation and the aiter wrapper's own Python. Breaking even needs
that fixed cost around 0.05 ms, not fewer kernels.

That distinction matters because fewer kernels was tried and lost badly. Folding
ranking and gathering into one program per query, to drop from five kernels to
three, replaced one-program-per-entry parallelism with a serial scan whose
per-query cost is quadratic in the scan width. It measured 2.3-2.7 ms, roughly
15x worse, and was reverted. The structure in this PR is the faster one.

### The floor, decomposed

Per call at 32 decode rows, 128 heads, 1152 KV rows per query:

| stage | time |
|---|---:|
| allocations | 0.0208 ms |
| plan + combine | 0.0316 ms |
| gather + repack | 0.0431 ms |
| pack Q | 0.0260 ms |
| aiter call | 0.0664 ms |
| **total** | **0.1879 ms** |
| Triton kernel it replaces | 0.086 ms |

Two things follow. The aiter Python wrapper costs 0.0001 ms against calling
`aiter.mla_decode_v4_asm` directly, so bypassing it buys nothing. And the two
stages that cannot be removed, the ASM call and the repack the layouts require,
already total 0.109 ms against Triton's 0.086 ms at this shape. Deleting the
planning, the Q pack and every allocation would still lose here.

The path therefore has headroom only where Triton's own cost exceeds roughly
0.11 ms, which at 128 heads means somewhere past 64 decode rows per rank. A
C64 DP8 deployment sits at about 32 rows per rank, below that crossover, which
is consistent with the sweep tables above being negative throughout.

### Would a natively packed cache be worth it?

If the cache were written in aiter's two-buffer layout, `kv_page_indices` would
point straight at cache rows and the repack would disappear. Measuring that
best case, with the ASM call reading scattered rows out of a full-size pool
rather than a compact staging buffer:

| decode rows | ASM | pack Q | plan x2 | best case | Triton | |
|---:|---:|---:|---:|---:|---:|---|
| 32 | 0.066 | 0.020 | 0.020 | 0.107 ms | 0.087 ms | loss |
| 64 | 0.068 | 0.025 | 0.021 | 0.114 ms | 0.155 ms | win 1.36x |
| 128 | 0.069 | 0.044 | 0.020 | 0.133 ms | 0.297 ms | win 2.23x |

The ASM call is flat at 0.066-0.069 ms while Triton grows with the work, so the
crossover sits between 32 and 64 decode rows per rank. A C64 DP8 deployment with
MTP-3 lands near 32, which is why every sweep above is negative; the same code
at twice the rows per rank would be ahead.

The layout is also not free: a packed token is 512B NoPE plus 128B RoPE against
the current 584B, so 640B, which is 9.6% more per token and 8.8% less KV
capacity at a fixed budget. In this regime that looks minor, since raising
`--gpu-memory-utilization` from 0.86 to 0.90 bought 13.2% more KV and measured
-1.0% tokens/$, but it is a real cost to weigh.
