### PR TITLE
Revert "[Rocm][Kimi-k3] Fix pipeline_parallel support for the kimik3 DCP mode  (#53664)"

### DIFF
--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -128,8 +128,6 @@ def test_registry_model_property(model_arch, is_mm, init_cuda, score_type):
         # in V1.
         # ("MLPSpeculatorPreTrainedModel", False, False),
         ("DeepseekV2ForCausalLM", True, False),
-        ("KimiLinearForCausalLM", True, False),
-        ("KimiK3ForConditionalGeneration", True, False),
         ("Qwen2VLForConditionalGeneration", True, True),
     ],
 )

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2544,16 +2544,6 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         if num_decodes > 0:
             dcp_tot_seq_lens_device = None
             if self.dcp_world_size > 1:
-                assert seq_lens is not None, (
-                    "MLA DCP decode requires seq_lens on CommonAttentionMetadata"
-                )
-                if dcp_local_seq_lens is None:
-                    dcp_local_seq_lens = get_dcp_local_seq_lens(
-                        seq_lens,
-                        dcp_size=self.dcp_world_size,
-                        dcp_rank=get_dcp_group().rank_in_group,
-                        cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
-                    )
                 dcp_tot_seq_lens_device = seq_lens[:num_decodes]
                 seq_lens = dcp_local_seq_lens
 


### PR DESCRIPTION
## Purpose

This PR reverts #53664 ("[Rocm][Kimi-k3] Fix pipeline_parallel support for the kimik3 DCP mode"). That PR added a fallback in `MLAAttentionLayer.build()` that derives `dcp_local_seq_lens` from `seq_lens` whenever `CommonAttentionMetadata` does not carry it, together with an assert and two test-registry entries. The fallback is dead code: in vLLM's in-tree paths, `dcp_local_seq_lens` is always populated before the MLA decode path runs whenever DCP is enabled.

Evidence:

- The monolithic V1 model runner populates `CommonAttentionMetadata.dcp_local_seq_lens` unconditionally when `decode_context_parallel_size > 1` (`vllm/v1/worker/gpu_model_runner.py:2456-2466`), and this has been in place since before #53664 was authored.
- The modular model runner (MRV2) does the same via `maybe_prepare_dcp_local_seq_lens()` right before attention metadata is built, after PCP batch partitioning (`vllm/v1/worker/gpu/model_runner.py:1728`, helper in `vllm/v1/worker/gpu/cp_utils.py`). The helper returns `None` only when `dcp_size == 1`, in which case the MLA layer's `dcp_world_size` is also 1 and the branch is never taken, so the fallback is unreachable.
- Both runners always set `seq_lens` on `CommonAttentionMetadata`, so the assert added by #53664 is likewise unreachable.

Keeping the fallback would also mask future regressions in runner-side population: if a path ever stopped populating `dcp_local_seq_lens`, the layer would silently derive it instead of failing loudly. Removing it restores a single source of truth for DCP-local sequence lengths (the model runner). The two test-registry entries added by #53664 are removed along with the revert.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

