### PR TITLE
[Perf][Model][Engram] Redistribute DeepSeek-V4.1 SP embeddings with all-to-all

### DIFF
--- a/tests/distributed/test_engram_parallel.py
+++ b/tests/distributed/test_engram_parallel.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Collective coverage of Engram's head-to-token redistribution."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm.models.deepseek_v4_1.common.engram_parallel import exchange_heads_for_tokens
+
+
+def _exchange_worker(rank: int, world_size: int, rendezvous: str):
+    dist.init_process_group(
+        "gloo",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        for tokens, heads in [(0, 23), (1, 1), (3, 7), (64, 24), (65, 23)]:
+            dim = 5
+            local_heads = (heads + world_size - 1) // world_size
+            chunk = (tokens + world_size - 1) // world_size
+            full = torch.arange(tokens * heads * dim, dtype=torch.float32).reshape(
+                tokens, heads, dim
+            )
+            padded = torch.nn.functional.pad(
+                full, (0, 0, 0, local_heads * world_size - heads)
+            )
+            local = padded[:, rank * local_heads : (rank + 1) * local_heads]
+
+            def exchange(rows):
+                received = torch.empty_like(rows)
+                dist.all_to_all_single(received, rows.contiguous())
+                return received
+
+            actual = exchange_heads_for_tokens(local, world_size, heads, exchange)
+            expected = torch.nn.functional.pad(
+                full, (0, 0, 0, 0, 0, chunk * world_size - tokens)
+            )[rank * chunk : (rank + 1) * chunk]
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_all_to_all_preserves_token_and_head_order(world_size, tmp_path):
+    mp.spawn(
+        _exchange_worker,
+        args=(world_size, (tmp_path / "rendezvous").as_uri()),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+def _cuda_exchange_worker(rank, tp_size, port):
+    from tests.utils import init_test_distributed_environment
+    from vllm.distributed import cleanup_dist_env_and_memory, get_tp_group
+    from vllm.models.deepseek_v4_1.common.engram import Engram
+
+    torch.accelerator.set_device_index(rank)
+    init_test_distributed_environment(tp_size, 4 // tp_size, rank, str(port), rank)
+    group = get_tp_group()
+    local_rank = group.rank_in_group
+    group_offset = group.ranks[0] * 7
+
+    def full_rows(tokens, heads, dtype, offset=0):
+        values = torch.arange(tokens * heads * 256, device="cuda")
+        return (
+            ((values % 97) + group_offset + offset).to(dtype).view(tokens, heads, 256)
+        )
+
+    def module_for(full, strided):
+        tokens, heads, dim = full.shape
+        local_heads = (heads + tp_size - 1) // tp_size
+        padded = torch.nn.functional.pad(full, (0, 0, 0, -heads % tp_size))
+        local = padded[:, local_rank * local_heads : (local_rank + 1) * local_heads]
+        rows = (
+            torch.empty(
+                tokens,
+                local_heads,
+                dim * (2 if strided else 1),
+                dtype=full.dtype,
+                device="cuda",
+            )[..., ::2]
+            if strided
+            else torch.empty_like(local, memory_format=torch.contiguous_format)
+        )
+        rows.copy_(local)
+        module = Engram.__new__(Engram)
+        torch.nn.Module.__init__(module)
+        module.embed_tokens = SimpleNamespace(tp_size=tp_size, n_hash_cols=heads)
+        module.use_sequence_parallel = True
+        module.staged_rows = rows
+        return module, torch.empty(tokens, heads, dtype=torch.int32, device="cuda")
+
+    def expected(full):
+        chunk = (len(full) + tp_size - 1) // tp_size
+        return torch.nn.functional.pad(full, (0, 0, 0, 0, 0, -len(full) % tp_size))[
+            local_rank * chunk : (local_rank + 1) * chunk
+        ]
+
+    try:
+        for tokens in sorted(
+            {
+                0,
+                1,
+                tp_size - 1,
+                tp_size,
+                tp_size + 1,
+                63,
+                64,
+                65,
+                127,
+                128,
+                129,
+                511,
+                512,
+                513,
+            }
+        ):
+            for heads in (23, 24):
+                for dtype in (torch.bfloat16, torch.float32):
+                    for strided in (False, True):
+                        full = full_rows(tokens, heads, dtype)
+                        module, ids = module_for(full, strided)
+                        torch.testing.assert_close(
+                            module.embed(ids), expected(full), rtol=0, atol=0
+                        )
+
+        # Two captures own separate buffers; ordered streams must not reuse
+        # each other's storage when fresh input is supplied on every replay.
+        captures = []
+        for offset in (0, 13):
+            full = full_rows(65, 23, torch.bfloat16, offset)
+            module, ids = module_for(full, True)
+            stream = torch.cuda.Stream()
+            stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(stream):
+                for _ in range(3):
+                    module.embed(ids)
+            torch.cuda.current_stream().wait_stream(stream)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=stream):
+                output = module.embed(ids)
+            captures.append((module, graph, output, stream, offset))
+        for iteration in range(100):
+            for module, graph, output, stream, offset in captures:
+                full = full_rows(65, 23, torch.bfloat16, offset + iteration % 17)
+                fresh, _ = module_for(full, True)
+                module.staged_rows.copy_(fresh.staged_rows)
+                stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(stream):
+                    graph.replay()
+                torch.cuda.current_stream().wait_stream(stream)
+                torch.testing.assert_close(output, expected(full), rtol=0, atol=0)
+        torch.accelerator.synchronize()
+        del captures, graph, output
+    finally:
+        cleanup_dist_env_and_memory()
+
+
+@pytest.mark.distributed(num_gpus=4)
+@pytest.mark.skipif(
+    torch.accelerator.device_count() < 4, reason="Requires four CUDA GPUs"
+)
+@pytest.mark.parametrize("tp_size", [1, 2, 4])
+def test_engram_nondefault_groups_and_changing_graph_inputs(tp_size):
+    """The production embed path preserves rows on every TP group and replay."""
+    from vllm.utils.network_utils import get_open_port
+
+    mp.spawn(_cuda_exchange_worker, args=(tp_size, get_open_port()), nprocs=4)

--- a/tests/distributed/test_engram_parallel.py
+++ b/tests/distributed/test_engram_parallel.py
@@ -13,7 +13,7 @@ import torch.multiprocessing as mp
 from vllm.models.deepseek_v4_1.common.engram_parallel import exchange_heads_for_tokens
 
 
-def _exchange_worker(rank: int, world_size: int, rendezvous: str):
+def _exchange_worker(rank: int, world_size: int, prepad: bool, rendezvous: str):
     dist.init_process_group(
         "gloo",
         init_method=rendezvous,
@@ -22,7 +22,7 @@ def _exchange_worker(rank: int, world_size: int, rendezvous: str):
         timeout=timedelta(seconds=30),
     )
     try:
-        for tokens, heads in [(0, 23), (1, 1), (3, 7), (64, 24), (65, 23)]:
+        for tokens, heads in [(0, 23), (1, 1), (3, 7), (4, 24), (64, 24), (65, 23)]:
             dim = 5
             local_heads = (heads + world_size - 1) // world_size
             chunk = (tokens + world_size - 1) // world_size
@@ -33,8 +33,16 @@ def _exchange_worker(rank: int, world_size: int, rendezvous: str):
                 full, (0, 0, 0, local_heads * world_size - heads)
             )
             local = padded[:, rank * local_heads : (rank + 1) * local_heads]
+            if prepad:
+                local = torch.nn.functional.pad(
+                    local, (0, 0, 0, 0, 0, chunk * world_size - tokens)
+                ).contiguous()
 
-            def exchange(rows):
+            def exchange(rows, local=local):
+                if prepad:
+                    # Lookup already emitted the communication buffer. A tail
+                    # batch must not allocate and copy that buffer again.
+                    assert rows.data_ptr() == local.data_ptr()
                 received = torch.empty_like(rows)
                 dist.all_to_all_single(received, rows.contiguous())
                 return received
@@ -49,10 +57,11 @@ def _exchange_worker(rank: int, world_size: int, rendezvous: str):
 
 
 @pytest.mark.parametrize("world_size", [2, 4])
-def test_all_to_all_preserves_token_and_head_order(world_size, tmp_path):
+@pytest.mark.parametrize("prepad", [False, True])
+def test_all_to_all_preserves_token_and_head_order(world_size, prepad, tmp_path):
     mp.spawn(
         _exchange_worker,
-        args=(world_size, (tmp_path / "rendezvous").as_uri()),
+        args=(world_size, prepad, (tmp_path / "rendezvous").as_uri()),
         nprocs=world_size,
         join=True,
     )

--- a/tests/kernels/test_engram.py
+++ b/tests/kernels/test_engram.py
@@ -631,6 +631,19 @@ def test_engram_head_shards_reconstruct_checkpoint(cpu_offload, tp_size, monkeyp
         monkeypatch.setattr(
             engram_ops, "get_tensor_model_parallel_rank", lambda rank=rank: rank
         )
+
+        def exchange(rows, rank=rank):
+            return torch.cat(
+                [
+                    torch.nn.functional.pad(
+                        shard, (0, 0, 0, 0, 0, (-len(ids)) % tp_size)
+                    )[rank * chunk : (rank + 1) * chunk]
+                    for shard in shards
+                ],
+                dim=0,
+            )
+
+        monkeypatch.setattr(engram_ops, "_engram_sp_exchange", exchange)
         torch.testing.assert_close(
             module.embed(ids), padded[rank * chunk : (rank + 1) * chunk], rtol=0, atol=0
         )

--- a/tests/kernels/test_engram.py
+++ b/tests/kernels/test_engram.py
@@ -652,8 +652,11 @@ def test_engram_head_shards_reconstruct_checkpoint(cpu_offload, tp_size, monkeyp
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
 @pytest.mark.parametrize("cpu_offload", [False, True])
 @pytest.mark.parametrize("background", [False, True])
-@pytest.mark.parametrize("num_tokens", [1, 7, 256])
-def test_engram_lookup_matches_torch(cpu_offload, background, num_tokens):
+@pytest.mark.parametrize("num_tokens", [0, 1, 7, 256])
+@pytest.mark.parametrize("token_padding", [0, 3])
+def test_engram_lookup_matches_torch(
+    cpu_offload, background, num_tokens, token_padding
+):
     """The fused gather must be bit-exact with the torch dequant path it
     replaces, from HBM and from pinned host memory alike, and must contribute
     zeros for rows another TP rank owns."""
@@ -667,7 +670,14 @@ def test_engram_lookup_matches_torch(cpu_offload, background, num_tokens):
         layer.vocab_start_idx,
         layer.vocab_end_idx,
     )
-    out = torch.empty(num_tokens, cols, layer.dim, dtype=torch.bfloat16, device="cuda")
+    expected = torch.nn.functional.pad(expected, (0, 0, 0, 0, 0, token_padding))
+    # Poison the reused output so stale rows cannot satisfy the zero-tail check.
+    out = torch.full(
+        (num_tokens + token_padding, cols, layer.dim),
+        37,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
     layer.lookup(ids, out, background=background)
     assert torch.equal(out, expected)
 
@@ -695,8 +705,10 @@ def _run_engram_prepared_rows(
     torch.nn.Module.__init__(engram)
     engram.embed_tokens = layer
     engram.use_sequence_parallel = use_sequence_parallel
+    engram._staged_token_multiple = tp_size if use_sequence_parallel else 1
+    staged_tokens = num_tokens + (-num_tokens) % engram._staged_token_multiple
     engram.staged_rows = torch.empty(
-        num_tokens,
+        staged_tokens,
         layer.part_n_hash_cols,
         layer.dim,
         dtype=torch.bfloat16,

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -597,6 +597,7 @@ def _engram_lookup_kernel(
     vocab_start,
     vocab_end,
     num_rows,
+    num_tokens,
     ids_stride_t,
     ids_stride_h,
     HEAD_START: tl.constexpr,
@@ -609,7 +610,7 @@ def _engram_lookup_kernel(
 ):
     """Gather fp8 rows, apply their ue8m0 block scales, write bf16.
 
-    Only this rank's heads are read; padded heads write zeros for all-gather.
+    Only this rank's heads are read; padded heads and token rows write zeros.
     `weight`/`scales` may address pinned host memory through UVA.
     """
     cols = tl.arange(0, DIM)
@@ -619,12 +620,12 @@ def _engram_lookup_kernel(
         valid = rows < num_rows
         head = HEAD_START + rows % LOCAL_HEADS
         token = (rows // LOCAL_HEADS).to(tl.int64)
+        owned = valid & (token < num_tokens) & (head < TOTAL_HEADS)
         index = tl.load(
             ids + token * ids_stride_t + head * ids_stride_h,
-            mask=valid & (head < TOTAL_HEADS),
+            mask=owned,
             other=-1,
         ).to(tl.int64)
-        owned = valid & (head < TOTAL_HEADS)
         owned &= (index >= vocab_start) & (index < vocab_end)
         local = tl.where(owned, index - vocab_start, 0)
         values = tl.load(
@@ -743,11 +744,11 @@ class ParallelEngramEmbedding(nn.Module):
     def lookup(
         self, indices: torch.Tensor, out: torch.Tensor, background: bool = False
     ) -> None:
-        """Look up local heads of [T, heads] into [T, local_heads, dim] bf16.
+        """Look up local heads, zeroing any extra token rows in ``out``.
 
         `background` limits the grid to leave SMs for concurrent work.
         """
-        rows = indices.shape[0] * self.part_n_hash_cols
+        rows = out.shape[0] * self.part_n_hash_cols
         if not rows:
             return
         weight, scales = self._storage()
@@ -763,6 +764,7 @@ class ParallelEngramEmbedding(nn.Module):
             self.vocab_start_idx,
             self.vocab_end_idx,
             rows,
+            indices.shape[0],
             indices.stride(0),
             indices.stride(1),
             HEAD_START=self.head_start,
@@ -937,6 +939,10 @@ class Engram(nn.Module):
         )
 
         max_tokens = get_current_vllm_config().scheduler_config.max_num_batched_tokens
+        self._staged_token_multiple = (
+            self.embed_tokens.tp_size if use_sequence_parallel else 1
+        )
+        max_tokens += -max_tokens % self._staged_token_multiple
         # Keep lookup results alive across breakable graph segments.
         self.staged_rows = torch.empty(
             max_tokens,
@@ -945,13 +951,19 @@ class Engram(nn.Module):
             dtype=torch.bfloat16,
         )
 
+    def _staged_embeddings(self, num_tokens: int) -> torch.Tensor:
+        # Hand-staged callers retain the unpadded exchange path.
+        multiple = getattr(self, "_staged_token_multiple", 1)
+        num_tokens += -num_tokens % multiple
+        return self.staged_rows[:num_tokens]
+
     def prepare_embeddings(self, hash_ids: torch.Tensor) -> None:
         """Gather this layer's rows on the main stream before decoder layers."""
-        self.embed_tokens.lookup(hash_ids, self.staged_rows[: hash_ids.shape[0]])
+        self.embed_tokens.lookup(hash_ids, self._staged_embeddings(hash_ids.shape[0]))
 
     def embed(self, hash_ids: torch.Tensor) -> torch.Tensor:
         """Gather heads, returning only local tokens when SP is enabled."""
-        rows = self.staged_rows[: hash_ids.shape[0]]
+        rows = self._staged_embeddings(hash_ids.shape[0])
         if self.embed_tokens.tp_size == 1:
             return rows
         if self.use_sequence_parallel:

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -44,6 +44,7 @@ from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    get_tp_group,
     tensor_model_parallel_all_gather,
 )
 from vllm.logger import init_logger
@@ -52,12 +53,38 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.triton_utils import tl, triton
 from vllm.utils.platform_utils import is_uva_available
-from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
+from vllm.utils.torch_utils import (
+    direct_register_custom_op,
+    get_accelerator_view_from_cpu_tensor,
+)
+
+from .engram_parallel import exchange_heads_for_tokens
 
 logger = init_logger(__name__)
 
 # Cache value for tokens that take no part in an n-gram (image spans).
 DEAD_ID = -1
+
+
+def _engram_sp_all_to_all(rows: torch.Tensor) -> torch.Tensor:
+    output = torch.empty_like(rows)
+    torch.distributed.all_to_all_single(output, rows, group=get_tp_group().device_group)
+    return output
+
+
+def _engram_sp_all_to_all_fake(rows: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(rows)
+
+
+direct_register_custom_op(
+    op_name="engram_sp_all_to_all",
+    op_func=_engram_sp_all_to_all,
+    fake_impl=_engram_sp_all_to_all_fake,
+)
+
+
+def _engram_sp_exchange(rows: torch.Tensor) -> torch.Tensor:
+    return torch.ops.vllm.engram_sp_all_to_all(rows)
 
 
 def _is_prime(n: int) -> bool:
@@ -854,28 +881,6 @@ def _fused_engram_post_wkv_kernel(
     )
 
 
-@triton.jit(do_not_specialize=["num_tokens", "token_start", "num_elements"])
-def _engram_sp_rows_kernel(
-    gathered,
-    output,
-    num_tokens,
-    token_start,
-    num_elements,
-    LOCAL_WIDTH: tl.constexpr,
-    WIDTH: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-):
-    offsets = tl.program_id(0).to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    tokens = token_start + offsets // WIDTH
-    cols = offsets % WIDTH
-    source = (cols // LOCAL_WIDTH * num_tokens + tokens) * LOCAL_WIDTH
-    source += cols % LOCAL_WIDTH
-    values = tl.load(
-        gathered + source, (offsets < num_elements) & (tokens < num_tokens), other=0
-    )
-    tl.store(output + offsets, values, offsets < num_elements)
-
-
 class Engram(nn.Module):
     """Writes an n-gram lookup into the residual stream, gated by how well it
     matches that stream.
@@ -950,22 +955,12 @@ class Engram(nn.Module):
         if self.embed_tokens.tp_size == 1:
             return rows
         if self.use_sequence_parallel:
-            tp_size = self.embed_tokens.tp_size
-            num_tokens, local_heads, dim = rows.shape
-            gathered = tensor_model_parallel_all_gather(rows, dim=0)
-            chunk = (num_tokens + tp_size - 1) // tp_size
-            rows = rows.new_empty((chunk, self.embed_tokens.n_hash_cols, dim))
-            _engram_sp_rows_kernel[(triton.cdiv(rows.numel(), 1024),)](
-                gathered,
+            return exchange_heads_for_tokens(
                 rows,
-                num_tokens,
-                get_tensor_model_parallel_rank() * chunk,
-                rows.numel(),
-                local_heads * dim,
-                self.embed_tokens.n_hash_cols * dim,
-                BLOCK_SIZE=1024,
+                self.embed_tokens.tp_size,
+                self.embed_tokens.n_hash_cols,
+                _engram_sp_exchange,
             )
-            return rows
         rows = tensor_model_parallel_all_gather(rows, dim=1)
         return rows[:, : self.embed_tokens.n_hash_cols]
 

--- a/vllm/models/deepseek_v4_1/common/engram_parallel.py
+++ b/vllm/models/deepseek_v4_1/common/engram_parallel.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Redistribute head-sharded Engram rows to sequence-parallel token owners."""
+
+from collections.abc import Callable
+
+import torch
+
+
+def exchange_heads_for_tokens(
+    rows: torch.Tensor,
+    tp_size: int,
+    num_heads: int,
+    exchange: Callable[[torch.Tensor], torch.Tensor],
+) -> torch.Tensor:
+    """Return this rank's padded token chunk with all non-padding heads.
+
+    Args:
+        rows: All tokens and this rank's padded head shard, shaped [T, H/P, D].
+        tp_size: Number of head and token owners.
+        num_heads: Unpadded global head count.
+        exchange: Equal-split all-to-all in rank order along the token dimension.
+    """
+    num_tokens, local_heads, dim = rows.shape
+    if not num_tokens:
+        return rows.new_empty((0, num_heads, dim))
+    chunk = (num_tokens + tp_size - 1) // tp_size
+    padding = chunk * tp_size - num_tokens
+    if padding:
+        rows = torch.nn.functional.pad(rows, (0, 0, 0, 0, 0, padding))
+    else:
+        rows = rows.contiguous()
+    received = exchange(rows)
+    return (
+        received.view(tp_size, chunk, local_heads, dim)
+        .permute(1, 0, 2, 3)
+        .reshape(chunk, tp_size * local_heads, dim)[:, :num_heads]
+    )


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/vllm-project/vllm/pull/56435/files) against `main`.

Redistribute DeepSeek-V4.1 Engram head shards directly to their SP token owners with all-to-all, then restore head order and trim padded heads. The latest implementation also makes the lookup kernel emit zero-padded tail rows directly into the staged communication buffer, avoiding the separate tail-padding copy. TP1, empty input, uneven heads/tokens and changing-input graph replay are covered.

**Main sync (2026-09-14):** current head `06c76927ac29b5c25d71508c82613e2e8a366028` merges `main` at `663d7f679eda78a8d48613dfede8a4b4bcff2b74`. The previous feature patch and upstream integration are preserved, with model paths and test imports updated from `deepseek_v4_1` to `deepseek_v41`. Normalized added/removed patch lines are identical. Changed-file pre-commit hooks (`.venv/bin/pre-commit run --files` for every final PR file), Python parsing and `git diff origin/main --check` passed. The Engram CPU suite passed 4 tests; 3 CUDA cases were skipped. CUDA compilation, GPU execution and full-model evaluations were not rerun; the model/performance evidence below remains historical. AI assistance was used for conflict resolution and validation.

## Test Result

### End-to-end outcome

| Item | Recorded details |
| --- | --- |
| Observed result | Latest candidate versus the original all-gather baseline: +10.62% / +8.36% observed output throughput at 512 / 2048 input tokens. |

### Output throughput

| Input → output tokens | Baseline (tok/s) | Candidate (tok/s) | Throughput change |
| --- | ---: | ---: | ---: |
| 512 → 128 | 16.8687 | 18.6605 | **+10.62%** |
| 2048 → 128 | 13.0784 | 14.1720 | **+8.36%** |

### Mean end-to-end latency

| Input → output tokens | Baseline E2E (s) | Candidate E2E (s) |
| --- | ---: | ---: |
| 512 → 128 | 30.259 | 27.350 |
| 2048 → 128 | 39.010 | 36.002 |

### Comparison setup

| Item | Recorded details |
| --- | --- |
| Baseline | The original baseline is `c9d909e802a39292f54101bff8a36096761ea605`. |
| Candidate | The candidate is frozen #56219 source `217c489d168537fa92d1af476e1fc77101898208` plus the tail-padding repair now present at `99fc95bb77e9cc0b147f776082e90af125b078c6`. |
| Previous-version comparison | Against the previous all-to-all version, the additional observed change is +9.64% / +8.70% (17.0204 → 18.6605 and 13.0378 → 14.1720 tok/s). |
| Interpretation | These are different comparisons, not additive gains. |
| Parallelism and offload | Both use TP2×DP2, PP1, EP4 and unchanged 8 GiB requested weight offload. |

### Correctness and regression checks

| Validation | Latest result |
| --- | --- |
| Candidate CUDA regressions | 54/54 passed; padded lookup, HBM/UVA, TP1/2/4 and graph coverage |
| Additional TP4 changing-input graph check | Passed |
| Full-model short QA | 6/6 correct |
| Serial / fixed-input / concurrent token comparisons | 4/4, 6/6, 4/4 matched the previous SP version; that version's same checks also matched the original baseline |
| Timed requests | 16/16 per input length, zero failures, 2048 generated tokens each |
| Changed-file pre-commit and Python parsing | Passed for the submitted repair |

### Measurement limits

| Item | Recorded details |
| --- | --- |
| Attribution | The measured microsecond-level lookup/exchange differences do not explain or isolate the full E2E change. |
| Incomplete microbenchmark | A separate TP2 microbenchmark wrote timings but hung during teardown; that run remains failed, and no completed replacement TP4 timing sweep is claimed. |
| Historical mismatches | Earlier output mismatches are retained in the historical evidence and are not explained by the newer passing probes. |

## Test configuration and commands

| Setting | Recorded configuration |
| --- | --- |
| Model and checkpoint | Official `deepseek-ai/DeepSeek-V4.1-Flash`, checkpoint revision `df42c109f1defefcbfcedbe7d905718a12266e40` |
| Hardware | one node, 4×H100 SXM 80 GB with NV18 links |
| Runner | V1 eager |
| Expert parallelism | EP with `allgather_reducescatter` |
| Engram placement | Engram CPU offload |
| KV cache | fixed 4 GiB KV cache per worker |
| Scheduler limits | max context 4096, batched tokens 512, max sequences 4 |
| Request protocol | Each workload uses random inputs, seed 42, concurrency 4, exactly 128 output tokens with EOS ignored, four separate warmup requests and then a prefix-cache reset before 16 timed requests. |
| Timing boundary | Startup is excluded. |

### Measurement scope

| Item | Recorded details |
| --- | --- |
| Comparison design | These are single non-interleaved comparisons against recorded baselines, without repeated A/B, A/A or confidence intervals. |
| Output checks | Token checks cover the listed prompts; log probabilities can differ and these checks are not a standard model-quality evaluation. |
| Latest-tree coverage | The complete rebased `main` tree was not rerun on GPU. |
| Source receipts | The attached source correspondence distinguishes matching repair code from pre-existing `main` differences. |

<details>
<summary>Regression and source-check commands</summary>

```sh
.venv/bin/python -m pytest --noconftest -o addopts= \
  tests/distributed/test_engram_parallel.py tests/kernels/test_engram.py -q
```

</details>

The recorded focused CUDA invocation and its selection are in the evidence; the 54-pass figure is for that selection, not an assertion that every case in both files was rerun.

<details>
<summary>Serving benchmark command</summary>

```sh
# On the source/configuration identified by the attached run receipt:
.venv/bin/vllm bench serve --backend vllm \
  --base-url http://127.0.0.1:18080 --endpoint /v1/completions --model dsv41 \
  --tokenizer "$MODEL" --tokenizer-mode deepseek_v41 --dataset-name random \
  --random-input-len "$INPUT_LEN" --random-output-len 128 \
  --random-range-ratio 0 --random-prefix-len 0 --num-prompts 16 \
  --max-concurrency 4 --request-rate inf --seed 42 --num-warmups 0 \
  --ready-check-timeout-sec 0 --ignore-eos --disable-tqdm --save-result --save-detailed \
  --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 10,50,90 \
  --result-dir "$RESULTS" --result-filename "$RESULT_FILE"
```

</details>

`INPUT_LEN` is 512 or 2048. Run the four warmup requests separately and reset the prefix cache before this timed command. Use the actual port and source/configuration in the attached receipt.

## Scope and evidence

#56230 changes DP table ownership; this PR preserves placement and changes TP head-to-SP-token redistribution. #56436 handles lookup scheduling and #56440 handles microbatch history, so those operations remain separate.

[Latest raw timing records, configuration, source hashes and validation receipts](https://gist.github.com/0z5a/d2997a0aa0d1a6a684c312a325adf777). Superseded E2E tables have been removed from this description.

[Earlier complete lookup/exchange diagnostics and focused GPU coverage](https://gist.github.com/0z5a/17782bef0d9485a04c7269cd46b21c20).
