### PR TITLE
[httpx migration] Import httpx from huggingface_hub

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,7 +8,7 @@ tqdm
 blake3
 py-cpuinfo
 transformers >= 5.10.4
-huggingface_hub >= 1.28.0
+huggingface_hub >= 1.31.0  # Required for the `huggingface_hub.utils.httpx` re-export
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 safetensors >= 0.6.2  # MXFP4/MXFP6 dtype support (F8_E8M0, F4) added in 0.6.0: https://github.com/huggingface/safetensors/pull/611
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994

--- a/requirements/test/cpu.txt
+++ b/requirements/test/cpu.txt
@@ -342,7 +342,7 @@ httpx==0.27.2
     #   schemathesis
 httpx2==2.12.0
     # via mcp
-huggingface-hub==1.28.0
+huggingface-hub==1.31.0
     # via
     #   -r requirements/test/../common.txt
     #   accelerate

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -361,7 +361,7 @@ httpx==0.27.2
     #   schemathesis
 httpx2==2.12.0
     # via mcp
-huggingface-hub==1.28.0
+huggingface-hub==1.31.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -354,7 +354,7 @@ httpx==0.27.2
     #   schemathesis
 httpx2==2.12.0
     # via mcp
-huggingface-hub==1.28.0
+huggingface-hub==1.31.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/requirements/test/xpu.txt
+++ b/requirements/test/xpu.txt
@@ -232,7 +232,7 @@ httpx2==2.10.0
     # via
     #   mcp
     #   openai
-huggingface-hub==1.28.0
+huggingface-hub==1.31.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/../common.txt

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -10,12 +10,12 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any
 
-import httpx
 import msgspec
 import numpy as np
 import torch
 import zmq
 import zmq.asyncio
+from huggingface_hub.utils import httpx
 
 from vllm import envs
 from vllm.config import VllmConfig

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -258,8 +258,10 @@ _configure_vllm_root_logger()
 
 # Transformers uses httpx to access the Hugging Face Hub. httpx is quite verbose,
 # so we set its logging level to WARNING when vLLM's logging level is INFO.
+# httpx2 is the successor huggingface_hub switches to in its 2.x releases.
 if envs.VLLM_LOGGING_LEVEL == "INFO":
     logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpx2").setLevel(logging.WARNING)
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
_(disclaimer: maintainer of huggingface_hub here :hugs: )_

Direct `httpx` imports will break when `huggingface_hub` migrates to `httpx2`. Import through `huggingface_hub.utils` instead, using the compatibility export shipped in `huggingface_hub` 1.31.0. Goal is to make vLLM compatible with both huggingface_hub 1.x and 2.x when the switch to `httpx2` happens.

Related: https://github.com/huggingface/huggingface_hub/pull/4803 and https://github.com/huggingface/huggingface_hub/issues/4802.

`huggingface_hub` is bumped to `>= 1.31.0` (the release the re-export landed in). The `logging.getLogger("httpx")` silencing in `vllm/logger.py` is extended to `httpx2`, which logs under its own name. Tests and examples keep importing `httpx` directly, since it stays an explicit test dependency in `requirements/test/*.in`.

<details>
<summary>AI assistance disclosure</summary>

This PR was written with AI assistance (Claude Code); I reviewed every changed line.

- Not a duplicate: no open PR or issue on `vllm-project/vllm` covers the httpx/huggingface_hub migration (searched open PRs for `httpx` and `huggingface_hub`, and open issues for `httpx`).
- Checks run: `pre-commit run --files <changed files>` (all hooks pass, including the `pip-compile` hooks that regenerated the four `requirements/test/*.txt` locks).
- Verified against `huggingface_hub==1.31.0` that `AsyncClient`, `ConnectError` and `HTTPStatusError` — the only symbols `mooncake_connector.py` uses — are all reachable from `huggingface_hub.utils.httpx`.
- I did not run `tests/v1/kv_connector/unit/test_mooncake_connector.py` locally (no GPU environment on hand); it is the relevant suite and CI should cover it.
- No model-output, accuracy or serving behaviour is affected, so no evals were run.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
