### PR TITLE
[Model][PP] Add DeepSeek-V4.1 sequence-parallel stage boundaries

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,6 +96,55 @@ def test_rocm_mm_prefix_lm_disables_chunked_mm_input(
     assert config.scheduler_config.disable_chunked_mm_input is expected
 
 
+@pytest.mark.parametrize("enabled", [False, True])
+def test_deepseek_v41_pp_sp_initializes_single_dp_communication(enabled):
+    import torch
+
+    from vllm.forward_context import DPMetadata
+    from vllm.model_executor.models.config import DeepseekV4ForCausalLMConfig
+
+    parallel = ParallelConfig(
+        tensor_parallel_size=2,
+        pipeline_parallel_size=2,
+        enable_expert_parallel=True,
+        is_moe_model=True,
+    )
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type="deepseek_v41")
+        ),
+        parallel_config=parallel,
+        additional_config={"deepseek_v41_pp_sp": enabled},
+    )
+    DeepseekV4ForCausalLMConfig.verify_and_update_config(cast(VllmConfig, config))
+    assert parallel.use_sequence_parallel_moe == enabled
+    assert parallel.use_all2all == enabled
+    if enabled:
+        metadata = DPMetadata.make(parallel, 7, torch.tensor([7]))
+        with metadata.sp_local_sizes(2):
+            assert metadata.get_chunk_sizes_across_dp_rank() == [4, 4]
+
+
+def test_deepseek_v41_single_dp_pp_sp_rejects_unvalidated_collectives():
+    from vllm.model_executor.models.config import DeepseekV4ForCausalLMConfig
+
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type="deepseek_v41")
+        ),
+        parallel_config=ParallelConfig(
+            tensor_parallel_size=2,
+            pipeline_parallel_size=2,
+            enable_expert_parallel=True,
+            is_moe_model=True,
+            all2all_backend="deepep_high_throughput",
+        ),
+        additional_config={"deepseek_v41_pp_sp": True},
+    )
+    with pytest.raises(ValueError, match="requires allgather_reducescatter"):
+        DeepseekV4ForCausalLMConfig.verify_and_update_config(cast(VllmConfig, config))
+
+
 def test_kda_recoverssm_derivation_is_revalidated():
     config = SimpleNamespace(
         cache_config=SimpleNamespace(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1328,6 +1328,30 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
+def test_pp_empty_uniform_group_does_not_allocate_remote_layers():
+    """An empty projected group retains its type, but must allocate no layers."""
+    spec = new_kv_cache_spec()
+    remote_spec = UniformTypeKVCacheSpecs(
+        block_size=spec.block_size,
+        kv_cache_specs={"remote": spec},
+    )
+    groups = kv_cache_utils._project_kv_cache_groups_to_worker(
+        [
+            KVCacheGroupSpec(["remote"], remote_spec),
+            KVCacheGroupSpec(["local"], spec),
+        ],
+        {"local": spec},
+    )
+    config = VllmConfig()
+    config.cache_config.kv_cache_layout = "BLHNC"
+    cache = kv_cache_utils.get_kv_cache_config_from_groups(
+        config, groups, spec.page_size_bytes * 4
+    )
+    assert cache.num_blocks == 4
+    assert [tensor.layers for tensor in cache.kv_cache_tensors] == [["local"]]
+    assert cache.kv_cache_groups[0].layer_names == []
+
+
 def test_dcp_world_size_for_kv_cache_spec_shards_full_attention_only():
     dcp = 8
     full = FullAttentionSpec(

--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
 
 pytestmark = pytest.mark.skipif(
@@ -209,6 +210,72 @@ def test_dcp_slot_mapping_with_smaller_kernel_blocks(cp_rank: int):
     expected[second_start : second_start + 128] = torch.arange(
         9 * 128, 10 * 128, dtype=torch.int64, device=device
     )
+    assert torch.equal(actual, expected)
+
+
+def test_v1_slot_mapping_masks_out_of_range_block_indices():
+    from vllm.v1.worker.block_table import BlockTable
+
+    device = torch.device("cuda")
+    block_table = BlockTable(
+        block_size=16,
+        max_num_reqs=2,
+        max_num_blocks_per_req=1,
+        max_num_batched_tokens=2,
+        pin_memory=False,
+        device=device,
+        kernel_block_size=16,
+        cp_kv_cache_interleave_size=1,
+    )
+    block_table.add_row([5], row_idx=0)
+    block_table.add_row([9], row_idx=1)
+    block_table.commit_block_table(num_reqs=2)
+
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    positions = torch.tensor([0, 16], dtype=torch.int64, device=device)
+    block_table.compute_slot_mapping(
+        num_reqs=1,
+        query_start_loc=query_start_loc,
+        positions=positions,
+    )
+
+    expected = torch.tensor([80, PAD_SLOT_ID], dtype=torch.int64, device=device)
+    assert torch.equal(block_table.slot_mapping.gpu[:2], expected)
+
+
+def test_v2_slot_mapping_masks_out_of_range_block_indices():
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[16],
+        max_num_reqs=2,
+        max_num_batched_tokens=2,
+        max_num_blocks_per_group=[1],
+        device=device,
+        kernel_block_sizes=[16],
+    )
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([5],),
+        overwrite=True,
+    )
+    block_tables.append_block_ids(
+        req_index=1,
+        new_block_ids=([9],),
+        overwrite=True,
+    )
+    block_tables.apply_staged_writes()
+
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    positions = torch.tensor([0, 16], dtype=torch.int64, device=device)
+    actual = block_tables.compute_slot_mappings(
+        idx_mapping,
+        query_start_loc,
+        positions,
+        num_tokens_padded=2,
+    )[0]
+
+    expected = torch.tensor([80, PAD_SLOT_ID], dtype=torch.int64, device=device)
     assert torch.equal(actual, expected)
 
 

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -205,6 +205,12 @@ class ParallelConfig:
     - "nixl_ep": Use nixl-ep kernels
     - "flashinfer_nvlink_one_sided": Use flashinfer high-throughput a2a kernels
     - "flashinfer_nvlink_two_sided": Use flashinfer two-sided kernels for mnnvl"""
+    enable_sequence_parallel_moe: bool = False
+    """Allow model-selected sequence-parallel MoE with a single DP rank.
+
+    Model config hooks enable this before communication groups are created.
+    The model must shard its inputs and set FusedMoE's is_sequence_parallel.
+    """
 
     max_parallel_loading_workers: int | None = Field(default=None, ge=1)
     """Maximum number of parallel loading workers when loading model
@@ -722,7 +728,7 @@ class ParallelConfig:
             )
             and self.enable_expert_parallel
             and self.tensor_parallel_size > 1
-            and self.data_parallel_size > 1
+            and (self.data_parallel_size > 1 or self.enable_sequence_parallel_moe)
         )
 
     @property

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -326,6 +326,27 @@ class DiffusionGemmaModelForBlockDiffusionConfig(VerifyAndUpdateConfig):
 
 class DeepseekV4ForCausalLMConfig(VerifyAndUpdateConfig):
     @staticmethod
