### PR TITLE
[KV Cache] Preserve EAGLE SWA replay blocks for external APC

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -404,6 +404,88 @@ def test_chunked_local_attention_possible_cached_prefix():
     run_one_case([random.choice([True, False])] * 8 + [False, False], 1, 10)
 
 
+def test_sliding_window_eagle_keeps_prefix_replay_slack():
+    block_size = 32
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=128,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    manager = SlidingWindowManager(
+        sliding_window_spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=64,
+        max_admission_blocks_per_request=10**9,
+    )
+    manager.use_eagle = True
+
+    # The attention window alone would skip to block 2044. EAGLE local APC
+    # lookup cannot use the partial tail as its lookahead block, so it falls
+    # back to the previous 64-token boundary and needs blocks 2042-2046.
+    assert manager.get_num_skipped_tokens(65551) // block_size == 2042
+
+
+def test_sliding_window_eagle_replay_slack_counts_toward_admission_cap():
+    block_size = 32
+    sliding_window_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=128,
+    )
+
+    base_cap = sliding_window_spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=64,
+        max_model_len=4096,
+    )
+    eagle_cap = sliding_window_spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=64,
+        max_model_len=4096,
+        prefix_replay_tokens=64,
+    )
+
+    assert base_cap == 7
+    assert eagle_cap == 9
+
+
+def test_swa_reachable_block_mask_eagle_partial_tail_replay_boundary():
+    from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+
+    spec = SlidingWindowSpec(
+        block_size=32,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=128,
+    )
+    mask = SlidingWindowManager.reachable_block_mask(
+        start_block=2042,
+        end_block=2048,
+        alignment_tokens=64,
+        kv_cache_spec=spec,
+        use_eagle=True,
+        retention_interval=0,
+        reachable_boundaries=(65472, 65536),
+    )
+    assert mask is not None
+    assert {2042 + i for i, keep in enumerate(mask) if keep} == {
+        2042,
+        2043,
+        2044,
+        2045,
+        2046,
+        2047,
+    }
+
+
 def test_sliding_window_possible_cached_prefix():
     block_size = 2
     sliding_window_spec = SlidingWindowSpec(

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -10,6 +10,7 @@ import asyncio
 from unittest.mock import patch
 
 import pytest
+import torch
 
 from vllm.config import set_current_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector import (
@@ -21,9 +22,21 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     SendBlockMeta,
     TransferRegion,
 )
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    SlidingWindowSpec,
+)
 
 from .test_mooncake_connector import FakeMooncakeWrapper, patch_worker_dependencies
 from .utils import create_request, create_vllm_config, make_kv_cache_config
+
+
+class _EagleBlockDropConfig:
+
+    def use_eagle_block_drop(self) -> bool:
+        return True
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +144,96 @@ def test_get_sw_clipped_blocks():
     # SW: clipped to last 9 blocks
     assert clipped[1] == sw_blocks[-9:]
     assert len(clipped[1]) == 9
