### PR TITLE
[Bugfix][Spec Decode] Fix extract_hidden_states to use last valid token for multi-token outputs

### DIFF
--- a/tests/v1/spec_decode/test_extract_hidden_states.py
+++ b/tests/v1/spec_decode/test_extract_hidden_states.py
@@ -195,6 +195,78 @@ def test_prepare_next_token_ids_padded():
     assert torch.equal(valid_sampled_tokens_count, expected_valid_sampled_tokens_count)
 
 
+def test_prepare_next_token_ids_padded_multi_token():
+    """
+    Test for prepare_next_token_ids_padded with multi-token outputs.
+
+    When num_speculative_tokens >= 1, sampled_token_ids can have shape
+    (batch_size, num_speculative_tokens + 1), e.g., [batch_size, 2].
+    The method should find the last valid token across all columns,
+    not just the first column.
+    """
+    device = torch.device(DEVICE_TYPE)
+
+    num_requests = 4
+    req_ids = [f"req_{i + 1}" for i in range(num_requests)]
+    mock_input_batch = mock.MagicMock(spec=InputBatch)
+    mock_input_batch.req_ids = req_ids
+    mock_input_batch.num_reqs = num_requests
+    mock_input_batch.vocab_size = 100
+    mock_input_batch.num_tokens_no_spec = np.array([5] * num_requests)
+
+    mock_requests = {}
+    for req_id in req_ids:
+        mock_request = mock.MagicMock(spec=CachedRequestState)
+        # Each request will have a backup next token id of 10, 20, 30, 40
+        mock_request.get_token_id.return_value = int(req_id.split("_")[1]) * 10
+        mock_requests[req_id] = mock_request
+
+    # explicitly discard the last request
+    discarded_req_mask = torch.tensor(
+        [False, False, False, True], dtype=torch.bool, device=device
+    )
+
+    # Multi-token outputs with shape [batch_size, 2]
+    # Simulating num_speculative_tokens=1, so we get target token + 1 speculative
+    sampled_token_ids = torch.tensor(
+        [
+            [15, 18],   # both valid, should use 18 (last valid)
+            [4, -1],    # first valid, second invalid, should use 4
+            [-1, -1],   # both invalid, use backup token "30"
+            [2, 7],     # explicitly discarded, use backup token "40"
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    # Expected: use the last valid token for each row
+    expected_next_token_ids_cpu = [18, 4, 30, 40]
+    expected_next_token_ids_tensor = torch.tensor(
+        expected_next_token_ids_cpu, dtype=torch.int32, device=device
+    )
+
+    proposer = _create_proposer(num_speculative_tokens=1)
+
+    # valid_sampled_tokens_count counts how many valid tokens in each row
+    expected_valid_sampled_tokens_count = torch.tensor(
+        [2, 1, 0, 2], dtype=torch.int32, device=device
+    )
+
+    next_token_ids, valid_sampled_tokens_count = proposer.prepare_next_token_ids_padded(
+        sampled_token_ids,
+        mock_requests,
+        mock_input_batch,
+        discarded_req_mask,
+    )
+
+    assert torch.equal(next_token_ids, expected_next_token_ids_tensor), (
+        f"Expected {expected_next_token_ids_tensor}, got {next_token_ids}"
+    )
+    assert torch.equal(valid_sampled_tokens_count, expected_valid_sampled_tokens_count), (
+        f"Expected {expected_valid_sampled_tokens_count}, got {valid_sampled_tokens_count}"
+    )
+
+
 def test_propose():
     """
     Test the propose() method of ExtractHiddenStatesProposer.

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.model_loader import get_model
 from vllm.v1.attention.backend import AttentionMetadataBuilder, CommonAttentionMetadata
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
+from vllm.v1.spec_decode.utils import eagle_prepare_next_token_padded_kernel, next_power_of_2
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
@@ -321,9 +322,9 @@ class ExtractHiddenStatesProposer:
         """
         Prepare next token IDs for speculative decoding.
 
-        Since num_speculative_tokens == 1, sampled_token_ids has shape
-        (batch_size, 1). For each request we either use the sampled token
-        (if valid and not discarded) or a backup token from the request state.
+        When multiple speculative tokens are produced, sampled_token_ids has shape
+        (batch_size, num_speculative_tokens + 1). For each request we find the last
+        valid token across all columns (if not discarded) or use a backup token.
         """
 
         # Precompute backup token IDs for discarded requests.
@@ -333,18 +334,33 @@ class ExtractHiddenStatesProposer:
                 gpu_input_batch.req_ids[i]
             ].get_token_id(gpu_input_batch.num_tokens_no_spec[i] - 1)
         self.backup_next_token_ids.copy_to_gpu(num_reqs)
-        backup_tokens_gpu = self.backup_next_token_ids.gpu[:num_reqs]
+        backup_tokens_gpu = self.backup_next_token_ids.gpu
+
+        batch_size, num_tokens = sampled_token_ids.shape
+        device = sampled_token_ids.device
 
         assert discard_request_mask.dtype == torch.bool
+        assert backup_tokens_gpu.dtype == torch.int32
 
-        # With num_speculative_tokens == 1, there is exactly one token
-        sampled = sampled_token_ids[:, 0]
-        is_valid = (sampled >= 0) & (sampled < gpu_input_batch.vocab_size)
-        valid_sampled_tokens_count = is_valid.to(torch.int32)
+        next_token_ids = torch.empty(batch_size, dtype=torch.int32, device=device)
+        valid_sampled_tokens_count = next_token_ids.new_empty(batch_size)
 
-        use_sampled = is_valid & ~discard_request_mask[:num_reqs]
-        next_token_ids = torch.where(
-            use_sampled, sampled.to(torch.int32), backup_tokens_gpu
+        # Kernel grid: one program per request (row)
+        grid = (batch_size,)
+
+        # Find the next power of 2 for block sizes
+        BLOCK_SIZE_TOKENS = next_power_of_2(num_tokens)
+        eagle_prepare_next_token_padded_kernel[grid](
+            sampled_token_ids,
+            discard_request_mask,
+            backup_tokens_gpu,
+            next_token_ids,
+            valid_sampled_tokens_count,
+            gpu_input_batch.vocab_size,
+            num_tokens,
+            batch_size,
+            sampled_token_ids.stride(0),
+            BLOCK_SIZE_TOKENS=BLOCK_SIZE_TOKENS,
         )
 
         return next_token_ids, valid_sampled_tokens_count


### PR DESCRIPTION
The `ExtractHiddenStatesProposer.prepare_next_token_ids_padded()` method incorrectly read only the first column of `sampled_token_ids` when determining the next token to use for continuation. During speculative decoding with `num_speculative_tokens >= 1`, the sampled token tensor can have shape `[batch_size, num_speculative_tokens + 1]`, containing multiple valid tokens per row. The old implementation always used column 0, causing it to report different progress and a different continuation token from what was actually committed to the output. This manifested as reproducible duplicated digits and punctuation in generated answers.

The fix replaces the simple column-0 slicing with the same `eagle_prepare_next_token_padded_kernel` used by EAGLE proposer. This kernel correctly iterates through all columns, counts valid tokens, and extracts the last valid token in each row. For a row `[15, 18]` with both tokens valid, the corrected method now reports `valid_count=2, next_token_id=18` instead of the incorrect `valid_count=1, next_token_id=15`.

A regression test `test_prepare_next_token_ids_padded_multi_token` has been added to verify correct behavior with multi-token outputs, including cases with mixed valid/invalid tokens and discarded requests.

Fixes #56417