+    def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+        model_config = vllm_config.model_config
+        additional = vllm_config.additional_config
+        if (
+            model_config is None
+            or getattr(model_config.hf_config, "model_type", None) != "deepseek_v41"
+            or not isinstance(additional, dict)
+            or not additional.get("deepseek_v41_pp_sp", False)
+        ):
+            return
+        parallel = vllm_config.parallel_config
+        if not parallel.enable_expert_parallel or parallel.tensor_parallel_size < 2:
+            raise ValueError("DeepSeek V4.1 PP+SP requires EP and TP >= 2")
+        if parallel.data_parallel_size == 1:
+            if parallel.all2all_backend != "allgather_reducescatter":
+                raise ValueError(
+                    "DeepSeek V4.1 PP+SP with DP=1 requires allgather_reducescatter"
+                )
+            parallel.enable_sequence_parallel_moe = True
+
+    @staticmethod
     def verify_and_update_model_config(model_config: "ModelConfig") -> None:
         quant_config = getattr(model_config.hf_config, "quantization_config", None)
         if quant_config is not None and quant_config.get("quant_method") == "fp8":

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -152,11 +152,19 @@ def _select_dsv4_attn_cls(vllm_config: VllmConfig) -> type[DeepseekV4Attention]:
 def _use_sequence_parallel(vllm_config: VllmConfig) -> bool:
     parallel_config = vllm_config.parallel_config
     use_mega_moe = vllm_config.kernel_config.moe_backend in MEGA_MOE_BACKENDS
