### PR TITLE
[Bugfix][Qwen4Exp] Support N-gram PLE with pipeline parallelism

### DIFF
--- a/tests/models/qwen4_exp/test_config.py
+++ b/tests/models/qwen4_exp/test_config.py
@@ -18,6 +18,7 @@ from vllm.models.qwen4_exp.config import (
     Qwen4ExpTextConfig,
 )
 from vllm.models.qwen4_exp.nvidia.model_state import Qwen4ExpModelState
+from vllm.sequence import IntermediateTensors
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
 from ...utils import spawn_new_process_for_each_test
@@ -141,10 +142,10 @@ def test_qwen4_exp_mtp_override_sets_draft_config(
 
 
 @pytest.mark.parametrize("ple_layer_ids", [[1], []])
-def test_qwen4_exp_rejects_pipeline_parallel_only_with_ple(ple_layer_ids) -> None:
-    """PLE needs raw input_ids, which non-first pipeline ranks never see. The
-    rest of the architecture is PP-capable, so the refusal must be conditional
-    -- and must land before the engine spends time loading weights."""
+def test_qwen4_exp_allows_pipeline_parallel_with_or_without_ple(
+    ple_layer_ids,
+) -> None:
+    """Qwen4Exp PP supports both the PLE and non-PLE configurations."""
     vllm_config = SimpleNamespace(
         model_config=SimpleNamespace(
             hf_text_config=_text_config(ple_layer_ids=ple_layer_ids),
@@ -158,13 +159,87 @@ def test_qwen4_exp_rejects_pipeline_parallel_only_with_ple(ple_layer_ids) -> Non
     with patch.object(
         Qwen3_5ForConditionalGenerationConfig, "verify_and_update_config"
     ):
-        if ple_layer_ids:
-            with pytest.raises(NotImplementedError, match="pipeline_parallel_size=1"):
-                Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(
-                    vllm_config
-                )
-        else:
-            Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+        Qwen4ExpForConditionalGenerationConfig.verify_and_update_config(vllm_config)
+
+
+@pytest.mark.parametrize("backend", ["amd", "nvidia"])
+def test_qwen4_exp_pp_intermediate_tensors_carry_input_ids(backend: str) -> None:
+    """PLE token IDs are transported alongside hidden states across PP."""
+    model_module = import_module(f"vllm.models.qwen4_exp.{backend}.model")
+    model = object.__new__(model_module.Qwen4ExpModel)
+    torch.nn.Module.__init__(model)
+    model.config = _text_config()
+
+    tensors = model.make_empty_intermediate_tensors(
+        batch_size=8,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+    )
+
+    assert set(tensors.tensors) == {"hidden_states", "input_ids"}
+    assert tensors["hidden_states"].shape == (8, 32)
+    assert tensors["input_ids"].shape == (8,)
+    assert tensors["input_ids"].dtype == torch.int32
+
+
+@pytest.mark.parametrize("backend", ["amd", "nvidia"])
+def test_qwen4_exp_pp_forward_preserves_input_ids(backend: str) -> None:
+    """Non-first PP ranks pass transported token IDs to their decoder layers."""
+    model_module = import_module(f"vllm.models.qwen4_exp.{backend}.model")
+    model = object.__new__(model_module.Qwen4ExpModel)
+    torch.nn.Module.__init__(model)
+    model.config = _text_config()
+    model.start_layer = 0
+    model.end_layer = 1
+    model.hyper_connection_mixer = None
+
+    seen_input_ids: list[torch.Tensor | None] = []
+
+    class CaptureLayer:
+        def __call__(self, **kwargs):
+            seen_input_ids.append(kwargs["input_ids"])
+            return kwargs["hidden_states"], None, None
+
+    model.layers = [CaptureLayer()]
+    input_ids = torch.tensor([11, 13], dtype=torch.int32)
+    intermediate_tensors = IntermediateTensors(
+        {
+            "hidden_states": torch.zeros(2, 32),
+            "input_ids": input_ids,
+        }
+    )
+    pp_group = SimpleNamespace(is_first_rank=False, is_last_rank=False)
+
+    with patch.object(model_module, "get_pp_group", return_value=pp_group):
+        output = model.forward(
+            input_ids=None,
+            positions=torch.arange(2),
+            intermediate_tensors=intermediate_tensors,
+        )
+
+    assert len(seen_input_ids) == 1
+    assert seen_input_ids[0] is input_ids
+    assert isinstance(output, IntermediateTensors)
+    torch.testing.assert_close(output["input_ids"], input_ids)
+
+
+@pytest.mark.parametrize("backend", ["amd", "nvidia"])
+def test_qwen4_exp_pp_intermediate_tensors_omit_input_ids_without_ple(
+    backend: str,
+) -> None:
+    """Non-PLE models retain the original intermediate tensor contract."""
+    model_module = import_module(f"vllm.models.qwen4_exp.{backend}.model")
+    model = object.__new__(model_module.Qwen4ExpModel)
+    torch.nn.Module.__init__(model)
+    model.config = _text_config(ple_layer_ids=[])
+
+    tensors = model.make_empty_intermediate_tensors(
+        batch_size=8,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+    )
+
+    assert set(tensors.tensors) == {"hidden_states"}
 
 
 def test_qwen4_exp_model_state_prepares_ngram_context() -> None:

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -874,14 +874,6 @@ class Qwen4ExpForConditionalGenerationConfig(Qwen3_5ForConditionalGenerationConf
             raise NotImplementedError(
                 "Qwen4Exp PLE/QSA does not support dual-batch overlap or microbatching"
             )
-        # Checked again in Qwen4ExpModelState; rejecting it here keeps the
-        # engine from loading weights first.
-        if text_config.ple_layer_ids and parallel_config.pipeline_parallel_size > 1:
-            raise NotImplementedError(
-                "Qwen4Exp N-gram PLE embedding requires pipeline_parallel_size=1 "
-                "because non-first pipeline ranks do not receive the raw input_ids "
-                "it needs. Please run with PP=1."
-            )
         multimodal_config = vllm_config.model_config.multimodal_config
         if multimodal_config is not None and multimodal_config.language_model_only:
             _strip_qwen4_exp_mrope(vllm_config.model_config)

--- a/vllm/models/qwen4_exp/amd/model.py
+++ b/vllm/models/qwen4_exp/amd/model.py
@@ -61,7 +61,6 @@ from vllm.model_executor.models.utils import (
     WeightsMapper,
     _merge_multimodal_embeddings,
     extract_layer_index,
-    make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_fuse_shared_experts,
     maybe_prefix,
@@ -423,11 +422,6 @@ class Qwen4ExpModel(nn.Module):
             Qwen4ExpSparseMoeBlock,
             "mlp",
         )
-        intermediate_size = config.hidden_size * config.hc_count
-        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
-            ["hidden_states"], intermediate_size
-        )
-
         self.hyper_connection_mixer: GatedResidual | None
         if get_pp_group().is_last_rank:
             hc_config = HyperConnectionConfig(
@@ -469,6 +463,30 @@ class Qwen4ExpModel(nn.Module):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
+    def make_empty_intermediate_tensors(
+        self,
+        batch_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> IntermediateTensors:
+        tensors = {
+            "hidden_states": torch.zeros(
+                (batch_size, self.config.hidden_size * self.config.hc_count),
+                dtype=dtype,
+                device=device,
+            )
+        }
+        if self.config.ple_layer_ids:
+            # PLE needs the raw token IDs on every pipeline stage. The model
+            # runner stores input IDs as int32, so preserve that compact dtype
+            # while transporting them through the PP intermediate tensors.
+            tensors["input_ids"] = torch.zeros(
+                batch_size,
+                dtype=torch.int32,
+                device=device,
+            )
+        return IntermediateTensors(tensors)
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
@@ -491,6 +509,8 @@ class Qwen4ExpModel(nn.Module):
             if intermediate_tensors is None:
                 raise ValueError("pipeline stage requires intermediate tensors")
             hidden_states = intermediate_tensors["hidden_states"]
+            if self.config.ple_layer_ids:
+                input_ids = intermediate_tensors["input_ids"]
 
         block_output = None
         injection = None
@@ -539,7 +559,11 @@ class Qwen4ExpModel(nn.Module):
                 hidden_states = last_layer.mlp_hyper_connection.combine(
                     hidden_states, block_output, injection
                 )
-            return IntermediateTensors({"hidden_states": hidden_states})
+            intermediate = {"hidden_states": hidden_states}
+            if self.config.ple_layer_ids:
+                assert input_ids is not None
+                intermediate["input_ids"] = input_ids
+            return IntermediateTensors(intermediate)
 
         # The final mixer consumes the last pending combine and returns both
         # the sampled single stream and the materialized multi-stream state.

--- a/vllm/models/qwen4_exp/amd/model_state.py
+++ b/vllm/models/qwen4_exp/amd/model_state.py
@@ -32,14 +32,6 @@ class Qwen4ExpModelState(MambaHybridModelState):
             self.ngram_eos_token_id = 0
             return
 
-        if vllm_config.parallel_config.pipeline_parallel_size > 1:
-            raise RuntimeError(
-                "N-gram PLE embedding currently requires "
-                "pipeline_parallel_size=1 because non-first pipeline ranks do "
-                "not receive the raw input_ids required by PLE. Please run "
-                "with PP=1."
-            )
-
         self.ngram_context_len = int(config.ngram_size) - 1
         if self.ngram_context_len <= 0:
             raise ValueError("N-gram embedding requires context length >= 1.")

--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -60,7 +60,6 @@ from vllm.model_executor.models.utils import (
     WeightsMapper,
     _merge_multimodal_embeddings,
     extract_layer_index,
-    make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_fuse_shared_experts,
     maybe_prefix,
@@ -415,11 +414,6 @@ class Qwen4ExpModel(nn.Module):
             Qwen4ExpSparseMoeBlock,
             "mlp",
         )
-        intermediate_size = config.hidden_size * config.hc_count
-        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
-            ["hidden_states"], intermediate_size
-        )
-
         self.hyper_connection_mixer: GatedResidual | None
         if get_pp_group().is_last_rank:
             hc_config = HyperConnectionConfig(
@@ -460,6 +454,30 @@ class Qwen4ExpModel(nn.Module):
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
+
+    def make_empty_intermediate_tensors(
+        self,
+        batch_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> IntermediateTensors:
+        tensors = {
+            "hidden_states": torch.zeros(
+                (batch_size, self.config.hidden_size * self.config.hc_count),
+                dtype=dtype,
+                device=device,
+            )
+        }
+        if self.config.ple_layer_ids:
+            # PLE needs the raw token IDs on every pipeline stage. The model
+            # runner stores input IDs as int32, so preserve that compact dtype
+            # while transporting them through the PP intermediate tensors.
+            tensors["input_ids"] = torch.zeros(
+                batch_size,
+                dtype=torch.int32,
+                device=device,
+            )
+        return IntermediateTensors(tensors)
 
     @staticmethod
     def _start_layer_ple_prefetch(
@@ -504,6 +522,8 @@ class Qwen4ExpModel(nn.Module):
             if intermediate_tensors is None:
                 raise ValueError("pipeline stage requires intermediate tensors")
             hidden_states = intermediate_tensors["hidden_states"]
+            if self.config.ple_layer_ids:
+                input_ids = intermediate_tensors["input_ids"]
 
         block_output = None
         injection = None
@@ -568,7 +588,11 @@ class Qwen4ExpModel(nn.Module):
                 hidden_states = last_layer.mlp_hyper_connection.combine(
                     hidden_states, block_output, injection
                 )
-            return IntermediateTensors({"hidden_states": hidden_states})
+            intermediate = {"hidden_states": hidden_states}
+            if self.config.ple_layer_ids:
+                assert input_ids is not None
+                intermediate["input_ids"] = input_ids
+            return IntermediateTensors(intermediate)
 
         # The final mixer consumes the last pending combine and returns both
         # the sampled single stream and the materialized multi-stream state.

--- a/vllm/models/qwen4_exp/nvidia/model_state.py
+++ b/vllm/models/qwen4_exp/nvidia/model_state.py
@@ -32,14 +32,6 @@ class Qwen4ExpModelState(MambaHybridModelState):
             self.ngram_eos_token_id = 0
             return
 
-        if vllm_config.parallel_config.pipeline_parallel_size > 1:
-            raise RuntimeError(
-                "N-gram PLE embedding currently requires "
-                "pipeline_parallel_size=1 because non-first pipeline ranks do "
-                "not receive the raw input_ids required by PLE. Please run "
-                "with PP=1."
-            )
-
         self.ngram_context_len = int(config.ngram_size) - 1
         if self.ngram_context_len <= 0:
             raise ValueError("N-gram embedding requires context length >= 1.")


### PR DESCRIPTION
## Summary
- carry raw PLE token IDs through Qwen4Exp pipeline-parallel intermediate tensors
- enable Qwen4Exp N-gram PLE with pipeline parallelism for NVIDIA and AMD backends
- add config, intermediate-tensor, and forward-propagation regression coverage

Fixes #55515

## Why this is not duplicate work
Issue #55515 is open and has no linked implementation or discussion. I searched open PRs for `55515`, `Qwen4Exp`, `PLE`, and pipeline-parallel support; no other PR implements this transport contract. The change is narrowly scoped to the reported Qwen4Exp PLE/PP incompatibility.

## Test plan
- Ruff check on changed files: passed
- Ruff format check on changed files: passed
- Compileall on changed files: passed
- `git diff --check`: passed after rebasing onto current `main`
- Focused pytest could not run locally because the available environment is missing required test/runtime dependencies (`tblib` and `uvloop`); no test assertion was reached
- Full functional validation requires the upstream GPU suite because this host cannot run the three-GPU Qwen4Exp reproducer

## Notes
Input IDs use int32, matching the V2 input buffer, and are converted to int64 inside PLE. The tensor is added to the pipeline contract only when PLE is configured.

## AI assistance
AI assistance was used to inspect the pipeline-parallel data flow, prepare the implementation and regression tests, audit duplicate work, and run the available checks. The human submitter will review and understand every changed line and remains responsible for the contribution and review discussion.