### PR TITLE
[Perf][Engram] Limit DeepSeek-V4.1 lookup overlap to configured workloads

### DIFF
--- a/tests/kernels/test_engram.py
+++ b/tests/kernels/test_engram.py
@@ -662,13 +662,14 @@ def test_engram_lookup_matches_torch(cpu_offload, background, num_tokens):
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
 @pytest.mark.parametrize("cpu_offload", [False, True])
 @pytest.mark.parametrize("capture", ["eager", "full", "breakable"])
-def test_engram_prepared_rows_survive_graph_breaks(cpu_offload, capture):
+@pytest.mark.parametrize("overlap", [False, True])
+def test_engram_prepared_rows_survive_graph_breaks(cpu_offload, capture, overlap):
     """Consume early lookup results after a break, with fresh IDs each replay."""
-    _run_engram_prepared_rows(cpu_offload, capture)
+    _run_engram_prepared_rows(cpu_offload, capture, overlap=overlap)
 
 
 def _run_engram_prepared_rows(
-    cpu_offload, capture, tp_size=1, rank=0, use_sequence_parallel=False
+    cpu_offload, capture, tp_size=1, rank=0, use_sequence_parallel=False, overlap=False
 ):
     from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
 
@@ -689,6 +690,7 @@ def _run_engram_prepared_rows(
         dtype=torch.bfloat16,
         device="cuda",
     )
+    engram._init_lookup_staging(1, overlap)
     # Match the non-contiguous per-layer slice of the model hash tensor.
     hashes = torch.randint(
         0,
@@ -762,17 +764,28 @@ def _engram_tp_worker(rank, tp_size, port):
         for cpu_offload in (False, True):
             for sp in (False, True):
                 for capture in ("eager", "compiled", "full", "breakable"):
-                    _run_engram_prepared_rows(cpu_offload, capture, tp_size, rank, sp)
+                    for overlap in (False, True):
+                        _run_engram_prepared_rows(
+                            cpu_offload, capture, tp_size, rank, sp, overlap=overlap
+                        )
     finally:
         cleanup_dist_env_and_memory()
 
 
-@pytest.mark.distributed(num_gpus=2)
+@pytest.mark.parametrize(
+    "tp_size",
+    [
+        pytest.param(2, marks=pytest.mark.distributed(num_gpus=2)),
+        pytest.param(4, marks=pytest.mark.distributed(num_gpus=4)),
+    ],
+)
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
-def test_engram_head_collectives_survive_graph_breaks():
-    """All-gather preserves head order and local SP tokens across graph replay."""
+def test_engram_head_collectives_survive_graph_breaks(tp_size):
+    """All-gather preserves staged SP tokens across graph and compile replay."""
     from vllm.utils.network_utils import get_open_port
 
-    if torch.accelerator.device_count() < 2:
-        pytest.skip("Requires two GPUs")
-    torch.multiprocessing.spawn(_engram_tp_worker, args=(2, get_open_port()), nprocs=2)
+    if torch.accelerator.device_count() < tp_size:
+        pytest.skip(f"Requires {tp_size} GPUs")
+    torch.multiprocessing.spawn(
+        _engram_tp_worker, args=(tp_size, get_open_port()), nprocs=tp_size
+    )

--- a/tests/kernels/test_engram.py
+++ b/tests/kernels/test_engram.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import bisect
+from contextlib import nullcontext
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -659,6 +661,61 @@ def test_engram_lookup_matches_torch(cpu_offload, background, num_tokens):
     assert torch.equal(out, expected)
 
 
+@pytest.mark.parametrize("capture", ["eager", "full", "breakable"])
+def test_engram_lookup_fallback_does_not_wait_on_previous_batch(monkeypatch, capture):
+    """Changing the route must not wait on an event from a previous batch."""
+    current = Mock()
+    streams, events = [Mock(), Mock()], [Mock(), Mock()]
+    stream_iter, event_iter = iter(streams), iter(events)
+    slot = [0]
+    monkeypatch.setattr(torch.cuda, "Stream", lambda **kwargs: next(stream_iter))
+    monkeypatch.setattr(torch.cuda, "Event", lambda: next(event_iter))
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: current)
+    monkeypatch.setattr(torch.cuda, "stream", lambda stream: nullcontext())
+    monkeypatch.setattr(
+        torch.cuda, "is_current_stream_capturing", lambda: capture == "full"
+    )
+    monkeypatch.setattr(
+        engram_ops.BreakableCUDAGraphCapture,
+        "is_active",
+        lambda: capture == "breakable",
+    )
+    monkeypatch.setattr(engram_ops, "dbo_current_ubatch_id", lambda: slot[0])
+    module = Engram.__new__(Engram)
+    torch.nn.Module.__init__(module)
+    module.staged_rows = torch.empty(2, 1, 1)
+    module._init_lookup_staging(2, True)
+    lookup = Mock(side_effect=lambda ids, out, **kwargs: out.copy_(ids.unsqueeze(-1)))
+    module.embed_tokens = SimpleNamespace(lookup=lookup)
+
+    for i, (slot_id, allowed) in enumerate(
+        [(0, True), (1, True), (0, False), (1, False), (0, True)]
+    ):
+        slot[0] = slot_id
+        current.reset_mock()
+        ids = torch.full((2, 1), i, dtype=torch.int32)
+        rows = module.prepare_embeddings(ids, allow_overlap=allowed)
+        module.wait_for_embeddings()
+        background = allowed and capture == "eager"
+        assert lookup.call_args.kwargs.get("background", False) is background
+        torch.testing.assert_close(rows.squeeze(-1), ids.float())
+        if background:
+            current.wait_event.assert_called_once_with(events[slot[0]])
+        else:
+            current.wait_event.assert_not_called()
+        if i == 2 and capture == "eager":
+            # Falling back in slot 0 must preserve slot 1's outstanding event.
+            slot[0] = 1
+            module.wait_for_embeddings()
+            current.wait_event.assert_called_once_with(events[1])
+
+    current.reset_mock()
+    module.prepare_embeddings(ids)
+    module.wait_for_embeddings()
+    assert "background" not in lookup.call_args.kwargs
+    current.wait_event.assert_not_called()
+
+
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
 @pytest.mark.parametrize("cpu_offload", [False, True])
 @pytest.mark.parametrize("capture", ["eager", "full", "breakable"])