+    additional_config = vllm_config.additional_config
+    pp_sp_enabled = isinstance(additional_config, dict) and additional_config.get(
+        "deepseek_v41_pp_sp", False
+    )
     return (
-        parallel_config.pipeline_parallel_size == 1
+        (parallel_config.pipeline_parallel_size == 1 or pp_sp_enabled)
         and parallel_config.enable_expert_parallel
         and parallel_config.tensor_parallel_size > 1
-        and (use_mega_moe or parallel_config.data_parallel_size > 1)
+        and (
+            use_mega_moe
+            or parallel_config.data_parallel_size > 1
+            or parallel_config.enable_sequence_parallel_moe
+        )
     )
 
 
@@ -319,6 +327,12 @@ class DeepseekV4DecoderLayer(nn.Module):
                 )
             else:
                 residual = x
+                if self.engram is not None and engram_hashes is not None:
+                    residual = self.engram(
+                        residual,
+                        engram_hashes[:, self.engram.layer_hash_index],
+                        engram_mask,
+                    )
                 post_mix, res_mix, x, attn_pre = mhc_pre_delayed_tilelang(
                     residual,
                     self.hc_attn_fn,
@@ -603,6 +617,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                         )
 
         full_num_tokens = positions.shape[0]
+        pre_mix: torch.Tensor | None = None
+        if not get_pp_group().is_first_rank:
+            assert intermediate_tensors is not None
+            pre_mix = intermediate_tensors["pre_mix"]
         if self.use_sequence_parallel:
             if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
                 forward_context = get_forward_context()
@@ -610,13 +628,12 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                     forward_context.is_padding, hidden_states
                 )
             hidden_states = sp_shard(hidden_states)
-            input_ids = sp_shard(input_ids)
+            if input_ids is not None:
+                input_ids = sp_shard(input_ids)
+            if pre_mix is not None:
+                pre_mix = sp_shard(pre_mix)
 
         residual, post_mix, res_mix = None, None, None
-        pre_mix: torch.Tensor | None = None
-        if not get_pp_group().is_first_rank:
-            assert intermediate_tensors is not None
-            pre_mix = intermediate_tensors["pre_mix"]
         aux_hidden_states: list[torch.Tensor] = []
         final_aux_recon: torch.Tensor | None = None  # avoid duplicate mhc_post call
         for idx, layer in enumerate(
@@ -654,6 +671,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 )
 
         if not get_pp_group().is_last_rank:
