### PR TITLE
[ROCm][Perf] Encoder prefill attention on gfx115x: split-D head dims, alignment hint, launch config

### DIFF
--- a/benchmarks/kernels/benchmark_vit_prefill_attn.py
+++ b/benchmarks/kernels/benchmark_vit_prefill_attn.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmark for the ViT prefill attention backends at a parametrizable
+shape, default = Gemma3-4B SigLIP ViT.
+
+Calls `triton.testing.do_bench`, which clears the L2 cache before every
+measurement iteration to approximate the kernel's cold-cache behavior inside
+a real transformer block (where surrounding qkv-proj / MLP / norm work
+evicts q/k/v/output between layer calls).
+
+Per-call shape (one SigLIP layer of Gemma3): B=1, S=4096, num_q_heads=
+num_kv_heads=16, head_dim=72, dtype=bf16, is_causal=False. 27 layers / image.
+
+--backend selects the attention implementation, matching the values accepted
+by --mm-encoder-attn-backend in vllm serve (TRITON_ATTN, TORCH_SDPA,
+FLASH_ATTN, ROCM_AITER_FA).  The default "all" runs every backend in sequence
+and emits one JSON line per backend.
+
+Triton-specific tuning knobs (--bm/--bn/--nw/--ns/--we) are passed directly
+to the kernel launch and are ignored for other backends.
+
+Output: one JSON line per backend to stdout.
+"""
+
+import argparse
+import json
+import sys
+
+import torch
+
+from vllm.triton_utils import triton
+from vllm.utils.math_utils import RCP_LN2
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.attention.ops.triton_prefill_attention import (
+    _fwd_kernel,
+    _split_head_dim,
+    get_block_size,
+)
+
+_SUPPORTED_BACKENDS = [
+    "TRITON_ATTN",
+    "TORCH_SDPA",
+    "FLASH_ATTN",
+    "ROCM_AITER_FA",
+]
+
+
+def _parse() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--batch", type=int, default=1)
+    p.add_argument("--seq", type=int, default=4096)
+    p.add_argument("--heads", type=int, default=16)
+    p.add_argument("--head-dim", type=int, default=72)
+
+    p.add_argument("--dtype", default="bf16", choices=("bf16", "fp16", "fp32"))
+    p.add_argument(
+        "--backend",
+        default="all",
+        choices=_SUPPORTED_BACKENDS + ["all"],
+        help=(
+            "Attention backend (same values as --mm-encoder-attn-backend), "
+            "or 'all' to run every backend in sequence (default)"
+        ),
+    )
+    # TRITON_ATTN-only tuning knobs
+    p.add_argument("--bm", type=int, default=None, help="BLOCK_M (TRITON_ATTN only)")
+    p.add_argument("--bn", type=int, default=None, help="BLOCK_N (TRITON_ATTN only)")
+    p.add_argument("--nw", type=int, default=None, help="num_warps (TRITON_ATTN only)")
+    p.add_argument("--ns", type=int, default=1, help="num_stages (TRITON_ATTN only)")
+    p.add_argument(
+        "--we", type=int, default=None, help="waves_per_eu (TRITON_ATTN only)"
+    )
+    p.add_argument("--warmup-ms", type=int, default=200)
+    p.add_argument("--rep-ms", type=int, default=600)
+    return p.parse_args()
+
+
+def _bench_one(
+    backend_name: str,
+    args: argparse.Namespace,
+    dtype: torch.dtype,
+    q4: torch.Tensor,
+    k4: torch.Tensor,
+    v4: torch.Tensor,
+    cu: torch.Tensor,
+    max_seqlen: torch.Tensor,
+) -> None:
+    """Benchmark one backend and write a JSON result line to stdout."""
+    B, S, H, D = args.batch, args.seq, args.heads, args.head_dim
+    backend = AttentionBackendEnum[backend_name]
+    scale = 1.0 / (D**0.5)
+
+    if backend == AttentionBackendEnum.TRITON_ATTN:
+        # Keep direct kernel launch so tuning knobs are honoured.
+        BLOCK_M = args.bm if args.bm is not None else get_block_size(dtype)
+        BLOCK_N = args.bn if args.bn is not None else BLOCK_M
+        num_warps = args.nw if args.nw is not None else (4 if D <= 64 else 8)
+        BLOCK_DMODEL, BLOCK_DMODEL_TAIL = _split_head_dim(D)
+        sm_scale = scale * RCP_LN2
+        grid = (B, H, triton.cdiv(S, BLOCK_M))
+
+        # Flat (B*S, H, D) layout expected by _fwd_kernel
+        q = q4.view(B * S, H, D)
+        k = k4.view(B * S, H, D)
+        v = v4.view(B * S, H, D)
+        o = torch.empty_like(q)
+        seqlen = cu[1:] - cu[:-1]
+
+        extra_kwargs: dict = {}
+        if args.we is not None:
+            extra_kwargs["waves_per_eu"] = args.we
+
+        def _fn():
+            _fwd_kernel[grid](
+                q,
+                k,
+                v,
+                q,  # Sinks, unused: USE_SINKS is False
+                sm_scale,
+                cu[:-1],
+                seqlen,
+                o,
+                q.stride(0),
+                q.stride(1),
+                k.stride(0),
+                k.stride(1),
+                v.stride(0),
+                v.stride(1),
+                o.stride(0),
+                o.stride(1),
+                kv_group_num=1,  # the ViT towers this models are MHA
+                BLOCK_M=BLOCK_M,
+                BLOCK_DMODEL=BLOCK_DMODEL,
+                BLOCK_DMODEL_TAIL=BLOCK_DMODEL_TAIL,
+                BLOCK_N=BLOCK_N,
+                IS_CAUSAL=False,
+                SLIDING_WINDOW_Q=0,
+                SLIDING_WINDOW_K=0,
+                SINKS_BIAS_KEY0=False,
+                USE_SINKS=False,
+                num_warps=num_warps,
+                num_stages=args.ns,
+                Lk=D,
+                **extra_kwargs,
+            )
+
+    elif backend in (
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.ROCM_AITER_FA,
+    ):
+        from vllm.v1.attention.backends.fa_utils import (
+            get_flash_attn_version,  # noqa: E402
+        )
+        from vllm.v1.attention.ops.vit_attn_wrappers import (
+            vit_flash_attn_wrapper,  # noqa: E402
+        )
+
+        fa_version = get_flash_attn_version(head_size=D)
+        is_rocm_aiter = backend == AttentionBackendEnum.ROCM_AITER_FA
+
+        def _fn():
+            vit_flash_attn_wrapper(
+                q=q4,
+                k=k4,
+                v=v4,
+                batch_size=B,
+                is_rocm_aiter=is_rocm_aiter,
+                fa_version=fa_version,
+                scale=scale,
+                cu_seqlens=cu,
+                max_seqlen=max_seqlen,
+            )
+
+    elif backend == AttentionBackendEnum.TORCH_SDPA:
+        from vllm.v1.attention.ops.vit_attn_wrappers import (
+            vit_torch_sdpa_wrapper,  # noqa: E402
+        )
+
+        def _fn():
+            vit_torch_sdpa_wrapper(
+                q=q4,
+                k=k4,
+                v=v4,
+                scale=scale,
+                cu_seqlens=cu,
+            )
+
+    else:
+        raise ValueError(f"Unsupported backend: {backend_name}")
+
+    # do_bench clears the L2 cache before each measurement iteration.
+    all_times = triton.testing.do_bench(
+        _fn,
+        warmup=args.warmup_ms,
+        rep=args.rep_ms,
+        return_mode="all",
+    )
+    all_times = sorted(all_times)
+    n = len(all_times)
+    mean = sum(all_times) / n
+    median = all_times[n // 2]
+    p10 = all_times[max(0, int(n * 0.10))]
+    p90 = all_times[min(n - 1, int(n * 0.90))]
+    fastest = all_times[0]
+
+    config: dict = {
+        "B": B,
+        "S": S,
+        "H": H,
+        "D": D,
+        "dtype": args.dtype,
+        "backend": backend_name,
+    }
+    if backend == AttentionBackendEnum.TRITON_ATTN:
+        config.update(
+            {
+                "BLOCK_M": BLOCK_M,
+                "BLOCK_DMODEL": BLOCK_DMODEL,
+                "BLOCK_DMODEL_TAIL": BLOCK_DMODEL_TAIL,
+                "BLOCK_N": BLOCK_N,
+                "num_warps": num_warps,
+                "num_stages": args.ns,
+                "waves_per_eu": args.we,
+            }
+        )
+
+    result = {
+        "per_call_ms_mean": mean,
+        "per_call_ms_median": median,
+        "per_call_ms_min": fastest,
+        "per_call_ms_p10": p10,
+        "per_call_ms_p90": p90,
+        "samples": n,
+        "config": config,
+    }
+    json.dump(result, sys.stdout)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    args = _parse()
+    device = "cuda"
+    dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[
+        args.dtype
+    ]
+    torch.manual_seed(0)
+
+    B, S, H, D = args.batch, args.seq, args.heads, args.head_dim
+
+    # Wrappers (FLASH_ATTN, ROCM_AITER_FA, TRITON_ATTN) expect (B, S, H, D).
+    # TORCH_SDPA expects the same via vit_torch_sdpa_wrapper.
+    q4 = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    k4 = torch.randn(B, S, H, D, dtype=dtype, device=device)
+    v4 = torch.randn(B, S, H, D, dtype=dtype, device=device)
+
+    # cu_seqlens / max_seqlen used by FA and Triton backends
+    cu = torch.tensor([i * S for i in range(B + 1)], dtype=torch.int32, device=device)
+    max_seqlen = torch.tensor(S, dtype=torch.int32)
+
+    backends = _SUPPORTED_BACKENDS if args.backend == "all" else [args.backend]
+    for backend_name in backends:
+        try:
+            _bench_one(backend_name, args, dtype, q4, k4, v4, cu, max_seqlen)
+        except Exception as exc:
+            if args.backend == "all":
+                sys.stderr.write(f"[skip] {backend_name}: {exc}\n")
+            else:
+                raise
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/kernels/benchmark_vit_prefill_attn.py
+++ b/benchmarks/kernels/benchmark_vit_prefill_attn.py
@@ -106,6 +106,12 @@ def _bench_one(
         v = v4.view(B * S, H, D)
         o = torch.empty_like(q)
         seqlen = cu[1:] - cu[:-1]
+        head_stride_aligned_8 = (
+            q.stride(1) % 8 == 0
+            and k.stride(1) % 8 == 0
+            and v.stride(1) % 8 == 0
+            and o.stride(1) % 8 == 0
+        )
 
         extra_kwargs: dict = {}
         if args.we is not None:
@@ -142,6 +148,7 @@ def _bench_one(
                 num_warps=num_warps,
                 num_stages=args.ns,
                 Lk=D,
+                HEAD_STRIDE_ALIGNED_8=head_stride_aligned_8,
                 **extra_kwargs,
             )
 

--- a/tests/kernels/attention/test_triton_prefill_attention.py
+++ b/tests/kernels/attention/test_triton_prefill_attention.py
@@ -238,6 +238,45 @@ def test_context_attention_sliding_window(
     torch.testing.assert_close(o, o_ref, rtol=2e-2, atol=2e-2)
 
 
+@pytest.mark.parametrize("D", [72, 128])
+def test_context_attention_non_contiguous_heads(D: int):
+    """A head stride the 16-byte alignment hint must not be applied to.
+
+    The hint is keyed off the runtime strides, not head_dim, so a view whose
+    head axis is not 8-element aligned has to fall back and stay correct.
+    """
+    torch.manual_seed(42)
+    B, S, H = 2, 256, 8
+    dtype = torch.bfloat16
+    total_tokens = B * S
+
+    seq_lens = torch.full((B,), S, dtype=torch.int32, device=DEVICE_TYPE)
+    b_start_loc = torch.zeros(B, dtype=torch.int32, device=DEVICE_TYPE)
+    b_start_loc[1:] = torch.cumsum(seq_lens[:-1], dim=0)
+
+    # Slicing a padded head axis keeps D contiguous but breaks the 8-element
+    # alignment of the head stride.
+    q, k, v, o = (
+        torch.randn(total_tokens, H, D + 4, dtype=dtype, device=DEVICE_TYPE)[..., :D]
+        for _ in range(4)
+    )
+    assert q.stride(1) % 8 != 0
+
+    context_attention_fwd(
+        q, k, v, o, b_start_loc, seq_lens, S, is_causal=True, sliding_window_q=None
+    )
+
+    o_ref = torch.zeros_like(o)
+    for i in range(B):
+        start = b_start_loc[i].item()
+        end = start + seq_lens[i].item()
+        o_ref[start:end] = ref_masked_attention(
+            q[start:end], k[start:end], v[start:end], is_causal=True
+        )
+
+    torch.testing.assert_close(o, o_ref, rtol=1e-2, atol=1e-2)
+
+
 def test_split_head_dim_never_widens_the_dot():
     """Whatever the head dim, the split is never worse than one block.
 