@@ -711,7 +768,7 @@ def _run_engram_prepared_rows(
         embed = torch.compile(embed, backend="eager", fullgraph=True, dynamic=True)
 
     def step(cap=None):
-        engram.prepare_embeddings(src)
+        engram.prepare_embeddings(src, allow_overlap=overlap)
         if cap is not None:
             cap.add_eager(lambda: None)
         out.copy_(embed(src))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1090,6 +1090,38 @@ def test_engram_tensor_parallel_size(dp_size: int, across_dp: bool, expected: in
     assert config.get_parallel_size(parallel) == expected
 
 
+@pytest.mark.parametrize(
+    "enabled, offload, limit, context, prompt, expected",
+    [
+        (False, True, 640, 512, 512, False),
+        (True, False, 640, 512, 512, False),
+        (True, True, 0, 512, 512, False),
+        (True, True, 640, 512, 512, True),
+        (True, True, 640, 640, 512, True),
+        (True, True, 640, 641, 512, False),
+        (True, True, 640, 32, 2048, False),
+        (True, True, 640, 2049, 2048, False),
+        (True, True, 640, 0, 512, False),
+        (True, True, 640, 512, 0, False),
+    ],
+)
+def test_engram_overlap_respects_full_request_lengths(
+    enabled, offload, limit, context, prompt, expected
+):
+    """A short chunk or decode step must not opt a long request into overlap."""
+    config = EngramConfig(
+        lookup_overlap=enabled,
+        cpu_offload=offload,
+        lookup_overlap_max_seq_len=limit,
+    )
+    assert config.allows_lookup_overlap(context, prompt) is expected
+
+
+def test_engram_overlap_rejects_negative_limit():
+    with pytest.raises(ValidationError, match="lookup_overlap_max_seq_len"):
+        EngramConfig(lookup_overlap_max_seq_len=-1)
+
+
 def test_engram_rejects_elastic_cross_dp():
     parallel = ParallelConfig(
         tensor_parallel_size=4,

--- a/tests/v1/worker/test_gpu_ubatch_slicing.py
+++ b/tests/v1/worker/test_gpu_ubatch_slicing.py
@@ -178,6 +178,25 @@ def test_slicing_matches_v1_split_attn_metadata(batch_name: str):
         )
 
 
+@pytest.mark.parametrize("allowed", [False, True])
+def test_engram_lookup_decision_survives_metadata_slicing(allowed):
+    """A microbatch inherits the conservative decision for the whole batch."""
+    metadata = create_common_attn_metadata(
+        BatchSpec(seq_lens=[64, 2048], query_lens=[1, 1]),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    metadata.engram_lookup_overlap = allowed
+    unpadded = metadata.unpadded(num_actual_tokens=2, num_actual_reqs=2)
+    assert unpadded.engram_lookup_overlap is allowed
+    slices = [
+        UBatchSlice(slice(0, 1), slice(0, 1)),
+        UBatchSlice(slice(1, 2), slice(1, 2)),
+    ]
+    for microbatch in split_attn_metadata(slices, metadata):
+        assert microbatch.engram_lookup_overlap is allowed
+
+
 def test_microbatches_do_not_share_buffers():
     """Both microbatches are live at once, so their buffers must be distinct."""
     query_lens, seq_lens = BATCHES["split_request"]

--- a/vllm/config/engram.py
+++ b/vllm/config/engram.py
@@ -47,6 +47,9 @@ class EngramConfig:
     """Shard embeddings across TP and all DP ranks when enabled.
     Otherwise, each DP rank has a separate TP-sharded embedding replica."""
 
+    lookup_overlap: bool = False
+    """Prefetch Engram rows on a separate CUDA stream while decoder layers run."""
+
     def verify_model_config(self, model_config: "ModelConfig | None") -> None:
         """Reject Engram configuration for models without n-gram embeddings."""
         from vllm.platforms import current_platform

--- a/vllm/config/engram.py
+++ b/vllm/config/engram.py
@@ -48,7 +48,22 @@ class EngramConfig:
     Otherwise, each DP rank has a separate TP-sharded embedding replica."""
 
     lookup_overlap: bool = False
-    """Prefetch Engram rows on a separate CUDA stream while decoder layers run."""
+    """Experimentally overlap Engram lookup within an explicit workload limit.
+    Supported for CPU-offloaded embeddings on the V1 eager runner."""
+
+    lookup_overlap_max_seq_len: int = Field(default=0, ge=0)
+    """Maximum full prompt and current context length eligible for overlap.
+    Zero disables overlap. Set a positive limit after profiling the target
+    workload; this is an execution policy, not a guaranteed speedup threshold."""
+
+    def allows_lookup_overlap(self, max_seq_len: int, max_prompt_len: int) -> bool:
+        """Require every request, including chunked prefills, to fit the limit."""
+        return (
+            self.lookup_overlap
+            and self.cpu_offload
+            and 0 < max_seq_len <= self.lookup_overlap_max_seq_len
+            and 0 < max_prompt_len <= self.lookup_overlap_max_seq_len
+        )
 
     def verify_model_config(self, model_config: "ModelConfig | None") -> None:
         """Reject Engram configuration for models without n-gram embeddings."""

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -908,7 +908,8 @@ class Engram(nn.Module):
         # Named ``embed_tokens`` so the checkpoint's ``engram.embed.weight``
         # survives the mapper's ``embed.weight`` -> ``embed_tokens.weight``
         # suffix rule.
-        engram_config = get_current_vllm_config().engram_config
+        vllm_config = get_current_vllm_config()
+        engram_config = vllm_config.engram_config
         self.embed_tokens = ParallelEngramEmbedding(
             layout.num_embeddings[layer_hash_index],
             layout.head_dim,
@@ -933,7 +934,7 @@ class Engram(nn.Module):
             requires_grad=False,
         )
 
-        max_tokens = get_current_vllm_config().scheduler_config.max_num_batched_tokens
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         # Keep lookup results alive across breakable graph segments.
         self.staged_rows = torch.empty(
             max_tokens,
@@ -941,10 +942,15 @@ class Engram(nn.Module):
             layout.head_dim,
             dtype=torch.bfloat16,
         )
-        parallel_config = get_current_vllm_config().parallel_config
+        parallel_config = vllm_config.parallel_config
         self._init_lookup_staging(
             parallel_config.num_ubatches if parallel_config.use_ubatching else 1,
-            engram_config.lookup_overlap if engram_config else False,
+            engram_config is not None
+            and engram_config.lookup_overlap
+            and engram_config.cpu_offload
+            and engram_config.lookup_overlap_max_seq_len > 0
+            and vllm_config.model_config.enforce_eager
+            and not vllm_config.use_v2_model_runner,
         )
 
     def _init_lookup_staging(self, num_slots: int, overlap: bool) -> None:
@@ -960,6 +966,7 @@ class Engram(nn.Module):
             else []
         )
         self._lookup_ready = [torch.cuda.Event() for _ in self._lookup_streams]
+        self._lookup_pending = [False] * num_slots
 
     def _lookup_slot(self) -> int:
         rows = getattr(self, "_lookup_rows", None)
@@ -967,14 +974,17 @@ class Engram(nn.Module):
 
     def wait_for_embeddings(self) -> None:
         if (
-            getattr(self, "_lookup_streams", None)
+            getattr(self, "_lookup_pending", None)
+            and self._lookup_pending[self._lookup_slot()]
             and not BreakableCUDAGraphCapture.is_active()
         ):
             torch.cuda.current_stream().wait_event(
                 self._lookup_ready[self._lookup_slot()]
             )
 
-    def prepare_embeddings(self, hash_ids: torch.Tensor) -> torch.Tensor:
+    def prepare_embeddings(
+        self, hash_ids: torch.Tensor, *, allow_overlap: bool = False
+    ) -> torch.Tensor:
         """Stage local heads after hashing, optionally overlapping decoder compute."""
         slot = self._lookup_slot()
         buffers = getattr(self, "_lookup_rows", None)
@@ -982,7 +992,17 @@ class Engram(nn.Module):
             : hash_ids.shape[0]
         ]
         streams = getattr(self, "_lookup_streams", None)
-        if streams and not BreakableCUDAGraphCapture.is_active():
+        overlap = bool(
+            streams
+            and allow_overlap
+            and not BreakableCUDAGraphCapture.is_active()
+            and not torch.cuda.is_current_stream_capturing()
+        )
+        pending = getattr(self, "_lookup_pending", None)
+        if pending is not None:
+            pending[slot] = overlap
+        if overlap:
+            assert streams is not None
             stream = streams[slot]
             stream.wait_stream(torch.cuda.current_stream())
             with torch.cuda.stream(stream):

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -40,6 +40,7 @@ import numpy as np
 import torch
 from torch import nn
 
+from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphCapture
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
@@ -53,6 +54,7 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.triton_utils import tl, triton
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
+from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 logger = init_logger(__name__)
 
@@ -939,14 +941,70 @@ class Engram(nn.Module):
             layout.head_dim,
             dtype=torch.bfloat16,
         )
+        parallel_config = get_current_vllm_config().parallel_config
+        self._init_lookup_staging(
+            parallel_config.num_ubatches if parallel_config.use_ubatching else 1,
+            engram_config.lookup_overlap if engram_config else False,
+        )
 
-    def prepare_embeddings(self, hash_ids: torch.Tensor) -> None:
-        """Gather this layer's rows on the main stream before decoder layers."""
-        self.embed_tokens.lookup(hash_ids, self.staged_rows[: hash_ids.shape[0]])
+    def _init_lookup_staging(self, num_slots: int, overlap: bool) -> None:
+        self._lookup_rows = [self.staged_rows] + [
+            torch.empty_like(self.staged_rows) for _ in range(num_slots - 1)
+        ]
+        self._lookup_streams = (
+            [
+                torch.cuda.Stream(device=self.staged_rows.device)
+                for _ in range(num_slots)
+            ]
+            if overlap
+            else []
+        )
+        self._lookup_ready = [torch.cuda.Event() for _ in self._lookup_streams]
 
-    def embed(self, hash_ids: torch.Tensor) -> torch.Tensor:
+    def _lookup_slot(self) -> int:
+        rows = getattr(self, "_lookup_rows", None)
+        return dbo_current_ubatch_id() if rows is not None and len(rows) > 1 else 0
+
+    def wait_for_embeddings(self) -> None:
+        if (
+            getattr(self, "_lookup_streams", None)
+            and not BreakableCUDAGraphCapture.is_active()
+        ):
+            torch.cuda.current_stream().wait_event(
+                self._lookup_ready[self._lookup_slot()]
+            )
+
+    def prepare_embeddings(self, hash_ids: torch.Tensor) -> torch.Tensor:
+        """Stage local heads after hashing, optionally overlapping decoder compute."""
+        slot = self._lookup_slot()
+        buffers = getattr(self, "_lookup_rows", None)
+        rows = (buffers[slot] if buffers is not None else self.staged_rows)[
+            : hash_ids.shape[0]
+        ]
+        streams = getattr(self, "_lookup_streams", None)
+        if streams and not BreakableCUDAGraphCapture.is_active():
+            stream = streams[slot]
+            stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(stream):
+                self.embed_tokens.lookup(hash_ids, rows, background=True)
+                self._lookup_ready[slot].record(stream)
+        else:
+            self.embed_tokens.lookup(hash_ids, rows)
+        return rows
+
+    def embed(
+        self, hash_ids: torch.Tensor, prepared_rows: torch.Tensor | None = None
+    ) -> torch.Tensor:
         """Gather heads, returning only local tokens when SP is enabled."""
-        rows = self.staged_rows[: hash_ids.shape[0]]
+        if prepared_rows is None:
+            self.wait_for_embeddings()
+            buffers = getattr(self, "_lookup_rows", None)
+            prepared_rows = (
+                buffers[self._lookup_slot()]
+                if buffers is not None
+                else self.staged_rows
+            )
+        rows = prepared_rows[: hash_ids.shape[0]]
         if self.embed_tokens.tp_size == 1:
             return rows
         if self.use_sequence_parallel:
@@ -974,11 +1032,12 @@ class Engram(nn.Module):
         hidden_states: torch.Tensor,
         hash_ids: torch.Tensor,
         token_mask: torch.Tensor | None = None,
+        prepared_rows: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """hidden_states: [T, hc_mult, dim]; hash_ids: [T, n_hash_cols] (all
         tokens, pre sequence-parallel shard); token_mask: [T], False shuts
         the gate so those positions pass through untouched."""
-        kv = self.wkv(self.embed(hash_ids).flatten(-2))
+        kv = self.wkv(self.embed(hash_ids, prepared_rows).flatten(-2))
         num_kv_tokens = hash_ids.shape[0]
         assert token_mask is None or token_mask.shape == (num_kv_tokens,)
         if self.use_sequence_parallel:

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -293,6 +293,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         residual: torch.Tensor | None = None,
         engram_hashes: torch.Tensor | None = None,
         engram_mask: torch.Tensor | None = None,
+        engram_rows: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         # The reference collapses each sublayer's input with the *previous*
         # sublayer's pre-mix: attention uses the pre-mix carried in (identity
@@ -343,6 +344,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                     residual,
                     engram_hashes[:, self.engram.layer_hash_index],
                     engram_mask,
+                    prepared_rows=engram_rows,
                 )
             post_mix, res_mix, x, attn_pre = mhc_pre_delayed_tilelang(
                 residual,
@@ -556,6 +558,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # profile runs (KV cache unbound).
         engram_hashes: torch.Tensor | None = None
         engram_mask: torch.Tensor | None = None
+        engram_rows: dict[int, torch.Tensor] = {}
         if (
             self.engram_hash is not None
             and input_ids is not None
@@ -598,8 +601,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 for layer in islice(self.layers, self.start_layer, self.end_layer):
                     engram = getattr(layer, "engram", None)
                     if engram is not None:
-                        engram.prepare_embeddings(
-                            engram_hashes[:, engram.layer_hash_index]
+                        engram_rows[engram.layer_hash_index] = (
+                            engram.prepare_embeddings(
+                                engram_hashes[:, engram.layer_hash_index]
+                            )
                         )
 
         full_num_tokens = positions.shape[0]
@@ -623,6 +628,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
         ):
+            prepared_rows = None
+            if layer.engram is not None and engram_hashes is not None:
+                layer.engram.wait_for_embeddings()
+                prepared_rows = engram_rows[layer.engram.layer_hash_index]
             hidden_states, residual, post_mix, res_mix, pre_mix = layer(
                 hidden_states,
                 positions,
@@ -633,6 +642,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 residual,
                 engram_hashes,
                 engram_mask,
+                prepared_rows,
             )
             if idx + 1 in self.aux_hidden_state_layers:
                 # Reconstruct the aux hidden state for draft models

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -603,7 +603,8 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                     if engram is not None:
                         engram_rows[engram.layer_hash_index] = (
                             engram.prepare_embeddings(
-                                engram_hashes[:, engram.layer_hash_index]
+                                engram_hashes[:, engram.layer_hash_index],
+                                allow_overlap=swa_metadata.engram_lookup_overlap,
                             )
                         )
 

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -454,6 +454,9 @@ class CommonAttentionMetadata:
     _num_computed_tokens_cache: torch.Tensor | None = None
     _token_to_req_indices_cache: torch.Tensor | None = None
 
+    engram_lookup_overlap: bool = False
+    """Runner-approved overlap for the whole batch; unknown paths stay disabled."""
+
     def batch_size(self) -> int:
         return self.seq_lens.shape[0]
 
@@ -511,6 +514,7 @@ class CommonAttentionMetadata:
             num_actual_tokens=num_actual_tokens,
             max_query_len=self.max_query_len,
             max_seq_len=self.max_seq_len,
+            engram_lookup_overlap=self.engram_lookup_overlap,
             block_table_tensor=self.block_table_tensor[:num_actual_reqs],
             slot_mapping=self.slot_mapping[:num_actual_tokens],
             causal=self.causal[:num_actual_reqs]

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -224,6 +224,7 @@ class DeepseekSparseSWAMetadata:
     flashinfer_sparse_index_cache: dict[str, tuple[torch.Tensor, torch.Tensor]] = field(
         default_factory=dict
     )
+    engram_lookup_overlap: bool = False
 
     def get_prefill_chunk_plan(
         self,
@@ -693,6 +694,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
 
         return DeepseekSparseSWAMetadata(
             seq_lens=seq_lens,
+            engram_lookup_overlap=common_attn_metadata.engram_lookup_overlap,
             query_start_loc=query_start_loc,
             query_start_loc_cpu=query_start_loc_cpu,
             block_table=block_table,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2456,6 +2456,21 @@ class GPUModelRunner(
                 self.input_batch.replayssm_decode_base_cpu_tensor[:num_reqs_padded]
             )
 
+        engram_config = self.vllm_config.engram_config
+        engram_lookup_overlap = False
+        if (
+            engram_config is not None
+            and engram_config.lookup_overlap
+            and self.model_config.enforce_eager
+            and not for_cudagraph_capture
+        ):
+            max_prompt_len = int(
+                self.input_batch.num_prompt_tokens[:num_reqs].max(initial=0)
+            )
+            engram_lookup_overlap = engram_config.allows_lookup_overlap(
+                max_seq_len, max_prompt_len
+            )
+
         cm_base = CommonAttentionMetadata(
             query_start_loc=self.query_start_loc.gpu[: num_reqs_padded + 1],
             query_start_loc_cpu=self.query_start_loc.cpu[: num_reqs_padded + 1],
@@ -2466,6 +2481,7 @@ class GPUModelRunner(
             num_actual_tokens=num_tokens_padded,
             max_query_len=max_query_len,
             max_seq_len=max_seq_len,
+            engram_lookup_overlap=engram_lookup_overlap,
             block_table_tensor=block_table_gid_0,
             slot_mapping=slot_mapping_gid_0,
             causal=True,

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -328,6 +328,7 @@ def _make_metadata_with_slice(
         num_actual_tokens=num_actual_tokens,
         max_query_len=max_query_len,
         max_seq_len=max_seq_len,
+        engram_lookup_overlap=attn_metadata.engram_lookup_overlap,
         block_table_tensor=block_table_tensor,
         slot_mapping=slot_mapping,
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/vllm-project/vllm/pull/56436/files) against `main`.

Keep DeepSeek-V4.1 Engram lookup overlap **experimental and default-off**, and enable it only within an explicitly configured workload limit. Eligible batches stage local Engram rows on a CUDA stream and wait immediately before the decoder consumes them. Batches outside that limit use the main-stream lookup path.

**Main sync (2026-09-14):** current head `1d36dc16d9f212fe410e3ca6d9e739db8011297e` merges `main` at `663d7f679eda78a8d48613dfede8a4b4bcff2b74`. The previous feature patch and upstream integration are preserved, with model paths and test imports updated from `deepseek_v4_1` to `deepseek_v41`. Normalized added/removed patch lines are identical. Changed-file pre-commit hooks (`.venv/bin/pre-commit run --files` for every final PR file), Python parsing and `git diff origin/main --check` passed. The routing CPU harness passed 25 tests using production source definitions and CUDA stream/event test doubles. CUDA compilation, GPU execution and full-model evaluations were not rerun; the model/performance evidence below remains historical. AI assistance was used for conflict resolution and validation.

The V1 eager runner checks both the **full prompt length** and the **current context length** of every request. A long prompt cannot become eligible merely because chunked prefill or decode processes a small number of tokens. The whole batch falls back if any request exceeds the limit. CPU offload, `lookup_overlap=true`, and a positive `lookup_overlap_max_seq_len` are required; a missing/zero limit, graph execution, V2, and other unapproved paths keep overlap disabled. Microbatch slots retain separate buffers and only wait for events recorded by their current lookup.

For example, on the V1 runner with `--enforce-eager`:

```bash
--engram-config '{"cpu_offload":true,"lookup_overlap":true,"lookup_overlap_max_seq_len":640}'
```

Here `640` is an explicit policy example covering a 512-token prompt plus up to 128 output tokens; it is **not an established performance crossover point**. Select the bound by profiling the target hardware and workload. Setting `lookup_overlap=true` alone does not enable overlap.

## Test Result

### End-to-end outcome

| Item | Recorded details |
| --- | --- |
| Observed workload | The selected 512 → 128 workload previously observed +2.21% output throughput on 4×H200 NVL over PCIe. |
| Other workloads | Other tested workloads did not show a throughput benefit. |
| Revision coverage | The table measures the earlier overlap implementation; the new bounded routing has not been rerun on GPU and has no new E2E speedup claim. |

| Input → output | Concurrency | Overlap off, tok/s | Overlap on, tok/s | Observed change |
| --- | ---: | ---: | ---: | ---: |
| 512 → 128 | 4 | 71.3980 | 72.9745 | **+2.21%** |

### Comparison setup

| Item | Recorded details |
| --- | --- |
| Source and deployment | Both historical arms used frozen source `2ae34345ee5919130a6a08fe91f969d174b8b69e`, TP4/PP1/DP1+EP, V1 eager, Engram CPU offload and zero generic weight offload, with checkpoint revision `df42c109f1defefcbfcedbe7d905718a12266e40`. |
| Requests and cache | Each arm used four warmups and sixteen timed requests, 128 outputs, concurrency 4, and prefix caching. |
| Cache reset | The cache was reset before warmup. |
| Timing boundary | Startup is excluded. |
| Statistical scope | This was one A/B pair, without repeated trials or confidence intervals, and does not establish a general speedup. |

### Correctness and regression checks

| Validation | Result |
| --- | --- |
| Historical timed requests | 16/16 per arm, zero failures, exactly 128 output tokens/request |
| Historical serial and fixed-input probes | Matched |
| Historical concurrent token comparison | 3/4 matched; one response diverged at generated token 5; cause unresolved, A/A diagnostic not run |
| New routing CPU contracts | **25 passed**: source definitions and added CPU cases, with stream/event test doubles; covers limits, full prompts, context growth, graph fallback, route changes, and metadata slicing |
| Current source checks | Changed-file pre-commit passed, including Ruff, mypy and configuration validation |
| New routing CUDA/full-model E2E | Not run; the historical +2.21% is not a measurement of the current routing change |

### Qualification

| Item | Recorded details |
| --- | --- |
| Output equivalence | The unresolved historical token difference means output equivalence and full-model merge qualification remain unestablished. |

## Test plan and evidence

### CPU test coverage

| Item | Recorded details |
| --- | --- |
| Production definitions | The CPU harness executes the production configuration decorator, policy, staging methods, metadata definitions, and runner policy statements directly from source. |
| Execution mode | It runs the added configuration and stream-routing pytest cases without importing the CUDA runtime. |
| Validation boundary | This verifies control-flow contracts, not GPU synchronization or model accuracy. |
| Existing CUDA tests | The existing `tests/kernels/test_engram.py` GPU cases retain eager/full/breakable-graph and prepared-row checks, with explicit overlap eligibility passed into the staging call. |

<details>
<summary>Regression and source-check commands</summary>

```bash
# In the evidence directory, with CPU Torch, NumPy, Pydantic and pytest installed:
LOOKUP_SOURCE_ROOT=/path/to/checkout .venv/bin/python -m pytest \
  -q -c /dev/null -p no:cacheprovider --confcutdir . test_lookup_routing_cpu.py

# In the checkout:
pre-commit run --files vllm/config/engram.py \
  vllm/models/deepseek_v41/common/engram.py \
  vllm/models/deepseek_v41/nvidia/model.py \
  vllm/v1/attention/backend.py vllm/v1/attention/backends/mla/sparse_swa.py \
  vllm/v1/worker/gpu_model_runner.py vllm/v1/worker/ubatch_utils.py \
  tests/test_config.py tests/kernels/test_engram.py \
  tests/v1/worker/test_gpu_ubatch_slicing.py
```

</details>

This PR retains the upstream all-gather exchange. #56435 changes SP redistribution, #56440 reconstructs microbatch history and #56230 changes DP table ownership; none implements this lookup scheduling policy.

[Historical positive-workload timing records, exact flags and source provenance](https://github.com/0z5a/vllm/tree/7469626a9b19e686801b535cdeddde42fdf02806/benchmarks/results/deepseek-v41-h200-20260911-positive512).

[Routing CPU harness, results and source provenance before this rebase](https://gist.github.com/0z5a/6a4af32ef52466a540cafd9aec46f051). Routing commit used for those CPU results: `22db4b6937d197562c563d562a7dbdbffadfd6b0`.
