### PR TITLE
[Model][PP] Validate DeepSeek-V4.1 sharing dependencies before construction

### DIFF
--- a/tests/models/test_deepseek_v41_pipeline.py
+++ b/tests/models/test_deepseek_v41_pipeline.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.models.deepseek_v4_1.common.pipeline import (
+    get_sharing_dependencies,
+    validate_local_sharing,
+)
+
+
+def _config():
+    return SimpleNamespace(
+        num_hidden_layers=40,
+        compress_ratios=[0, 0] + [2] * 18 + [1] * 20,
+        kv_source_layer_ids=[2, 8, 14, 20],
+        index_source_layer_ids=[2, 8, 14, 20, 24, 28, 32, 36],
+        candidate_source_layer_id=20,
+        candidate_topk_blocks=2048,
+    )
+
+
+@pytest.mark.parametrize(
+    "ranges", [[(0, 40)], [(0, 20), (20, 40)], [(0, 8), (8, 14), (14, 20), (20, 40)]]
+)
+def test_group_aligned_pipeline_cuts_keep_all_sources_local(ranges):
+    validate_local_sharing(get_sharing_dependencies(_config(), ranges))
+
+
+def test_equal_pp4_reports_cross_stage_kv_index_and_candidates():
+    dependencies = get_sharing_dependencies(
+        _config(), [(0, 10), (10, 20), (20, 30), (30, 40)]
+    )
+    cross = {
+        (d.kind, d.source_layer, d.consumer_layer)
+        for d in dependencies
+        if d.source_stage != d.consumer_stage
+    }
+    assert {("kv", 8, 10), ("index", 28, 30), ("candidate", 20, 32)} <= cross
+    with pytest.raises(NotImplementedError, match="source layer 8.*stage 0.*stage 1"):
+        validate_local_sharing(dependencies)
+
+
+@pytest.mark.parametrize("values", [[8, 2], [2, 2], [0, 2], [-1, 2], [2, 40]])
+def test_invalid_source_lists_fail_before_layer_construction(values):
+    config = _config()
+    config.kv_source_layer_ids = values
+    with pytest.raises(ValueError, match="kv_source_layer_ids"):
+        get_sharing_dependencies(config, [(0, 40)])
+
+
+def test_compressed_consumer_requires_an_earlier_source():
+    config = _config()
+    config.kv_source_layer_ids = [8, 14, 20]
+    with pytest.raises(ValueError, match="layer 2 has no preceding kv source"):
+        get_sharing_dependencies(config, [(0, 40)])
+
+
+def test_candidate_source_must_publish_indices():
+    config = _config()
+    config.candidate_source_layer_id = 21
+    with pytest.raises(ValueError, match="candidate source must be an index source"):
+        get_sharing_dependencies(config, [(0, 40)])

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1328,6 +1328,30 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
+def test_pp_empty_uniform_group_does_not_allocate_remote_layers():
+    """An empty projected group retains its type, but must allocate no layers."""
+    spec = new_kv_cache_spec()
+    remote_spec = UniformTypeKVCacheSpecs(
+        block_size=spec.block_size,
+        kv_cache_specs={"remote": spec},
+    )
+    groups = kv_cache_utils._project_kv_cache_groups_to_worker(
+        [
+            KVCacheGroupSpec(["remote"], remote_spec),
+            KVCacheGroupSpec(["local"], spec),
+        ],
+        {"local": spec},
+    )
+    config = VllmConfig()
+    config.cache_config.kv_cache_layout = "BLHNC"
+    cache = kv_cache_utils.get_kv_cache_config_from_groups(
+        config, groups, spec.page_size_bytes * 4
+    )
+    assert cache.num_blocks == 4
+    assert [tensor.layers for tensor in cache.kv_cache_tensors] == [["local"]]
+    assert cache.kv_cache_groups[0].layer_names == []
+
+
 def test_dcp_world_size_for_kv_cache_spec_shards_full_attention_only():
     dcp = 8
     full = FullAttentionSpec(

--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
 
 pytestmark = pytest.mark.skipif(
@@ -209,6 +210,72 @@ def test_dcp_slot_mapping_with_smaller_kernel_blocks(cp_rank: int):
     expected[second_start : second_start + 128] = torch.arange(
         9 * 128, 10 * 128, dtype=torch.int64, device=device
     )
+    assert torch.equal(actual, expected)
+
+
+def test_v1_slot_mapping_masks_out_of_range_block_indices():
+    from vllm.v1.worker.block_table import BlockTable
+
+    device = torch.device("cuda")
+    block_table = BlockTable(
+        block_size=16,
+        max_num_reqs=2,
+        max_num_blocks_per_req=1,
+        max_num_batched_tokens=2,
+        pin_memory=False,
+        device=device,
+        kernel_block_size=16,
+        cp_kv_cache_interleave_size=1,
+    )
+    block_table.add_row([5], row_idx=0)
+    block_table.add_row([9], row_idx=1)
+    block_table.commit_block_table(num_reqs=2)
+
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    positions = torch.tensor([0, 16], dtype=torch.int64, device=device)
+    block_table.compute_slot_mapping(
+        num_reqs=1,
+        query_start_loc=query_start_loc,
+        positions=positions,
+    )
+
+    expected = torch.tensor([80, PAD_SLOT_ID], dtype=torch.int64, device=device)
+    assert torch.equal(block_table.slot_mapping.gpu[:2], expected)
+
+
+def test_v2_slot_mapping_masks_out_of_range_block_indices():
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[16],
+        max_num_reqs=2,
+        max_num_batched_tokens=2,
+        max_num_blocks_per_group=[1],
+        device=device,
+        kernel_block_sizes=[16],
+    )
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([5],),
+        overwrite=True,
+    )
+    block_tables.append_block_ids(
+        req_index=1,
+        new_block_ids=([9],),
+        overwrite=True,
+    )
+    block_tables.apply_staged_writes()
+
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    positions = torch.tensor([0, 16], dtype=torch.int64, device=device)
+    actual = block_tables.compute_slot_mappings(
+        idx_mapping,
+        query_start_loc,
+        positions,
+        num_tokens_padded=2,
+    )[0]
+
+    expected = torch.tensor([80, PAD_SLOT_ID], dtype=torch.int64, device=device)
     assert torch.equal(actual, expected)
 
 