--- a/tests/kernels/attention/test_triton_prefill_attention.py
+++ b/tests/kernels/attention/test_triton_prefill_attention.py
@@ -9,6 +9,7 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import triton
 from vllm.v1.attention.ops import triton_prefill_attention as prefill_attn
 from vllm.v1.attention.ops.triton_prefill_attention import (
+    _get_encoder_launch,
     _get_head_dim_blocks,
     _split_head_dim,
     context_attention_fwd,
@@ -346,3 +347,34 @@ def test_context_attention_split_d_forced(monkeypatch: pytest.MonkeyPatch, D: in
         )
 
     torch.testing.assert_close(o, o_ref, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "head_dim,expected",
+    [(64, (16, 4)), (72, (16, 4)), (80, (16, 4)), (96, (32, 8)), (128, (32, 8))],
+)
+def test_gfx115x_encoder_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    head_dim: int,
+    expected: tuple[int, int],
+    dtype: torch.dtype,
+):
+    """gfx115x takes a narrow KV tile, widening it past a head dim of 80."""
+    monkeypatch.setattr(prefill_attn, "_ON_GFX115X", True)
+    assert _get_encoder_launch(head_dim, dtype) == expected
+
+
+@pytest.mark.parametrize(
+    "on_gfx115x,dtype",
+    [
+        (False, torch.bfloat16),  # any other architecture
+        (True, torch.float32),  # untuned dtype
+    ],
+)
+def test_get_encoder_launch_declines(
+    monkeypatch: pytest.MonkeyPatch, on_gfx115x: bool, dtype: torch.dtype
+):
+    """Everything outside the measured envelope keeps the generic config."""
+    monkeypatch.setattr(prefill_attn, "_ON_GFX115X", on_gfx115x)
+    assert _get_encoder_launch(72, dtype) is None

