### PR TITLE
[Perf]Support Support bounded prefill admission for scheduler.

### DIFF
--- a/tests/v1/core/test_prefill_admission.py
+++ b/tests/v1/core/test_prefill_admission.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config import SchedulerConfig
+from vllm.v1.core.sched.prefill_admission import PrefillAdmissionPolicy
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.parametrize(
+    ("max_num_seqs", "prefill_admission_slots", "expected"),
+    [
+        (128, 0, 128),
+        (128, 25, 153),
+        (4, 10, 8),
+    ],
+)
+def test_scheduler_config_resident_capacity(
+    max_num_seqs: int,
+    prefill_admission_slots: int,
+    expected: int,
+):
+    config = SchedulerConfig(
+        max_num_seqs=max_num_seqs,
+        prefill_admission_slots=prefill_admission_slots,
+        max_model_len=2048,
+        is_encoder_decoder=False,
+    )
+
+    assert config.max_num_resident_seqs == expected
+
+
+def test_prefill_admission_changes_scheduler_hash():
+    default_config = SchedulerConfig(
+        max_num_seqs=128,
+        prefill_admission_slots=0,
+        max_model_len=2048,
+        is_encoder_decoder=False,
+    )
+    admission_config = SchedulerConfig(
+        max_num_seqs=128,
+        prefill_admission_slots=25,
+        max_model_len=2048,
+        is_encoder_decoder=False,
+    )
+
+    assert default_config.compute_hash() != admission_config.compute_hash()
+
+
+def test_prefill_admission_rejects_non_generation_runner():
+    with pytest.raises(
+        ValueError,
+        match="only supported for generation models",
+    ):
+        SchedulerConfig(
+            runner_type="pooling",
+            max_num_seqs=128,
+            prefill_admission_slots=25,
+            max_model_len=2048,
+            is_encoder_decoder=False,
+        )
+
+
+def test_prefill_admission_disabled_preserves_default_limits():
+    policy = PrefillAdmissionPolicy(
+        max_num_seqs=128,
+        prefill_admission_slots=0,
+    )
+
+    limits = policy.get_limits(
+        num_resident_decodes=64,
+        num_running_prefills=0,
+        num_waiting_prefills=25,
+        resident_prefill_capacity=0,
+        defer_prefills=False,
+    )
+
+    assert not policy.enabled
+    assert policy.max_num_resident_reqs == 128
+    assert limits.max_scheduled_running == 128
+    assert limits.max_new_prefills is None
+    assert not limits.defer_running_prefills
+
+
+@pytest.mark.parametrize(
+    (
+        "num_resident_decodes",
+        "num_running_prefills",
+        "num_waiting_prefills",
+        "resident_prefill_capacity",
+        "expected_running",
+        "expected_prefills",
+    ),
+    [
+        (128, 0, 25, 25, 128, 0),
+        (127, 0, 1, 25, 127, 1),
+        (100, 0, 25, 25, 103, 25),
+        (100, 20, 25, 25, 123, 5),
+        (100, 0, 25, 3, 125, 3),
+    ],
+)
+def test_prefill_admission_limits(
+    num_resident_decodes: int,
+    num_running_prefills: int,
+    num_waiting_prefills: int,
+    resident_prefill_capacity: int,
+    expected_running: int,
+    expected_prefills: int,
+):
+    policy = PrefillAdmissionPolicy(
+        max_num_seqs=128,
+        prefill_admission_slots=25,
+    )
+
+    limits = policy.get_limits(
+        num_resident_decodes=num_resident_decodes,
+        num_running_prefills=num_running_prefills,
+        num_waiting_prefills=num_waiting_prefills,
+        resident_prefill_capacity=resident_prefill_capacity,
+        defer_prefills=False,
+    )
+
+    assert policy.max_num_resident_reqs == 153
+    assert limits.max_scheduled_running == expected_running
+    assert limits.max_new_prefills == expected_prefills
+    assert limits.defer_running_prefills == (num_resident_decodes >= 128)
+
+
+def test_prefill_admission_respects_external_throttling():
+    policy = PrefillAdmissionPolicy(
+        max_num_seqs=128,
+        prefill_admission_slots=25,
+    )
+
+    limits = policy.get_limits(
+        num_resident_decodes=100,
+        num_running_prefills=0,
+        num_waiting_prefills=25,
+        resident_prefill_capacity=25,
+        defer_prefills=True,
+    )
+
+    assert limits.max_scheduled_running == 128
+    assert limits.max_new_prefills == 0
+    assert not limits.defer_running_prefills

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -56,6 +56,129 @@ from .utils import EOS_TOKEN_ID, create_requests, create_scheduler, mock_kv
 pytestmark = pytest.mark.cpu_test
 
 
