### PR TITLE
[ROCm][Docker] Pin AINIC apt repo to snapshot 1.117.5-a-77

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -19,7 +19,7 @@ ARG NIC_BACKEND=all
 # Users can specify a custom version compatible with their host drivers.
 # The default version has been tested with ionic-dkms=26.03.3.001
 # (libionic1=54.0-187-1), required for MoRI-EP/NIXL on Pollara/AINIC.
-ARG AINIC_VERSION=1.117.5
+ARG AINIC_VERSION=1.117.5-a-77
 ARG UBUNTU_CODENAME=jammy
 
 # Sccache configuration. Release builds use this today; CI can opt in when a

--- a/docker/Dockerfile.rocm_gfx1250
+++ b/docker/Dockerfile.rocm_gfx1250
@@ -15,7 +15,7 @@ ARG NIC_BACKEND=all
 # Users can specify a custom version compatible with their host drivers.
 # The default version has been tested with ionic-dkms=26.03.3.001
 # (libionic1=54.0-187-1), required for MoRI-EP/NIXL on Pollara/AINIC.
-ARG AINIC_VERSION=1.117.5
+ARG AINIC_VERSION=1.117.5-a-77
 ARG UBUNTU_CODENAME=jammy
 
 # Sccache configuration. Release builds use this today; CI can opt in when a

--- a/docs/features/moriio_connector_usage.md
+++ b/docs/features/moriio_connector_usage.md
@@ -253,7 +253,7 @@ To run MoRI with RDMA, your environment must have the necessary RDMA userspace l
 
 The official image `vllm/vllm-openai-rocm:nightly` comes pre-installed with userspace libraries for the following NICs and kernel module versions:
 
-- AINIC (AMD Pensando Pollara): version `1.117.5`, ships `libionic1=54.0-187-1`, tested with `ionic-dkms=26.03.3.001`
+- AINIC (AMD Pensando Pollara): version `1.117.5-a-77`, ships `libionic1=54.0-187-1`, tested with `ionic-dkms=26.03.3.001`
 - Thor2 (Broadcom): version `235.2.86.0`, tested with `bnxt-en-dkms=1.10.3.235.2.86.0`, `bnxt-re-dkms=235.2.86.0`
 
 Refer to [Dockerfile.rocm](../../docker/Dockerfile.rocm) for more details. For users with NICs, kernel modules, and/or FW other than those stated above we refer to


### PR DESCRIPTION
## Purpose
The AMD Model Executor job fails during environment setup:

```
E: Failed to fetch .../amdainic/pensando/ubuntu/1.117.5/dists/jammy/main/binary-amd64/Packages.gz 
File has unexpected size (3363 != 3397). Mirror sync in progress?
```

`AINIC_VERSION=1.117.5`, set in #54112, points at a mutable path whose contents are updated in place. The index files behind `repo.radeon.com` are cached per file, so a client can end up pairing an `InRelease` manifest from one publication with a `Packages.gz` from another, which fails apt's integrity check. 

This pins `1.117.5-a-77`, a per-build snapshot path that is not reused for later builds. That snapshot was chosen specifically because it is the one that ships `libionic1=54.0-187-1` and `ionic-dkms=26.03.3.001`, exactly the versions #54112 selected, so image contents are unchanged.

## Test Plan
Run `apt-get update` against both paths in an isolated apt root, pinned to the CDN edge node that the failing CI pod connected to, and check the resulting package candidate.
## Test Result
| Path | InRelease expects | Served | Result |
| --- | --- | --- | --- |
| `1.117.5` | 3397 | 3363 | mismatch, exit 100 |
| `1.117.5-a-77` | 3363 | 3363 | ok, exit 0 |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