--- a/tests/kernels/attention/test_triton_prefill_attention.py
+++ b/tests/kernels/attention/test_triton_prefill_attention.py
@@ -6,7 +6,13 @@ import torch
 import torch.nn.functional as F
 
 from vllm.platforms import current_platform
-from vllm.v1.attention.ops.triton_prefill_attention import context_attention_fwd
+from vllm.triton_utils import triton
+from vllm.v1.attention.ops import triton_prefill_attention as prefill_attn
+from vllm.v1.attention.ops.triton_prefill_attention import (
+    _get_head_dim_blocks,
+    _split_head_dim,
+    context_attention_fwd,
+)
 
 DEVICE_TYPE = current_platform.device_type
 
@@ -79,7 +85,7 @@ def ref_masked_attention(
 @pytest.mark.parametrize("max_seq_len", [1024])
 @pytest.mark.parametrize("H_Q", [32])
 @pytest.mark.parametrize("H_KV", [32, 8])
-@pytest.mark.parametrize("D", [128])
+@pytest.mark.parametrize("D", [64, 72, 80, 96, 128])
 @pytest.mark.parametrize("is_causal", [True, False])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_context_attention(
@@ -157,7 +163,7 @@ def test_context_attention(
 @pytest.mark.parametrize("max_seq_len", [1024])
 @pytest.mark.parametrize("H_Q", [32])
 @pytest.mark.parametrize("H_KV", [32, 8])
-@pytest.mark.parametrize("D", [128])
+@pytest.mark.parametrize("D", [64, 72, 80, 96, 128])
 @pytest.mark.parametrize("sliding_window", [(32, 32), (32, 0), (0, 32)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_context_attention_sliding_window(
@@ -230,3 +236,74 @@ def test_context_attention_sliding_window(
 
     # Compare outputs
     torch.testing.assert_close(o, o_ref, rtol=2e-2, atol=2e-2)
+
+
+def test_split_head_dim_never_widens_the_dot():
+    """Whatever the head dim, the split is never worse than one block.
+
+    A tail pass costs an extra dot, two extra loads and an accumulator, so it
+    has to buy a strictly narrower extent or not happen at all.
+    """
+    for Lk in range(1, 513):
+        main, tail = _split_head_dim(Lk)
+        npo2 = triton.next_power_of_2(Lk)
+
+        assert main & (main - 1) == 0, Lk
+        assert tail & (tail - 1) == 0, Lk
+        assert main + tail >= Lk, f"Lk={Lk} is not covered"
+
+        if tail == 0:
+            assert main == npo2, Lk
+        else:
+            assert main + tail < npo2, f"Lk={Lk} tail pass does not narrow"
+
+
+def test_split_head_dim_vit_shapes():
+    """Real vision head dims, covering both tail widths the kernel can emit."""
+    assert _split_head_dim(72) == (64, 16)  # SigLIP, Qwen3-VL
+    assert _split_head_dim(80) == (64, 16)  # Qwen2.5-VL
+    assert _split_head_dim(96) == (64, 32)
+
+
+@pytest.mark.parametrize("Lk", [12, 24, 100, 112, 120])
+def test_split_head_dim_declines_when_it_would_not_pay(Lk: int):
+    """Head dims whose tail block would cover no fewer lanes keep one block."""
+    assert _split_head_dim(Lk) == (triton.next_power_of_2(Lk), 0)
+
+
+@pytest.mark.parametrize("on_gfx115x", [True, False])
+def test_get_head_dim_blocks_is_gated(monkeypatch: pytest.MonkeyPatch, on_gfx115x):
+    """The split is only taken where it has been measured."""
+    monkeypatch.setattr(prefill_attn, "_ON_GFX115X", on_gfx115x)
+    assert _get_head_dim_blocks(72) == ((64, 16) if on_gfx115x else (128, 0))
+    assert _get_head_dim_blocks(128) == (128, 0)
+
+
+@pytest.mark.parametrize("D", [72, 96])
+def test_context_attention_split_d_forced(monkeypatch: pytest.MonkeyPatch, D: int):
+    """Exercise the split-D kernel even off gfx115x, so CI always covers it."""
+    monkeypatch.setattr(prefill_attn, "_ON_GFX115X", True)
+    assert _get_head_dim_blocks(D)[1] > 0
+
+    torch.manual_seed(42)
+    B, S, H = 2, 256, 8
+    seq_lens = torch.full((B,), S, dtype=torch.int32, device=DEVICE_TYPE)
+    b_start_loc = torch.zeros(B, dtype=torch.int32, device=DEVICE_TYPE)
+    b_start_loc[1:] = torch.cumsum(seq_lens[:-1], dim=0)
+
+    q, k, v = (
+        torch.randn(B * S, H, D, dtype=torch.bfloat16, device=DEVICE_TYPE)
+        for _ in range(3)
+    )
+    o = torch.zeros_like(q)
+    context_attention_fwd(q, k, v, o, b_start_loc, seq_lens, S, is_causal=True)
+
+    o_ref = torch.zeros_like(o)
+    for i in range(B):
+        start = b_start_loc[i].item()
+        end = start + seq_lens[i].item()
+        o_ref[start:end] = ref_masked_attention(
+            q[start:end], k[start:end], v[start:end], is_causal=True
+        )
+
+    torch.testing.assert_close(o, o_ref, rtol=1e-2, atol=1e-2)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -218,6 +218,9 @@ _ON_GFX1X = any(arch in _GCN_ARCH for arch in ["gfx11", "gfx12"])
 _ON_GFX11 = "gfx11" in _GCN_ARCH
 _ON_GFX1100 = "gfx1100" in _GCN_ARCH
 _ON_GFX1151 = "gfx1151" in _GCN_ARCH
+_ON_GFX115X = any(
+    arch in _GCN_ARCH for arch in ["gfx1150", "gfx1151", "gfx1152", "gfx1153"]
+)
 _ON_GFX12X = any(arch in _GCN_ARCH for arch in ["gfx12"])
 _ON_MI3XX = any(arch in _GCN_ARCH for arch in ["gfx942", "gfx950"])
 _ON_GFX9 = any(arch in _GCN_ARCH for arch in ["gfx90a", "gfx942", "gfx950"])
@@ -317,6 +320,10 @@ def on_gfx1100() -> bool:
 
 def on_gfx1151() -> bool:
     return _ON_GFX1151
+
+
+def on_gfx115x() -> bool:
+    return _ON_GFX115X
 
 
 def on_gfx12x() -> bool:

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -67,6 +67,7 @@ def _fwd_kernel(
     SINKS_BIAS_KEY0: tl.constexpr,
     USE_SINKS: tl.constexpr,
     Lk: tl.constexpr,
+    HEAD_STRIDE_ALIGNED_8: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -83,13 +84,32 @@ def _fwd_kernel(
     offs_n = tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, BLOCK_DMODEL)
     offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+
+    # In the packed [seq, heads, dim] layout the head stride equals head_dim.
+    # When head_dim is a multiple of 8 but not 16 (e.g. 72), Triton's integer
+    # auto-specialization does not attach tt.divisibility=8 to stride_*h -- its
+    # threshold is 16 -- so the D-contiguous Q/K/V loads are treated as 2-byte
+    # aligned and lower to scalar loads instead of vectorized 16-byte ones.
+    # Hinting the head offset restores the alignment fact. The wrapper sets the
+    # flag from the actual runtime strides, so this stays sound for
+    # non-contiguous views.
+    off_h_q = cur_head * stride_qh
+    off_h_k = cur_kv_head * stride_kh
+    off_h_v = cur_kv_head * stride_vh
+    off_h_o = cur_head * stride_oh
+    if HEAD_STRIDE_ALIGNED_8:
+        off_h_q = tl.multiple_of(off_h_q, 8)
+        off_h_k = tl.multiple_of(off_h_k, 8)
+        off_h_v = tl.multiple_of(off_h_v, 8)
+        off_h_o = tl.multiple_of(off_h_o, 8)
+
     off_q = (
         (cur_batch_in_all_start_index + offs_m[:, None]) * stride_qbs
-        + cur_head * stride_qh
+        + off_h_q
         + offs_d[None, :]
     )
-    off_k = offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh + offs_d[:, None]
-    off_v = offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh + offs_d[None, :]
+    off_k = offs_n[None, :] * stride_kbs + off_h_k + offs_d[:, None]
+    off_v = offs_n[:, None] * stride_vbs + off_h_v + offs_d[None, :]
 
     mask_d = offs_d < Lk
 
@@ -113,15 +133,11 @@ def _fwd_kernel(
         mask_dt = offs_dt < Lk
         off_qt = (
             (cur_batch_in_all_start_index + offs_m[:, None]) * stride_qbs
-            + cur_head * stride_qh
+            + off_h_q
             + offs_dt[None, :]
         )
-        off_kt = (
-            offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh + offs_dt[:, None]
-        )
-        off_vt = (
-            offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh + offs_dt[None, :]
-        )
+        off_kt = offs_n[None, :] * stride_kbs + off_h_k + offs_dt[:, None]
+        off_vt = offs_n[:, None] * stride_vbs + off_h_v + offs_dt[None, :]
         qt = tl.load(
             Q + off_qt,
             mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_dt[None, :]),
@@ -247,7 +263,7 @@ def _fwd_kernel(
     acc = acc / l_i[:, None]
     off_o = (
         (cur_batch_in_all_start_index + offs_m[:, None]) * stride_obs
-        + cur_head * stride_oh
+        + off_h_o
         + offs_d[None, :]
     )
     out_ptrs = Out + off_o
@@ -258,7 +274,7 @@ def _fwd_kernel(
         acc_t = acc_t / l_i[:, None]
         off_o_tail = (
             (cur_batch_in_all_start_index + offs_m[:, None]) * stride_obs
-            + cur_head * stride_oh
+            + off_h_o
             + offs_dt[None, :]
         )
         tl.store(
@@ -369,6 +385,15 @@ def context_attention_fwd(
 
     block_dmodel, block_dmodel_tail = _get_head_dim_blocks(Lk)
 
+    # Checked against the actual runtime strides rather than head_dim, so the
+    # hint stays sound for non-contiguous Q/K/V/O views. See _fwd_kernel.
+    head_stride_aligned_8 = (
+        q.stride(1) % 8 == 0
+        and k.stride(1) % 8 == 0
+        and v.stride(1) % 8 == 0
+        and o.stride(1) % 8 == 0
+    )
+
     _fwd_kernel[grid](
         q,
         k,
@@ -399,4 +424,5 @@ def context_attention_fwd(
         num_warps=num_warps,
         num_stages=1,
         Lk=Lk,
+        HEAD_STRIDE_ALIGNED_8=head_stride_aligned_8,
     )

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -32,6 +32,11 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import RCP_LN2
 
+if current_platform.is_rocm():
+    from vllm.platforms.rocm import _ON_GFX115X
+else:
+    _ON_GFX115X = False
+
 
 @triton.jit
 def _fwd_kernel(
@@ -54,6 +59,7 @@ def _fwd_kernel(
     kv_group_num: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DMODEL_TAIL: tl.constexpr,
     BLOCK_N: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     SLIDING_WINDOW_Q: tl.constexpr,
@@ -96,6 +102,34 @@ def _fwd_kernel(
     k_ptrs = K + off_k
     v_ptrs = V + off_v
 
+    # Split-D path: a non-power-of-2 head_dim (e.g. 72) would otherwise force
+    # BLOCK_DMODEL = next_pow2(Lk) = 128, so the qk/pv dots run 8 K-passes when
+    # only ceil(Lk / 16) are needed. Covering D as a power-of-2 main block plus
+    # a power-of-2 tail block (72 -> 64 + 16 = 80) drops that to 5. Constexpr
+    # guarded: BLOCK_DMODEL_TAIL == 0 is dead code, so every power-of-2 head_dim
+    # compiles to the single-block kernel exactly as before.
+    if BLOCK_DMODEL_TAIL > 0:
+        offs_dt = BLOCK_DMODEL + tl.arange(0, BLOCK_DMODEL_TAIL)
+        mask_dt = offs_dt < Lk
+        off_qt = (
+            (cur_batch_in_all_start_index + offs_m[:, None]) * stride_qbs
+            + cur_head * stride_qh
+            + offs_dt[None, :]
+        )
+        off_kt = (
+            offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh + offs_dt[:, None]
+        )
+        off_vt = (
+            offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh + offs_dt[None, :]
+        )
+        qt = tl.load(
+            Q + off_qt,
+            mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_dt[None, :]),
+            other=0.0,
+        )
+        kt_ptrs = K + off_kt
+        vt_ptrs = V + off_vt
+
     # initialize pointer to m and l
     if USE_SINKS:
         sink = tl.load(Sinks + cur_head) * 1.4426950408889634
@@ -112,6 +146,8 @@ def _fwd_kernel(
         m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
         l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
     acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    if BLOCK_DMODEL_TAIL > 0:
+        acc_t = tl.zeros([BLOCK_M, BLOCK_DMODEL_TAIL], dtype=tl.float32)
 
     block_mask = tl.where(block_start_loc < cur_batch_seq_len, 1, 0)
 
@@ -167,6 +203,13 @@ def _fwd_kernel(
         )
 
         qk = tl.dot(q, k)
+        if BLOCK_DMODEL_TAIL > 0:
+            kt = tl.load(
+                kt_ptrs + (cur_batch_in_all_start_index + start_n) * stride_kbs,
+                mask=(pos_k < cur_batch_seq_len) & (mask_dt[:, None]),
+                other=0.0,
+            )
+            qk = tl.dot(qt, kt, qk)
         qk = tl.where(mask, qk * sm_scale, -1.0e8)
         if USE_SINKS and SINKS_BIAS_KEY0:
             qk = tl.where(mask & (pos_k == 0), qk + sink, qk)
@@ -180,6 +223,8 @@ def _fwd_kernel(
         l_i = l_i * alpha + l_ij
         # -- update output accumulator --
         acc = acc * alpha[:, None]
+        if BLOCK_DMODEL_TAIL > 0:
+            acc_t = acc_t * alpha[:, None]
         # update acc
         v = tl.load(
             v_ptrs + (cur_batch_in_all_start_index + start_n) * stride_vbs,
@@ -188,6 +233,14 @@ def _fwd_kernel(
         )
         p = p.to(v.dtype)
         acc = tl.dot(p, v, acc)
+        if BLOCK_DMODEL_TAIL > 0:
+            vt = tl.load(
+                vt_ptrs + (cur_batch_in_all_start_index + start_n) * stride_vbs,
+                mask=((start_n + offs_n[:, None]) < cur_batch_seq_len)
+                & (mask_dt[None, :]),
+                other=0.0,
+            )
+            acc_t = tl.dot(p, vt, acc_t)
         # update m_i
         m_i = m_ij
 
@@ -201,6 +254,66 @@ def _fwd_kernel(
     tl.store(
         out_ptrs, acc, mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_d[None, :])
     )
+    if BLOCK_DMODEL_TAIL > 0:
+        acc_t = acc_t / l_i[:, None]
+        off_o_tail = (
+            (cur_batch_in_all_start_index + offs_m[:, None]) * stride_obs
+            + cur_head * stride_oh
+            + offs_dt[None, :]
+        )
+        tl.store(
+            Out + off_o_tail,
+            acc_t,
+            mask=(offs_m[:, None] < cur_batch_seq_len) & (mask_dt[None, :]),
+        )
+
+
+def _split_head_dim(Lk: int) -> tuple[int, int]:
+    """Pick ``(BLOCK_DMODEL, BLOCK_DMODEL_TAIL)`` covering head_dim ``Lk``.
+
+    A power-of-2 ``Lk`` returns ``(Lk, 0)``, the single-block kernel. Otherwise
+    ``Lk`` is covered by the largest power-of-2 block below it plus a power-of-2
+    tail block, so the dot extent rounds up near ``Lk`` (72 -> 64 + 16 = 80)
+    instead of to ``next_power_of_2(Lk)`` = 128.
+
+    The tail pass only earns its extra dot, loads and accumulator when it
+    actually narrows that extent, which is not true for every ``Lk``: 112 would
+    split into 64 + 64, covering the same 128 lanes for 12% more time. Those
+    keep the single block.
+
+    Args:
+        Lk: Head dimension.
+
+    Returns:
+        The main and tail block sizes; a tail of 0 means no tail pass.
+    """
+    npo2 = triton.next_power_of_2(Lk)
+    if npo2 == Lk:
+        return npo2, 0
+    main = npo2 // 2
+    tail = max(16, triton.next_power_of_2(Lk - main))
+    if main + tail >= npo2:
+        return npo2, 0
+    return main, tail
+
+
+def _get_head_dim_blocks(Lk: int) -> tuple[int, int]:
+    """Pick the head-dim blocking for this architecture.
+
+    The split is only taken where it has been measured. It is a strict
+    reduction in dot extent, so it should carry over, but the extra dot and
+    loads it costs have only been shown to pay for themselves on gfx115x.
+    Everywhere else keeps the single padded block this kernel has always used.
+
+    Args:
+        Lk: Head dimension.
+
+    Returns:
+        ``(BLOCK_DMODEL, BLOCK_DMODEL_TAIL)``.
+    """
+    if _ON_GFX115X:
+        return _split_head_dim(Lk)
+    return triton.next_power_of_2(Lk), 0
 
 
 def get_block_size(dtype: torch.dtype) -> int:
@@ -254,6 +367,8 @@ def context_attention_fwd(
     sliding_window_q = sliding_window_q if sliding_window_q is not None else 0
     sliding_window_k = sliding_window_k if sliding_window_k is not None else 0
 
+    block_dmodel, block_dmodel_tail = _get_head_dim_blocks(Lk)
+
     _fwd_kernel[grid](
         q,
         k,
@@ -273,7 +388,8 @@ def context_attention_fwd(
         o.stride(1),
         kv_group_num=kv_group_num,
         BLOCK_M=BLOCK,
-        BLOCK_DMODEL=triton.next_power_of_2(Lk),
+        BLOCK_DMODEL=block_dmodel,
+        BLOCK_DMODEL_TAIL=block_dmodel_tail,
         BLOCK_N=BLOCK,
         IS_CAUSAL=is_causal,
         SLIDING_WINDOW_Q=sliding_window_q,

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -332,6 +332,47 @@ def _get_head_dim_blocks(Lk: int) -> tuple[int, int]:
     return triton.next_power_of_2(Lk), 0
 
 
+def _gfx115x_encoder_launch(
+    head_dim: int, dtype: torch.dtype
+) -> tuple[int, int] | None:
+    """KV tile and warp count for this kernel on gfx115x.
+
+    The generic config gives the kernel a square tile, so the KV tile inherits
+    ``BLOCK_M`` = 128. That is far wider than this kernel wants: a narrow KV
+    tile is 1.9x to 3.4x faster across every encoder shape measured on
+    gfx1151. The best pairing flips at a head dim of 80, above which the wider
+    tile and 8 warps win.
+
+    Args:
+        head_dim: Attention head dimension.
+        dtype: Query dtype; only the 16-bit paths were tuned.
+
+    Returns:
+        ``(BLOCK_N, num_warps)``, or None to keep the generic config.
+    """
+    if dtype not in (torch.bfloat16, torch.float16):
+        return None
+    return (16, 4) if head_dim <= 80 else (32, 8)
+
+
+def _get_encoder_launch(head_dim: int, dtype: torch.dtype) -> tuple[int, int] | None:
+    """Pick the launch config for this architecture.
+
+    Add a branch here to tune another architecture; the generic config is
+    whatever falls through.
+
+    Args:
+        head_dim: Attention head dimension.
+        dtype: Query dtype.
+
+    Returns:
+        ``(BLOCK_N, num_warps)``, or None to keep the generic config.
+    """
+    if _ON_GFX115X:
+        return _gfx115x_encoder_launch(head_dim, dtype)
+    return None
+
+
 def get_block_size(dtype: torch.dtype) -> int:
     if dtype == torch.float32:
         return 32
@@ -364,9 +405,13 @@ def context_attention_fwd(
     b_seq_len: [b]
     out: [b * s, head, head_dim]
     """
-    BLOCK = get_block_size(q.dtype)
-
     Lq, Lk, _ = q.shape[-1], k.shape[-1], v.shape[-1]
+
+    block_m = block_n = get_block_size(q.dtype)
+    num_warps = 4 if Lk <= 64 else 8
+    tuned_launch = _get_encoder_launch(Lk, q.dtype)
+    if tuned_launch is not None:
+        block_n, num_warps = tuned_launch
 
     sm_scale = 1.0 / (Lq**0.5) if softmax_scale is None else softmax_scale
     # rescale with 1/ln(2) for triton exp2
@@ -377,8 +422,7 @@ def context_attention_fwd(
     if sinks is not None:
         assert sinks.shape[0] == head, "Sinks must be num_query_heads size"
 
-    grid = (batch, head, triton.cdiv(max_input_len, BLOCK))
-    num_warps = 4 if Lk <= 64 else 8
+    grid = (batch, head, triton.cdiv(max_input_len, block_m))
 
     sliding_window_q = sliding_window_q if sliding_window_q is not None else 0
     sliding_window_k = sliding_window_k if sliding_window_k is not None else 0
@@ -412,10 +456,10 @@ def context_attention_fwd(
         o.stride(0),
         o.stride(1),
         kv_group_num=kv_group_num,
-        BLOCK_M=BLOCK,
+        BLOCK_M=block_m,
         BLOCK_DMODEL=block_dmodel,
         BLOCK_DMODEL_TAIL=block_dmodel_tail,
-        BLOCK_N=BLOCK,
+        BLOCK_N=block_n,
         IS_CAUSAL=is_causal,
         SLIDING_WINDOW_Q=sliding_window_q,
         SLIDING_WINDOW_K=sliding_window_k,


### PR DESCRIPTION

## Summary

`vllm/v1/attention/ops/triton_prefill_attention.py` is the **encoder** attention kernel — ViT towers via the mm-encoder backend, the encoder branches of `TRITON_ATTN` and `ROCM_ATTN`, and `mimo_v2_omni`'s visual attention. (The paged LLM prefill path imports a same-named `context_attention_fwd` from `prefix_prefill.py`; that is a different module and is untouched here.)

It has no launch configuration of its own, and it pads the head-dim tile to `next_power_of_2(head_dim)`, which wastes most of the matmul on the non-power-of-2 head dims that vision towers use. On gfx1151 this series takes Gemma3-4B's TTFT down **41%** and Qwen2.5-VL-7B's down **15%**.

Everything is gated on gfx115x, the only architecture measured; every other architecture keeps today's behaviour exactly. The split and the alignment hint are mechanically vendor-neutral and should carry to CDNA and NVIDIA, but I have no hardware to confirm that, and an unmeasured regression on someone else's GPU is worse than a missed win. Widening the gate later is a branch in `_get_head_dim_blocks` / `_get_encoder_launch`.

## Commits

| commit | what it does |
|---|---|
| `[ROCm] Add a gfx115x architecture predicate` | `_ON_GFX115X` / `on_gfx115x()`. The other two ROCm commits gate on it, so it lands first. |
| `[ROCm] Cover non-power-of-2 head dims with a split-D block on gfx115x` | `head_dim=72` ran the `qk`/`pv` dots over 128 lanes when only 5 K-passes of 16 are needed. Covers the head dim as a power-of-2 main block plus a power-of-2 tail block (72 → 64+16 = 80) behind a new constexpr `BLOCK_DMODEL_TAIL`; a tail of 0 is dead code and reproduces the single-block kernel exactly. `_split_head_dim` only takes the tail when it strictly narrows the extent — 112 would split into 64+64, covering the same 128 lanes for 12% more time. |
| `[Attention] Hint 16-byte head-stride alignment in ViT prefill attention` | When `head_dim % 16 == 8`, Triton does not attach `tt.divisibility=8` to the head stride, so the D-contiguous Q/K/V loads lower to scalar 2-byte loads. Hints `tl.multiple_of(off_h_*, 8)` behind a constexpr the wrapper sets from the **actual runtime strides**, so it stays sound for non-contiguous views. |
| `[ROCm] Give the encoder prefill attention a gfx115x launch config` | `BLOCK_N` inherits `BLOCK_M`, so gfx115x gets a 128x128 square tile chosen for NVIDIA. `_get_encoder_launch` dispatches on architecture and `_gfx115x_encoder_launch` holds the tuning, so another architecture is a branch in the former rather than a change to the latter. |

## Performance

Radeon 8060S (gfx1151). Each cell carries that commit's own contribution in brackets; the predicate commit is a no-op and is omitted.

**Kernel** — `context_attention_fwd`, B=1, S=3520, H=16, bf16, non-causal, ms/call. Each pass checks out every point in turn and the table is the median of 3 such passes, so drift cannot be mistaken for a commit's effect:

| head_dim | baseline | `+split-D` | `+alignment hint` | `+launch config` | total |
|---:|---:|---:|---:|---:|---:|
| 64 | 4.519 | 4.530 (1.00x) | 4.522 (1.00x) | 1.856 (**2.44x**) | **2.43x** |
| 72 | 9.265 | 7.536 (**1.23x**) | 6.946 (**1.08x**) | 2.233 (**3.11x**) | **4.15x** |
| 80 | 8.674 | 7.423 (**1.17x**) | 7.440 (1.00x) | 2.351 (**3.16x**) | **3.69x** |
| 128 | 16.331 | 16.087 (1.02x) | 16.082 (1.00x) | 3.907 (**4.12x**) | **4.18x** |
| 256 | 29.949 | 29.943 (1.00x) | 29.985 (1.00x) | 13.711 (**2.19x**) | **2.18x** |

split-D moves only the non-power-of-2 head dims, as it must — elsewhere the tail is dead code. The alignment hint moves only `head_dim=72`, the only dim measured with `head_dim % 16 == 8`.

**End to end** — TTFT, single image, `max_tokens=1`, prefix caching and the multimodal processor cache disabled and a different image per repetition so every call really re-runs the vision tower. Median of 5, ms:

| model | ViT head_dim | image | baseline | `+split-D` | `+alignment hint` | `+launch config` | total |
|---|---:|---|---:|---:|---:|---:|---:|
| `gemma-3-4b-it-quantized.w4a16` (SigLIP) | 72 | 1920x1080 | 604.6 | 545.8 (**−9.7%**) | 523.4 (**−4.1%**) | 356.6 (**−31.9%**) | **−41.0%** |
| `Qwen2.5-VL-7B-Instruct` | 80 | 1920x1080 | 2296.3 | 2203.3 (**−4.0%**) | 2219.8 (+0.7%) | 1947.8 (**−12.3%**) | **−15.2%** |
| `Qwen2.5-VL-7B-Instruct` | 80 | 1024x800 | 786.8 | 762.7 (**−3.1%**) | 766.3 (+0.5%) | 717.1 (**−6.4%**) | **−8.9%** |

Gemma3 pads to a fixed 896x896 and pairs a 4B w4a16 language model with a 27-layer tower, so the vision encoder dominates its TTFT; Qwen2.5-VL-7B spends proportionally more time in the language model. Both runs were checked to really reach this kernel — 27 calls per request at shape `(16, 72)` and 32 at `(16, 80)`, matching each tower's depth.

## Testing

```
pytest tests/kernels/attention/test_triton_prefill_attention.py   125 passed
pre-commit run --files <changed files>                            clean (ruff, ruff-format, mypy, SPDX)
```

## Not a duplicate

## AI assistance

This change was prepared with AI assistance (Claude). Every line was reviewed by the submitter, and the measurements above were run and checked by hand.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

