### PR TITLE
[Security] Hold MoRIIO deferred-send blocks until a finished_sending ACK

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_deferred_send.py
+++ b/tests/v1/kv_connector/unit/test_moriio_deferred_send.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Producer deferred-send ACK vs timeout: blocks must not be force-freed."""
+
+import threading
+import time
+from types import MethodType, SimpleNamespace
+
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
+    MoRIIOConnectorScheduler,
+    MoRIIOConnectorWorker,
+)
+from vllm.v1.outputs import KVConnectorOutput
+
+_update = MoRIIOConnectorScheduler.update_connector_output
+_unmap = MoRIIOConnectorScheduler.unmap_request_id
+_map = MoRIIOConnectorScheduler.map_request_id
+
+
+def _producer_sched() -> SimpleNamespace:
+    sched = SimpleNamespace(
+        is_producer=True,
+        _deferred_send_deadlines={},
+        _pending_sent_acks={},
+        _defer_timeout=60.0,
+        _stale_deferred_sends=set(),
+        transfer_id_to_request_id={},
+        request_id_to_transfer_id={},
+    )
+    sched.unmap_request_id = MethodType(_unmap, sched)
+    sched.map_request_id = MethodType(_map, sched)
+    return sched
+
+
+def test_expired_deferred_send_is_not_finished_sending():
+    sched = _producer_sched()
+    sched.map_request_id("rid-a", "tid-a")
+    sched._deferred_send_deadlines["rid-a"] = (time.monotonic() - 1.0, "tid-a")
+    output = KVConnectorOutput(finished_sending=None)
+
+    _update(sched, output)
+
+    assert output.finished_sending is None
+    assert "rid-a" in sched._deferred_send_deadlines
+    assert sched.request_id_to_transfer_id == {"rid-a": "tid-a"}
+    assert "rid-a" in sched._stale_deferred_sends
+
+
+def test_ack_still_surfaces_deferred_send_for_free():
+    sched = _producer_sched()
+    sched.map_request_id("rid-a", "tid-a")
+    sched._deferred_send_deadlines["rid-a"] = (time.monotonic() + 60.0, "tid-a")
+    output = KVConnectorOutput(finished_sending={"rid-a"})
+
+    _update(sched, output)
+
+    assert output.finished_sending == {"rid-a"}
+    assert "rid-a" not in sched._deferred_send_deadlines
+    assert sched.request_id_to_transfer_id == {}
+    assert sched.transfer_id_to_request_id == {}
+
+
+def test_late_ack_after_timeout_still_frees():
+    sched = _producer_sched()
+    sched.map_request_id("rid-a", "tid-a")
+    sched._deferred_send_deadlines["rid-a"] = (time.monotonic() - 1.0, "tid-a")
+    stale_output = KVConnectorOutput(finished_sending=None)
+    _update(sched, stale_output)
+    assert stale_output.finished_sending is None
+    assert "rid-a" in sched._stale_deferred_sends
+
+    ack_output = KVConnectorOutput(finished_sending={"rid-a"})
+    _update(sched, ack_output)
+
+    assert ack_output.finished_sending == {"rid-a"}
+    assert "rid-a" not in sched._deferred_send_deadlines
+    assert "rid-a" not in sched._stale_deferred_sends
+    assert sched.request_id_to_transfer_id == {}
+
+
+def test_consumer_is_noop_for_deferred_send_reap():
+    sched = SimpleNamespace(
+        is_producer=False,
+        _deferred_send_deadlines={"rid-a": (time.monotonic() - 1.0, "tid-a")},
+    )
+    output = KVConnectorOutput(finished_sending=None)
+    _update(sched, output)
+    assert output.finished_sending is None
+    assert "rid-a" in sched._deferred_send_deadlines
+
+
+class _PendingStatus:
+    def Succeeded(self):
+        return False
+
+    def Failed(self):
+        return False
+
+
+class _FakeNotifyWrapper:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.sent: list[tuple] = []
+
+    def send_notify(
+        self,
+        transfer_id,
+        host,
+        port,
+        message_type=None,
+        message_fields=None,
+    ):
+        self.sent.append((transfer_id, host, port, message_type, message_fields))
+
+    def shutdown(self):
+        pass
+
+
+def test_timed_out_read_notifies_producer_to_release():
+    worker = MoRIIOConnectorWorker.__new__(MoRIIOConnectorWorker)
+    worker.world_size = 4
+    worker.moriio_wrapper = _FakeNotifyWrapper()
+    worker._recving_transfers = {"req": {"layer0": _PendingStatus()}}
+    worker._recving_transfers_callback_addr = {
+        "req": ("127.0.0.1", "7000", "tx-timeout")
+    }
+    worker._recving_transfers_start = {"req": time.monotonic() - 200.0}
+
+    assert worker._pop_done_transfers() == set()
+    assert worker.moriio_wrapper.sent == [
+        (
+            "tx-timeout",
+            "127.0.0.1",
+            "7000",
+            "release",
+            {"consumer_tp_size": 4},
+        )
+    ]
+    assert worker._recving_transfers == {}
+    assert worker._recving_transfers_callback_addr == {}
+    assert worker._recving_transfers_start == {}

--- a/tests/v1/kv_connector/unit/test_moriio_deferred_send.py
+++ b/tests/v1/kv_connector/unit/test_moriio_deferred_send.py
@@ -24,6 +24,7 @@ def _producer_sched() -> SimpleNamespace:
         _pending_sent_acks={},
         _defer_timeout=60.0,
         _stale_deferred_sends=set(),
+        _stale_deferred_log_at=0.0,
         transfer_id_to_request_id={},
         request_id_to_transfer_id={},
     )
@@ -44,6 +45,41 @@ def test_expired_deferred_send_is_not_finished_sending():
     assert "rid-a" in sched._deferred_send_deadlines
     assert sched.request_id_to_transfer_id == {"rid-a": "tid-a"}
     assert "rid-a" in sched._stale_deferred_sends
+    assert sched.transfer_id_to_request_id == {"tid-a": "rid-a"}
+
+
+def test_lost_acks_retain_all_deferred_entries_and_mappings():
+    """A lost ACK path must keep every deferred entry and transfer-id
+    mapping so a late ACK can still free. Force-freeing or dropping
+    maps would return blocks to the pool while a READ may still
+    reference them."""
+    sched = _producer_sched()
+    n = 1000
+    expired_at = time.monotonic() - 1.0
+    for i in range(n):
+        rid, tid = f"rid-{i}", f"tid-{i}"
+        sched.map_request_id(rid, tid)
+        sched._deferred_send_deadlines[rid] = (expired_at, tid)
+
+    output = KVConnectorOutput(finished_sending=None)
+    _update(sched, output)
+
+    assert output.finished_sending is None
+    assert len(sched._deferred_send_deadlines) == n
+    assert len(sched.request_id_to_transfer_id) == n
+    assert len(sched.transfer_id_to_request_id) == n
+    assert len(sched._stale_deferred_sends) == n
+
+    ack_output = KVConnectorOutput(finished_sending={"rid-7"})
+    _update(sched, ack_output)
+
+    assert ack_output.finished_sending == {"rid-7"}
+    assert "rid-7" not in sched._deferred_send_deadlines
+    assert "rid-7" not in sched.request_id_to_transfer_id
+    assert "tid-7" not in sched.transfer_id_to_request_id
+    assert len(sched._deferred_send_deadlines) == n - 1
+    assert len(sched.request_id_to_transfer_id) == n - 1
+    assert len(sched.transfer_id_to_request_id) == n - 1
 
 
 def test_ack_still_surfaces_deferred_send_for_free():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -281,8 +281,8 @@ class MoRIIOConfig:
         #                     WRITE mode.
         # transfer_timeout -> Timeout for waiting_for_transfer_complete before
         #                     raising TransferError (sec).
-        # defer_timeout    -> Timeout before a deferred send with no finished_sending
-        #                     notification is reaped and its blocks force-freed (sec).
+        # defer_timeout    -> How long to wait for a finished_sending ACK
+        #                     before warning; blocks stay held until the ACK.
 
         # Knobs for RDMA transfers, ignored if on xgmi backend
         # qp_per_transfer  -> Number of RDMA Queue Pairs per KV transfer.
@@ -370,7 +370,7 @@ class MoRIIOConstants:
     # Overridable via kv_connector_extra_config["transfer_timeout"].
     DEFAULT_TRANSFER_TIMEOUT = 30.0
     # Timeout (seconds) before a deferred send with no finished_sending
-    # notification is reaped and its blocks force-freed.
+    # ACK is logged as stale. Blocks stay allocated until the ACK.
     # Overridable via kv_connector_extra_config["defer_timeout"].
     DEFAULT_DEFER_TIMEOUT = 60.0
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -282,7 +282,9 @@ class MoRIIOConfig:
         # transfer_timeout -> Timeout for waiting_for_transfer_complete before
         #                     raising TransferError (sec).
         # defer_timeout    -> How long to wait for a finished_sending ACK
-        #                     before warning; blocks stay held until the ACK.
+        #                     before warning; blocks and transfer-id maps
+        #                     stay held until the ACK (lost ACKs are not
+        #                     force-freed).
 
         # Knobs for RDMA transfers, ignored if on xgmi backend
         # qp_per_transfer  -> Number of RDMA Queue Pairs per KV transfer.
@@ -370,7 +372,8 @@ class MoRIIOConstants:
     # Overridable via kv_connector_extra_config["transfer_timeout"].
     DEFAULT_TRANSFER_TIMEOUT = 30.0
     # Timeout (seconds) before a deferred send with no finished_sending
-    # ACK is logged as stale. Blocks stay allocated until the ACK.
+    # ACK is logged as stale. Blocks and transfer-id mappings stay
+    # allocated until the ACK; lost ACKs are not force-freed.
     # Overridable via kv_connector_extra_config["defer_timeout"].
     DEFAULT_DEFER_TIMEOUT = 60.0
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -425,10 +425,9 @@ class MoRIIOConnectorScheduler:
         # Reqs to send and their expiration time
         self._reqs_need_send: dict[ReqId, float] = {}
         # Deadlines for requests whose block freeing was deferred.
-        # Survives across scheduler steps. If the worker never reports
-        # finished_sending before the deadline, we inject them into
-        # connector_output.finished_sending so the scheduler frees the blocks to avoid
-        # hanging indefinitely waiting for a free notification that never comes.
+        # Survives across scheduler steps. Blocks stay allocated until a
+        # finished_sending ACK arrives; a timeout must not force-free them
+        # while a consumer READ may still reference the source blocks.
         # Value: (deadline, transfer_id) for unmapping after mutation.
         self._deferred_send_deadlines: dict[ReqId, tuple[float, TransferId | None]] = {}
         self._defer_timeout = float(
@@ -436,6 +435,8 @@ class MoRIIOConnectorScheduler:
                 "defer_timeout", MoRIIOConstants.DEFAULT_DEFER_TIMEOUT
             )
         )
+        # Expired deferred sends already logged; still waiting for an ACK.
+        self._stale_deferred_sends: set[ReqId] = set()
         # Buffer for early ACKs that arrive before request_finished.
         self._pending_sent_acks: dict[ReqId, float] = {}
         self.paths: dict[str, zmq.Socket] = {}
@@ -1003,11 +1004,11 @@ class MoRIIOConnectorScheduler:
         * An ACK that arrives BEFORE its request finished is parked in
           ``_pending_sent_acks`` and released on a later step once the
           request enters ``_deferred_send_deadlines``.
-        * A deferred send whose ACK never arrives is reaped after
-          ``_defer_timeout`` and surfaced, so leaked blocks are freed.
+        * A deferred send whose ACK never arrives is held past
+          ``_defer_timeout``. Force-freeing would return blocks to the
+          pool while a consumer READ may still reference them.
         * A parked ACK that never matches a deferral before its own
-          deadline is a stale duplicate (e.g. a real ACK landing after the
-          send was already reaped) and is dropped.
+          deadline is a stale duplicate and is dropped.
 
         Consumers never populate finished_sending (they report
         finished_recving), and they unmap in request_finished, so this is a
@@ -1033,19 +1034,25 @@ class MoRIIOConnectorScheduler:
             if req_id in self._deferred_send_deadlines:
                 safe.add(req_id)
 
-        # Reap deferred sends whose ACK never arrived (avoid leaking blocks).
+        # Hold expired deferred sends. Do not surface them as
+        # finished_sending: the scheduler would return the blocks to
+        # BlockPool while a still-pending READ may observe the reused
+        # physical blocks of a later request.
         expired = [
             req_id
             for req_id, (deadline, _) in self._deferred_send_deadlines.items()
             if now >= deadline
         ]
-        if expired:
-            safe.update(expired)
+        newly_stale = [
+            req_id for req_id in expired if req_id not in self._stale_deferred_sends
+        ]
+        if newly_stale:
+            self._stale_deferred_sends.update(newly_stale)
             logger.warning(
-                "Reaped %d deferred sends with no finished_sending "
-                "notification after %.0fs. This indicates lost async KV "
-                "completion notifications from the KV connector.",
-                len(expired),
+                "Holding %d deferred sends with no finished_sending "
+                "notification after %.0fs. Blocks stay allocated until "
+                "an ACK arrives.",
+                len(newly_stale),
                 self._defer_timeout,
             )
 
@@ -1055,6 +1062,7 @@ class MoRIIOConnectorScheduler:
             deferred_info = self._deferred_send_deadlines.pop(req_id, None)
             transfer_id = deferred_info[1] if deferred_info else None
             self._pending_sent_acks.pop(req_id, None)
+            self._stale_deferred_sends.discard(req_id)
             self.unmap_request_id(req_id, transfer_id=transfer_id)
 
         # Drop stale parked ACKs that never matched a deferral in time.
@@ -2068,11 +2076,30 @@ class MoRIIOConnectorWorker:
                     if _age > _xfer_timeout:
                         logger.error(
                             "RDMA read TIMED OUT for req %s after %.1fs "
-                            "(VLLM_MORIIO_TRANSFER_TIMEOUT_S=%d)",
+                            "(VLLM_MORIIO_TRANSFER_TIMEOUT_S=%d). "
+                            "Notifying prefill so producer blocks can be "
+                            "freed after this consumer has abandoned the "
+                            "read.",
                             req_id,
                             _age,
                             _xfer_timeout,
                         )
+                        host, port, xfer_id = self._recving_transfers_callback_addr[
+                            req_id
+                        ]
+                        try:
+                            self.moriio_wrapper.send_notify(
+                                xfer_id,
+                                host,
+                                port,
+                                message_type="release",
+                                message_fields={"consumer_tp_size": self.world_size},
+                            )
+                        except Exception:
+                            logger.exception(
+                                "Failed to send timeout notification for request %s",
+                                req_id,
+                            )
                         to_remove.append(req_id)
             for req_id in to_remove:
                 del self._recving_transfers[req_id]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -436,7 +436,11 @@ class MoRIIOConnectorScheduler:
             )
         )
         # Expired deferred sends already logged; still waiting for an ACK.
+        # Lost ACKs keep these entries (and transfer-id maps) until a real
+        # ACK arrives: dropping them would prevent a late free, and
+        # surfacing them as finished_sending would reuse the blocks.
         self._stale_deferred_sends: set[ReqId] = set()
+        self._stale_deferred_log_at: float = 0.0
         # Buffer for early ACKs that arrive before request_finished.
         self._pending_sent_acks: dict[ReqId, float] = {}
         self.paths: dict[str, zmq.Socket] = {}
@@ -1005,8 +1009,12 @@ class MoRIIOConnectorScheduler:
           ``_pending_sent_acks`` and released on a later step once the
           request enters ``_deferred_send_deadlines``.
         * A deferred send whose ACK never arrives is held past
-          ``_defer_timeout``. Force-freeing would return blocks to the
-          pool while a consumer READ may still reference them.
+          ``_defer_timeout``, including its transfer-id mapping. That is
+          the fail-safe: force-freeing would return blocks to the pool
+          while a consumer READ may still reference them, and dropping
+          the mapping would make a late ACK unable to free. KV-cache
+          pressure from held blocks is the backpressure if the ACK path
+          is lost; a consumer transfer timeout still sends ``release``.
         * A parked ACK that never matches a deferral before its own
           deadline is a stale duplicate and is dropped.
 
@@ -1048,13 +1056,17 @@ class MoRIIOConnectorScheduler:
         ]
         if newly_stale:
             self._stale_deferred_sends.update(newly_stale)
+        n_stale = len(self._stale_deferred_sends)
+        log_at = getattr(self, "_stale_deferred_log_at", 0.0)
+        if n_stale and (newly_stale or now >= log_at):
             logger.warning(
-                "Holding %d deferred sends with no finished_sending "
-                "notification after %.0fs. Blocks stay allocated until "
-                "an ACK arrives.",
-                len(newly_stale),
-                self._defer_timeout,
+                "Holding %d deferred sends with no finished_sending ACK "
+                "(%d transfer-id mappings). Blocks stay allocated until "
+                "an ACK arrives; lost ACKs are not force-freed.",
+                n_stale,
+                len(self.request_id_to_transfer_id),
             )
+            self._stale_deferred_log_at = now + self._defer_timeout
 
         # Finalize the requests we are surfacing: drop their deferral/park
         # bookkeeping and unmap their transfer ids.


### PR DESCRIPTION
## Summary

In MoRIIO READ (and other delay-free) producer mode, `update_connector_output` treated a missing `finished_sending` ACK as permission to free KV blocks after `defer_timeout`. The scheduler then returned those blocks to the pool while a consumer READ could still reference them, so a later request could reuse the same physical blocks. This change keeps the blocks allocated until a real ACK arrives. Timed-out consumer reads now send the same release notify as a failed transfer so the producer can still free after the consumer has abandoned the read.

A lost ACK path is fail-closed on purpose: deferred entries and transfer-id mappings stay until a real ACK, so a late ACK can still free and the scheduler never returns those blocks to the pool. KV-cache pressure from held blocks is the backpressure. The warning now re-logs the total held count so a silent ACK path stays visible.

## Changes
- `moriio_connector.py`: stop injecting expired deferred sends into `finished_sending`; hold mappings until ACK; re-log the total stale count. On consumer RDMA-read timeout, send a `release` notify to the producer.
- `moriio_common.py`: document that `defer_timeout` is a stale-ACK warning, not a force-free.
- `tests/v1/kv_connector/unit/test_moriio_deferred_send.py`: regression and completeness coverage, including a 1000-entry lost-ACK retention probe.

## Codepath coverage
- Prefill `request_finished` delay-free → scheduler `update_connector_output` timeout reap → `_free_blocks`: held until ACK.
- Worker ACK `finished_sending` path: still frees (unchanged, correct).
- Late ACK after timeout: still frees.
- Lost ACK / many deferred entries: all entries and transfer-id maps retained; a late ACK still frees only that request.
- Consumer scheduler: no-op (unchanged).
- Consumer `_pop_done_transfers` timeout: now notifies producer, matching the failed-transfer path.
- All HTTP/gRPC inference entry points that complete a MoRIIO producer request go through this scheduler method.

## Duplicate-work check
Searched open and merged PRs for MoRIIO deferred send / `finished_sending` / `moriio_connector`. Closest hits:
- https://github.com/vllm-project/vllm/pull/51301 makes `defer_timeout` configurable and raises the default; it still force-frees on timeout.
- https://github.com/vllm-project/vllm/pull/43541 is READ-mode release / `best_of_n` mapping, not timeout force-free.
- https://github.com/vllm-project/vllm/pull/45230 (closed, not merged) tolerated late completions; it did not stop timeout force-free.
- https://github.com/vllm-project/vllm/pull/46874 hardens transfer-id bookkeeping, not this sink.
- https://github.com/vllm-project/vllm/pull/55470 is NixlPush deferred WRITE after lease expiry, a different connector.

## Tests
- `test_expired_deferred_send_is_not_finished_sending`: timeout does not surface `finished_sending`.
- `test_lost_acks_retain_all_deferred_entries_and_mappings`: 1000 no-ACK entries keep deadlines and maps; one late ACK frees only that request.
- `test_ack_still_surfaces_deferred_send_for_free`: a real ACK still frees.
- `test_late_ack_after_timeout_still_frees`: ACK after timeout still frees.
- `test_consumer_is_noop_for_deferred_send_reap`: consumer scheduler does not reap.
- `test_timed_out_read_notifies_producer_to_release`: timed-out READ sends `release`.

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_moriio_deferred_send.py tests/v1/kv_connector/unit/test_moriio_tp_ack.py tests/v1/kv_connector/unit/test_moriio_unmap.py -v
```

6 new tests plus existing MoRIIO unit tests: 31 passed.

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)