+def _add_running_decodes(scheduler: Scheduler, count: int) -> list[Request]:
+    requests = create_requests(
+        num_requests=count,
+        req_ids=[f"decode-{i}" for i in range(count)],
+    )
+    for request in requests:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[request.request_id for request in requests],
+            req_id_to_index={
+                request.request_id: index
+                for index, request in enumerate(requests)
+            },
+            sampled_token_ids=[[100 + index] for index in range(count)],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    return requests
+
+
+def test_prefill_admission_wave_keeps_full_decode_batch():
+    scheduler = create_scheduler(
+        max_num_seqs=4,
+        prefill_admission_slots=2,
+    )
+    decodes = _add_running_decodes(scheduler, 4)
+    prefills = create_requests(
+        num_requests=2,
+        req_ids=["prefill-0", "prefill-1"],
+    )
+    for request in prefills:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert set(output.num_scheduled_tokens) == {
+        request.request_id for request in decodes
+    }
+    assert len(scheduler.running) == 4
+    assert len(scheduler.waiting) == 2
+
+
+def test_prefill_admission_wave_returns_unused_slots_to_decode():
+    scheduler = create_scheduler(
+        max_num_seqs=4,
+        prefill_admission_slots=2,
+    )
+    decodes = _add_running_decodes(scheduler, 3)
+    prefill = create_requests(
+        num_requests=1,
+        req_ids=["prefill"],
+    )[0]
+    scheduler.add_request(prefill)
+
+    output = scheduler.schedule()
+
+    assert set(output.num_scheduled_tokens) == {
+        *(request.request_id for request in decodes),
+        prefill.request_id,
+    }
+    assert len(scheduler.running) == 4
+
+
+def test_prefill_admission_wave_bounds_new_prefills():
+    scheduler = create_scheduler(
+        max_num_seqs=4,
+        prefill_admission_slots=2,
+    )
+    decodes = _add_running_decodes(scheduler, 3)
+    prefills = create_requests(
+        num_requests=4,
+        req_ids=[f"prefill-{i}" for i in range(4)],
+    )
+    for request in prefills:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert set(output.num_scheduled_tokens) == {
+        decodes[0].request_id,
+        decodes[1].request_id,
+        prefills[0].request_id,
+        prefills[1].request_id,
+    }
+    assert [request.request_id for request in scheduler.running[:2]] == [
+        prefills[0].request_id,
+        prefills[1].request_id,
+    ]
+    assert len(scheduler.running) == 5
+    assert len(scheduler.waiting) == 2
+
+
+def test_prefill_admission_caps_total_scheduled_requests():
+    scheduler = create_scheduler(
+        max_num_seqs=4,
+        prefill_admission_slots=2,
+    )
+    decodes = _add_running_decodes(scheduler, 3)
+    cached_decodes = create_requests(
+        num_requests=3,
+        req_ids=[f"cached-decode-{i}" for i in range(3)],
+    )
+    for request in cached_decodes:
+        request.num_computed_tokens = request.num_tokens - 1
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert len(output.num_scheduled_tokens) == 4
+    assert set(output.num_scheduled_tokens) == {
+        *(request.request_id for request in decodes),
+        cached_decodes[0].request_id,
+    }
+    assert len(scheduler.running) == 4
+    assert len(scheduler.waiting) == 2
+
+
 def test_make_scheduled_encoder_input_stats_output_embeddings():
     scheduler = create_scheduler()
     mm_features = [

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -52,6 +52,7 @@ def mock_kv(matched_tokens: int, is_async: bool, num_defers_before_matching: int
 def create_scheduler(
     model: str = "facebook/opt-125m",
     max_num_seqs: int = 16,
+    prefill_admission_slots: int = 0,
     max_num_batched_tokens: int = 8192,
     enable_chunked_prefill: bool = True,
     enable_prefix_caching: bool = False,
@@ -106,6 +107,7 @@ def create_scheduler(
         max_model_len = max_num_batched_tokens
     scheduler_config = SchedulerConfig(
         max_num_seqs=max_num_seqs,
+        prefill_admission_slots=prefill_admission_slots,
         max_num_batched_tokens=max_num_batched_tokens,
         max_model_len=max_model_len,
         long_prefill_token_threshold=long_prefill_token_threshold,

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -67,6 +67,23 @@ class SchedulerConfig:
     In real usage, this should be set in `EngineArgs.create_engine_config`.
     """
 
+    prefill_admission_slots: int = Field(default=0, ge=0)
+    """Maximum number of sequence slots used for a prefill admission wave.
+
+    When positive, a full resident decode batch is kept decode-only. After
+    decode residency drops below ``max_num_seqs``, up to this many waiting
+    prefills are admitted together. Decodes deferred by the wave retain their
+    KV cache, and slots without a waiting prefill remain available to decode.
+    0 disables prefill admission waves."""
+
+    @property
+    def max_num_resident_seqs(self) -> int:
+        """Maximum requests retained by the scheduler and model runner."""
+        return self.max_num_seqs + min(
+            self.prefill_admission_slots,
+            self.max_num_seqs,
+        )
+
     long_prefill_token_threshold: int = Field(default=0, ge=0)
     """For chunked prefill, a request is considered long if the prompt is
     longer than this number of tokens. 0 disables the cap (default)."""
@@ -258,8 +275,9 @@ class SchedulerConfig:
         factors.append(self.max_num_batched_tokens)
 
         # PLE and other model components allocate static per-request buffers.
-        # Their shapes are captured in compiled graphs.
-        factors.append(self.max_num_seqs)
+        # Their shapes are captured in compiled graphs. Prefill admission can
+        # retain more requests than a single execution step can schedule.
+        factors.append(self.max_num_resident_seqs)
 
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
@@ -271,6 +289,11 @@ class SchedulerConfig:
         return None if value is None else handler(value)
 
     def __post_init__(self, max_model_len: int, is_encoder_decoder: bool) -> None:
+        if self.prefill_admission_slots > 0 and self.runner_type != "generate":
+            raise ValueError(
+                "prefill_admission_slots is only supported for generation models."
+            )
+
         if is_encoder_decoder:
             # Chunked prefill should be disabled for encoder-decoder models.
             self.disable_chunked_mm_input = True

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -548,6 +548,7 @@ class EngineArgs:
     max_num_scheduled_tokens: int | None = None
     long_prefill_token_threshold: int = SchedulerConfig.long_prefill_token_threshold
     max_num_seqs: int | None = None
+    prefill_admission_slots: int = SchedulerConfig.prefill_admission_slots
     max_num_queued_reqs: int | None = None
     max_num_queued_tokens: int | None = None
     max_logprobs: int = ModelConfig.max_logprobs
@@ -1586,6 +1587,10 @@ class EngineArgs:
             },
         )
         scheduler_group.add_argument(
+            "--prefill-admission-slots",
+            **scheduler_kwargs["prefill_admission_slots"],
+        )
+        scheduler_group.add_argument(
             "--max-num-queued-reqs", **scheduler_kwargs["max_num_queued_reqs"]
         )
         scheduler_group.add_argument(
@@ -2412,6 +2417,7 @@ class EngineArgs:
             max_num_batched_tokens=self.max_num_batched_tokens,
             max_num_scheduled_tokens=self.max_num_scheduled_tokens,
             max_num_seqs=self.max_num_seqs,
+            prefill_admission_slots=self.prefill_admission_slots,
             max_num_queued_reqs=self.max_num_queued_reqs,
             max_num_queued_tokens=self.max_num_queued_tokens,
             max_model_len=model_config.max_model_len,

--- a/vllm/v1/core/sched/prefill_admission.py
+++ b/vllm/v1/core/sched/prefill_admission.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PrefillAdmissionLimits:
+    """Per-step limits produced by a prefill admission policy."""
+
+    max_scheduled_running: int
+    max_new_prefills: int | None
+    defer_running_prefills: bool
+
+
+class PrefillAdmissionPolicy:
+    """Controls bounded prefill waves without evicting resident decodes."""
+
+    def __init__(self, max_num_seqs: int, prefill_admission_slots: int) -> None:
+        self.max_num_seqs = max_num_seqs
+        self.prefill_admission_slots = min(
+            prefill_admission_slots, max_num_seqs
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return self.prefill_admission_slots > 0
+
+    @property
+    def max_num_resident_reqs(self) -> int:
+        # Deferred decodes retain their KV cache while a prefill wave runs.
+        return self.max_num_seqs + self.prefill_admission_slots
+
+    def get_limits(
+        self,
+        *,
+        num_resident_decodes: int,
+        num_running_prefills: int,
+        num_waiting_prefills: int,
+        resident_prefill_capacity: int,
+        defer_prefills: bool,
+    ) -> PrefillAdmissionLimits:
+        if not self.enabled:
+            return PrefillAdmissionLimits(self.max_num_seqs, None, False)
+
+        # Preserve a full decode batch so it can keep using decode-optimized
+        # execution. Open a bounded prefill wave only after decode residency
+        # naturally drops below max_num_seqs.
+        decode_batch_is_full = num_resident_decodes >= self.max_num_seqs
+        if defer_prefills or decode_batch_is_full:
+            num_reserved_slots = 0
+        else:
+            num_reserved_slots = min(
+                self.prefill_admission_slots - num_running_prefills,
+                num_waiting_prefills,
+                resident_prefill_capacity,
+            )
+            num_reserved_slots = max(0, num_reserved_slots)
+
+        return PrefillAdmissionLimits(
+            max_scheduled_running=self.max_num_seqs - num_reserved_slots,
+            max_new_prefills=num_reserved_slots,
+            defer_running_prefills=decode_batch_is_full,
+        )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -47,6 +47,7 @@ from vllm.v1.core.sched.output import (
     ScheduledEncoderInputStats,
     SchedulerOutput,
 )
+from vllm.v1.core.sched.prefill_admission import PrefillAdmissionPolicy
 from vllm.v1.core.sched.request_queue import (
     RequestQueue,
     SchedulingPolicy,
@@ -123,6 +124,13 @@ class Scheduler(SchedulerInterface):
 
         # Scheduling constraints.
         self.max_num_running_reqs = self.scheduler_config.max_num_seqs
+        self.prefill_admission_policy = PrefillAdmissionPolicy(
+            self.max_num_running_reqs,
+            self.scheduler_config.prefill_admission_slots,
+        )
+        self.max_num_resident_reqs = (
+            self.prefill_admission_policy.max_num_resident_reqs
+        )
         self.max_num_scheduled_tokens = (
             self.scheduler_config.max_num_scheduled_tokens
             if self.scheduler_config.max_num_scheduled_tokens is not None
@@ -609,9 +617,58 @@ class Scheduler(SchedulerInterface):
             throttle_prefills and not self.prefill_capacity_bound
         ) and any(not r.is_prefill_chunk for r in self.running)
 
+        if self.prefill_admission_policy.enabled:
+            num_running_prefills = sum(
+                request.is_prefill_chunk for request in self.running
+            )
+            num_resident_decodes = (
+                len(self.running)
+                - num_running_prefills
+                + self.num_waiting_for_streaming_input
+            )
+            waiting_prefills = (
+                request
+                for queue in (self.skipped_waiting, self.waiting)
+                for request in queue
+                if request.num_computed_tokens < request.num_tokens - 1
+            )
+            num_waiting_prefills = sum(
+                1
+                for _ in itertools.islice(
+                    waiting_prefills,
+                    self.prefill_admission_policy.prefill_admission_slots,
+                )
+            )
+            resident_prefill_capacity = max(
+                0,
+                self.max_num_resident_reqs
+                - len(self.running)
+                - self.num_waiting_for_streaming_input,
+            )
+            admission_limits = self.prefill_admission_policy.get_limits(
+                num_resident_decodes=num_resident_decodes,
+                num_running_prefills=num_running_prefills,
+                num_waiting_prefills=num_waiting_prefills,
+                resident_prefill_capacity=resident_prefill_capacity,
+                defer_prefills=defer_prefills,
+            )
+        else:
+            admission_limits = self.prefill_admission_policy.get_limits(
+                num_resident_decodes=0,
+                num_running_prefills=0,
+                num_waiting_prefills=0,
+                resident_prefill_capacity=0,
+                defer_prefills=defer_prefills,
+            )
+
         # First, schedule the RUNNING requests.
         req_index = 0
-        while req_index < len(self.running) and token_budget > 0:
+        while (
+            req_index < len(self.running)
+            and token_budget > 0
+            and len(scheduled_running_reqs)
+            < admission_limits.max_scheduled_running
+        ):
             request = self.running[req_index]
             if input_budget <= draft_slots:
                 break
@@ -638,9 +695,11 @@ class Scheduler(SchedulerInterface):
                 req_index += 1
                 continue
 
-            if defer_prefills and request.is_prefill_chunk:
-                # DP prefill balancing: defer this in-progress prefill chunk to a
-                # cadence-aligned step; decodes still run to fill this step.
+            if (
+                defer_prefills or admission_limits.defer_running_prefills
+            ) and request.is_prefill_chunk:
+                # Keep this step decode-only when required by DP balancing or
+                # when decode residency already fills max_num_seqs.
                 req_index += 1
                 continue
 
@@ -848,16 +907,25 @@ class Scheduler(SchedulerInterface):
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
         # Next, schedule the WAITING requests.
+        newly_admitted_prefill_ids: set[str] = set()
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
             step_skipped_waiting = create_request_queue(self.policy)
+            num_new_prefills = 0
 
             while (self.waiting or self.skipped_waiting) and token_budget > 0:
                 if input_budget <= draft_slots:
                     break
+                num_scheduled_reqs = (
+                    len(scheduled_running_reqs)
+                    + len(scheduled_new_reqs)
+                    + len(scheduled_resumed_reqs)
+                )
+                if num_scheduled_reqs >= self.max_num_running_reqs:
+                    break
                 # Paused streaming sessions (WAITING_FOR_STREAMING_REQ) are not
                 # in `running` but still hold a model-runner request slot.
                 num_running = len(self.running) + self.num_waiting_for_streaming_input
-                if num_running >= self.max_num_running_reqs:
+                if num_running >= self.max_num_resident_reqs:
                     break
 
                 request_queue = self._select_waiting_queue_for_scheduling()
@@ -1013,6 +1081,14 @@ class Scheduler(SchedulerInterface):
                         request_queue.pop_request()
                         step_skipped_waiting.prepend_request(request)
                         continue
+
+                requires_prefill = num_computed_tokens < request.num_tokens - 1
+                if (
+                    requires_prefill
+                    and admission_limits.max_new_prefills is not None
+                    and num_new_prefills >= admission_limits.max_new_prefills
+                ):
+                    break
 
                 encoder_inputs_to_schedule = None
                 external_load_encoder_input = []
@@ -1235,6 +1311,9 @@ class Scheduler(SchedulerInterface):
                     continue
 
                 self.running.append(request)
+                if requires_prefill:
+                    num_new_prefills += 1
+                    newly_admitted_prefill_ids.add(request_id)
                 if num_external_computed_tokens > 0:
                     # load_kv_async is False here
                     has_sync_kv_loads = True
@@ -1292,19 +1371,43 @@ class Scheduler(SchedulerInterface):
             if not defer_prefills:
                 self.prefill_capacity_bound = bool(self.waiting)
 
+        if newly_admitted_prefill_ids:
+            scheduled_running_ids = {
+                request.request_id for request in scheduled_running_reqs
+            }
+            newly_admitted = [
+                request
+                for request in self.running
+                if request.request_id in newly_admitted_prefill_ids
+            ]
+            scheduled_running = [
+                request
+                for request in self.running
+                if request.request_id in scheduled_running_ids
+            ]
+            deferred_running = [
+                request
+                for request in self.running
+                if request.request_id
+                not in newly_admitted_prefill_ids | scheduled_running_ids
+            ]
+            # Keep the active wave at the front of the persistent batch.
+            self.running = newly_admitted + scheduled_running + deferred_running
+
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
         assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
 
         assert token_budget >= 0
         assert input_budget >= 0
-        assert len(self.running) <= self.max_num_running_reqs
+        assert len(self.running) <= self.max_num_resident_reqs
         # Since some requests in the RUNNING queue may not be scheduled in
         # this step, the total number of scheduled requests can be smaller than
         # len(self.running).
         assert len(scheduled_new_reqs) + len(scheduled_resumed_reqs) + len(
             scheduled_running_reqs
         ) <= len(self.running)
+        assert len(num_scheduled_tokens) <= self.max_num_running_reqs
 
         # Get the longest common prefix among all requests in the running queue.
         # This can be potentially used for cascade attention.

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -215,7 +215,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.vocab_size = self.model_config.get_vocab_size()
         self.max_model_len = self.model_config.max_model_len
         self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        # The scheduler can retain deferred decodes while admitting a bounded
+        # prefill wave. Execution buffers remain limited by max_num_seqs.
         self.max_num_reqs = self.scheduler_config.max_num_seqs
+        self.max_num_resident_reqs = self.scheduler_config.max_num_resident_seqs
         self.is_encoder_decoder = self.model_config.is_encoder_decoder
 
         self.output_copy_stream = torch.cuda.Stream(self.device)
@@ -308,7 +311,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # General request states.
         self.req_states = RequestState(
-            max_num_reqs=self.max_num_reqs,
+            max_num_reqs=self.max_num_resident_reqs,
             max_model_len=self.max_model_len,
             max_num_batched_tokens=self.max_num_tokens,
             num_speculative_steps=self.num_speculative_steps,
@@ -325,7 +328,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.fast_prefill: FastPrefillHelper | None = None
         if self.use_pp:
             self.pp_handler = PPHandler(
-                max_num_reqs=self.max_num_reqs,
+                max_num_reqs=self.max_num_resident_reqs,
                 num_speculative_steps=self.num_speculative_steps,
                 device=self.device,
             )
@@ -340,7 +343,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.cudagraph_manager: ModelCudaGraphManager | None = None
 
         # LoRA-related workers.
-        self.lora_state = LoraState(max_num_reqs=self.max_num_reqs)
+        self.lora_state = LoraState(max_num_reqs=self.max_num_resident_reqs)
         self.lora_capture_cases = [0]
         if self.lora_config:
             self.lora_capture_cases = get_lora_capture_cases(
@@ -457,7 +460,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Initialize samplers. Model states may override via custom_sampler().
         if self.is_last_pp_rank and not self.is_pooling_model:
             sampler_kwargs: dict[str, Any] = {
-                "max_num_reqs": self.max_num_reqs,
+                "max_num_reqs": self.max_num_resident_reqs,
                 "vocab_size": self.vocab_size,
                 "device": self.device,
                 "req_states": self.req_states,
@@ -485,7 +488,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     self.device,
                 )
             self.prompt_logprobs_worker = PromptLogprobsWorker(
-                self.max_num_reqs,
+                self.max_num_resident_reqs,
                 logprobs_mode=self.model_config.logprobs_mode,
             )
             self.structured_outputs_worker = StructuredOutputsWorker(
@@ -642,7 +645,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         self.block_tables = BlockTables(
             block_sizes=block_sizes,
-            max_num_reqs=self.max_num_reqs,
+            max_num_reqs=self.max_num_resident_reqs,
             max_num_batched_tokens=self.max_num_tokens,
             max_num_blocks_per_group=max_num_blocks_per_group,
             device=self.device,

--- a/vllm/v1/worker/gpu/model_states/interface.py
+++ b/vllm/v1/worker/gpu/model_states/interface.py
@@ -60,7 +60,7 @@ class ModelState(ABC):
         self.device = device
 
         self.max_model_len = self.model_config.max_model_len
-        self.max_num_reqs = self.scheduler_config.max_num_seqs
+        self.max_num_reqs = self.scheduler_config.max_num_resident_seqs
         self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
         self.inputs_embeds_size = self.model_config.get_inputs_embeds_size()
         self.dtype = self.model_config.dtype


### PR DESCRIPTION
PR description:

## Summary

This PR supports bounded prefill admission waves for chunked prefill.

The policy works as follows:

- When the resident decode batch reaches `max_num_seqs`, do not reserve
  prefill slots and run a decode-only batch.
- After decode residency drops below `max_num_seqs`, admit up to a bounded
  number of waiting prefills as one wave.
- Running prefill chunks count toward the wave limit.
- If there are not enough waiting prefills, return unused slots to decode
  requests.
- Decode requests deferred by a prefill wave remain resident and retain their
  KV cache.
- No periodic request rotation is introduced.

The goal is to increase the proportion of decode-only batches under chunked
prefill workloads. Decode-only batches can use the full CUDA graph path,
instead of repeatedly mixing small prefill chunks into decode execution and
falling back to piecewise graphs.

This policy is mainly effective for offline dataset serving with high client
concurrency and a sustained waiting backlog. When concurrency is close to or
lower than `max_num_seqs`, the performance difference is expected to be
small.

## Configuration

The feature is disabled by default and can be enabled with:

```bash
--prefill-admission-slots <N>
```

Example:

```bash
--max-num-seqs 128 \
--prefill-admission-slots 25
```

`prefill_admission_slots=0` preserves the original scheduler behavior.

## Benchmark

Setup:

- Model: Qwen2.5-7B-Instruct
- Dataset: ShareGPT
- Requests: 2,000
- Client concurrency: 256
- Request rate: unlimited
- `max_num_seqs`: 128
- `max_num_batched_tokens`: 4096
- `temperature`: 0
- Independent cold server for each configuration
- Successful requests: 2,000/2,000 for both configurations

| Metric | slots=0 | slots=25 | Change |
| --- | ---: | ---: | ---: |
| Duration | 99.24 s | 86.81 s | -12.53% |
| Request throughput | 20.15 req/s | 23.04 req/s | +14.32% |
| Total token throughput | 8592.63 tok/s | 9817.99 tok/s | +14.26% |
| Mean TTFT | 5409.58 ms | 4418.56 ms | -18.32% |
| P99 TTFT | 6795.35 ms | 5981.20 ms | -11.98% |
| Mean TPOT | 29.08 ms | 23.14 ms | -20.44% |
| P99 TPOT | 63.73 ms | 79.39 ms | +24.58% |
| Mean ITL | 26.99 ms | 24.19 ms | -10.40% |
| P99 ITL | 87.70 ms | 252.28 ms | +187.65% |