--- a/vllm/models/deepseek_v4_1/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4_1/common/ops/cache_utils.py
@@ -565,6 +565,7 @@ def combine_topk_swa_indices(
         )
     else:
         combined_indices, combined_lens = out
+        combined_indices.fill_(-1)
 
     _COMBINE_TOPK_SWA_INDICES_KERNEL(
         combined_indices,

--- a/vllm/models/deepseek_v4_1/common/pipeline.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layer-sharing dependencies of a DeepSeek V4.1 pipeline partition."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SharingDependency:
+    kind: str
+    source_layer: int
+    consumer_layer: int
+    source_stage: int
+    consumer_stage: int
+
+
+def get_sharing_dependencies(
+    config: Any, stage_ranges: list[tuple[int, int]]
+) -> tuple[SharingDependency, ...]:
+    """Resolve KV, index and candidate sources before constructing any layers."""
+    num_layers = config.num_hidden_layers
+    if (
+        not stage_ranges
+        or stage_ranges[0][0] != 0
+        or stage_ranges[-1][1] != num_layers
+        or any(start >= end for start, end in stage_ranges)
+        or any(a[1] != b[0] for a, b in zip(stage_ranges, stage_ranges[1:]))
+    ):
+        raise ValueError("DeepSeek V4.1 pipeline stages must partition all layers")
+    owners = {
+        layer: stage
+        for stage, (start, end) in enumerate(stage_ranges)
+        for layer in range(start, end)
+    }
+    ratios = config.compress_ratios
+    if len(ratios) < num_layers:
+        raise ValueError(
+            "DeepSeek V4.1 compress_ratios must cover every backbone layer"
+        )
+
+    sources = {}
+    for kind, field in (
+        ("kv", "kv_source_layer_ids"),
+        ("index", "index_source_layer_ids"),
+    ):
+        values = tuple(getattr(config, field, None) or ())
+        if (
+            any(
+                type(layer) is not int or not 0 <= layer < num_layers
+                for layer in values
+            )
+            or values != tuple(sorted(set(values)))
+            or any(ratios[layer] == 0 for layer in values)
+        ):
+            raise ValueError(
+                f"DeepSeek V4.1 {field} must contain sorted, unique compressed layers"
+            )
+        sources[kind] = values
+
+    if not set(sources["kv"]).issubset(sources["index"]):
+        raise ValueError("DeepSeek V4.1 KV sources must also publish index keys")
+
+    dependencies = []
+
+    def append(kind: str, source: int, consumer: int) -> None:
+        if source != consumer:
+            dependencies.append(
+                SharingDependency(
+                    kind, source, consumer, owners[source], owners[consumer]
+                )
+            )
+
+    for layer in range(num_layers):
+        if ratios[layer] == 0:
+            continue
+        for kind, values in sources.items():
+            preceding = [source for source in values if source <= layer]
+            if not preceding:
+                raise ValueError(
+                    f"DeepSeek V4.1 layer {layer} has no preceding {kind} source"
+                )
+            append(kind, preceding[-1], layer)
+            if kind == "kv" and layer in sources["index"]:
+                append("index_k", preceding[-1], layer)
+
+    candidate = getattr(config, "candidate_source_layer_id", -1)
+    if candidate >= 0 and getattr(config, "candidate_topk_blocks", 0) > 0:
+        if candidate not in sources["index"]:
+            raise ValueError("DeepSeek V4.1 candidate source must be an index source")
+        for layer in sources["index"]:
+            if layer > candidate:
+                append("candidate", candidate, layer)
+    return tuple(dependencies)
+
+
+def validate_local_sharing(dependencies: tuple[SharingDependency, ...]) -> None:
+    """Reject stage cuts that require sharing tensors between pipeline ranks."""
+    cross_stage = [d for d in dependencies if d.source_stage != d.consumer_stage]
+    if cross_stage:
+        detail = "; ".join(
+            f"{d.kind} source layer {d.source_layer} (stage {d.source_stage}) -> "
+            f"layer {d.consumer_layer} (stage {d.consumer_stage})"
+            for d in cross_stage[:4]
+        )
+        raise NotImplementedError(
+            "DeepSeek V4.1 pipeline partition crosses layer-sharing dependencies: "
+            f"{detail}. Keep each sharing group on one pipeline stage."
+        )

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -76,6 +76,7 @@ from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 from ..common.engram import Engram, EngramLayout, NgramHashState
 from ..common.mm_preprocess import IMAGE_SENTINEL_BASE_ID, image_sentinel_mask
+from ..common.pipeline import get_sharing_dependencies, validate_local_sharing
 
 if typing.TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
@@ -391,6 +392,14 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
 
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
+        from vllm.distributed.utils import get_pp_indices
+
+        pp_size = get_pp_group().world_size
+        stage_ranges = [
+            get_pp_indices(config.num_hidden_layers, rank, pp_size)
+            for rank in range(pp_size)
+        ]
+        validate_local_sharing(get_sharing_dependencies(config, stage_ranges))
         self.config = config
         self.quant_config = quant_config
         self.parallel_config = vllm_config.parallel_config

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1725,13 +1725,9 @@ def get_kv_cache_config_from_groups(
 
     kv_cache_tensors = []
     for group in kv_cache_groups:
-        group_spec = group.kv_cache_spec
         layers_by_spec: defaultdict[KVCacheSpec, list[str]] = defaultdict(list)
-        if isinstance(group_spec, UniformTypeKVCacheSpecs):
-            for layer_name, spec in group_spec.kv_cache_specs.items():
-                layers_by_spec[spec].append(layer_name)
-        elif group.layer_names:
-            layers_by_spec[group_spec].extend(group.layer_names)
+        for layer_name in group.layer_names:
+            layers_by_spec[_get_per_layer_spec(group, layer_name)].append(layer_name)
 
         byte_offset = 0
         for spec, layer_names in layers_by_spec.items():

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -466,14 +466,15 @@ class ComputeSlotMappingKernel(
                 virtual_block_indices * BLOCKS_PER_KV_BLOCK
                 + local_block_offsets // block_size
             )
+            in_range = block_indices < block_table_stride
             block_numbers = tl.load(
                 block_table_ptr + row_offset + block_indices,
-                mask=mask & is_local,
+                mask=mask & is_local & in_range,
                 other=0,
             ).to(tl.int64)
             slot_offsets = local_block_offsets % block_size
             slot_ids = block_numbers * block_size + slot_offsets
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+            slot_ids = tl.where(is_local & in_range, slot_ids, PAD_ID)
             tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
 
     def dispatch(  # type: ignore[override]

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -340,14 +340,14 @@ def _compute_slot_mappings_kernel(
             mapping_enabled, local_positions // kernel_block_size, 0
         )
         block_offsets = local_positions % kernel_block_size
+        in_range = block_indices < block_table_stride
         block_numbers = tl.load(
             block_table_ptr + req_state_idx * block_table_stride + block_indices,
-            mask=is_local,
+            mask=is_local & in_range,
             other=0,
         )
         slot_ids = block_numbers * kernel_block_size + block_offsets
-        if CP_SIZE != 1:
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        slot_ids = tl.where(is_local & in_range, slot_ids, PAD_ID)
 
         slot_ids = tl.where(mapping_enabled, slot_ids, PAD_ID)
         tl.store(slot_mapping_ptr + offset, slot_ids, mask=offset < end_idx)


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/vllm-project/vllm/pull/56437/files) against `main`.

Validate DeepSeek-V4.1 KV/index/top-k/candidate dependencies before constructing pipeline layers, reject invalid stage cuts with source/consumer details, and allocate projected cache groups only for local layer names. The latest update also carries the slot-row bounds guard and V4.1 prefill-workspace initialization required by the validated PP2 serving configuration.

**Main sync (2026-09-14):** current head `c9e76fdfce983276450d8e40eb7791e30190e9db` merges `main` at `663d7f679eda78a8d48613dfede8a4b4bcff2b74`. The previous feature patch and upstream integration are preserved, with model paths and test imports updated from `deepseek_v4_1` to `deepseek_v41`. Normalized added/removed patch lines are identical. Changed-file pre-commit hooks (`.venv/bin/pre-commit run --files` for every final PR file), Python parsing and `git diff origin/main --check` passed. The pipeline validation CPU suite passed 11 tests. CUDA compilation, GPU execution and full-model evaluations were not rerun; the model/performance evidence below remains historical. AI assistance was used for conflict resolution and validation.

## Test Result

### End-to-end outcome

| Item | Recorded details |
| --- | --- |
| Observed result | The repaired TP2×PP2 configuration observed +43.98% / +47.15% output throughput at 512 / 2048 input tokens. |

### Output throughput

| Input → output tokens | Baseline (tok/s) | Candidate (tok/s) | Throughput change |
| --- | ---: | ---: | ---: |
| 512 → 128 | 13.2953 | 19.1430 | **+43.98%** |
| 2048 → 128 | 7.8010 | 11.4790 | **+47.15%** |

### Mean end-to-end latency

| Input → output tokens | Baseline E2E (s) | Candidate E2E (s) |
| --- | ---: | ---: |
| 512 → 128 | 38.422 | 26.687 |
| 2048 → 128 | 65.387 | 44.426 |

### Comparison setup

| Item | Recorded details |
| --- | --- |
| Baseline | Baseline: frozen #56221 source `4f8b7e3872b878e76bffff2b46a03173961f89a5`, TP2×PP2 with 20/20 layers, 8 GiB requested weight offload. |
| Candidate | Latest: the same partition and fixed 4 GiB KV cache, plus slot/prefill repairs and 4 GiB requested weight offload. |
| Attribution | This is a code-and-configuration comparison; there is no same-offload A/B that isolates the code's contribution. |

| Deployment reference | 512-input tok/s | 2048-input tok/s |
| --- | ---: | ---: |
| Measured TP4 | 23.1467 | 13.5691 |
| Latest TP2×PP2 | 19.1430 | 11.4790 |
| PP throughput relative to TP4 | −17.30% | −15.40% |

| Item | Recorded details |
| --- | --- |
| Deployment interpretation | The result improves the tested PP path; it does not establish a throughput advantage over TP4 or a capacity limit that TP4 cannot meet. |

### Correctness and regression checks

| Validation | Latest result |
| --- | --- |
| V4.1 prefill workspace GPU regressions | 2/2 passed |
| Full-model short QA | 6/6 correct |
| Serial / fixed-input / concurrent token comparisons | 4/4, 6/6, 4/4 matched the baseline |
| Timed requests | 16/16 per input length, zero failures, 2048 generated tokens each |
| Pure dependency validation | 11 CPU cases passed on the isolated source |
| Publication checks | 11/11 CPU dependency cases; all applicable changed-file pre-commit hooks, Python parsing and whitespace checks passed |

### Earlier attempt

| Item | Recorded details |
| --- | --- |
| Untimed failure | The earlier 4 GiB attempt without the prefill repair had one concurrent first-token mismatch and did not enter timing. |
| Evidence retention | That failed attempt is preserved; the table reports the later fully passing candidate. |

## Configuration, commands and scope

| Setting | Recorded configuration |
| --- | --- |
| Model and checkpoint | Official `deepseek-ai/DeepSeek-V4.1-Flash`, checkpoint revision `df42c109f1defefcbfcedbe7d905718a12266e40` |
| Hardware | one node, 4×H100 SXM 80 GB with NV18 links |
| Runner | V1 eager |
| Expert parallelism | EP with `allgather_reducescatter` |
| Engram placement | Engram CPU offload |
| KV cache | fixed 4 GiB KV cache per worker |
| Scheduler limits | max context 4096, batched tokens 512, max sequences 4 |
| Request protocol | Each workload uses random inputs, seed 42, concurrency 4, exactly 128 output tokens with EOS ignored, four separate warmup requests and then a prefix-cache reset before 16 timed requests. |
| Timing boundary | Startup is excluded. |

### Measurement scope

| Item | Recorded details |
| --- | --- |
| Comparison design | These are single non-interleaved comparisons against recorded baselines, without repeated A/B, A/A or confidence intervals. |
| Output checks | Token checks cover the listed prompts; log probabilities can differ and these checks are not a standard model-quality evaluation. |
| Latest-tree coverage | The complete rebased `main` tree was not rerun on GPU. |
| Source receipts | The attached source correspondence distinguishes matching repair code from pre-existing `main` differences. |

The bounds guard is adapted from existing [#54296](https://github.com/vllm-project/vllm/pull/54296), preserving V2 `mapping_enabled`. The prefill initialization applies the V4.1 counterpart of merged [#55299](https://github.com/vllm-project/vllm/pull/55299). These are explicit prerequisites, not separate competing fixes. #56438 supplies SP stage boundaries and #56439 supplies cross-stage state transfer; this PR keeps sharing disabled.

<details>
<summary>Regression and source-check commands</summary>

```sh
.venv/bin/python -m pytest --noconftest -o addopts= \
  tests/v1/worker/test_gpu_block_table.py -q
DSV41_SPLIT_REPO="$PWD" .venv/bin/python run_cpu_checks.py \
  tests/models/test_deepseek_v41_pipeline.py
```

</details>

The two prefill-workspace CUDA checks use the attached focused harness. The slot guard's recorded 11-case GPU suite is shared with the identical prerequisite repair, not a new complete GPU run of this main tree.

<details>
<summary>Serving benchmark command</summary>

```sh
# On the source/configuration identified by the attached run receipt:
.venv/bin/vllm bench serve --backend vllm \
  --base-url http://127.0.0.1:18080 --endpoint /v1/completions --model dsv41 \
  --tokenizer "$MODEL" --tokenizer-mode deepseek_v41 --dataset-name random \
  --random-input-len "$INPUT_LEN" --random-output-len 128 \
  --random-range-ratio 0 --random-prefix-len 0 --num-prompts 16 \
  --max-concurrency 4 --request-rate inf --seed 42 --num-warmups 0 \
  --ready-check-timeout-sec 0 --ignore-eos --disable-tqdm --save-result --save-detailed \
  --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 10,50,90 \
  --result-dir "$RESULTS" --result-filename "$RESULT_FILE"
```

</details>

`INPUT_LEN` is 512 or 2048. Run the four warmup requests separately and reset the prefix cache before this timed command. Use the actual port and source/configuration in the attached receipt.

[Latest timing records, repair patch, exact configuration and source correspondence](https://gist.github.com/0z5a/d2997a0aa0d1a6a684c312a325adf777). Current rebased branch: `24363d0174165cb8adb0ff4054ba139f39067eb5`.