+
+
+@pytest.mark.cpu_test
+def test_get_sw_clipped_blocks_keeps_eagle_replay_slack():
+    """EAGLE SWA groups keep enough blocks for the previous replay boundary."""
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector",
+        kv_role="kv_both",
+        block_size=32,
+    )
+    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
+    swa_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=4,
+        head_size=16,
+        dtype=torch.float16,
+        sliding_window=64,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["fa"],
+                FullAttentionSpec(
+                    block_size=32,
+                    num_kv_heads=4,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(["swa0"], swa_spec),
+            KVCacheGroupSpec(["swa1"], swa_spec, is_eagle_group=True),
+        ],
+    )
+
+    scheduler = MooncakeConnectorScheduler(
+        vllm_config=vllm_config,
+        engine_id="test-engine",
+        kv_cache_config=kv_cache_config,
+    )
+    assert scheduler.blocks_per_sw == [0, 7, 7]
+    clipped = scheduler.get_sw_clipped_blocks(
+        (list(range(20)), list(range(100, 120)), list(range(200, 220)))
+    )
+    assert clipped[1] == list(range(100, 120))[-7:]
+    assert clipped[2] == list(range(200, 220))[-7:]
+
+
+@pytest.mark.cpu_test
+def test_get_sw_clipped_blocks_keeps_eagle_replay_slack_without_marked_group():
+    """Mirror core's fallback when EAGLE has no explicitly marked KV group."""
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector",
+        kv_role="kv_both",
+        block_size=32,
+    )
+    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
+    vllm_config.speculative_config = _EagleBlockDropConfig()
+    swa_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=4,
+        head_size=16,
+        dtype=torch.float16,
+        sliding_window=64,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["fa"],
+                FullAttentionSpec(
+                    block_size=32,
+                    num_kv_heads=4,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(["swa0"], swa_spec),
+            KVCacheGroupSpec(["swa1"], swa_spec),
+        ],
+    )
+
+    scheduler = MooncakeConnectorScheduler(
+        vllm_config=vllm_config,
+        engine_id="test-engine",
+        kv_cache_config=kv_cache_config,
+    )
+    assert scheduler.blocks_per_sw == [0, 7, 7]
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -15,6 +15,12 @@ from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
     SlidingWindowManager,
 )
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    SlidingWindowSpec,
+)
 
 from .utils import (
     create_request,
@@ -22,6 +28,12 @@ from .utils import (
     make_kv_cache_config,
     make_nixl_scheduler,
 )
+
+
+class _EagleBlockDropConfig:
+
+    def use_eagle_block_drop(self) -> bool:
+        return True
 
 
 @pytest.mark.cpu_test
@@ -61,6 +73,97 @@ def test_sw_sizes(mock_platform, swa_enabled, expected_sw_sizes):
     assert scheduler.blocks_per_sw == expected_sw_sizes, (
         f"Expected sw_sizes={expected_sw_sizes}, got {scheduler.blocks_per_sw}"
     )
+
+
+@pytest.mark.cpu_test
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler.current_platform"
+)
+def test_sw_sizes_keep_eagle_replay_slack_for_matching_specs(mock_platform):
+    """EAGLE SWA groups keep enough blocks for the previous replay boundary."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.scheduler import (
+        NixlConnectorScheduler,
+    )
+
+    mock_platform.device_type = "cpu"
+    vllm_config = create_vllm_config(block_size=32)
+    swa_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=4,
+        head_size=16,
+        dtype=torch.float16,
+        sliding_window=64,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["fa"],
+                FullAttentionSpec(
+                    block_size=32,
+                    num_kv_heads=4,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(["swa0"], swa_spec),
+            KVCacheGroupSpec(["swa1"], swa_spec, is_eagle_group=True),
+        ],
+    )
+
+    scheduler = NixlConnectorScheduler(
+        vllm_config=vllm_config,
+        engine_id="test-engine",
+        kv_cache_config=kv_cache_config,
+    )
+    assert scheduler.blocks_per_sw == [0, 7, 7]
+
+
+@pytest.mark.cpu_test
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.base_scheduler.current_platform"
+)
+def test_sw_sizes_keep_eagle_replay_slack_without_marked_group(mock_platform):
+    """Mirror core's fallback when EAGLE has no explicitly marked KV group."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.scheduler import (
+        NixlConnectorScheduler,
+    )
+
+    mock_platform.device_type = "cpu"
+    vllm_config = create_vllm_config(block_size=32)
+    vllm_config.speculative_config = _EagleBlockDropConfig()
+    swa_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=4,
+        head_size=16,
+        dtype=torch.float16,
+        sliding_window=64,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["fa"],
+                FullAttentionSpec(
+                    block_size=32,
+                    num_kv_heads=4,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            ),
+            KVCacheGroupSpec(["swa0"], swa_spec),
+            KVCacheGroupSpec(["swa1"], swa_spec),
+        ],
+    )
+
+    scheduler = NixlConnectorScheduler(
+        vllm_config=vllm_config,
+        engine_id="test-engine",
+        kv_cache_config=kv_cache_config,
+    )
+    assert scheduler.blocks_per_sw == [0, 7, 7]
 
 
 @pytest.mark.cpu_test

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import logging
+import math
 import threading
 import time
 from collections import defaultdict