+            if self.use_sequence_parallel:
+                hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
+                assert pre_mix is not None
+                pre_mix = sp_all_gather(pre_mix)[:full_num_tokens]
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "pre_mix": pre_mix}
             )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1725,13 +1725,9 @@ def get_kv_cache_config_from_groups(
 
     kv_cache_tensors = []
     for group in kv_cache_groups:
-        group_spec = group.kv_cache_spec
         layers_by_spec: defaultdict[KVCacheSpec, list[str]] = defaultdict(list)
-        if isinstance(group_spec, UniformTypeKVCacheSpecs):
-            for layer_name, spec in group_spec.kv_cache_specs.items():
-                layers_by_spec[spec].append(layer_name)
-        elif group.layer_names:
-            layers_by_spec[group_spec].extend(group.layer_names)
+        for layer_name in group.layer_names:
+            layers_by_spec[_get_per_layer_spec(group, layer_name)].append(layer_name)
 
         byte_offset = 0
         for spec, layer_names in layers_by_spec.items():

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -466,14 +466,15 @@ class ComputeSlotMappingKernel(
                 virtual_block_indices * BLOCKS_PER_KV_BLOCK
                 + local_block_offsets // block_size
             )
+            in_range = block_indices < block_table_stride
             block_numbers = tl.load(
                 block_table_ptr + row_offset + block_indices,
-                mask=mask & is_local,
+                mask=mask & is_local & in_range,
                 other=0,
             ).to(tl.int64)
             slot_offsets = local_block_offsets % block_size
             slot_ids = block_numbers * block_size + slot_offsets
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+            slot_ids = tl.where(is_local & in_range, slot_ids, PAD_ID)
             tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
 
     def dispatch(  # type: ignore[override]

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -340,14 +340,14 @@ def _compute_slot_mappings_kernel(
             mapping_enabled, local_positions // kernel_block_size, 0
         )
         block_offsets = local_positions % kernel_block_size
+        in_range = block_indices < block_table_stride
         block_numbers = tl.load(
             block_table_ptr + req_state_idx * block_table_stride + block_indices,
-            mask=is_local,
+            mask=is_local & in_range,
             other=0,
         )
         slot_ids = block_numbers * kernel_block_size + block_offsets
-        if CP_SIZE != 1:
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        slot_ids = tl.where(is_local & in_range, slot_ids, PAD_ID)
 
         slot_ids = tl.where(mapping_enabled, slot_ids, PAD_ID)
         tl.store(slot_mapping_ptr + offset, slot_ids, mask=offset < end_idx)


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/vllm-project/vllm/pull/56438/files) against `main`.

Add default-off DeepSeek-V4.1 sequence-parallel stage boundaries. Gather/trim hidden states and delayed `pre_mix` at the pipeline exit, then shard both at the next stage; apply the first layer's Engram before attention pre-mix. Include the slot-row range guard needed by the repaired PP-SP path, while preserving V2 `mapping_enabled`.

**Main sync (2026-09-14):** current head `5af13bd896bdc966775795f008371c8dba0717fc` merges `main` at `663d7f679eda78a8d48613dfede8a4b4bcff2b74`. The previous feature patch and upstream integration are preserved, with model paths and test imports updated from `deepseek_v4_1` to `deepseek_v41`. Normalized added/removed patch lines are identical. Changed-file pre-commit hooks (`.venv/bin/pre-commit run --files` for every final PR file), Python parsing and `git diff origin/main --check` passed. No GPU or model execution was performed for this merge; validation for this PR was static. CUDA compilation, GPU execution and full-model evaluations were not rerun; the model/performance evidence below remains historical. AI assistance was used for conflict resolution and validation.

## Test Result

### End-to-end outcome

| Item | Recorded details |
| --- | --- |
| Observed result | The repaired SP-on candidate observed +10.28% / +13.82% output throughput versus the original SP-off baseline. |

### Output throughput

| Input → output tokens | Baseline (tok/s) | Candidate (tok/s) | Throughput change |
| --- | ---: | ---: | ---: |
| 512 → 128 | 11.6566 | 12.8543 | **+10.28%** |
| 2048 → 128 | 6.8018 | 7.7418 | **+13.82%** |

### Mean end-to-end latency

| Input → output tokens | Baseline E2E (s) | Candidate E2E (s) |
| --- | ---: | ---: |
| 512 → 128 | 43.827 | 39.725 |
| 2048 → 128 | 74.999 | 65.818 |

### Comparison setup

| Item | Recorded details |
| --- | --- |
| Source and treatment | Both arms use frozen #56222 source `3dc4d14b5e3bd564d73460635c6e1d3d9d231d27`; B additionally enables PP-SP and applies the guard from [#54296](https://github.com/vllm-project/vllm/pull/54296), pinned at `191f82d710493c9a02077d976d8cf0403ab8c96a`. |
| Attribution | Thus this is SP plus its prerequisite repair, not an isolated estimate of the guard. |
| Fixed configuration | TP2×PP2, DP1+EP, 20/20 layers and 8 GiB requested weight offload are unchanged. |
| Repair revision | The repair is already included at `e22aa31305f9a3b17c8a332ca227013cad56206f`. |

### Correctness and regression checks

| Validation | Latest result |
| --- | --- |
| Unmodified source, out-of-range V1/V2 cases | Both failed as expected |
| Repaired block-table GPU suite | 11/11 passed |
| Original failing 975-input request | Completed; output matched A |
| Full-model short QA | 6/6 correct |
| Serial / fixed-input / concurrent token comparisons | 4/4, 6/6, 4/4 matched A |
| Timed requests | 16/16 per input length, zero failures, 2048 generated tokens each |
| Repair source correspondence | Two implementation files and the regression test match the GPU-tested repair |
| Submitted-repair checks | Changed-file pre-commit, parsing and whitespace checks passed |

### Measurement limits

| Item | Recorded details |
| --- | --- |
| Timing instrumentation | Slot tracing and CUDA launch blocking were disabled during timing. |
| Unrepaired attempt | The unrepaired SP-on run failed before benchmarking and remains in the raw evidence. |
| Historical mismatches | Earlier combined-integration mismatches are not explained by the later passing probes; superseded E2E tables have been removed from this description. |

## Configuration and commands

| Setting | Recorded configuration |
| --- | --- |
| Model and checkpoint | Official `deepseek-ai/DeepSeek-V4.1-Flash`, checkpoint revision `df42c109f1defefcbfcedbe7d905718a12266e40` |
| Hardware | one node, 4×H100 SXM 80 GB with NV18 links |
| Runner | V1 eager |
| Expert parallelism | EP with `allgather_reducescatter` |
| Engram placement | Engram CPU offload |
| KV cache | fixed 4 GiB KV cache per worker |
| Scheduler limits | max context 4096, batched tokens 512, max sequences 4 |
| Request protocol | Each workload uses random inputs, seed 42, concurrency 4, exactly 128 output tokens with EOS ignored, four separate warmup requests and then a prefix-cache reset before 16 timed requests. |
| Timing boundary | Startup is excluded. |

### Measurement scope

| Item | Recorded details |
| --- | --- |
| Comparison design | These are single non-interleaved comparisons against recorded baselines, without repeated A/B, A/A or confidence intervals. |
| Output checks | Token checks cover the listed prompts; log probabilities can differ and these checks are not a standard model-quality evaluation. |
| Latest-tree coverage | The complete rebased `main` tree was not rerun on GPU. |
| Source receipts | The attached source correspondence distinguishes matching repair code from pre-existing `main` differences. |

<details>
<summary>Regression and source-check commands</summary>

```sh
.venv/bin/python -m pytest --noconftest \
  tests/v1/worker/test_gpu_block_table.py -vv
```

</details>

<details>
<summary>Serving benchmark command</summary>

```sh
# On the source/configuration identified by the attached run receipt:
.venv/bin/vllm bench serve --backend vllm \
  --base-url http://127.0.0.1:18080 --endpoint /v1/completions --model dsv41 \
  --tokenizer "$MODEL" --tokenizer-mode deepseek_v41 --dataset-name random \
  --random-input-len "$INPUT_LEN" --random-output-len 128 \
  --random-range-ratio 0 --random-prefix-len 0 --num-prompts 16 \
  --max-concurrency 4 --request-rate inf --seed 42 --num-warmups 0 \
  --ready-check-timeout-sec 0 --ignore-eos --disable-tqdm --save-result --save-detailed \
  --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 10,50,90 \
  --result-dir "$RESULTS" --result-filename "$RESULT_FILE"
```

</details>

`INPUT_LEN` is 512 or 2048. Run the four warmup requests separately and reset the prefix cache before this timed command. Use the actual port and source/configuration in the attached receipt.

## Scope and evidence

Enable with `--additional-config '{"deepseek_v41_pp_sp":true}'`. Requires EP and TP≥2; DP1 uses `allgather_reducescatter`. The local-cache prerequisite is shared with #56437; #56439 is separate cross-stage sharing. #53191 addresses other model families and does not implement V4.1 delayed mHC/Engram boundaries.

[Latest timing records, exact configuration and source receipts](https://gist.github.com/0z5a/d2997a0aa0d1a6a684c312a325adf777). [Detailed repaired-run evidence](https://gist.github.com/0z5a/988be414646d7d5ef7e09abe6bfac454).
