### PR TITLE
[Model][PP] Relay DeepSeek-V4.1 cache and index state across stages

### DIFF
--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -536,6 +536,48 @@ def test_isend_tensor_dict_self_retains_for_fire_and_forget(
     assert handles0[0]._retained == ()
 
 
+def test_isend_cpu_buffers_wait_even_when_gloo_reports_completed(monkeypatch):
+    """A premature Gloo completion report must not release live CPU buffers."""
+    works = []
+
+    def fake_isend(t, *args, **kwargs):
+        work = _DummyWork()
+        work.completed = True
+        works.append(work)
+        return work
+
+    monkeypatch.setattr(torch.distributed, "isend", fake_isend)
+    group = _make_group_for_unit_test()
+    data = {"ids": torch.arange(4)}
+    handles = group.isend_tensor_dict(data, dst=1)
+    assert handles[1]._retained == (data["ids"],)
+    assert works[-1].wait_calls == 0
+    group._reap_completed_isends()
+    assert not group._pending_isends
+    assert handles[1]._retained == ()
+    assert all(work.wait_calls == 1 for work in works)
+    for handle in handles:
+        handle.wait()
+    assert all(work.wait_calls == 1 for work in works)
+
+
+def test_isend_cpu_buffers_retained_while_device_send_is_pending():
+    """A mixed payload keeps CPU refs until the device payload completes."""
+    group = _make_group_for_unit_test()
+    metadata, cpu, device = _DummyWork(), _DummyWork(), _DummyWork()
+    cpu.completed = True
+    cpu_tensor = torch.arange(4)
+    device_tensor = torch.empty(4, device="meta")
+    group._pending_isends.append(([metadata, cpu, device], [cpu_tensor, device_tensor]))
+    group._reap_completed_isends()
+    assert len(group._pending_isends) == 1
+    assert cpu.wait_calls == metadata.wait_calls == 0
+    device.completed = True
+    group._reap_completed_isends()
+    assert not group._pending_isends
+    assert cpu.wait_calls == metadata.wait_calls == 1
+
+
 def test_send_tensor_dict_sync_path_does_not_self_retain(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/distributed/test_deepseek_v41_pipeline_transfer.py
+++ b/tests/distributed/test_deepseek_v41_pipeline_transfer.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exercise eager cache snapshots through multiple actual process boundaries."""
+
+from datetime import timedelta
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from vllm.models.deepseek_v4_1.common.pipeline_transfer import (
+    restore_cache_blocks,
+    snapshot_cache_blocks,
+)
+
+
+def _relay_worker(rank, rendezvous):
+    dist.init_process_group(
+        "gloo",
+        init_method=rendezvous,
+        rank=rank,
+        world_size=3,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        expected = torch.arange(6 * 3 * 4, dtype=torch.uint8).reshape(6, 3, 4)
+        cache = expected.clone() if rank == 0 else torch.zeros_like(expected)
+        table = torch.tensor([[1, 4, -1]])
+        if rank:
+            ids = torch.empty(2, dtype=torch.int64)
+            blocks = torch.empty(2, 3, 4, dtype=torch.uint8)
+            dist.recv(ids, src=rank - 1)
+            dist.recv(blocks, src=rank - 1)
+            restore_cache_blocks(cache, ids, blocks)
+        torch.testing.assert_close(cache[[1, 4]], expected[[1, 4]], rtol=0, atol=0)
+        if rank < 2:
+            ids, blocks = snapshot_cache_blocks(cache, [table], max_bytes=1024)
+            dist.send(ids, dst=rank + 1)
+            dist.send(blocks, dst=rank + 1)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_cache_blocks_survive_two_pipeline_hops(tmp_path):
+    mp.spawn(_relay_worker, args=((tmp_path / "rendezvous").as_uri(),), nprocs=3)

--- a/tests/distributed/test_deepseek_v41_pipeline_transfer.py
+++ b/tests/distributed/test_deepseek_v41_pipeline_transfer.py
@@ -43,3 +43,76 @@ def _relay_worker(rank, rendezvous):
 
 def test_cache_blocks_survive_two_pipeline_hops(tmp_path):
     mp.spawn(_relay_worker, args=((tmp_path / "rendezvous").as_uri(),), nprocs=3)
+
+
+def _mixed_relay_worker(rank, port, asynchronous):
+    from tests.utils import init_test_distributed_environment
+    from vllm.distributed import get_pp_group
+    from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
+
+    torch.accelerator.set_device_index(rank)
+    init_test_distributed_environment(1, 4, rank, port, local_rank=rank)
+    group = get_pp_group()
+    try:
+        # Distinct rounds refresh a prefix block and then reuse a physical block.
+        for round_id, selected in enumerate(([1, 4], [1, 4], [4], [])):
+            expected = (
+                torch.arange(6 * 2 * 3 * 4, device="cuda")
+                .reshape(6, 2, 3, 4)
+                .add(round_id * 19)
+                .to(torch.uint8)[:, 0]
+            )
+            cache = torch.full((6, 2, 3, 4), 17, device="cuda", dtype=torch.uint8)[:, 0]
+            if rank == 0:
+                cache.copy_(expected)
+            else:
+                if asynchronous:
+                    payload, handles, postprocess = group.irecv_tensor_dict(
+                        src=rank - 1
+                    )
+                    for handle in handles:
+                        handle.wait()
+                    for callback in postprocess:
+                        callback()
+                else:
+                    payload = group.recv_tensor_dict(src=rank - 1)
+                assert payload["ids"].device.type == "cpu"
+                assert payload["blocks"].device.type == "cuda"
+                assert payload["round"] == round_id
+                restore_cache_blocks(cache, payload["ids"], payload["blocks"])
+                untouched = [i for i in range(6) if i not in selected]
+                assert torch.all(cache[untouched] == 17)
+            torch.testing.assert_close(
+                cache[selected], expected[selected], rtol=0, atol=0
+            )
+            if rank < 3:
+                table = torch.tensor([selected + [-1]], dtype=torch.int32)
+                ids, blocks = snapshot_cache_blocks(cache, [table], max_bytes=1024)
+                payload = {"ids": ids, "blocks": blocks, "round": round_id}
+                if asynchronous:
+                    handles = group.isend_tensor_dict(payload, dst=rank + 1)
+                    for handle in handles:
+                        handle.wait()
+                    group._reap_completed_isends()
+                    # The CPU Gloo handle must also tolerate a caller's second wait.
+                    for handle in handles:
+                        handle.wait()
+                else:
+                    group.send_tensor_dict(payload, dst=rank + 1)
+            group.barrier()
+        torch.accelerator.synchronize()
+    finally:
+        cleanup_dist_env_and_memory()
+
+
+def test_host_ids_and_cuda_cache_survive_three_pipeline_hops():
+    import pytest
+
+    from vllm.utils.network_utils import get_open_port
+
+    if not torch.cuda.is_available() or torch.accelerator.device_count() < 4:
+        pytest.skip("Four CUDA devices required")
+    for asynchronous in (False, True):
+        mp.spawn(
+            _mixed_relay_worker, args=(str(get_open_port()), asynchronous), nprocs=4
+        )

--- a/tests/models/test_deepseek_v41_pipeline.py
+++ b/tests/models/test_deepseek_v41_pipeline.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.models.deepseek_v4_1.common.pipeline import (
+    get_sharing_dependencies,
+    validate_local_sharing,
+)
+
+
+def _config():
+    return SimpleNamespace(
+        num_hidden_layers=40,
+        compress_ratios=[0, 0] + [2] * 18 + [1] * 20,
+        kv_source_layer_ids=[2, 8, 14, 20],
+        index_source_layer_ids=[2, 8, 14, 20, 24, 28, 32, 36],
+        candidate_source_layer_id=20,
+        candidate_topk_blocks=2048,
+    )
+
+
+@pytest.mark.parametrize(
+    "ranges", [[(0, 40)], [(0, 20), (20, 40)], [(0, 8), (8, 14), (14, 20), (20, 40)]]
+)
+def test_group_aligned_pipeline_cuts_keep_all_sources_local(ranges):
+    validate_local_sharing(get_sharing_dependencies(_config(), ranges))
+
+
+def test_equal_pp4_reports_cross_stage_kv_index_and_candidates():
+    dependencies = get_sharing_dependencies(
+        _config(), [(0, 10), (10, 20), (20, 30), (30, 40)]
+    )
+    cross = {
+        (d.kind, d.source_layer, d.consumer_layer)
+        for d in dependencies
+        if d.source_stage != d.consumer_stage
+    }
+    assert {("kv", 8, 10), ("index", 28, 30), ("candidate", 20, 32)} <= cross
+    with pytest.raises(NotImplementedError, match="source layer 8.*stage 0.*stage 1"):
+        validate_local_sharing(dependencies)
+
+
+@pytest.mark.parametrize("values", [[8, 2], [2, 2], [0, 2], [-1, 2], [2, 40]])
+def test_invalid_source_lists_fail_before_layer_construction(values):
+    config = _config()
+    config.kv_source_layer_ids = values
+    with pytest.raises(ValueError, match="kv_source_layer_ids"):
+        get_sharing_dependencies(config, [(0, 40)])
+
+
+def test_compressed_consumer_requires_an_earlier_source():
+    config = _config()
+    config.kv_source_layer_ids = [8, 14, 20]
+    with pytest.raises(ValueError, match="layer 2 has no preceding kv source"):
+        get_sharing_dependencies(config, [(0, 40)])
+
+
+def test_candidate_source_must_publish_indices():
+    config = _config()
+    config.candidate_source_layer_id = 21
+    with pytest.raises(ValueError, match="candidate source must be an index source"):
+        get_sharing_dependencies(config, [(0, 40)])

--- a/tests/models/test_deepseek_v41_pipeline_transfer.py
+++ b/tests/models/test_deepseek_v41_pipeline_transfer.py
@@ -65,3 +65,57 @@ def test_snapshot_rejects_invalid_physical_blocks():
 def test_restore_rejects_different_cache_layouts(blocks):
     with pytest.raises(ValueError, match="different block layout"):
         restore_cache_blocks(torch.ones(2, 3, 4), torch.tensor([0]), blocks)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.bfloat16])
+@pytest.mark.parametrize("empty", [False, True])
+def test_host_block_plan_restores_cuda_prefix_without_device_readback(dtype, empty):
+    """Keep packed prefix bytes exact while host IDs avoid CUDA scalar reads."""
+    source = (
+        torch.arange(6 * 2 * 3 * 4, device="cuda").reshape(6, 2, 3, 4).to(dtype)[:, 0]
+    )
+    replica = torch.full((6, 2, 3, 4), 17, device="cuda", dtype=dtype)[:, 0]
+    table = (
+        torch.tensor([[-1, -1]]) if empty else torch.tensor([[4, 1, -1], [1, 4, -1]])
+    )
+    expected = source.clone()
+    # Initialize lazy CUDA facilities before enabling the synchronization guard.
+    warm_ids, warm_blocks = snapshot_cache_blocks(source, [table], max_bytes=1024)
+    restore_cache_blocks(replica, warm_ids, warm_blocks)
+    replica.fill_(17)
+    torch.accelerator.synchronize()
+    previous = torch.cuda.get_sync_debug_mode()
+    try:
+        torch.cuda.set_sync_debug_mode("error")
+        ids, blocks = snapshot_cache_blocks(source, [table], max_bytes=1024)
+        restore_cache_blocks(replica, ids, blocks)
+    finally:
+        torch.cuda.set_sync_debug_mode(previous)
+    assert ids.device.type == "cpu"
+    selected = [] if empty else [1, 4]
+    assert ids.tolist() == selected
+    torch.testing.assert_close(replica[selected], expected[selected], rtol=0, atol=0)
+    untouched = [i for i in range(6) if i not in selected]
+    assert torch.all(replica[untouched] == 17)
+
+
+def test_unpadding_preserves_the_matching_host_block_table():
+    from vllm.v1.attention.backend import CommonAttentionMetadata
+
+    table = torch.tensor([[3, 7], [4, 9]], dtype=torch.int32)
+    metadata = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 1, 2]),
+        query_start_loc_cpu=torch.tensor([0, 1, 2]),
+        seq_lens=torch.tensor([1, 1]),
+        num_reqs=2,
+        num_actual_tokens=2,
+        max_query_len=1,
+        max_seq_len=1,
+        block_table_tensor=table,
+        slot_mapping=torch.tensor([0, 1]),
+        block_table_cpu=table.clone(),
+    )
+    actual = metadata.unpadded(1, 1)
+    torch.testing.assert_close(actual.block_table_cpu, table[:1])
+    assert actual.block_table_cpu.shape == actual.block_table_tensor.shape

--- a/tests/models/test_deepseek_v41_pipeline_transfer.py
+++ b/tests/models/test_deepseek_v41_pipeline_transfer.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+from vllm.models.deepseek_v4_1.common.pipeline import SharingDependency
+from vllm.models.deepseek_v4_1.common.pipeline_transfer import (
+    get_sharing_routes,
+    restore_cache_blocks,
+    snapshot_cache_blocks,
+)
+
+
+def test_sharing_routes_relay_across_idle_stages_without_duplicate_sends():
+    routes = get_sharing_routes(
+        (
+            SharingDependency("kv", 2, 8, 0, 2),
+            SharingDependency("kv", 2, 9, 0, 2),
+            SharingDependency("kv", 2, 10, 0, 3),
+            SharingDependency("index", 2, 3, 0, 0),
+        )
+    )
+    assert [(r.kind, r.source_layer, r.sender, r.receiver) for r in routes] == [
+        ("kv", 2, 0, 1),
+        ("kv", 2, 1, 2),
+        ("kv", 2, 2, 3),
+    ]
+    assert len({r.payload_keys for r in routes}) == 1
+
+
+@pytest.mark.parametrize("dtype", [torch.uint8, torch.bfloat16])
+def test_snapshot_refreshes_prefix_blocks_and_keeps_packed_layout(dtype):
+    # Interleaved cache allocations have gaps between physical blocks.
+    source = torch.arange(6 * 2 * 3 * 4).reshape(6, 2, 3, 4).to(dtype)[:, 0]
+    replica = torch.full((6, 2, 3, 4), 17, dtype=dtype)[:, 0]
+    ids, blocks = snapshot_cache_blocks(
+        source, [torch.tensor([[4, 1, -1], [1, 4, -1]])], max_bytes=1024
+    )
+    assert ids.tolist() == [1, 4]
+    old = source.clone()
+    source.zero_()
+    restore_cache_blocks(replica, ids, blocks)
+    torch.testing.assert_close(replica[ids], old[ids], rtol=0, atol=0)
+    assert torch.all(replica[[0, 2, 3, 5]] == 17)
+
+
+def test_empty_snapshot_preserves_replica():
+    cache = torch.ones(2, 3, 4)
+    ids, blocks = snapshot_cache_blocks(cache, [torch.tensor([[-1]])], max_bytes=0)
+    restore_cache_blocks(cache, ids, blocks)
+    assert torch.all(cache == 1)
+
+
+def test_snapshot_enforces_memory_budget():
+    with pytest.raises(ValueError, match="byte budget"):
+        snapshot_cache_blocks(torch.ones(2, 3, 4), [torch.tensor([[0, 1]])], 1)
+
+
+def test_snapshot_rejects_invalid_physical_blocks():
+    with pytest.raises(ValueError, match="unallocated cache block"):
+        snapshot_cache_blocks(torch.ones(2, 3, 4), [torch.tensor([[2]])], 1024)
+
+
+@pytest.mark.parametrize("blocks", [torch.zeros(1, 4, 3), torch.zeros(1, 3, 4).int()])
+def test_restore_rejects_different_cache_layouts(blocks):
+    with pytest.raises(ValueError, match="different block layout"):
+        restore_cache_blocks(torch.ones(2, 3, 4), torch.tensor([0]), blocks)

--- a/tests/v1/attention/test_deepseek_v4_swa_visible.py
+++ b/tests/v1/attention/test_deepseek_v4_swa_visible.py
@@ -373,6 +373,34 @@ COMBINE_CASES = [
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_v41_combine_topk_swa_clears_reused_workspace_padding():
+    from vllm.models.deepseek_v4_1.common.ops.cache_utils import (
+        combine_topk_swa_indices as combine_v41,
+    )
+
+    device = torch.device("cuda")
+    args = (
+        torch.zeros((3, 512), dtype=torch.int32, device=device),
+        torch.tensor([0, 3], dtype=torch.int32, device=device),
+        torch.tensor([3], dtype=torch.int32, device=device),
+        torch.tensor([3], dtype=torch.int32, device=device),
+        128,
+        2,
+        512,
+        1024,
+        512,
+    )
+    expected, expected_lens = combine_v41(*args)
+    # Reused buffers must not expose stale indices beyond the active lengths.
+    workspace = torch.full_like(expected, 2113501039)
+    lens = torch.full_like(expected_lens, -99)
+    actual, actual_lens = combine_v41(*args, out=(workspace, lens))
+    assert actual is workspace and actual_lens is lens
+    torch.testing.assert_close(actual_lens, expected_lens)
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("cfg", COMBINE_CASES)
 def test_combine_topk_swa_with_image_spans(cfg):
     case = CASES[0]

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1328,6 +1328,30 @@ def test_project_kv_cache_groups_to_worker():
     assert set(proj_spec.kv_cache_specs.keys()) == {"layer1", "layer3"}
 
 
+def test_pp_empty_uniform_group_does_not_allocate_remote_layers():
+    """An empty projected group retains its type, but must allocate no layers."""
+    spec = new_kv_cache_spec()
+    remote_spec = UniformTypeKVCacheSpecs(
+        block_size=spec.block_size,
+        kv_cache_specs={"remote": spec},
+    )
+    groups = kv_cache_utils._project_kv_cache_groups_to_worker(
+        [
+            KVCacheGroupSpec(["remote"], remote_spec),
+            KVCacheGroupSpec(["local"], spec),
+        ],
+        {"local": spec},
+    )
+    config = VllmConfig()
+    config.cache_config.kv_cache_layout = "BLHNC"
+    cache = kv_cache_utils.get_kv_cache_config_from_groups(
+        config, groups, spec.page_size_bytes * 4
+    )
+    assert cache.num_blocks == 4
+    assert [tensor.layers for tensor in cache.kv_cache_tensors] == [["local"]]
+    assert cache.kv_cache_groups[0].layer_names == []
+
+
 def test_dcp_world_size_for_kv_cache_spec_shards_full_attention_only():
     dcp = 8
     full = FullAttentionSpec(

--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
 
 pytestmark = pytest.mark.skipif(
@@ -209,6 +210,72 @@ def test_dcp_slot_mapping_with_smaller_kernel_blocks(cp_rank: int):
     expected[second_start : second_start + 128] = torch.arange(
         9 * 128, 10 * 128, dtype=torch.int64, device=device
     )
+    assert torch.equal(actual, expected)
+
+
+def test_v1_slot_mapping_masks_out_of_range_block_indices():
+    from vllm.v1.worker.block_table import BlockTable
+
+    device = torch.device("cuda")
+    block_table = BlockTable(
+        block_size=16,
+        max_num_reqs=2,
+        max_num_blocks_per_req=1,
+        max_num_batched_tokens=2,
+        pin_memory=False,
+        device=device,
+        kernel_block_size=16,
+        cp_kv_cache_interleave_size=1,
+    )
+    block_table.add_row([5], row_idx=0)
+    block_table.add_row([9], row_idx=1)
+    block_table.commit_block_table(num_reqs=2)
+
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    positions = torch.tensor([0, 16], dtype=torch.int64, device=device)
+    block_table.compute_slot_mapping(
+        num_reqs=1,
+        query_start_loc=query_start_loc,
+        positions=positions,
+    )
+
+    expected = torch.tensor([80, PAD_SLOT_ID], dtype=torch.int64, device=device)
+    assert torch.equal(block_table.slot_mapping.gpu[:2], expected)
+
+
+def test_v2_slot_mapping_masks_out_of_range_block_indices():
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[16],
+        max_num_reqs=2,
+        max_num_batched_tokens=2,
+        max_num_blocks_per_group=[1],
+        device=device,
+        kernel_block_sizes=[16],
+    )
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([5],),
+        overwrite=True,
+    )
+    block_tables.append_block_ids(
+        req_index=1,
+        new_block_ids=([9],),
+        overwrite=True,
+    )
+    block_tables.apply_staged_writes()
+
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    positions = torch.tensor([0, 16], dtype=torch.int64, device=device)
+    actual = block_tables.compute_slot_mappings(
+        idx_mapping,
+        query_start_loc,
+        positions,
+        num_tokens_padded=2,
+    )[0]
+
+    expected = torch.tensor([80, PAD_SLOT_ID], dtype=torch.int64, device=device)
     assert torch.equal(actual, expected)
 
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1111,16 +1111,10 @@ class GroupCoordinator:
         """Lazily drop self-retained ``isend_tensor_dict`` entries that have
         completed, oldest first (FIFO).
 
-        gloo ``Work.is_completed()`` is unreliable (it can report completion
-        before the background copy of the source buffer finishes), so the
-        metadata handle (``handles[0]``, a gloo-backed ``_RetainedHandle``) is
-        never used as the completion gate. Instead we gate on the tensor-send
-        handles (``handles[1:]``), which run on the device backend where
-        ``is_completed()`` is reliable. Once all tensor sends are done the
-        peer must already have posted the matching tensor recvs — and since
-        the receiver ingests metadata before tensors, the gloo metadata send
-        is then guaranteed complete, so ``wait()`` on it is ~instant and only
-        serves to drop the retained refs.
+        Gloo completion reports do not guarantee source-buffer lifetime. Use
+        tensor completion to avoid blocking on active device transfers, then
+        wait the CPU tensor handles and metadata before releasing their refs.
+        CPU handles have idempotent waits because callers may have waited them.
 
         Metadata-only entries (``handles[1:]`` empty, e.g. an empty
         ``IntermediateTensors``) have no reliable completion signal; drop them
@@ -1132,7 +1126,7 @@ class GroupCoordinator:
             # super().__init__ may not have the attribute yet.
             self._pending_isends = pending = deque()
         while pending:
-            handles, _ = pending[0]
+            handles, tensors = pending[0]
             tensor_handles = handles[1:]
             if not tensor_handles:
                 pending.popleft()
@@ -1141,6 +1135,9 @@ class GroupCoordinator:
                 # The oldest send is still in flight; FIFO ordering means the
                 # rest are no further along, so stop here.
                 break
+            for handle, tensor in zip(tensor_handles, tensors):
+                if tensor.is_cpu:
+                    handle.wait()
             handles[0].wait()
             pending.popleft()
 
@@ -1211,6 +1208,8 @@ class GroupCoordinator:
             )
             if tensor.is_cuda:
                 tensor.record_stream(torch.cuda.current_stream(tensor.device))
+            if tensor.is_cpu:
+                handle = _RetainedHandle([handle], (tensor,))
             handles.append(handle)
             sent_tensors.append(tensor)
 

--- a/vllm/models/deepseek_v4_1/attention.py
+++ b/vllm/models/deepseek_v4_1/attention.py
@@ -147,6 +147,28 @@ def _resolve_dsv4_kv_cache_dtype(
     return kv_cache_dtype, torch.bfloat16
 
 
+def _compressed_cache_spec(
+    vllm_config: VllmConfig,
+    head_dim: int,
+    compress_ratio: int,
+    cache_dtype: str,
+    cache_torch_dtype: torch.dtype,
+) -> MLAAttentionSpec:
+    uses_fp8_ds_mla_layout = cache_dtype == "fp8_ds_mla"
+    return MLAAttentionSpec(
+        block_size=vllm_config.cache_config.block_size,
+        num_kv_heads=1,
+        head_size=head_dim,
+        dtype=torch.uint8 if uses_fp8_ds_mla_layout else cache_torch_dtype,
+        tokens_per_state=compress_ratio,
+        cache_dtype_str=cache_dtype,
+        alignment=576 if uses_fp8_ds_mla_layout else 512,
+        model_version="deepseek_v4",
+        kv_quant_mode=get_kv_quant_mode(cache_dtype),
+        state_content_bytes=584 if uses_fp8_ds_mla_layout else None,
+    )
+
+
 class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
     """DeepseekV4 MLA attention layer.
 
@@ -937,20 +959,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         # fp8_ds_mla is a UE8M0 block-scaled uint8 layout and needs 576B
         # alignment; plain bf16 / per-tensor fp8 rows use natural element-size
         # pages.
-        uses_fp8_ds_mla_layout = self.kv_cache_dtype == "fp8_ds_mla"
-        return MLAAttentionSpec(
-            block_size=vllm_config.cache_config.block_size,
-            num_kv_heads=1,
-            head_size=self.head_dim,
-            dtype=torch.uint8 if uses_fp8_ds_mla_layout else self.kv_cache_torch_dtype,
-            tokens_per_state=self.compress_ratio,
-            cache_dtype_str=self.kv_cache_dtype,
-            alignment=576 if uses_fp8_ds_mla_layout else 512,
-            model_version="deepseek_v4",
-            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
-            # DeepseekV4: 448B NoPE + 128B RoPE + 8B fp8 scale = 584B per token;
-            # head_size stays semantic (512).
-            state_content_bytes=584 if uses_fp8_ds_mla_layout else None,
+        return _compressed_cache_spec(
+            vllm_config,
+            self.head_dim,
+            self.compress_ratio,
+            self.kv_cache_dtype,
+            self.kv_cache_torch_dtype,
         )
 
     def _compressed_kv_cache(self) -> torch.Tensor:
@@ -1006,6 +1020,76 @@ class DeepseekV4IndexerCache(torch.nn.Module, AttentionLayerBase):
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return DeepseekV41IndexerBackend
+
+
+class DeepseekV4PipelineCache(nn.Module, AttentionLayerBase):
+    """Weight-free replica registered under the original KV source's layer name."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str,
+        source_layer: int,
+        attn_cls: type[DeepseekV4Attention],
+    ) -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        cache_config = vllm_config.cache_config
+        self.head_dim = config.head_dim
+        self.compress_ratio = config.compress_ratios[source_layer]
+        self.kv_cache_dtype, self.kv_cache_torch_dtype = _resolve_dsv4_kv_cache_dtype(
+            attn_cls.use_fp8_ds_mla_layout, cache_config.cache_dtype, cache_config
+        )
+        self.backend_cls = attn_cls.backend_cls
+        self.prefix = prefix
+        self.kv_cache = torch.tensor([])
+        context = vllm_config.compilation_config.static_forward_context
+        if prefix in context:
+            raise ValueError(f"Duplicate pipeline cache name: {prefix}")
+        context[prefix] = self
+
+    def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
+        self.kv_cache = kv_cache.squeeze(1)
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return self.backend_cls
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        return _compressed_cache_spec(
+            vllm_config,
+            self.head_dim,
+            self.compress_ratio,
+            self.kv_cache_dtype,
+            self.kv_cache_torch_dtype,
+        )
+
+    def forward(self):
+        raise RuntimeError("Pipeline cache replicas do not execute attention")
+
+
+def make_pipeline_cache_replica(
+    vllm_config: VllmConfig,
+    source_prefix: str,
+    source_layer: int,
+    kind: str,
+    attn_cls: type[DeepseekV4Attention],
+) -> DeepseekV4PipelineCache | DeepseekV4IndexerCache:
+    if kind == "kv":
+        return DeepseekV4PipelineCache(
+            vllm_config, source_prefix, source_layer, attn_cls
+        )
+    if kind != "index_k":
+        raise ValueError(f"Unsupported pipeline cache kind: {kind}")
+    config = vllm_config.model_config.hf_config
+    return DeepseekV4IndexerCache(
+        head_dim=_indexer_k_cache_head_dim(
+            config.index_head_dim, dsa_indexer_uses_fp4(vllm_config)
+        ),
+        dtype=torch.uint8,
+        prefix=f"{source_prefix}.indexer.k_cache",
+        cache_config=vllm_config.cache_config,
+        compress_ratio=config.compress_ratios[source_layer],
+    )
 
 
 class DeepseekV4Indexer(nn.Module):

--- a/vllm/models/deepseek_v4_1/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4_1/common/ops/cache_utils.py
@@ -565,6 +565,7 @@ def combine_topk_swa_indices(
         )
     else:
         combined_indices, combined_lens = out
+        combined_indices.fill_(-1)
 
     _COMBINE_TOPK_SWA_INDICES_KERNEL(
         combined_indices,

--- a/vllm/models/deepseek_v4_1/common/pipeline.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layer-sharing dependencies of a DeepSeek V4.1 pipeline partition."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SharingDependency:
+    kind: str
+    source_layer: int
+    consumer_layer: int
+    source_stage: int
+    consumer_stage: int
+
+
+def get_sharing_dependencies(
+    config: Any, stage_ranges: list[tuple[int, int]]
+) -> tuple[SharingDependency, ...]:
+    """Resolve KV, index and candidate sources before constructing any layers."""
+    num_layers = config.num_hidden_layers
+    if (
+        not stage_ranges
+        or stage_ranges[0][0] != 0
+        or stage_ranges[-1][1] != num_layers
+        or any(start >= end for start, end in stage_ranges)
+        or any(a[1] != b[0] for a, b in zip(stage_ranges, stage_ranges[1:]))
+    ):
+        raise ValueError("DeepSeek V4.1 pipeline stages must partition all layers")
+    owners = {
+        layer: stage
+        for stage, (start, end) in enumerate(stage_ranges)
+        for layer in range(start, end)
+    }
+    ratios = config.compress_ratios
+    if len(ratios) < num_layers:
+        raise ValueError(
+            "DeepSeek V4.1 compress_ratios must cover every backbone layer"
+        )
+
+    sources = {}
+    for kind, field in (
+        ("kv", "kv_source_layer_ids"),
+        ("index", "index_source_layer_ids"),
+    ):
+        values = tuple(getattr(config, field, None) or ())
+        if (
+            any(
+                type(layer) is not int or not 0 <= layer < num_layers
+                for layer in values
+            )
+            or values != tuple(sorted(set(values)))
+            or any(ratios[layer] == 0 for layer in values)
+        ):
+            raise ValueError(
+                f"DeepSeek V4.1 {field} must contain sorted, unique compressed layers"
+            )
+        sources[kind] = values
+
+    if not set(sources["kv"]).issubset(sources["index"]):
+        raise ValueError("DeepSeek V4.1 KV sources must also publish index keys")
+
+    dependencies = []
+
+    def append(kind: str, source: int, consumer: int) -> None:
+        if source != consumer:
+            dependencies.append(
+                SharingDependency(
+                    kind, source, consumer, owners[source], owners[consumer]
+                )
+            )
+
+    for layer in range(num_layers):
+        if ratios[layer] == 0:
+            continue
+        for kind, values in sources.items():
+            preceding = [source for source in values if source <= layer]
+            if not preceding:
+                raise ValueError(
+                    f"DeepSeek V4.1 layer {layer} has no preceding {kind} source"
+                )
+            append(kind, preceding[-1], layer)
+            if kind == "kv" and layer in sources["index"]:
+                append("index_k", preceding[-1], layer)
+
+    candidate = getattr(config, "candidate_source_layer_id", -1)
+    if candidate >= 0 and getattr(config, "candidate_topk_blocks", 0) > 0:
+        if candidate not in sources["index"]:
+            raise ValueError("DeepSeek V4.1 candidate source must be an index source")
+        for layer in sources["index"]:
+            if layer > candidate:
+                append("candidate", candidate, layer)
+    return tuple(dependencies)
+
+
+def validate_local_sharing(dependencies: tuple[SharingDependency, ...]) -> None:
+    """Reject stage cuts that require sharing tensors between pipeline ranks."""
+    cross_stage = [d for d in dependencies if d.source_stage != d.consumer_stage]
+    if cross_stage:
+        detail = "; ".join(
+            f"{d.kind} source layer {d.source_layer} (stage {d.source_stage}) -> "
+            f"layer {d.consumer_layer} (stage {d.consumer_stage})"
+            for d in cross_stage[:4]
+        )
+        raise NotImplementedError(
+            "DeepSeek V4.1 pipeline partition crosses layer-sharing dependencies: "
+            f"{detail}. Keep each sharing group on one stage or explicitly enable "
+            "the experimental deepseek_v41_pp_sharing eager path."
+        )

--- a/vllm/models/deepseek_v4_1/common/pipeline_sharing.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline_sharing.py
@@ -121,7 +121,10 @@ class PipelineSharing(nn.Module):
                 prefix = self._cache_prefix(route)
                 layer = self._context[prefix]
                 meta = metadata[prefix]
-                if route.kind == "kv":
+                host_table = getattr(meta, "block_table_cpu", None)
+                if host_table is not None:
+                    tables = [host_table]
+                elif route.kind == "kv":
                     tables = [meta.block_table[: meta.num_reqs]]
                 else:
                     tables = []

--- a/vllm/models/deepseek_v4_1/common/pipeline_sharing.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline_sharing.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Experimental eager relay of KV, index keys, indices and candidate blocks."""
+
+from typing import Any
+
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig
+from vllm.models.deepseek_v4_1.attention import (
+    DeepseekV4Attention,
+    make_pipeline_cache_replica,
+)
+
+from .pipeline import SharingDependency
+from .pipeline_transfer import (
+    SharingRoute,
+    get_sharing_routes,
+    restore_cache_blocks,
+    snapshot_cache_blocks,
+)
+
+
+class PipelineSharing(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str,
+        stage: int,
+        dependencies: tuple[SharingDependency, ...],
+        attn_cls: type[DeepseekV4Attention],
+        max_bytes: int,
+    ) -> None:
+        super().__init__()
+        parallel = vllm_config.parallel_config
+        if (
+            not vllm_config.model_config.enforce_eager
+            or vllm_config.use_v2_model_runner
+            or parallel.use_ubatching
+            or parallel.decode_context_parallel_size != 1
+            or parallel.prefill_context_parallel_size != 1
+            or vllm_config.speculative_config is not None
+            or vllm_config.kv_transfer_config is not None
+            or parallel.distributed_executor_backend == "external_launcher"
+        ):
+            raise ValueError(
+                "deepseek_v41_pp_sharing requires eager V1 execution without "
+                "microbatching, context parallelism, speculative decoding, KV transfer "
+                "or external_launcher"
+            )
+        if type(max_bytes) is not int or max_bytes <= 0:
+            raise ValueError(
+                "deepseek_v41_pp_share_max_bytes must be a positive integer"
+            )
+        self.max_bytes = max_bytes
+        routes = get_sharing_routes(dependencies)
+        self.inbound = tuple(r for r in routes if r.receiver == stage)
+        self.outbound = tuple(r for r in routes if r.sender == stage)
+        self.payload_keys = frozenset(k for r in routes for k in r.payload_keys)
+        self._context = vllm_config.compilation_config.static_forward_context
+        self._prefix = prefix
+        self.replicas = nn.ModuleList()
+        # Resolve the main cache dtype before constructing index-K replicas.
+        for kind in ("kv", "index_k"):
+            for route in self.inbound:
+                if route.kind == kind:
+                    self.replicas.append(
+                        make_pipeline_cache_replica(
+                            vllm_config,
+                            self._source_prefix(route),
+                            route.source_layer,
+                            kind,
+                            attn_cls,
+                        )
+                    )
+
+    def _source_prefix(self, route: SharingRoute) -> str:
+        return f"{self._prefix}.layers.{route.source_layer}.attn"
+
+    def _cache_prefix(self, route: SharingRoute) -> str:
+        prefix = self._source_prefix(route)
+        return f"{prefix}.indexer.k_cache" if route.kind == "index_k" else prefix
+
+    def receive(
+        self,
+        tensors: dict[str, torch.Tensor],
+        topk: torch.Tensor,
+        candidates: torch.Tensor | None,
+        num_tokens: int,
+    ) -> None:
+        for route in self.inbound:
+            if any(key not in tensors for key in route.payload_keys):
+                raise ValueError(f"Missing pipeline sharing payload: {route.key}")
+            if route.kind in ("kv", "index_k"):
+                cache = self._context[self._cache_prefix(route)].kv_cache
+                restore_cache_blocks(
+                    cache, tensors[f"{route.key}.ids"], tensors[f"{route.key}.blocks"]
+                )
+            else:
+                target = topk if route.kind == "index" else candidates
+                assert target is not None
+                values = tensors[route.key]
+                if values.shape != target[:num_tokens].shape:
+                    raise ValueError(
+                        f"Pipeline sharing token shape mismatch: {route.key}"
+                    )
+                target[:num_tokens].copy_(values)
+
+    def send(
+        self,
+        metadata: dict[str, Any],
+        topk: torch.Tensor,
+        candidates: torch.Tensor | None,
+        num_tokens: int,
+    ) -> dict[str, torch.Tensor]:
+        payload = {}
+        remaining = self.max_bytes
+        for route in self.outbound:
+            if route.kind in ("kv", "index_k"):
+                prefix = self._cache_prefix(route)
+                layer = self._context[prefix]
+                meta = metadata[prefix]
+                if route.kind == "kv":
+                    tables = [meta.block_table[: meta.num_reqs]]
+                else:
+                    tables = []
+                    if meta.decode is not None:
+                        tables.append(meta.decode.block_table)
+                    if meta.prefill is not None:
+                        tables.extend(
+                            chunk.block_table for chunk in meta.prefill.chunks
+                        )
+                ids, blocks = snapshot_cache_blocks(layer.kv_cache, tables, remaining)
+                values = {f"{route.key}.ids": ids, f"{route.key}.blocks": blocks}
+            else:
+                source = topk if route.kind == "index" else candidates
+                assert source is not None
+                values = {route.key: source[:num_tokens].clone()}
+            remaining -= sum(t.numel() * t.element_size() for t in values.values())
+            if remaining < 0:
+                raise ValueError("Pipeline sharing snapshot exceeds its byte budget")
+            payload.update(values)
+        return payload

--- a/vllm/models/deepseek_v4_1/common/pipeline_transfer.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline_transfer.py
@@ -49,8 +49,8 @@ def snapshot_cache_blocks(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Snapshot all referenced blocks, including prefix hits and quantization data.
 
-    This deliberately uses dynamic tensors and GPU-to-CPU synchronization. It is
-    an eager correctness path; a delta protocol and graph capture are separate work.
+    Scheduler-owned CPU tables keep ID selection and validation on the host.
+    GPU tables retain the eager fallback, which synchronizes to select IDs.
     """
     if block_tables:
         ids = torch.cat([table.reshape(-1) for table in block_tables]).to(torch.int64)
@@ -62,7 +62,8 @@ def snapshot_cache_blocks(
     block_bytes = cache[0].numel() * cache.element_size() if cache.shape[0] else 0
     if ids.numel() * (block_bytes + ids.element_size()) > max_bytes:
         raise ValueError("Pipeline sharing snapshot exceeds its configured byte budget")
-    return ids, cache.index_select(0, ids)
+    device_ids = ids.to(device=cache.device, non_blocking=True)
+    return ids, cache.index_select(0, device_ids)
 
 
 def restore_cache_blocks(
@@ -75,4 +76,5 @@ def restore_cache_blocks(
         raise ValueError("Pipeline cache block ids must be an int64 vector")
     if ids.numel() and (int(ids.min()) < 0 or int(ids.max()) >= cache.shape[0]):
         raise ValueError("Pipeline snapshot refers to an unallocated replica block")
-    cache.index_copy_(0, ids, blocks)
+    device_ids = ids.to(device=cache.device, non_blocking=True)
+    cache.index_copy_(0, device_ids, blocks)

--- a/vllm/models/deepseek_v4_1/common/pipeline_transfer.py
+++ b/vllm/models/deepseek_v4_1/common/pipeline_transfer.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Eager pipeline snapshots for DeepSeek V4.1 shared state."""
+
+from dataclasses import dataclass
+
+import torch
+
+from .pipeline import SharingDependency
+
+
+@dataclass(frozen=True, order=True)
+class SharingRoute:
+    kind: str
+    source_layer: int
+    sender: int
+    receiver: int
+
+    @property
+    def key(self) -> str:
+        return f"__dsv41_pp__{self.kind}.{self.source_layer}"
+
+    @property
+    def payload_keys(self) -> tuple[str, ...]:
+        if self.kind in ("kv", "index_k"):
+            return (f"{self.key}.ids", f"{self.key}.blocks")
+        return (self.key,)
+
+
+def get_sharing_routes(
+    dependencies: tuple[SharingDependency, ...],
+) -> tuple[SharingRoute, ...]:
+    """Deduplicate consumers and relay state through every intervening stage."""
+    return tuple(
+        sorted(
+            {
+                SharingRoute(d.kind, d.source_layer, stage, stage + 1)
+                for d in dependencies
+                for stage in range(d.source_stage, d.consumer_stage)
+            }
+        )
+    )
+
+
+def snapshot_cache_blocks(
+    cache: torch.Tensor,
+    block_tables: list[torch.Tensor],
+    max_bytes: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Snapshot all referenced blocks, including prefix hits and quantization data.
+
+    This deliberately uses dynamic tensors and GPU-to-CPU synchronization. It is
+    an eager correctness path; a delta protocol and graph capture are separate work.
+    """
+    if block_tables:
+        ids = torch.cat([table.reshape(-1) for table in block_tables]).to(torch.int64)
+        ids = torch.unique(ids[ids >= 0])
+    else:
+        ids = torch.empty(0, dtype=torch.int64, device=cache.device)
+    if ids.numel() and int(ids[-1]) >= cache.shape[0]:
+        raise ValueError("Pipeline snapshot refers to an unallocated cache block")
+    block_bytes = cache[0].numel() * cache.element_size() if cache.shape[0] else 0
+    if ids.numel() * (block_bytes + ids.element_size()) > max_bytes:
+        raise ValueError("Pipeline sharing snapshot exceeds its configured byte budget")
+    return ids, cache.index_select(0, ids)
+
+
+def restore_cache_blocks(
+    cache: torch.Tensor, ids: torch.Tensor, blocks: torch.Tensor
+) -> None:
+    """Refresh a local replica using the global scheduler's physical block ids."""
+    if blocks.shape != (ids.numel(), *cache.shape[1:]) or blocks.dtype != cache.dtype:
+        raise ValueError("Pipeline cache replica has a different block layout")
+    if ids.ndim != 1 or ids.dtype != torch.int64:
+        raise ValueError("Pipeline cache block ids must be an int64 vector")
+    if ids.numel() and (int(ids.min()) < 0 or int(ids.max()) >= cache.shape[0]):
+        raise ValueError("Pipeline snapshot refers to an unallocated replica block")
+    cache.index_copy_(0, ids, blocks)

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -76,6 +76,8 @@ from vllm.v1.worker.ubatching import dbo_current_ubatch_id
 
 from ..common.engram import Engram, EngramLayout, NgramHashState
 from ..common.mm_preprocess import IMAGE_SENTINEL_BASE_ID, image_sentinel_mask
+from ..common.pipeline import get_sharing_dependencies, validate_local_sharing
+from ..common.pipeline_sharing import PipelineSharing
 
 if typing.TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
@@ -391,6 +393,33 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
 
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
+        from vllm.distributed.utils import get_pp_indices
+
+        pp_size = get_pp_group().world_size
+        stage_ranges = [
+            get_pp_indices(config.num_hidden_layers, rank, pp_size)
+            for rank in range(pp_size)
+        ]
+        self.sharing_dependencies = get_sharing_dependencies(config, stage_ranges)
+        additional_config = vllm_config.additional_config
+        sharing_enabled = isinstance(additional_config, dict) and additional_config.get(
+            "deepseek_v41_pp_sharing", False
+        )
+        self.pipeline_sharing: PipelineSharing | None = None
+        self.pipeline_payload_keys: frozenset[str] = frozenset()
+        if sharing_enabled:
+            assert isinstance(additional_config, dict)
+            self.pipeline_sharing = PipelineSharing(
+                vllm_config,
+                prefix,
+                get_pp_group().rank_in_group,
+                self.sharing_dependencies,
+                _select_dsv4_attn_cls(vllm_config),
+                additional_config.get("deepseek_v41_pp_share_max_bytes", 512 * 1024**2),
+            )
+            self.pipeline_payload_keys = self.pipeline_sharing.payload_keys
+        else:
+            validate_local_sharing(self.sharing_dependencies)
         self.config = config
         self.quant_config = quant_config
         self.parallel_config = vllm_config.parallel_config
@@ -547,6 +576,26 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
 
+        pipeline_metadata = None
+        if self.pipeline_sharing is not None and is_forward_context_available():
+            context = get_forward_context()
+            if context.attn_metadata is not None and not context.additional_kwargs.get(
+                "is_dummy_run", False
+            ):
+                if not isinstance(context.attn_metadata, dict):
+                    raise ValueError(
+                        "Pipeline sharing requires unsliced attention metadata"
+                    )
+                pipeline_metadata = context.attn_metadata
+                if not get_pp_group().is_first_rank:
+                    assert intermediate_tensors is not None
+                    self.pipeline_sharing.receive(
+                        intermediate_tensors.tensors,
+                        self.topk_indices_buffer,
+                        self.candidate_block_buffer,
+                        positions.shape[0],
+                    )
+
         if self.use_mega_moe:
             input_ids = input_ids.to(torch.int64)
 
@@ -654,9 +703,17 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 )
 
         if not get_pp_group().is_last_rank:
-            return IntermediateTensors(
-                {"hidden_states": hidden_states, "pre_mix": pre_mix}
-            )
+            tensors = {"hidden_states": hidden_states, "pre_mix": pre_mix}
+            if self.pipeline_sharing is not None and pipeline_metadata is not None:
+                tensors.update(
+                    self.pipeline_sharing.send(
+                        pipeline_metadata,
+                        self.topk_indices_buffer,
+                        self.candidate_block_buffer,
+                        full_num_tokens,
+                    )
+                )
+            return IntermediateTensors(tensors)
 
         # MTP needs full HC states; otherwise collapse and normalize locally
         # before gathering to reduce communication.
@@ -1023,6 +1080,7 @@ class DeepseekV41LLMForCausalLM(
         self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
             self.model.make_empty_intermediate_tensors
         )
+        self.pipeline_payload_keys = self.model.pipeline_payload_keys
 
         self.set_moe_parameters()
 

--- a/vllm/models/deepseek_v4_1/nvidia/vl_model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/vl_model.py
@@ -178,6 +178,7 @@ class DeepseekV41ForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, Supports
         self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
             self.language_model.make_empty_intermediate_tensors
         )
+        self.pipeline_payload_keys = self.language_model.pipeline_payload_keys
 
         expert_dtype = getattr(config, "expert_dtype", "fp4")
         self.hf_to_vllm_mapper = _make_deepseek_v4_vl_weights_mapper(

--- a/vllm/models/deepseek_v4_1/sparse_mla.py
+++ b/vllm/models/deepseek_v4_1/sparse_mla.py
@@ -139,6 +139,7 @@ class DeepseekV4FlashMLAMetadata(AttentionMetadata):
     req_id_per_token: torch.Tensor
     block_size: int
     topk_tokens: int
+    block_table_cpu: torch.Tensor | None = None
 
 
 class DeepseekV4SparseMLAMetadataBuilder(
@@ -214,6 +215,11 @@ class DeepseekV4SparseMLAMetadataBuilder(
             req_id_per_token=req_id_per_token,
             block_size=self.kv_cache_spec.block_size,
             topk_tokens=self.topk_tokens,
+            block_table_cpu=(
+                cm.block_table_cpu.clamp(min=0)
+                if self.compress_ratio > 1 and cm.block_table_cpu is not None
+                else cm.block_table_cpu
+            ),
         )
 
 

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -454,6 +454,9 @@ class CommonAttentionMetadata:
     _num_computed_tokens_cache: torch.Tensor | None = None
     _token_to_req_indices_cache: torch.Tensor | None = None
 
+    # Snapshot of scheduler-owned tables for eager pipeline sharing.
+    block_table_cpu: torch.Tensor | None = None
+
     def batch_size(self) -> int:
         return self.seq_lens.shape[0]
 
@@ -512,6 +515,7 @@ class CommonAttentionMetadata:
             max_query_len=self.max_query_len,
             max_seq_len=self.max_seq_len,
             block_table_tensor=self.block_table_tensor[:num_actual_reqs],
+            block_table_cpu=maybe_slice_reqs(self.block_table_cpu),
             slot_mapping=self.slot_mapping[:num_actual_tokens],
             causal=self.causal[:num_actual_reqs]
             if isinstance(self.causal, torch.Tensor)

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -515,6 +515,7 @@ class DeepseekV32IndexerMetadata:
 
     decode: DeepSeekV32IndexerDecodeMetadata | None = None
     prefill: DeepseekV32IndexerPrefillMetadata | None = None
+    block_table_cpu: torch.Tensor | None = None
 
 
 def compute_kpool_tail_slot_mapping(
@@ -1068,6 +1069,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         compressed_slot_mapping = slot_mapping
         compressed_seq_lens = seq_lens
         indexer_block_table = block_table
+        indexer_block_table_cpu = common_attn_metadata.block_table_cpu
         if self.compress_ratio > 1:
             kernel_block_size = self.kernel_block_size
             if (
@@ -1077,6 +1079,10 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             ):
                 factor = self.kv_cache_spec.block_size // kernel_block_size
                 indexer_block_table = (block_table[:, ::factor] // factor).contiguous()
+                if indexer_block_table_cpu is not None:
+                    indexer_block_table_cpu = (
+                        indexer_block_table_cpu[:, ::factor] // factor
+                    ).contiguous()
             padded_num_tokens = num_tokens
             if self.pcp_world_size > 1:
                 padded_num_tokens = slot_mapping.shape[0] // self.pcp_world_size
@@ -1316,6 +1322,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             num_prefill_tokens=num_prefill_tokens,
             prefill=prefill_metadata,
             decode=decode_metadata,
+            block_table_cpu=indexer_block_table_cpu,
         )
 
         return attn_metadata

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1725,13 +1725,9 @@ def get_kv_cache_config_from_groups(
 
     kv_cache_tensors = []
     for group in kv_cache_groups:
-        group_spec = group.kv_cache_spec
         layers_by_spec: defaultdict[KVCacheSpec, list[str]] = defaultdict(list)
-        if isinstance(group_spec, UniformTypeKVCacheSpecs):
-            for layer_name, spec in group_spec.kv_cache_specs.items():
-                layers_by_spec[spec].append(layer_name)
-        elif group.layer_names:
-            layers_by_spec[group_spec].extend(group.layer_names)
+        for layer_name in group.layer_names:
+            layers_by_spec[_get_per_layer_spec(group, layer_name)].append(layer_name)
 
         byte_offset = 0
         for spec, layer_names in layers_by_spec.items():

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -466,14 +466,15 @@ class ComputeSlotMappingKernel(
                 virtual_block_indices * BLOCKS_PER_KV_BLOCK
                 + local_block_offsets // block_size
             )
+            in_range = block_indices < block_table_stride
             block_numbers = tl.load(
                 block_table_ptr + row_offset + block_indices,
-                mask=mask & is_local,
+                mask=mask & is_local & in_range,
                 other=0,
             ).to(tl.int64)
             slot_offsets = local_block_offsets % block_size
             slot_ids = block_numbers * block_size + slot_offsets
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+            slot_ids = tl.where(is_local & in_range, slot_ids, PAD_ID)
             tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
 
     def dispatch(  # type: ignore[override]

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -340,14 +340,14 @@ def _compute_slot_mappings_kernel(
             mapping_enabled, local_positions // kernel_block_size, 0
         )
         block_offsets = local_positions % kernel_block_size
+        in_range = block_indices < block_table_stride
         block_numbers = tl.load(
             block_table_ptr + req_state_idx * block_table_stride + block_indices,
-            mask=is_local,
+            mask=is_local & in_range,
             other=0,
         )
         slot_ids = block_numbers * kernel_block_size + block_offsets
-        if CP_SIZE != 1:
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        slot_ids = tl.where(is_local & in_range, slot_ids, PAD_ID)
 
         slot_ids = tl.where(mapping_enabled, slot_ids, PAD_ID)
         tl.store(slot_mapping_ptr + offset, slot_ids, mask=offset < end_idx)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2356,6 +2356,22 @@ class GPUModelRunner(
             blk_table_tensor[num_reqs:num_reqs_padded].fill_(NULL_BLOCK_ID)
             return blk_table_tensor
 
+        def _get_block_table_cpu(kv_cache_gid: int):
+            additional_config = self.vllm_config.additional_config
+            if not isinstance(additional_config, dict) or not additional_config.get(
+                "deepseek_v41_pp_sharing"
+            ):
+                return None
+            assert num_reqs_padded is not None
+            if isinstance(
+                kv_cache_groups[kv_cache_gid].kv_cache_spec, EncoderOnlyAttentionSpec
+            ):
+                return torch.zeros((num_reqs_padded, 1), dtype=torch.int32)
+            table = self.input_batch.block_table[kv_cache_gid].get_cpu_tensor()
+            snapshot = table[:num_reqs_padded].clone()
+            snapshot[num_reqs:num_reqs_padded].fill_(NULL_BLOCK_ID)
+            return snapshot
+
         assert slot_mappings is not None
         block_table_gid_0 = _get_block_table(0)
         slot_mapping_gid_0 = slot_mappings[0]
@@ -2590,6 +2606,7 @@ class GPUModelRunner(
         spec_decode_common_attn_metadata = None
         for kv_cache_gid, kv_cache_group in enumerate(kv_cache_groups):
             cm = copy(cm_base)  # shallow copy
+            cm.block_table_cpu = _get_block_table_cpu(kv_cache_gid)
 
             # Basically only the encoder seq_lens, block_table and slot_mapping change
             # for each kv_cache_group.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -55,6 +55,7 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.forward_context import (
     BatchDescriptor,
+    get_forward_context,
     set_forward_context,
 )
 from vllm.logger import init_logger
@@ -3374,6 +3375,10 @@ class GPUModelRunner(
 
         return tuple(tasks)
 
+    @property
+    def pipeline_payload_keys(self) -> frozenset[str]:
+        return getattr(self.get_model(), "pipeline_payload_keys", frozenset())
+
     def sync_and_gather_intermediate_tensors(
         self,
         num_tokens: int,
@@ -3384,6 +3389,8 @@ class GPUModelRunner(
 
         tp = self.vllm_config.parallel_config.tensor_parallel_size
         is_rs = is_residual_scattered_for_sp(self.vllm_config, num_tokens)
+        payload_keys = self.pipeline_payload_keys
+        payloads = {}
 
         # When sequence parallelism is enabled, the "residual" tensor is
         # sharded across TP ranks. All-gather it here because downstream
@@ -3391,6 +3398,10 @@ class GPUModelRunner(
         if sync_self:
             assert intermediate_tensors is not None
             for k, v in intermediate_tensors.items():
+                if k in payload_keys:
+                    # Eager model-owned state may have a block axis, not tokens.
+                    payloads[k] = v
+                    continue
                 is_scattered = k == "residual" and is_rs
                 if is_scattered:
                     local_len = num_tokens // tp
@@ -3401,7 +3412,7 @@ class GPUModelRunner(
                 )
 
         return IntermediateTensors(
-            {k: v[:num_tokens] for k, v in self.intermediate_tensors.items()}
+            {k: v[:num_tokens] for k, v in self.intermediate_tensors.items()} | payloads
         )
 
     def eplb_step(self, is_dummy: bool = False, is_profile: bool = False) -> None:
@@ -6172,6 +6183,7 @@ class GPUModelRunner(
                     slot_mapping=slot_mappings,
                 ),
             ):
+                get_forward_context().additional_kwargs["is_dummy_run"] = True
                 outputs = self.model(
                     input_ids=input_ids,
                     positions=positions,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1165,6 +1165,12 @@ class Worker(WorkerBase):
                 )
             }
 
+        all_gather_tensors.update(
+            {
+                key: False
+                for key in getattr(self.model_runner, "pipeline_payload_keys", ())
+            }
+        )
         if forward_pass and not get_pp_group().is_first_rank:
             tensor_dict, comm_handles, comm_postprocess = (
                 get_pp_group().irecv_tensor_dict(


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/vllm-project/vllm/pull/56439/files) against `main`.

Relay DeepSeek-V4.1 cache and index state across PP stage boundaries. The latest update carries scheduler CPU block tables into attention metadata, selects/validates cache IDs on the CPU, sends IDs through Gloo and packed GPU cache blocks through NCCL, and retains CPU send buffers until completion. Prefix refresh, physical block reuse, empty transfers and packed cache bytes are preserved.

**Main sync (2026-09-14):** current head `8bd8c68ec1bf41e47011bed09f9656d7227ee2c5` merges `main` at `663d7f679eda78a8d48613dfede8a4b4bcff2b74`. The previous feature patch and upstream integration are preserved, with model paths and test imports updated from `deepseek_v4_1` to `deepseek_v41`. Normalized added/removed patch lines are identical. Changed-file pre-commit hooks (`.venv/bin/pre-commit run --files` for every final PR file), Python parsing and `git diff origin/main --check` passed. The pipeline and transfer CPU suites passed 21 tests; 5 CUDA cases were skipped. CUDA compilation, GPU execution and full-model evaluations were not rerun; the model/performance evidence below remains historical. AI assistance was used for conflict resolution and validation.

The opt-in path remains eager V1, with a default 512 MiB outgoing snapshot budget. Existing checks continue to reject microbatching, context parallelism, speculative decoding, KV transfer and external-launcher execution.

## Test Result

### End-to-end outcome

| Item | Recorded details |
| --- | --- |
| Observed result | The latest configuration observed +144.01% / +146.25% output throughput versus the already-correct PP-sharing baseline. |

### Output throughput

| Input → output tokens | Baseline (tok/s) | Candidate (tok/s) | Throughput change |
| --- | ---: | ---: | ---: |
| 512 → 128 | 5.8312 | 14.2286 | **+144.01%** |
| 2048 → 128 | 3.5123 | 8.6489 | **+146.25%** |

### Mean end-to-end latency

| Input → output tokens | Baseline E2E (s) | Candidate E2E (s) |
| --- | ---: | ---: |
| 512 → 128 | 87.502 | 35.867 |
| 2048 → 128 | 145.175 | 58.943 |

### Comparison setup

| Item | Recorded details |
| --- | --- |
| Valid baseline | The baseline is frozen #56223 `dfe0c6f292703b22b933a72d3db945d1f6785b0b` after slot/prefill correctness repairs, with TP1×PP4, 10/10/10/10 layers and 8 GiB requested weight offload. |
| Baseline checks | It passed correctness and timed requests. |
| Invalid earlier baseline | The original uncorrected version failed correctness and is not a valid performance baseline. |
| Candidate treatment | The latest candidate adds CPU metadata/ID transfer and send-lifetime repairs and changes requested weight offload 8→4 GiB, with Engram tables still offloaded. |
| Actual offload | Actual general-weight offload was about 11.27–11.42 GiB/worker before and 4.38–4.39 GiB/worker after. |
| Attribution | This is a combined code/configuration result; the code-only gain was not isolated. |
| Untimed attempt | A zero-weight-offload attempt ran out of memory during model loading and was not timed. |

| Deployment reference | 512-input tok/s | 2048-input tok/s |
| --- | ---: | ---: |
| Measured TP4 | 23.1467 | 13.5691 |
| Latest TP1×PP4 sharing | 14.2286 | 8.6489 |
| Sharing throughput relative to TP4 | −38.53% | −36.26% |

| Item | Recorded details |
| --- | --- |
| Deployment reference | TP4 already runs this model and workload. |
| Interpretation | These results establish a working cross-stage sharing option and improve that path, not a capability or deployment-performance advantage over TP4 on this hardware. |

### Correctness and regression checks

| Validation | Latest result |
| --- | --- |
| Focused regression suite | 23/23 passed, zero skips/errors; includes real four-GPU three-hop sync/async transfers and CUDA packed-cache checks |
| Cold / warm prefix | 1921 input tokens; cached 0/1920; all 8 output tokens matched |
| Short QA and token comparisons | 6/6 QA; 4/4 serial, 6/6 fixed-input, 4/4 concurrent matched the valid baseline |
| Actual CPU host-plan path | Observed on sending stages; diagnostic wrappers removed before timing |
| Final timed cohorts | 16/16 per input length; zero failures; 2048 generated tokens each |
| Publication checks | 9 transfer/metadata + 5 send-contract + 5 configuration/snapshot CPU checks passed; applicable changed-file pre-commit hooks passed |

### Process and timing provenance

| Item | Recorded details |
| --- | --- |
| Process separation | Correctness and timing used separate processes with the same verified source/configuration. |
| Correctness process | After full correctness passed, a harness error reading an RPC wrapper terminated that process before timing. |
| Timing process | The timing-only process checked all four workers' source/native-library/worker/partition receipts, removed diagnostics, passed a fresh-process token smoke, and ran the unchanged warmup and timed workloads. |
| Failed-attempt retention | The earlier failed attempt is preserved. |
| Session boundary | This is not a single uninterrupted correctness-plus-performance session. |

## Configuration, commands and scope

| Setting | Recorded configuration |
| --- | --- |
| Model and checkpoint | Official `deepseek-ai/DeepSeek-V4.1-Flash`, checkpoint revision `df42c109f1defefcbfcedbe7d905718a12266e40` |
| Hardware | one node, 4×H100 SXM 80 GB with NV18 links |
| Runner | V1 eager |
| Expert parallelism | EP with `allgather_reducescatter` |
| Engram placement | Engram CPU offload |
| KV cache | fixed 4 GiB KV cache per worker |
| Scheduler limits | max context 4096, batched tokens 512, max sequences 4 |
| Request protocol | Each workload uses random inputs, seed 42, concurrency 4, exactly 128 output tokens with EOS ignored, four separate warmup requests and then a prefix-cache reset before 16 timed requests. |
| Timing boundary | Startup is excluded. |

### Measurement scope

| Item | Recorded details |
| --- | --- |
| Comparison design | These are single non-interleaved comparisons against recorded baselines, without repeated A/B, A/A or confidence intervals. |
| Output checks | Token checks cover the listed prompts; log probabilities can differ and these checks are not a standard model-quality evaluation. |
| Latest-tree coverage | The complete rebased `main` tree was not rerun on GPU. |
| Source receipts | The attached source correspondence distinguishes matching repair code from pre-existing `main` differences. |

Enable with `--additional-config '{"deepseek_v41_pp_sharing":true}'`. The slot guard is adapted from #54296; prefill initialization follows merged #55299. These prerequisites are also used by #56437/#56438, which do not implement the CPU-ID and packed-state relay here. Existing asynchronous PP work is reused; this update supplies V4.1 state transfer and protects the CPU-buffer lifetime in that path.

<details>
<summary>Regression and source-check commands</summary>

```sh
.venv/bin/python -m pytest --noconftest -o addopts= \
  tests/models/test_deepseek_v41_pipeline_transfer.py \
  tests/distributed/test_deepseek_v41_pipeline_transfer.py -q
```

</details>

The recorded 23-case invocation also includes the two workspace checks and six CPU send-contract cases, loaded from the real test definitions to avoid an unrelated Ray import. Exact selections and receipts are attached. Publication adds a dictionary-type guard for the main configuration union and uses accelerator APIs in CUDA test setup; the sharing-enabled snapshot body and transfer assertions are preserved. The guard passed five CPU cases. These are CPU publication checks, not a new GPU E2E run.

<details>
<summary>Serving benchmark command</summary>

```sh
# On the source/configuration identified by the attached run receipt:
.venv/bin/vllm bench serve --backend vllm \
  --base-url http://127.0.0.1:18080 --endpoint /v1/completions --model dsv41 \
  --tokenizer "$MODEL" --tokenizer-mode deepseek_v41 --dataset-name random \
  --random-input-len "$INPUT_LEN" --random-output-len 128 \
  --random-range-ratio 0 --random-prefix-len 0 --num-prompts 16 \
  --max-concurrency 4 --request-rate inf --seed 42 --num-warmups 0 \
  --ready-check-timeout-sec 0 --ignore-eos --disable-tqdm --save-result --save-detailed \
  --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 10,50,90 \
  --result-dir "$RESULTS" --result-filename "$RESULT_FILE"
```

</details>

`INPUT_LEN` is 512 or 2048. Run the four warmup requests separately and reset the prefix cache before this timed command. Use the actual port and source/configuration in the attached receipt.

[Latest raw timing records, validation receipts, patch and source correspondence](https://gist.github.com/0z5a/d2997a0aa0d1a6a684c312a325adf777). Current rebased branch: `6bc8615dc426ee07f4ba5f7b8d044f40ed867525`.

[Earlier repaired baseline and prefill-workspace diagnostics](https://gist.github.com/0z5a/8f385f902bc280b72a8f6be0634c2bce).