@@ -60,6 +61,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MambaSpec,
     SlidingWindowSpec,
+    get_eagle_kv_cache_specs,
 )
 from vllm.v1.request import RequestStatus
 from vllm.v1.worker.block_table import BlockTable
@@ -84,6 +86,14 @@ if TYPE_CHECKING:
 
 ReqId = str  # Internal scheduler request ID
 TransferId = str  # KV transfer coordination ID (shared by P/D)
+
+
+def _use_eagle_block_drop(vllm_config: VllmConfig) -> bool:
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    use_eagle_block_drop = getattr(speculative_config, "use_eagle_block_drop", None)
+    return bool(
+        use_eagle_block_drop is not None and use_eagle_block_drop()
+    )
 
 
 @dataclass(frozen=True)
@@ -665,18 +675,39 @@ class MooncakeConnectorScheduler:
         # remote prefill or aborted.
         self._reqs_not_processed: set[TransferId] = set()
 
+        groups = kv_cache_config.kv_cache_groups
+        cache_hit_alignment_tokens = math.lcm(
+            *(group.kv_cache_spec.block_size for group in groups)
+        )
+        eagle_kv_cache_specs = get_eagle_kv_cache_specs(
+            groups, _use_eagle_block_drop(vllm_config)
+        )
         # Compute sliding window block counts per KV cache group.
         sw_sizes_tokens: list[tuple[int, int]] = [
             (g.kv_cache_spec.sliding_window, g.kv_cache_spec.block_size)
             if isinstance(g.kv_cache_spec, SlidingWindowSpec)
             else (0, self.block_size)
-            for g in kv_cache_config.kv_cache_groups
+            for g in groups
         ]
         # cdiv(n_tokens, block_size) gives blocks/window; add 1 to
-        # conservatively account for boundary overlap.
+        # conservatively account for boundary overlap. EAGLE groups need one
+        # extra cache-hit alignment of replay slack: when the prompt ends shortly
+        # after an aligned boundary, the EAGLE lookahead block can be incomplete,
+        # so the reusable SWA hit falls back to the previous aligned boundary.
         self.blocks_per_sw = [
-            cdiv(n_tokens, block_size) + 1 if n_tokens else 0
-            for n_tokens, block_size in sw_sizes_tokens
+            cdiv(
+                n_tokens
+                + (
+                    cache_hit_alignment_tokens
+                    if group.kv_cache_spec in eagle_kv_cache_specs
+                    else 0
+                ),
+                block_size,
+            )
+            + 1
+            if n_tokens
+            else 0
+            for group, (n_tokens, block_size) in zip(groups, sw_sizes_tokens)
         ]
 
     def get_sw_clipped_blocks(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/base_scheduler.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Base scheduler-side logic for the NIXL connector."""
 
+import math
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -36,6 +37,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     MambaSpec,
     SlidingWindowSpec,
+    get_eagle_kv_cache_specs,
 )
 
 if TYPE_CHECKING:
@@ -46,6 +48,14 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+
+def _use_eagle_block_drop(vllm_config: "VllmConfig") -> bool:
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    use_eagle_block_drop = getattr(speculative_config, "use_eagle_block_drop", None)
+    return bool(
+        use_eagle_block_drop is not None and use_eagle_block_drop()
+    )
 
 
 class NixlBaseConnectorScheduler:
@@ -127,19 +137,41 @@ class NixlBaseConnectorScheduler:
         self._heartbeat_req_engine: dict[ReqId, tuple[EngineId, ReqId]] = {}
         self._last_heartbeat_time: float = 0.0
 
+        groups = kv_cache_config.transfer_groups
+        cache_hit_alignment_tokens = math.lcm(
+            *(group.kv_cache_spec.block_size for group in groups)
+        )
+        eagle_kv_cache_specs = get_eagle_kv_cache_specs(
+            groups, _use_eagle_block_drop(vllm_config)
+        )
         # Gather Sliding Window sizes for each kv cache group (if any) in number of
         # blocks per KV cache group. This is used to clip the local attention window.
         sw_sizes_tokens: list[tuple[int, int]] = [
             (g.kv_cache_spec.sliding_window, g.kv_cache_spec.block_size)
             if isinstance(g.kv_cache_spec, SlidingWindowSpec)
             else (0, self.block_size)
-            for g in kv_cache_config.transfer_groups
+            for g in groups
         ]
         # cdiv(n_tokens, block_size) gives blocks/window; add 1 to conservatively
         # account for boundary overlap eg window isn't fully aligned with blocks.
+        # EAGLE groups need one extra cache-hit alignment of replay slack: when
+        # the prompt ends shortly after an aligned boundary, the EAGLE lookahead
+        # block can be incomplete, so the reusable SWA hit falls back to the
+        # previous aligned boundary.
         self.blocks_per_sw = [
-            cdiv(n_tokens, block_size) + 1 if n_tokens else 0
-            for n_tokens, block_size in sw_sizes_tokens
+            cdiv(
+                n_tokens
+                + (
+                    cache_hit_alignment_tokens
+                    if group.kv_cache_spec in eagle_kv_cache_specs
+                    else 0
+                ),
+                block_size,
+            )
+            + 1
+            if n_tokens
+            else 0
+            for group, (n_tokens, block_size) in zip(groups, sw_sizes_tokens)
         ]
 
         # Trailing scratch slots that mamba managers co-allocate per request

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -25,6 +25,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MambaSpec,
     SlidingWindowSpec,
+    get_eagle_kv_cache_specs,
 )
 from vllm.v1.request import Request
 
@@ -103,13 +104,16 @@ class KVCacheCoordinator(ABC):
             metrics_collector=metrics_collector,
         )
 
-        # KV cache group indices that get the EAGLE last-block drop.
+        # KV cache group indices that get the EAGLE last-block drop. Groups
+        # sharing a spec are treated consistently, matching `verify_and_split`.
+        eagle_kv_cache_specs = get_eagle_kv_cache_specs(
+            kv_cache_config.kv_cache_groups, use_eagle
+        )
         self.eagle_group_ids: set[int] = {
-            i for i, g in enumerate(kv_cache_config.kv_cache_groups) if g.is_eagle_group
+            i
+            for i, g in enumerate(kv_cache_config.kv_cache_groups)
+            if g.kv_cache_spec in eagle_kv_cache_specs
         }
-        # Conservatively fall back to flag all groups when no group is flagged.
-        if use_eagle and not self.eagle_group_ids:
-            self.eagle_group_ids = set(range(len(kv_cache_config.kv_cache_groups)))
 
         # During chunked prefill with EAGLE, the single next prefill lookahead
         # token past the chunk boundary is combined with the final hidden state
@@ -147,6 +151,7 @@ class KVCacheCoordinator(ABC):
                 pcp_world_size=pcp_world_size,
                 scheduler_block_size=self.scheduler_block_size,
                 needs_kv_cache_zeroing=self.kv_cache_config.needs_kv_cache_zeroing,
+                use_eagle=i in self.eagle_group_ids,
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1158,15 +1158,30 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         re-prefill the last num_spec_prefill_tokens - 1 tokens from the end
         of the sequence, and thus needs to delay freeing/caching of blocks.
 
+        With EAGLE, prefix-cache lookups need one extra block past the matched
+        boundary and then drop it. If the current prompt tail is not long enough
+        to provide that lookahead block, the lookup falls back to the previous
+        aligned boundary; keep one cache-hit alignment of replay slack so that
+        boundary's SWA window can be cached after a remote KV receive.
+
         Args:
             num_computed_tokens: The number of tokens that have been computed.
 
         Returns:
             The number of tokens that will be skipped for attention computation.
         """
+        prefix_replay_tokens = (
+            self.cache_hit_alignment_tokens
+            if self.enable_caching and self.use_eagle
+            else 0
+        )
         return max(
             0,
-            num_computed_tokens - self.sliding_window + 1 - self.extra_retained_tokens,
+            num_computed_tokens
+            - self.sliding_window
+            + 1
+            - self.extra_retained_tokens
+            - prefix_replay_tokens,
         )
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
@@ -2195,6 +2210,7 @@ def get_manager_for_kv_cache_spec(
     kv_cache_spec: KVCacheSpec,
     max_in_flight_tokens: int,
     max_model_len: int,
+    use_eagle: bool = False,
     **kwargs,
 ) -> SingleTypeKVCacheManager:
     """
@@ -2222,10 +2238,16 @@ def get_manager_for_kv_cache_spec(
     # R-SWA also recycles gap blocks but peak physical KV still fits the
     # full-attention bound (prefix + window <= max_model_len), so it inherits
     # FullAttentionSpec sizing without a separate admission cap.
-    if isinstance(
-        kv_cache_spec,
-        (SlidingWindowSpec, ChunkedLocalAttentionSpec),
-    ):
+    if isinstance(kv_cache_spec, SlidingWindowSpec):
+        prefix_replay_tokens = kwargs["scheduler_block_size"] if use_eagle else 0
+        kwargs["max_admission_blocks_per_request"] = (
+            kv_cache_spec.max_admission_blocks_per_request(
+                max_in_flight_tokens=max_in_flight_tokens,
+                max_model_len=max_model_len,
+                prefix_replay_tokens=prefix_replay_tokens,
+            )
+        )
+    elif isinstance(kv_cache_spec, ChunkedLocalAttentionSpec):
         kwargs["max_admission_blocks_per_request"] = (
             kv_cache_spec.max_admission_blocks_per_request(
                 max_in_flight_tokens=max_in_flight_tokens,

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -714,7 +714,10 @@ class SlidingWindowSpec(AttentionSpec):
     extra_retained_tokens: int = 0
 
     def max_admission_blocks_per_request(
-        self, max_in_flight_tokens: int, max_model_len: int
+        self,
+        max_in_flight_tokens: int,
+        max_model_len: int,
+        prefix_replay_tokens: int = 0,
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -731,9 +734,15 @@ class SlidingWindowSpec(AttentionSpec):
         # computed tokens plus the in-flight tokens (frees happen on the
         # processed-token basis); never more than `max_model_len`. An additional
         # `extra_retained_tokens` trailing tokens are kept alive below the
-        # window for multi-module spec decoding, and must be accounted here too.
+        # window for multi-module spec decoding, and EAGLE prefix replay may keep
+        # one more cache-hit alignment below the window. Both must be accounted
+        # here too.
         num_tokens = min(
-            self.sliding_window - 1 + self.extra_retained_tokens + max_in_flight_tokens,
+            self.sliding_window
+            - 1
+            + self.extra_retained_tokens
+            + prefix_replay_tokens
+            + max_in_flight_tokens,
             max_model_len,
         )
         # +1 because the sliding window may not start from the beginning of
@@ -745,9 +754,19 @@ class SlidingWindowSpec(AttentionSpec):
         assert vllm_config.parallel_config.decode_context_parallel_size == 1, (
             "DCP not support sliding window."
         )
+        speculative_config = vllm_config.speculative_config
+        use_eagle_block_drop = getattr(
+            speculative_config, "use_eagle_block_drop", None
+        )
+        prefix_replay_tokens = (
+            vllm_config.cache_config.block_size
+            if use_eagle_block_drop is not None and use_eagle_block_drop()
+            else 0
+        )
         max_blocks = self.max_admission_blocks_per_request(
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             max_model_len=vllm_config.model_config.max_model_len,
+            prefix_replay_tokens=prefix_replay_tokens,
         )
         return max_blocks * self.page_size_bytes
 
@@ -1276,6 +1295,19 @@ class KVCacheGroupSpec:
     is_eagle_group: bool = False
     # Whether this group is part of the externally transferable KV state.
     enable_kv_transfer: bool = True
+
+
+def get_eagle_kv_cache_specs(
+    kv_cache_groups: Sequence[KVCacheGroupSpec],
+    use_eagle: bool,
+) -> list[KVCacheSpec]:
+    """Return specs that should be treated as EAGLE for replay handling."""
+    eagle_specs = [
+        group.kv_cache_spec for group in kv_cache_groups if group.is_eagle_group
+    ]
+    if use_eagle and not eagle_specs:
+        return [group.kv_cache_spec for group in kv_cache_groups]
+    return eagle_specs
 
 
 @dataclass


### PR DESCRIPTION
## Purpose

This PR preserves reusable sliding-window replay blocks for EAGLE hybrid KV cache groups after remote KV receive, and aligns Mooncake/NIXL sliding-window transfer clipping with the same EAGLE replay slack so Decode-side local APC can reuse prefixes that were first loaded from external prefix cache.

We found this while benchmarking DeepSeek-V4.1-Flash with PD disaggregation on an 8x NVIDIA H20 setup using the `iaas-gpu-cn-beijing.cr.volces.com/serving/vllm:community_deepseekv41-flash-0909` image, EAGLE/DSpark enabled, hybrid KV cache enabled, and long shared-prefix Decode traffic generated by `sglang.bench_serving` with the `generated-shared-prefix` dataset. In the 64k shared-prefix Decode case, Prefill-side local APC was hot and Decode-side external prefix cache reported full hits, but Decode-side local APC did not grow at all. A fixed-engine discriminator with Decode switched to a single TP8 engine reproduced the same behavior for serial `x+a` then `x+b` requests, ruling out Decode DP cross-engine cache isolation as the primary cause.

The root cause is that sliding-window groups may receive or keep only the local attention tail after external KV loading, while EAGLE local prefix-cache lookup needs one extra lookahead block and can fall back to the previous aligned replay boundary when the prompt tail is partial. In that case the full-attention group can have a reusable prefix, but the SWA group is missing the earlier replay-boundary blocks required for the hybrid fixed-point lookup, so the common local APC hit collapses to zero. This PR fixes that by retaining one cache-hit alignment of replay slack for EAGLE SWA managers and by making Mooncake/NIXL transfer clipping preserve the same replay slack for all SWA groups that share an EAGLE-marked KV cache spec.

## Relationship to Existing Work

#50897 is the strongest functional overlap. It introduces successor-aware EAGLE prefix hashes and disables the legacy last-block drop for supporting connectors, including direct Mooncake and NIXL. If that broader protocol change lands and is enabled end to end, it can avoid the same Decode local-APC failure without retaining replay slack. It does not implement the conservative legacy-drop path in this PR, and its hash, publication, and connector lifecycle changes are substantially broader.

#56227 takes a different, DeepSeek-V4.1-specific approach behind an opt-in environment flag: it marks the SWA cache as non-prefix-cacheable and recomputes the trailing window after a hit. That avoids transferring and reusing the SWA prefix rather than preserving replay-boundary blocks, and it does not provide a generic direct Mooncake/NIXL fix for prefix-cacheable SWA groups.

#44082 and #54713 fix colocated SWA lookahead and replay-boundary retention, but they do not cover blocks first materialized by direct remote KV receive. #52287 keeps the EAGLE SWA replay window for the offloading scheduler path, but it does not update direct Mooncake/NIXL transfer clipping. #51295 and #53802 improve hybrid replay/checkpoint boundary handling without preserving replay-boundary SWA blocks received from remote Prefill. #44882 concerns concurrent external-prefix materialization and coalescing; #48189 was closed and explicitly excludes NIXL, hybrid/EAGLE, and full-prompt external-prefix paths; #40268 concerns GPU KV-cache scan pollution.

No existing PR covers the exact path implemented here: preserving legacy EAGLE block-drop semantics while retaining one cache-hit alignment of SWA replay slack consistently in the core manager, direct Mooncake/NIXL transfer clipping, and admission/pool sizing. However, #50897 and #56227 can avoid the same user-visible symptom through alternative designs within their supported scope.

## Test Plan

### Common Configuration

- Hardware: NVIDIA H20
- Image: `iaas-gpu-cn-beijing.cr.volces.com/serving/vllm:community_deepseekv41-flash-0909`
- vLLM image version: `0.1.dev20904+g179dd0fa9`
- Deployment: Prefill/Decode disaggregation over Mooncake RDMA
- Prefix caching: enabled
- A/B baseline: image-original runtime
- Patched variant: PR head `d117baf57c50309bb17affb501b6f4ec791ba3ca`

### DeepSeek-V4.1-Flash

- Prefill: TP8 on one 8x H20 node
- Decode: TP8 single engine on one 8x H20 node
- Speculative decoding: DSpark, 5 speculative tokens
- Fixed-engine correctness probe: two 64k shared-prefix prompts `x+a` and `x+b`, `max_tokens=1`, sent as a first remote load, serial siblings, and overlapping siblings
- Performance dataset: vLLM `prefix_repetition`, one 65,504-token prefix, 64-token suffix, one same-prefix warmup
- Performance groups: c1/output1 with 8 formal requests, c8/output1 with 40 formal requests, and c8/output128 with 40 formal requests
- Stress dataset: `generated-shared-prefix`, 64k system prefix, 64-token question, 1,500-token output, concurrency 64, 320 formal requests

### GPT-OSS-20B

- Target: `openai/gpt-oss-20b`
- Draft: `RedHatAI/gpt-oss-20b-speculator.eagle3`
- Prefill: TP2 on 2x H20
- Decode: TP2 single engine on 2x H20
- Performance dataset: vLLM `prefix_repetition`, one 65,504-token prefix, 64-token suffix
- A/B/A order: image baseline A1, PR patch B, image baseline A2
- Performance groups: one warmup plus one formal c1/output1 request, c1/output1 with 8 formal requests, c8/output1 with 40 formal requests, and c8/output128 with 40 formal requests
- Sampling: `temperature=0`, `ignore_eos=true`

Representative performance command:

```bash
vllm bench serve \
  --backend vllm \
  --base-url http://<router>:<port> \
  --model <local-model-path> \
  --served-model-name <served-model-name> \
  --tokenizer <local-model-path> \
  --dataset-name prefix_repetition \
  --prefix-repetition-num-prefixes 1 \
  --prefix-repetition-prefix-len 65504 \
  --prefix-repetition-suffix-len 64 \
  --prefix-repetition-output-len 128 \
  --num-prompts 40 \
  --num-warmups 8 \
  --max-concurrency 8 \
  --request-rate inf \
  --temperature 0 \
  --ignore-eos
```

## Test Result

### DeepSeek-V4.1-Flash Fixed-Engine Correctness

Without the PR, the Decode TP8 single-engine probe recorded zero Decode local APC hits even when the same engine received the serial `x+a` then `x+b` requests. The serial and overlap phases each queried 131,210 prefix tokens, produced zero local hits, and reported full external-prefix hits.

With the PR:

- First remote load: Decode external hit `65,551`, local hit `0`
- Serial `x+a` then `x+b`: Decode local hit `65,472`, external hit `65,628`
- Overlapping sibling requests: Decode local hit `130,944`, external hit `156`
- Every probe request succeeded and stayed on Decode engine 0

This demonstrates that externally received KV is published into Decode local APC and reused by later same-engine requests.

### DeepSeek-V4.1-Flash Prefix-Repetition Performance

| Group | Metric | Baseline | PR | Change |
|---|---:|---:|---:|---:|
| c1/output1 | Request throughput | 0.346 req/s | 1.556 req/s | +349.9% |
| c1/output1 | Mean TTFT | 2891.2 ms | 642.4 ms | -77.8% |
| c1/output1 | P99 TTFT | 9605.2 ms | 652.3 ms | -93.2% |
| c8/output1 | Request throughput | 1.285 req/s | 5.657 req/s | +340.1% |
| c8/output1 | Mean TTFT | 5524.0 ms | 1114.8 ms | -79.8% |
| c8/output1 | P99 TTFT | 19013.5 ms | 3402.5 ms | -82.1% |
| c8/output128 | Output throughput | 315.5 tok/s | 755.3 tok/s | +139.4% |
| c8/output128 | Mean TTFT | 2665.2 ms | 821.9 ms | -69.2% |
| c8/output128 | P99 TTFT | 10224.6 ms | 1185.7 ms | -88.4% |
| c8/output128 | Mean TPOT | 3.81 ms | 3.37 ms | -11.4% |

All groups completed without failed requests and generated all requested output tokens. Formal TTFT did not include TileLang compilation: compilation completed during service startup, and each formal group ran only after readiness and a same-prefix warmup.

For this random-token prefix-repetition workload, Decode local APC stayed at zero and Decode external prefix cache stayed at 100% in both variants. The measured performance gain was associated primarily with Prefill local APC becoming reusable after one warmup.

### DeepSeek-V4.1-Flash 64k/c64 Stress Result

The patched 64k/c64 run completed 320/320 formal requests:

- Request throughput: `2.16 req/s`
- Output throughput: `3247.40 tok/s`
- Mean / P99 TTFT: `15817.56 / 27784.90 ms`
- Mean / P99 TPOT: `8.14 / 9.57 ms`
- Prefill local APC across warmup and formal: `99.31%`
- Decode external prefix-cache hit: `100.00%`
- Decode local APC: `0.31%`

The fixed-engine probe still produced 65,472 serial and 130,944 overlapping Decode local-hit tokens after this stress run, but high-concurrency traffic remained dominated by external-prefix materialization. Concurrent load coalescing and capacity churn are not addressed by this PR.

### GPT-OSS-20B + EAGLE3 Performance

Baseline values below are the mean of A1 and A2, except output128 where A2 had one transient router-to-Decode connection reset and A1 is used.

| Group | Metric | Baseline | PR | Change |
|---|---:|---:|---:|---:|
| pair c1/output1 | Request throughput | 0.235 req/s | 1.797 req/s | +665.50% |
| pair c1/output1 | TTFT | 4259.44 ms | 556.18 ms | -86.94% |
| c1/output1 | Request throughput | 0.498 req/s | 1.255 req/s | +152.01% |
| c1/output1 | Mean TTFT | 2008.55 ms | 796.92 ms | -60.32% |
| c1/output1 | P99 TTFT | 4379.61 ms | 1330.14 ms | -69.63% |
| c8/output1 | Request throughput | 3.551 req/s | 4.901 req/s | +38.03% |
| c8/output1 | Mean TTFT | 2134.78 ms | 1515.96 ms | -28.99% |
| c8/output1 | P99 TTFT | 5801.49 ms | 2577.43 ms | -55.57% |
| c8/output128 | Output throughput | 315.07 tok/s | 395.64 tok/s | +25.57% |
| c8/output128 | Mean TTFT | 1745.22 ms | 1094.30 ms | -37.30% |
| c8/output128 | P99 TTFT | 6096.41 ms | 2691.77 ms | -55.85% |
| c8/output128 | Mean TPOT | 10.56 ms | 10.48 ms | -0.81% |

All A1 and PR formal requests succeeded and generated the requested output-token counts. The strict pair result was repeatable: baseline A1/A2 TTFT was `4257.04/4261.85 ms`, while the PR result was `556.18 ms`.

On GPT-OSS, Decode local APC remained zero and Decode external prefix cache remained 100% hit for both baseline and patched variants. The performance gain came from Prefill local APC: the pair changed from `0` to `65,536` local-hit tokens, c1 improved from `55.49%` to `86.02%`, and c8 improved from `93.65%` to `97.55%`. GPT-OSS therefore validates a cross-model end-to-end performance benefit but does not independently validate Decode external-to-local APC publication.

AI assistance was used for code analysis, test orchestration, and drafting; the submitter reviewed the changes and end-to-end results.

