### PR TITLE
[WIP][ReplaySSM] Support prefix caching for GDN speculative decode

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -195,8 +195,12 @@ class CacheConfig:
       caching is enabled.
     """
     replayssm_buffer_len: int = Field(default=16, gt=0)
-    """ReplaySSM history buffer length B for standard Mamba2 decode. Kimi-K3
-    speculative decoding does not use B. Default 16."""
+    """ReplaySSM history buffer length B: with use_replayssm, standard decode
+    caches recent SSM inputs in a size-B ring buffer and flushes the checkpoint
+    state to HBM every B steps. With use_replayssm_spec, B is the maximum history
+    the ring carries into a verify step, so the flush rule is
+    history + 1 + num_speculative_tokens > B. Kimi-K3 speculative decoding does
+    not use B. Default 16."""
     use_replayssm: bool = False
     """Use the ReplaySSM Mamba2 decode kernel: cache recent SSM inputs and skip
     the per-step full-state store, writing the checkpoint back only on flush.
@@ -204,6 +208,13 @@ class CacheConfig:
     mamba backend; standard (non-speculative) decode only. In align mode flushes
     are most efficient when mamba_block_size is a multiple of replayssm_buffer_len,
     but this is not required."""
+    use_replayssm_spec: bool = False
+    """Use the ReplaySSM Mamba2 speculative-decode kernel: verify a whole draft
+    window against one checkpoint plus a circular input ring, so rollback is a
+    cursor move instead of a per-draft state snapshot. Requires speculative
+    decoding, mamba_cache_mode 'none' and the Triton mamba backend; mutually
+    exclusive with use_replayssm. replayssm_buffer_len must be at least
+    1 + num_speculative_tokens."""
     use_kda_recoverssm: bool = field(default=False, init=False)
     """Whether Kimi-K3 KDA uses RecoverSSM speculative decode."""
 

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -212,8 +212,8 @@ class CacheConfig:
     """Use the ReplaySSM Mamba2 speculative-decode kernel: verify a whole draft
     window against one checkpoint plus a circular input ring, so rollback is a
     cursor move instead of a per-draft state snapshot. Requires speculative
-    decoding, mamba_cache_mode 'none' and the Triton mamba backend; mutually
-    exclusive with use_replayssm. replayssm_buffer_len must be at least
+    decoding, mamba_cache_mode 'none' or 'align', and the Triton mamba backend;
+    mutually exclusive with use_replayssm. replayssm_buffer_len must be at least
     1 + num_speculative_tokens."""
     use_kda_recoverssm: bool = field(default=False, init=False)
     """Whether Kimi-K3 KDA uses RecoverSSM speculative decode."""

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2758,7 +2758,8 @@ class VllmConfig:
             )
         if self.model_config is not None and not self.model_config.supports_replayssm:
             raise ValueError(
-                "--use-replayssm-spec is only supported for Nemotron-H models "
+                "--use-replayssm-spec is only supported for models that declare "
+                "ReplaySSM support via the SupportsReplaySSM interface "
                 f"(got architecture {self.model_config.architecture!r})"
             )
         # Inverted against --use-replayssm, which forbids speculative decoding.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2747,6 +2747,56 @@ class VllmConfig:
             )
         return self
 
+    @model_validator(mode="after")
+    def validate_mamba_cached_spec_kernel(self) -> "VllmConfig":
+        if not self.cache_config.use_replayssm_spec:
+            return self
+        if self.cache_config.use_replayssm:
+            raise ValueError(
+                "--use-replayssm-spec is mutually exclusive with --use-replayssm "
+                "(different page shapes and decode paths)"
+            )
+        if self.model_config is not None and not self.model_config.supports_replayssm:
+            raise ValueError(
+                "--use-replayssm-spec is only supported for Nemotron-H models "
+                f"(got architecture {self.model_config.architecture!r})"
+            )
+        # Inverted against --use-replayssm, which forbids speculative decoding.
+        if self.num_speculative_tokens <= 0:
+            raise ValueError(
+                "--use-replayssm-spec requires speculative decoding "
+                "(num_speculative_tokens > 0)"
+            )
+        if self.cache_config.mamba_cache_mode != "none":
+            raise ValueError(
+                "--use-replayssm-spec does not support prefix caching; "
+                "pass --mamba-cache-mode none"
+            )
+        if self.mamba_config.backend != MambaBackendEnum.TRITON:
+            raise ValueError("--use-replayssm-spec requires --mamba-backend triton")
+        if self.mamba_config.enable_stochastic_rounding:
+            raise ValueError(
+                "--use-replayssm-spec does not support Mamba cache stochastic rounding"
+            )
+        if (
+            self.kv_transfer_config is not None
+            and self.kv_transfer_config.is_kv_transfer_instance
+        ):
+            raise ValueError(
+                "--use-replayssm-spec is incompatible with KV connectors "
+                "(P/D disaggregation, KV cache offload)"
+            )
+        # The ring holds L = B + max_spec_len slots and flushes once the next
+        # window would not fit, so B below max_spec_len can never seat a window.
+        max_spec_len = 1 + self.num_speculative_tokens
+        if self.cache_config.replayssm_buffer_len < max_spec_len:
+            raise ValueError(
+                "--use-replayssm-spec requires --replayssm-buffer-len >= "
+                f"1 + num_speculative_tokens ({max_spec_len}); got "
+                f"{self.cache_config.replayssm_buffer_len}"
+            )
+        return self
+
 
 _current_vllm_config: VllmConfig | None = None
 _current_prefix: str | None = None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2768,10 +2768,9 @@ class VllmConfig:
                 "--use-replayssm-spec requires speculative decoding "
                 "(num_speculative_tokens > 0)"
             )
-        if self.cache_config.mamba_cache_mode != "none":
+        if self.cache_config.mamba_cache_mode not in ("none", "align"):
             raise ValueError(
-                "--use-replayssm-spec does not support prefix caching; "
-                "pass --mamba-cache-mode none"
+                "--use-replayssm-spec supports only none and align Mamba cache modes"
             )
         if self.mamba_config.backend != MambaBackendEnum.TRITON:
             raise ValueError("--use-replayssm-spec requires --mamba-backend triton")

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -723,6 +723,7 @@ class EngineArgs:
     mamba_cache_mode: MambaCacheMode = CacheConfig.mamba_cache_mode
     replayssm_buffer_len: int = CacheConfig.replayssm_buffer_len
     use_replayssm: bool = CacheConfig.use_replayssm
+    use_replayssm_spec: bool = CacheConfig.use_replayssm_spec
 
     mamba_backend: MambaBackendEnum = MambaBackendEnum.TRITON
     mamba_ssu_algorithm: MambaSSUAlgorithm | None = None
@@ -1275,6 +1276,9 @@ class EngineArgs:
             "--replayssm-buffer-len", **cache_kwargs["replayssm_buffer_len"]
         )
         cache_group.add_argument("--use-replayssm", **cache_kwargs["use_replayssm"])
+        cache_group.add_argument(
+            "--use-replayssm-spec", **cache_kwargs["use_replayssm_spec"]
+        )
         cache_group.add_argument(
             "--kv-offloading-size", **cache_kwargs["kv_offloading_size"]
         )
@@ -2043,6 +2047,7 @@ class EngineArgs:
             mamba_cache_mode=self.mamba_cache_mode,
             replayssm_buffer_len=self.replayssm_buffer_len,
             use_replayssm=self.use_replayssm,
+            use_replayssm_spec=self.use_replayssm_spec,
             kv_offloading_size=self.kv_offloading_size,
             kv_offloading_backend=self.kv_offloading_backend,
         )

--- a/vllm/model_executor/layers/mamba/abstract.py
+++ b/vllm/model_executor/layers/mamba/abstract.py
@@ -71,11 +71,14 @@ class MambaBase(AttentionLayerBase):
             page_size_padded=page_size_padded,
             mamba_type=self.mamba_type,
             mamba_cache_mode=vllm_config.cache_config.mamba_cache_mode,
-            # RecoverSSM verifies the whole window off one checkpoint, so it
-            # never writes the baseline's per-draft-token state slots.
+            # ReplaySSM/RecoverSSM verifies the whole window off one checkpoint,
+            # so it never writes the baseline's per-draft-token state slots.
             num_speculative_blocks=(
                 0
-                if vllm_config.cache_config.use_kda_recoverssm
+                if (
+                    vllm_config.cache_config.use_kda_recoverssm
+                    or vllm_config.cache_config.use_replayssm_spec
+                )
                 else vllm_config.num_speculative_tokens
             ),
         )

--- a/vllm/model_executor/layers/mamba/gdn/base.py
+++ b/vllm/model_executor/layers/mamba/gdn/base.py
@@ -51,8 +51,13 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         return MambaAttentionBackendEnum.GDN_ATTN
 
     def get_state_dtype(self) -> tuple[torch.dtype, ...]:
-        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+        base_dtype = MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             self.model_config.dtype,
             self.cache_config.mamba_cache_dtype,
             self.cache_config.mamba_ssm_cache_dtype,
         )
+        if self.cache_config.use_replayssm_spec:
+            return MambaStateDtypeCalculator.append_gated_delta_net_replayssm_spec_ring(
+                base_dtype, self.model_config.dtype
+            )
+        return base_dtype

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1867,7 +1867,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     ) -> bool:
         state_indices = attn_metadata.spec_state_indices_tensor
         return (
-            attn_metadata.spec_sequence_masks is not None
+            # ReplaySSM owns the complete post-conv recurrent-attention path.
+            # The baseline fused CUDA MTP kernel updates the checkpoint state
+            # directly and assumes the baseline state-index layout, while the
+            # ReplaySSM path keeps that checkpoint behind a circular d/k/g
+            # history.  Routing ReplaySSM metadata through the fused shortcut
+            # both bypasses the ReplaySSM kernel and can access invalid state
+            # indices at serving batch sizes.
+            not self.use_replayssm_spec
+            and attn_metadata.spec_sequence_masks is not None
             and attn_metadata.num_decodes == 0
             and attn_metadata.num_spec_decodes > 0
             and self.kv_cache[1].dtype in FUSED_GDN_STATE_DTYPES

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -525,7 +525,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
     def _fused_gdn_decode_unsupported_reason(
         self, vllm_config: VllmConfig
     ) -> str | None:
-        conv_state_dtype, recurrent_state_dtype = self.get_state_dtype()
+        state_dtypes = self.get_state_dtype()
+        conv_state_dtype, recurrent_state_dtype = state_dtypes[:2]
         if (
             self.gqa_interleaved_layout
             or self.head_k_dim != 128

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -348,10 +348,8 @@ class ChunkGatedDeltaRule(CustomOp):
 
 @PluggableLayer.register("qwen_gated_delta_net_attention")
 class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
-    def get_state_shape(
-        self,
-    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
-        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+    def get_state_shape(self) -> tuple[tuple[int, ...], ...]:
+        base_shape = MambaStateShapeCalculator.gated_delta_net_state_shape(
             self.tp_size,
             self.num_k_heads,
             self.num_v_heads,
@@ -360,6 +358,18 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             self.conv_kernel_size,
             self.num_spec,
         )
+        if self.cache_config.use_replayssm_spec:
+            return MambaStateShapeCalculator.append_gated_delta_net_replayssm_spec_ring(
+                base_shape,
+                self.num_k_heads,
+                self.num_v_heads,
+                self.head_k_dim,
+                self.head_v_dim,
+                self.tp_size,
+                self.cache_config.replayssm_buffer_len,
+                self.num_spec,
+            )
+        return base_shape
 
     def __init__(
         self,
@@ -379,6 +389,9 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.key_dim = self.head_k_dim * self.num_k_heads
         self.value_dim = self.head_v_dim * self.num_v_heads
         self.gqa_interleaved_layout = gqa_interleaved_layout
+        self.use_replayssm_spec = self.cache_config.use_replayssm_spec
+        self.replayssm_buffer_len = self.cache_config.replayssm_buffer_len
+        self.max_spec_len = 1 + self.num_spec
         if current_platform.is_xpu():
             self._forward_method = self.forward_xpu
         elif current_platform.is_cpu():
@@ -1082,7 +1095,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         dtype = qkv_or_qkvz.dtype
         num_k_heads = self.num_k_heads // self.tp_size
         num_v_heads = self.num_v_heads // self.tp_size
-        _, state_dtype = self.get_state_dtype()
+        # get_state_dtype() is (conv, ssm[, d, k, g]); only the ssm dtype is needed.
+        state_dtype = self.get_state_dtype()[1]
 
         # All kernels use BT = chunk_size, so a single pass with T = chunk_size
         # is sufficient to populate every autotuner cache. Mirror the real
@@ -1342,7 +1356,11 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 ],
                 num_accepted_tokens=num_accepted_tokens,
                 query_start_loc=spec_query_start_loc,
-                max_query_len=spec_state_indices_tensor.size(-1),
+                max_query_len=(
+                    self.max_spec_len
+                    if self.use_replayssm_spec
+                    else spec_state_indices_tensor.size(-1)
+                ),
                 validate_data=False,
             )
 
@@ -1379,7 +1397,10 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         else:
             mixed_qkv_non_spec = None
 
-        query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
+        if spec_sequence_masks is not None and self.use_replayssm_spec:
+            query_spec, key_spec, value_spec = None, None, None
+        else:
+            query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
 
         # Split mixed non-spec-decode+prefill to process independently
         split_non_spec = (
@@ -1442,7 +1463,49 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # 2. Recurrent attention
 
         # 2.1: Process the multi-query part
-        if spec_sequence_masks is not None:
+        if spec_sequence_masks is not None and self.use_replayssm_spec:
+            from vllm.third_party.flash_linear_attention.ops.gdn_replayssm_spec_decode import (  # noqa: E501
+                gdn_replayssm_spec_decode,
+            )
+
+            assert mixed_qkv_spec is not None
+            num_spec_decodes = attn_metadata.num_spec_decodes
+            d_cache, k_cache, g_cache = self_kv_cache[2:5]
+            cs_out = torch.empty(
+                mixed_qkv_spec.shape[0],
+                self.num_v_heads // self.tp_size,
+                self.head_v_dim,
+                dtype=mixed_qkv_spec.dtype,
+                device=mixed_qkv_spec.device,
+            )
+            gdn_replayssm_spec_decode(
+                mixed_qkv=mixed_qkv_spec,
+                a=a,
+                b=b,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                checkpoint_state=ssm_state,
+                d_cache=d_cache,
+                k_cache=k_cache,
+                g_cache=g_cache,
+                out=cs_out,
+                query_start_loc=spec_query_start_loc[  # type: ignore[index]
+                    : num_spec_decodes + 1
+                ],
+                ssm_state_indices=spec_state_indices_tensor[  # type: ignore[index]
+                    :num_spec_decodes, 0
+                ],
+                write_pos=attn_metadata.spec_write_pos_d,
+                cache_base=attn_metadata.spec_cache_base_d,
+                is_flush=attn_metadata.spec_is_flush_d,
+                max_cache_len=self.replayssm_buffer_len + self.max_spec_len,
+                max_spec_len=self.max_spec_len,
+                scale=self.head_k_dim**-0.5,
+                use_qk_l2norm_in_kernel=True,
+            )
+            core_attn_out_spec = cs_out.unsqueeze(0)
+            last_recurrent_state = None
+        elif spec_sequence_masks is not None:
             core_attn_out_spec, last_recurrent_state = (
                 fused_sigmoid_gating_delta_rule_update(
                     A_log=self.A_log,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1470,6 +1470,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
 
             assert mixed_qkv_spec is not None
+            assert a_spec is not None
+            assert b_spec is not None
             num_spec_decodes = attn_metadata.num_spec_decodes
             d_cache, k_cache, g_cache = self_kv_cache[2:5]
             cs_out = torch.empty(
@@ -1481,8 +1483,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
             gdn_replayssm_spec_decode(
                 mixed_qkv=mixed_qkv_spec,
-                a=a,
-                b=b,
+                a=a_spec,
+                b=b_spec,
                 A_log=self.A_log,
                 dt_bias=self.dt_bias,
                 checkpoint_state=ssm_state,
@@ -1503,6 +1505,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 max_spec_len=self.max_spec_len,
                 scale=self.head_k_dim**-0.5,
                 use_qk_l2norm_in_kernel=True,
+                launch_mode="unified",
             )
             core_attn_out_spec = cs_out.unsqueeze(0)
             last_recurrent_state = None
@@ -1616,14 +1619,15 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
 
         # 3. Merge core attention output
         if spec_sequence_masks is not None and core_attn_out_non_spec is not None:
-            merged_out = torch.empty(
-                (1, num_actual_tokens, *core_attn_out_spec.shape[2:]),
-                dtype=core_attn_out_non_spec.dtype,
-                device=core_attn_out_non_spec.device,
+            # Scatter directly into the caller-owned output.  The previous path
+            # allocated a full-size merged tensor, scattered both partitions
+            # into it, then copied the whole tensor into core_attn_out.
+            core_attn_out[:num_actual_tokens].index_copy_(
+                0, spec_token_indx, core_attn_out_spec.squeeze(0)
             )
-            merged_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
-            merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
-            core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
+            core_attn_out[:num_actual_tokens].index_copy_(
+                0, non_spec_token_indx, core_attn_out_non_spec.squeeze(0)
+            )
         elif spec_sequence_masks is not None:
             core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
         else:
@@ -1830,6 +1834,125 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             norm_eps=self.layer_norm_epsilon,
         )
 
+    def _can_use_replayssm_spec_fused_norm(
+        self, attn_metadata: GDNAttentionMetadata
+    ) -> bool:
+        """Return whether the decode-only ReplaySSM fast path is applicable.
+
+        ReplaySSM cannot use ``fused_gdn_decode_post_conv_mtp`` because that
+        kernel updates the checkpoint state directly instead of the ReplaySSM
+        ring.  It can still bypass the generic mixed prefill/decode dispatcher,
+        write directly into the caller-owned output buffer, and normalize the
+        result in place.
+        """
+        return (
+            self.use_replayssm_spec
+            and attn_metadata.spec_sequence_masks is not None
+            and attn_metadata.num_prefills == 0
+            and attn_metadata.num_decodes == 0
+            and attn_metadata.num_spec_decodes > 0
+            and attn_metadata.spec_state_indices_tensor is not None
+            and attn_metadata.spec_query_start_loc is not None
+            and attn_metadata.num_accepted_tokens is not None
+            and attn_metadata.spec_write_pos_d is not None
+            and attn_metadata.spec_cache_base_d is not None
+            and attn_metadata.spec_is_flush_d is not None
+        )
+
+    def _forward_core_decode_replayssm_fused_norm(
+        self,
+        mixed_qkv: torch.Tensor,
+        b: torch.Tensor,
+        a: torch.Tensor,
+        output_gate: torch.Tensor,
+        core_attn_out: torch.Tensor,
+        attn_metadata: GDNAttentionMetadata,
+    ) -> None:
+        """Decode-only ReplaySSM path without generic-dispatch temporaries.
+
+        The old path allocated a second recurrent-output tensor for every GDN
+        layer and copied it back into ``core_attn_out`` before launching RMS
+        normalization.  At 30 GDN layers this introduced allocator, copy and
+        Python launch overhead on every decode step.  The ReplaySSM kernel
+        already accepts a preallocated output, so write into the final buffer
+        directly and normalize it in place.
+        """
+        from vllm.third_party.flash_linear_attention.ops.gdn_replayssm_spec_decode import (  # noqa: E501
+            gdn_replayssm_spec_decode,
+        )
+
+        state_indices = attn_metadata.spec_state_indices_tensor
+        query_start_loc = attn_metadata.spec_query_start_loc
+        num_accepted_tokens = attn_metadata.num_accepted_tokens
+        write_pos = attn_metadata.spec_write_pos_d
+        cache_base = attn_metadata.spec_cache_base_d
+        is_flush = attn_metadata.spec_is_flush_d
+        assert state_indices is not None
+        assert query_start_loc is not None
+        assert num_accepted_tokens is not None
+        assert write_pos is not None
+        assert cache_base is not None
+        assert is_flush is not None
+
+        num_requests = attn_metadata.num_spec_decodes
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        # Compact these split views before the recurrent kernel.  Although the
+        # kernel supports arbitrary row strides, the packed source row also
+        # contains the other gate; reading it strided costs substantially more
+        # than the two compact copies at serving batch sizes.
+        b = b[:num_actual_tokens].contiguous()
+        a = a[:num_actual_tokens].contiguous()
+        conv_state = (
+            self.kv_cache[0]
+            if is_conv_state_dim_first()
+            else self.kv_cache[0].transpose(-1, -2)
+        )
+        conv_weights = self.conv1d.weight.view(
+            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
+        )
+        mixed_qkv = causal_conv1d_update(
+            mixed_qkv[:num_actual_tokens],
+            conv_state,
+            conv_weights,
+            self.conv1d.bias,
+            self.activation,
+            conv_state_indices=state_indices[:num_requests, 0],
+            num_accepted_tokens=num_accepted_tokens[:num_requests],
+            query_start_loc=query_start_loc[: num_requests + 1],
+            max_query_len=self.max_spec_len,
+            validate_data=False,
+        )
+
+        d_cache, k_cache, g_cache = self.kv_cache[2:5]
+        out = core_attn_out[:num_actual_tokens]
+        gdn_replayssm_spec_decode(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=self.A_log,
+            dt_bias=self.dt_bias,
+            checkpoint_state=self.kv_cache[1],
+            d_cache=d_cache,
+            k_cache=k_cache,
+            g_cache=g_cache,
+            out=out,
+            query_start_loc=query_start_loc[: num_requests + 1],
+            ssm_state_indices=state_indices[:num_requests, 0],
+            write_pos=write_pos,
+            cache_base=cache_base,
+            is_flush=is_flush,
+            max_cache_len=self.replayssm_buffer_len + self.max_spec_len,
+            max_spec_len=self.max_spec_len,
+            scale=self.head_k_dim**-0.5,
+            use_qk_l2norm_in_kernel=True,
+            launch_mode="unified",
+        )
+        self._rms_norm_gated_cuda(
+            out,
+            output_gate[:num_actual_tokens],
+            out,
+        )
+
     def _forward_core_fused_norm_packed(
         self,
         mixed_qkvz: torch.Tensor,
@@ -1939,6 +2062,16 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             return
 
         assert isinstance(attn_metadata, GDNAttentionMetadata)
+        if self._can_use_replayssm_spec_fused_norm(attn_metadata):
+            self._forward_core_decode_replayssm_fused_norm(
+                mixed_qkv=mixed_qkv,
+                b=b,
+                a=a,
+                output_gate=output_gate,
+                core_attn_out=core_attn_out,
+                attn_metadata=attn_metadata,
+            )
+            return
         if (
             self._can_use_fused_gdn_mtp_decode(attn_metadata)
             and attn_metadata.num_prefills == 0
@@ -1952,10 +2085,16 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 attn_metadata=attn_metadata,
             )
             return
+        # A mixed speculative/non-spec batch immediately packs both partitions
+        # with index_select inside _forward_core.  Compacting the full gate
+        # views here first only adds two redundant device copies per GDN layer.
+        mixed_spec_batch = attn_metadata.spec_sequence_masks is not None and (
+            attn_metadata.num_prefills > 0 or attn_metadata.num_decodes > 0
+        )
         self._forward_core(
             mixed_qkv=mixed_qkv,
-            b=b.contiguous(),
-            a=a.contiguous(),
+            b=b if mixed_spec_batch else b.contiguous(),
+            a=a if mixed_spec_batch else a.contiguous(),
             core_attn_out=core_attn_out,
         )
         num_actual_tokens = attn_metadata.num_actual_tokens

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -35,6 +35,9 @@ from vllm.model_executor.layers.mamba.ops.layernorm_gated import rms_norm_gated
 from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_output_only import (  # noqa: E501
     selective_state_update_replayssm_output_only,
 )
+from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_spec import (
+    selective_state_update_replayssm_spec,
+)
 from vllm.model_executor.layers.mamba.ops.ssd_combined import (
     mamba_chunk_scan_combined_varlen,
 )
@@ -505,22 +508,36 @@ class MambaMixer2(MambaBase, PluggableLayer):
         self.use_replayssm = (
             cache_config.use_replayssm if cache_config is not None else False
         )
+        self.use_replayssm_spec = (
+            cache_config.use_replayssm_spec if cache_config is not None else False
+        )
         self.replayssm_buffer_len = (
             cache_config.replayssm_buffer_len
-            if cache_config is not None and cache_config.use_replayssm
+            if cache_config is not None
+            and (cache_config.use_replayssm or cache_config.use_replayssm_spec)
             else None
         )
         self.mamba_config = vllm_config.mamba_config
-        if self.use_replayssm and self.num_heads % self.tp_size != 0:
+        if (
+            self.use_replayssm or self.use_replayssm_spec
+        ) and self.num_heads % self.tp_size != 0:
             raise ValueError(
-                "--use-replayssm requires tensor-parallel heads to divide evenly"
+                "ReplaySSM requires tensor-parallel heads to divide evenly"
             )
         # The tuple is (conv_state, ssm_state); with the cached (ReplaySSM) decode
-        # kernel enabled it is (conv_state, ssm_state, x_cache, dt_cache, B_cache).
-        _n_state = 5 if self.use_replayssm else 2
+        # kernel enabled it is (conv_state, ssm_state, x_cache, dt_cache, B_cache),
+        # and with the cached-spec kernel (conv_state, ssm_state, post_conv_cache,
+        # dt_cache).
+        if self.use_replayssm_spec:
+            _n_state = 4
+        elif self.use_replayssm:
+            _n_state = 5
+        else:
+            _n_state = 2
         self.kv_cache = tuple(torch.tensor([]) for _ in range(_n_state))
 
         self.num_spec = vllm_config.num_speculative_tokens
+        self.max_spec_len = 1 + self.num_spec
         if self.num_spec > 0:
             self.register_buffer(
                 "_decode_state_offsets",
@@ -722,10 +739,12 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 else self.kv_cache[0].transpose(-1, -2)
             )
             ssm_state = self.kv_cache[1]
-            if self.use_replayssm:
+            spec_post_conv_cache = spec_dt_cache = None
+            x_cache = dt_cache = B_cache = None
+            if self.use_replayssm_spec:
+                spec_post_conv_cache, spec_dt_cache = self.kv_cache[2:]
+            elif self.use_replayssm:
                 x_cache, dt_cache, B_cache = self.kv_cache[2:]
-            else:
-                x_cache = dt_cache = B_cache = None
             has_initial_states_p = attn_metadata.has_initial_states_p
             prep_initial_states = attn_metadata.prep_initial_states
             chunk_size = attn_metadata.chunk_size
@@ -1027,8 +1046,17 @@ class MambaMixer2(MambaBase, PluggableLayer):
                 initial_state_idx=block_idx_last_computed_token_d,
                 num_accepted_tokens=num_accepted_tokens,
                 query_start_loc=query_start_loc_d,
-                max_query_len=state_indices_tensor_d.size(-1),
+                max_query_len=(
+                    self.max_spec_len
+                    if self.use_replayssm_spec
+                    else state_indices_tensor_d.size(-1)
+                ),
             )
+
+            # The spec kernel consumes the full channel-last post-conv output and
+            # the raw dt; capture both before the split reshapes them.
+            conv_out_spec = hidden_states_B_C_d
+            dt_d_raw = dt_d
 
             hidden_states_d, B_d, C_d = self.split_hidden_states_B_C_fn(
                 hidden_states_B_C_d
@@ -1058,7 +1086,37 @@ class MambaMixer2(MambaBase, PluggableLayer):
             preallocated_ssm_out_d = preallocated_ssm_out_d.view(
                 num_decode_tokens, -1, self.head_dim
             )
-            if self.use_replayssm:
+            if self.use_replayssm_spec:
+                assert self.replayssm_buffer_len is not None
+                assert spec_post_conv_cache is not None
+                assert spec_dt_cache is not None
+                assert query_start_loc_d is not None
+                assert attn_metadata.spec_write_pos_d is not None
+                selective_state_update_replayssm_spec(
+                    ssm_state,
+                    spec_post_conv_cache,
+                    spec_dt_cache,
+                    conv_out_spec,
+                    dt_d_raw,
+                    A_d,
+                    write_pos=attn_metadata.spec_write_pos_d,
+                    post_conv_state_pos=attn_metadata.spec_post_origin_d,
+                    is_flush=attn_metadata.spec_is_flush_d,
+                    query_start_loc=query_start_loc_d,
+                    state_batch_indices=state_indices_tensor_d_input[:, 0],
+                    max_cache_len=self.replayssm_buffer_len + self.max_spec_len,
+                    max_spec_len=self.max_spec_len,
+                    d_inner=self.intermediate_size // self.tp_size,
+                    ngroups=n_groups,
+                    dstate=self.ssm_state_size,
+                    D=D_d,
+                    z=None,
+                    dt_bias=dt_bias,
+                    dt_softplus=True,
+                    out=preallocated_ssm_out_d,
+                    bc_pre=attn_metadata.spec_bc_pre_scratch,
+                )
+            elif self.use_replayssm:
                 assert self.replayssm_buffer_len is not None
                 selective_state_update_replayssm_output_only(
                     ssm_state,
@@ -1116,6 +1174,10 @@ class MambaMixer2(MambaBase, PluggableLayer):
             self.cache_config.mamba_cache_dtype,
             self.cache_config.mamba_ssm_cache_dtype,
         )
+        if self.use_replayssm_spec:
+            return MambaStateDtypeCalculator.append_replayssm_spec_ring(
+                base_dtype, self.model_config.dtype
+            )
         if self.use_replayssm:
             return MambaStateDtypeCalculator.append_replayssm_ring(
                 base_dtype, self.model_config.dtype
@@ -1134,6 +1196,16 @@ class MambaMixer2(MambaBase, PluggableLayer):
             conv_kernel=self.conv_kernel_size,
             num_spec=self.num_spec,
         )
+        if self.use_replayssm_spec:
+            assert self.replayssm_buffer_len is not None
+            return MambaStateShapeCalculator.append_replayssm_spec_ring(
+                base_shape,
+                self.intermediate_size,
+                self.n_groups,
+                tp_world_size,
+                self.replayssm_buffer_len,
+                self.num_spec,
+            )
         if self.use_replayssm:
             assert self.replayssm_buffer_len is not None
             return MambaStateShapeCalculator.append_replayssm_ring(

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -93,6 +93,19 @@ class MambaStateDtypeCalculator:
         return (*base_dtypes, activation_dtype, torch.float32, activation_dtype)
 
     @classmethod
+    def append_replayssm_spec_ring(
+        cls,
+        base_dtypes: tuple[torch.dtype, ...],
+        model_dtype: ModelDType | torch.dtype,
+    ) -> tuple[torch.dtype, ...]:
+        """Append the ReplaySSM spec ring dtypes to a base ``(conv, ssm)`` tuple:
+        ``(post_conv_cache, dt_cache)`` = ``(activation, fp32)``. ``dt`` drives
+        the cumulative decay replay and stays fp32 regardless of state dtype.
+        """
+        activation_dtype = get_kv_cache_torch_dtype("auto", model_dtype)
+        return (*base_dtypes, activation_dtype, torch.float32)
+
+    @classmethod
     def _mamba_state_dtype(
         cls,
         model_dtype: ModelDType | torch.dtype,
@@ -227,6 +240,43 @@ class MambaStateShapeCalculator:
             (local_nheads, replayssm_buffer_len, head_dim),
             (local_nheads, replayssm_buffer_len),
             (local_ngroups, replayssm_buffer_len, state_size),
+        )
+
+    @classmethod
+    def replayssm_spec_ring_len(cls, replayssm_buffer_len: int, num_spec: int) -> int:
+        """Physical ring length: next_pow2 of the L = B + 1 + num_spec window,
+        so wraparound indexing is a bit-mask instead of a modulo.
+        """
+        return 1 << (replayssm_buffer_len + num_spec).bit_length()
+
+    @classmethod
+    def append_replayssm_spec_ring(
+        cls,
+        base_shapes: tuple[tuple[int, ...], ...],
+        intermediate_size: int,
+        n_groups: int,
+        tp_world_size: int,
+        replayssm_buffer_len: int,
+        num_spec: int,
+    ) -> tuple[tuple[int, ...], ...]:
+        """Append the ReplaySSM spec ring shapes (post_conv_cache, dt_cache) to a
+        base ``(conv, ssm)`` tuple. ``post_conv_cache`` holds x|B only; C is read
+        fresh from conv_out, so its width excludes one n_groups * state_size
+        block of the conv width. ``base_shapes`` must already carry the spec conv
+        window (``mamba2_state_shape(..., num_spec=num_spec)``).
+        """
+        local_nheads, _head_dim, state_size = base_shapes[1]
+        n_groups_ext = n_groups + cls.extra_groups_for_head_shards(
+            n_groups, tp_world_size
+        )
+        conv_dim_local = divide(
+            intermediate_size + n_groups_ext * state_size, tp_world_size
+        )
+        ring_len = cls.replayssm_spec_ring_len(replayssm_buffer_len, num_spec)
+        return (
+            *base_shapes,
+            (ring_len, conv_dim_local),
+            (local_nheads, ring_len),
         )
 
     @classmethod

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -106,6 +106,23 @@ class MambaStateDtypeCalculator:
         return (*base_dtypes, activation_dtype, torch.float32)
 
     @classmethod
+    def append_gated_delta_net_replayssm_spec_ring(
+        cls,
+        base_dtypes: tuple[torch.dtype, ...],
+        model_dtype: ModelDType | torch.dtype,
+    ) -> tuple[torch.dtype, ...]:
+        """Append the GDN ReplaySSM spec ring dtypes to a base ``(conv, ssm)``
+        tuple: ``(d_cache, k_cache, g_cache)``. The d/k caches use fp16 for bf16
+        activations, which reconstructs the state more accurately at the same
+        width; ``g`` drives the cumulative decay replay and stays fp32.
+        """
+        activation_dtype = get_kv_cache_torch_dtype("auto", model_dtype)
+        ring_dtype = (
+            torch.float16 if activation_dtype == torch.bfloat16 else activation_dtype
+        )
+        return (*base_dtypes, ring_dtype, ring_dtype, torch.float32)
+
+    @classmethod
     def _mamba_state_dtype(
         cls,
         model_dtype: ModelDType | torch.dtype,
@@ -326,6 +343,32 @@ class MambaStateShapeCalculator:
             head_k_dim,
         )
         return conv_state_shape, temporal_state_shape
+
+    @classmethod
+    def append_gated_delta_net_replayssm_spec_ring(
+        cls,
+        base_shapes: tuple[tuple[int, ...], ...],
+        num_k_heads: int,
+        num_v_heads: int,
+        head_k_dim: int,
+        head_v_dim: int,
+        tp_world_size: int,
+        replayssm_buffer_len: int,
+        num_spec: int,
+    ) -> tuple[tuple[int, ...], ...]:
+        """Append the GDN ReplaySSM spec ring shapes (d_cache, k_cache, g_cache)
+        to a base ``(conv, ssm)`` tuple. ``base_shapes`` must already carry the
+        spec conv window (``gated_delta_net_state_shape(..., num_spec)``).
+        """
+        ring_len = cls.replayssm_spec_ring_len(replayssm_buffer_len, num_spec)
+        local_v_heads = divide(num_v_heads, tp_world_size)
+        local_k_heads = divide(num_k_heads, tp_world_size)
+        return (
+            *base_shapes,
+            (local_v_heads, ring_len, head_v_dim),
+            (local_k_heads, ring_len, head_k_dim),
+            (local_v_heads, ring_len),
+        )
 
     @classmethod
     def kda_state_shape(

--- a/vllm/model_executor/layers/mamba/ops/replayssm_config.py
+++ b/vllm/model_executor/layers/mamba/ops/replayssm_config.py
@@ -66,12 +66,51 @@ def _mamba2_spec_flush(dstate, base_block, is_blackwell):
     return 32, 1, _dstate_tile(dstate, 128), 2
 
 
+# GDN spec configs are (block_v, num_warps, block_s, num_stages), swept on
+# B300 at the Qwen3.5 geometry. The head_k_dim gate matters: these tuples
+# regress badly at K=64, which the default covers instead.
+_GDN_SPEC_VERIFY_BLACKWELL = {
+    2: (128, 2, 4, 3),
+    4: (128, 2, 4, 3),
+    6: (128, 2, 8, 4),
+    8: (128, 2, 8, 4),
+}
+_GDN_SPEC_FLUSH_BLACKWELL = {
+    2: (64, 1, 8, 4),
+    4: (64, 1, 8, 4),
+    6: (64, 1, 8, 2),
+    8: (64, 1, 8, 2),
+}
+
+
+def _gdn_spec_default(max_spec_len):
+    return 64, 1, (4 if max_spec_len >= 6 else 2), 2
+
+
+def _gdn_spec_verify(max_spec_len, head_k_dim, is_blackwell):
+    if is_blackwell and head_k_dim == 128:
+        return _GDN_SPEC_VERIFY_BLACKWELL.get(
+            max_spec_len, _gdn_spec_default(max_spec_len)
+        )
+    return _gdn_spec_default(max_spec_len)
+
+
+def _gdn_spec_flush(max_spec_len, head_k_dim, is_blackwell):
+    if is_blackwell and head_k_dim == 128:
+        return _GDN_SPEC_FLUSH_BLACKWELL.get(
+            max_spec_len, _gdn_spec_default(max_spec_len)
+        )
+    return _gdn_spec_default(max_spec_len)
+
+
 def get_replayssm_config(kernel: str, **shape) -> tuple:
     """Return the launch config for ``kernel`` (override > tuned default).
 
-    kernel: "mamba2_output_only", "mamba2_spec_verify" or "mamba2_spec_flush".
-    ``shape`` carries the keying dims (dstate; ``L`` for the buffer length,
-    default 16; ``base_block`` for spec); hardware is auto-detected.
+    kernel: "mamba2_output_only", "mamba2_spec_verify", "mamba2_spec_flush",
+    "gdn_spec_verify" or "gdn_spec_flush". ``shape`` carries the keying dims
+    (dstate; ``L`` for the buffer length, default 16; ``base_block`` for Mamba2
+    spec; ``max_spec_len`` and ``head_k_dim`` for GDN spec); hardware is
+    auto-detected.
     """
     if kernel in _overrides:
         return _overrides[kernel]
@@ -82,4 +121,8 @@ def get_replayssm_config(kernel: str, **shape) -> tuple:
         return _mamba2_spec_verify(shape["dstate"], shape["base_block"], bw)
     if kernel == "mamba2_spec_flush":
         return _mamba2_spec_flush(shape["dstate"], shape["base_block"], bw)
+    if kernel == "gdn_spec_verify":
+        return _gdn_spec_verify(shape["max_spec_len"], shape["head_k_dim"], bw)
+    if kernel == "gdn_spec_flush":
+        return _gdn_spec_flush(shape["max_spec_len"], shape["head_k_dim"], bw)
     raise ValueError(f"unknown ReplaySSM kernel config key: {kernel}")

--- a/vllm/model_executor/layers/mamba/ops/replayssm_config.py
+++ b/vllm/model_executor/layers/mamba/ops/replayssm_config.py
@@ -52,15 +52,34 @@ def _mamba2_output_only(dstate, L, is_blackwell):
     return 16, 1, _dstate_tile(dstate, 64), _dstate_tile(dstate, 128), 2
 
 
+def _mamba2_spec_verify(dstate, base_block, is_blackwell):
+    # (block_size_m, num_warps, dstate_tile, num_stages)
+    bsm = 64 if (is_blackwell or base_block <= 16) else 32
+    return bsm, 2, _dstate_tile(dstate, 64), 2
+
+
+def _mamba2_spec_flush(dstate, base_block, is_blackwell):
+    if base_block <= 16:
+        return 32, 2, _dstate_tile(dstate, 64), 2
+    if is_blackwell:
+        return 64, 2, _dstate_tile(dstate, 128), 2
+    return 32, 1, _dstate_tile(dstate, 128), 2
+
+
 def get_replayssm_config(kernel: str, **shape) -> tuple:
     """Return the launch config for ``kernel`` (override > tuned default).
 
-    kernel: "mamba2_output_only". ``shape`` carries the keying dims (dstate;
-    ``L`` for the buffer length, default 16); hardware is auto-detected.
+    kernel: "mamba2_output_only", "mamba2_spec_verify" or "mamba2_spec_flush".
+    ``shape`` carries the keying dims (dstate; ``L`` for the buffer length,
+    default 16; ``base_block`` for spec); hardware is auto-detected.
     """
     if kernel in _overrides:
         return _overrides[kernel]
     bw = _is_blackwell()
     if kernel == "mamba2_output_only":
         return _mamba2_output_only(shape["dstate"], shape.get("L", 16), bw)
+    if kernel == "mamba2_spec_verify":
+        return _mamba2_spec_verify(shape["dstate"], shape["base_block"], bw)
+    if kernel == "mamba2_spec_flush":
+        return _mamba2_spec_flush(shape["dstate"], shape["base_block"], bw)
     raise ValueError(f"unknown ReplaySSM kernel config key: {kernel}")

--- a/vllm/model_executor/layers/mamba/ops/replayssm_config.py
+++ b/vllm/model_executor/layers/mamba/ops/replayssm_config.py
@@ -66,7 +66,7 @@ def _mamba2_spec_flush(dstate, base_block, is_blackwell):
     return 32, 1, _dstate_tile(dstate, 128), 2
 
 
-# GDN spec configs are (block_v, num_warps, block_s, num_stages), swept on
+# GDN spec configs are (block_v, num_warps, nk, num_stages), swept on
 # B300 at the Qwen3.5 geometry. The head_k_dim gate matters: these tuples
 # regress badly at K=64, which the default covers instead.
 _GDN_SPEC_VERIFY_BLACKWELL = {

--- a/vllm/model_executor/layers/mamba/ops/selective_state_update_replayssm_spec.py
+++ b/vllm/model_executor/layers/mamba/ops/selective_state_update_replayssm_spec.py
@@ -1,0 +1,1162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E501
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.mamba_ssm import softplus
+from vllm.model_executor.layers.mamba.ops.replayssm_config import get_replayssm_config
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+
+# ======================================================================
+# Fused scatter + precompute  (grid: (batch, ngroups))
+#
+# Scatters all conv_dim channels (x|B|C, partitioned by group) + dt of the
+# fresh spec tokens into the circular post-conv / dt caches at
+# ``(origin + write_pos + s) % buf``, and computes ``bc[k, s] = B_full[k] . C[s]``
+# over the window (history B from the cache + fresh spec B, no read-back).
+# ======================================================================
+@triton.heuristics(
+    {"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])}
+)
+@triton.jit
+def _fused_scatter_precompute_kernel(
+    conv_out_ptr,  # (total_tokens, conv_dim) packed channel-last conv output
+    dt_spec_ptr,  # (total_tokens, nheads) packed raw dt
+    post_conv_cache_ptr,  # (num_blocks, buf, conv_dim) circular paged
+    dt_cache_ptr,  # (num_blocks, nheads, buf) circular paged
+    write_pos_ptr,  # (num_state_slots,) block-keyed
+    post_origin_ptr,  # (num_state_slots,) block-keyed
+    bc_pre_ptr,  # (max_bs, ngroups, max_cache_len, block_spec) dense per-row scratch
+    state_batch_indices_ptr,  # (batch,) physical block per dense decode row
+    query_start_loc_ptr,  # (batch + 1,) packed token offsets
+    null_block_id,
+    batch,
+    ngroups,
+    nheads,
+    dstate,
+    d_inner,
+    conv_dim,
+    max_cache_len,
+    stride_conv_out_tok,
+    stride_conv_out_c,
+    stride_dt_spec_tok,
+    stride_dt_spec_h,
+    stride_post_conv_cache_b,
+    stride_post_conv_cache_pos,
+    stride_post_conv_cache_c,
+    stride_dt_cache_b,
+    stride_dt_cache_h,
+    stride_dt_cache_pos,
+    stride_bc_pre_batch,
+    stride_bc_pre_group,
+    stride_bc_pre_pos,
+    stride_bc_pre_spec,
+    stride_state_indices_batch,
+    RATIO: tl.constexpr,
+    RATIO_P: tl.constexpr,
+    NCX: tl.constexpr,
+    BLOCK_CX: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    BLOCK_SIZE_CACHE: tl.constexpr,
+    BLOCK_SIZE_SPEC: tl.constexpr,
+    BLOCK_HL: tl.constexpr,
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    pid_g = tl.program_id(1)
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + pid_b * stride_state_indices_batch
+    ).to(tl.int64)
+    if state_batch_idx == null_block_id:
+        return
+    bos = tl.load(query_start_loc_ptr + pid_b).to(tl.int64)
+    eos = tl.load(query_start_loc_ptr + pid_b + 1).to(tl.int64)
+    spec_len = (eos - bos).to(tl.int32)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx).to(tl.int32)
+
+    offs_s = tl.arange(0, BLOCK_SIZE_SPEC)
+    offs_n = tl.arange(0, BLOCK_SIZE_DSTATE)
+    spec_valid = offs_s < spec_len
+    nmask = offs_n < dstate
+    phys_spec = (post_origin + write_pos + offs_s) & (CACHE_BUF_LEN - 1)
+
+    b_c0 = d_inner + pid_g * dstate
+    c_c0 = d_inner + ngroups * dstate + pid_g * dstate
+
+    src_base = conv_out_ptr + bos * stride_conv_out_tok
+    # fresh spec B / C  [S, N]
+    B_spec = tl.load(
+        src_base
+        + (b_c0 + offs_n[None, :]) * stride_conv_out_c
+        + offs_s[:, None] * stride_conv_out_tok,
+        mask=spec_valid[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    C_spec = tl.load(
+        src_base
+        + (c_c0 + offs_n[None, :]) * stride_conv_out_c
+        + offs_s[:, None] * stride_conv_out_tok,
+        mask=spec_valid[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    cache_base = post_conv_cache_ptr + state_batch_idx * stride_post_conv_cache_b
+    # scatter B (C is not cached; read fresh from conv_out)
+    tl.store(
+        cache_base
+        + phys_spec[:, None] * stride_post_conv_cache_pos
+        + (b_c0 + offs_n[None, :]) * stride_post_conv_cache_c,
+        B_spec,
+        mask=spec_valid[:, None] & nmask[None, :],
+    )
+
+    # scatter x channels owned by this group: [g*RATIO_P, (g+1)*RATIO_P)
+    gx0 = pid_g * RATIO_P
+    for i in tl.static_range(NCX):
+        offs_cx = i * BLOCK_CX + tl.arange(0, BLOCK_CX)
+        cxm = offs_cx < RATIO_P
+        gx = gx0 + offs_cx
+        xv = tl.load(
+            src_base
+            + gx[None, :] * stride_conv_out_c
+            + offs_s[:, None] * stride_conv_out_tok,
+            mask=spec_valid[:, None] & cxm[None, :],
+            other=0.0,
+        )
+        tl.store(
+            cache_base
+            + phys_spec[:, None] * stride_post_conv_cache_pos
+            + gx[None, :] * stride_post_conv_cache_c,
+            xv,
+            mask=spec_valid[:, None] & cxm[None, :],
+        )
+
+    # scatter dt for this group's heads
+    offs_hl = tl.arange(0, BLOCK_HL)
+    hlm = offs_hl < RATIO
+    gh = pid_g * RATIO + offs_hl
+    dt_base = dt_spec_ptr + bos * stride_dt_spec_tok
+    dtv = tl.load(
+        dt_base + offs_s[:, None] * stride_dt_spec_tok + gh[None, :] * stride_dt_spec_h,
+        mask=spec_valid[:, None] & hlm[None, :],
+        other=0.0,
+    )
+    dtc_base = dt_cache_ptr + state_batch_idx * stride_dt_cache_b
+    tl.store(
+        dtc_base
+        + gh[None, :] * stride_dt_cache_h
+        + phys_spec[:, None] * stride_dt_cache_pos,
+        dtv,
+        mask=spec_valid[:, None] & hlm[None, :],
+    )
+
+    # bc: history B from cache + fresh spec B  (no read-back of spec B)
+    offs_k = tl.arange(0, BLOCK_SIZE_CACHE)
+    hist_mask = offs_k < write_pos
+    cache_valid = (offs_k < max_cache_len) & (offs_k < (write_pos + spec_len))
+    spec_tok = (offs_k >= write_pos) & (offs_k < (write_pos + spec_len))
+    spec_off = offs_k - write_pos
+    phys_k = (post_origin + offs_k) & (CACHE_BUF_LEN - 1)
+    B_hist = tl.load(
+        cache_base
+        + phys_k[:, None] * stride_post_conv_cache_pos
+        + (b_c0 + offs_n[None, :]) * stride_post_conv_cache_c,
+        mask=hist_mask[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    B_specrows = tl.load(
+        src_base
+        + (b_c0 + offs_n[None, :]) * stride_conv_out_c
+        + spec_off[:, None] * stride_conv_out_tok,
+        mask=spec_tok[:, None] & nmask[None, :],
+        other=0.0,
+    )
+    B_full = tl.where(spec_tok[:, None], B_specrows, B_hist)
+    B_full = tl.where(cache_valid[:, None], B_full.to(tl.float32), 0.0).to(
+        conv_out_ptr.dtype.element_ty
+    )
+    bc = tl.dot(
+        B_full,
+        tl.trans(C_spec.to(conv_out_ptr.dtype.element_ty)),
+        input_precision="tf32x3",
+    ).to(tl.float32)
+    bc_ptrs = (
+        bc_pre_ptr
+        + pid_b * stride_bc_pre_batch
+        + pid_g * stride_bc_pre_group
+        + offs_k[:, None] * stride_bc_pre_pos
+        + offs_s[None, :] * stride_bc_pre_spec
+    )
+    tl.store(
+        bc_ptrs,
+        bc.to(bc_pre_ptr.dtype.element_ty),
+        mask=cache_valid[:, None] & spec_valid[None, :],
+    )
+
+
+# ======================================================================
+# Verify launch (non-flush rows): per-draft output from the fixed checkpoint
+# S_0, no state write. dstate-tiled. Flush rows early-exit.
+# ======================================================================
+@triton.heuristics({"HAS_DT_BIAS": lambda args: args["dt_bias_ptr"] is not None})
+@triton.heuristics({"HAS_D": lambda args: args["D_ptr"] is not None})
+@triton.heuristics({"HAS_Z": lambda args: args["z_ptr"] is not None})
+@triton.heuristics(
+    {"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])}
+)
+@triton.jit
+def _replayssm_spec_nf_kernel(
+    state_ptr,
+    x_cache_ptr,
+    dt_cache_ptr,
+    B_cache_ptr,
+    C_src_ptr,
+    bc_pre_ptr,
+    D_ptr,
+    z_ptr,
+    dt_bias_ptr,
+    A_ptr,
+    out_ptr,
+    is_flush_flags_ptr,
+    write_pos_ptr,
+    post_origin_ptr,
+    state_batch_indices_ptr,
+    query_start_loc_ptr,
+    null_block_id,
+    batch,
+    nheads,
+    dim,
+    dstate,
+    max_cache_len,
+    nheads_ngroups_ratio,
+    stride_state_batch,
+    stride_state_head,
+    stride_state_dim,
+    stride_state_dstate,
+    stride_x_cache_batch,
+    stride_x_cache_head,
+    stride_x_cache_dim,
+    stride_x_cache_pos,
+    stride_dt_cache_batch,
+    stride_dt_cache_head,
+    stride_dt_cache_pos,
+    stride_B_cache_batch,
+    stride_B_cache_group,
+    stride_B_cache_dstate,
+    stride_B_cache_pos,
+    stride_C_src_tok,
+    stride_C_src_c,
+    stride_bc_pre_batch,
+    stride_bc_pre_group,
+    stride_bc_pre_pos,
+    stride_bc_pre_spec,
+    stride_D_head,
+    stride_D_dim,
+    stride_z_tok,
+    stride_z_head,
+    stride_z_dim,
+    stride_dt_bias_head,
+    stride_A_head,
+    stride_out_tok,
+    stride_out_head,
+    stride_out_dim,
+    stride_state_indices_batch,
+    DT_SOFTPLUS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_CACHE: tl.constexpr,
+    BLOCK_SIZE_SPEC: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    HAS_D: tl.constexpr,
+    HAS_Z: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    DSTATE_TILE: tl.constexpr,
+    NDS: tl.constexpr,
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+    pid_h = tl.program_id(axis=2)
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + pid_b * stride_state_indices_batch
+    ).to(tl.int64)
+    if state_batch_idx == null_block_id:
+        return
+    if tl.load(is_flush_flags_ptr + state_batch_idx) != 0:
+        return
+    bos = tl.load(query_start_loc_ptr + pid_b).to(tl.int64)
+    eos = tl.load(query_start_loc_ptr + pid_b + 1).to(tl.int64)
+    spec_len = (eos - bos).to(tl.int32)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx).to(tl.int32)
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_k = tl.arange(0, BLOCK_SIZE_CACHE)
+    offs_s = tl.arange(0, BLOCK_SIZE_SPEC)
+    offs_nt = tl.arange(0, DSTATE_TILE)
+    spec_valid_mask = offs_s < spec_len
+    hist_mask = offs_k < write_pos
+    cache_valid_mask = (offs_k < max_cache_len) & (offs_k < (write_pos + spec_len))
+    spec_token_mask = (offs_k >= write_pos) & (offs_k < (write_pos + spec_len))
+    spec_cache_pos = write_pos + offs_s
+    spec_prefix_mask = (
+        spec_valid_mask[:, None]
+        & spec_token_mask[None, :]
+        & (offs_k[None, :] <= spec_cache_pos[:, None])
+    )
+    phys_k = (post_origin + offs_k) & (CACHE_BUF_LEN - 1)
+    phys_spec = (post_origin + spec_cache_pos) & (CACHE_BUF_LEN - 1)
+
+    state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+    x_cache_ptr += state_batch_idx * stride_x_cache_batch + pid_h * stride_x_cache_head
+    dt_cache_ptr += (
+        state_batch_idx * stride_dt_cache_batch + pid_h * stride_dt_cache_head
+    )
+    C_src_ptr += (
+        bos * stride_C_src_tok
+        + (pid_h // nheads_ngroups_ratio) * dstate * stride_C_src_c
+    )
+    bc_pre_ptr += (
+        pid_b * stride_bc_pre_batch
+        + (pid_h // nheads_ngroups_ratio) * stride_bc_pre_group
+    )
+    if HAS_D:
+        D_ptr += pid_h * stride_D_head
+    if HAS_Z:
+        z_ptr += bos * stride_z_tok + pid_h * stride_z_head
+    if HAS_DT_BIAS:
+        dt_bias_ptr += pid_h * stride_dt_bias_head
+    A_ptr += pid_h * stride_A_head
+    out_ptr += bos * stride_out_tok + pid_h * stride_out_head
+    A_val = tl.load(A_ptr).to(tl.float32)
+    dt_bias_val = tl.load(dt_bias_ptr).to(tl.float32) if HAS_DT_BIAS else 0.0
+
+    # dt over the window (+ bias / softplus), then the per-draft decay weights.
+    dt_blk = tl.load(
+        dt_cache_ptr + phys_k * stride_dt_cache_pos, mask=cache_valid_mask, other=0.0
+    ).to(tl.float32)
+    dt_blk = tl.where(cache_valid_mask, dt_blk, 0.0)
+    if HAS_DT_BIAS:
+        dt_blk = tl.where(cache_valid_mask, dt_blk + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_blk = tl.where(
+            cache_valid_mask, tl.where(dt_blk <= 20.0, softplus(dt_blk), dt_blk), 0.0
+        )
+    dt_cum = tl.cumsum(dt_blk, axis=0)
+    hist_total = tl.sum(tl.where(hist_mask, dt_blk, 0.0), axis=0)
+    spec_cum = tl.sum(tl.where(spec_prefix_mask, dt_blk[None, :], 0.0), axis=1)
+    spec_cum = tl.where(spec_valid_mask, spec_cum, 0.0)
+    spec_total = hist_total + spec_cum
+    checkpoint_decay = tl.where(
+        spec_valid_mask, tl.exp(tl.minimum(A_val * spec_total, 0.0)), 0.0
+    )
+
+    # Causal weighted sum over cached values: spec_contrib = x_cache @ factor.
+    x_blk = tl.load(
+        x_cache_ptr
+        + phys_k[None, :] * stride_x_cache_pos
+        + offs_m[:, None] * stride_x_cache_dim,
+        mask=(offs_m[:, None] < dim) & cache_valid_mask[None, :],
+        other=0.0,
+    )
+    x_ty = x_blk.to(x_cache_ptr.dtype.element_ty)
+    bc = tl.load(
+        bc_pre_ptr
+        + offs_k[:, None] * stride_bc_pre_pos
+        + offs_s[None, :] * stride_bc_pre_spec,
+        mask=cache_valid_mask[:, None] & spec_valid_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    spec_scale = dt_blk[:, None] * tl.exp(
+        tl.minimum(A_val * (spec_total[None, :] - dt_cum[:, None]), 0.0)
+    )
+    causal = (
+        spec_valid_mask[None, :]
+        & cache_valid_mask[:, None]
+        & (offs_k[:, None] <= spec_cache_pos[None, :])
+    )
+    factor = tl.where(causal, bc * spec_scale, 0.0)
+    spec_contrib = tl.dot(
+        x_ty, factor.to(x_cache_ptr.dtype.element_ty), input_precision="tf32x3"
+    ).to(tl.float32)
+
+    # Decayed checkpoint readout S_0 @ C, dstate-tiled. tf32x3 keeps fp32-act
+    # parity; bf16 act uses single-pass tf32 (the flag is a no-op on bf16 inputs).
+    checkpoint_out = tl.zeros([BLOCK_SIZE_M, BLOCK_SIZE_SPEC], dtype=tl.float32)
+    for i in tl.static_range(NDS):
+        offs_n = i * DSTATE_TILE + offs_nt
+        nmask = offs_n < dstate
+        st = tl.load(
+            state_ptr
+            + offs_m[:, None] * stride_state_dim
+            + offs_n[None, :] * stride_state_dstate,
+            mask=(offs_m[:, None] < dim) & nmask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        c_mask = spec_valid_mask[:, None] & nmask[None, :]
+        c_chunk = tl.load(
+            C_src_ptr
+            + offs_s[:, None] * stride_C_src_tok
+            + offs_n[None, :] * stride_C_src_c,
+            mask=c_mask,
+            other=0.0,
+        ).to(tl.float32)
+        if x_cache_ptr.dtype.element_ty == tl.float32:
+            checkpoint_out += tl.dot(
+                st, tl.trans(c_chunk), input_precision="tf32x3"
+            ).to(tl.float32)
+        else:
+            checkpoint_out += tl.dot(st, tl.trans(c_chunk), input_precision="tf32").to(
+                tl.float32
+            )
+    checkpoint_out *= checkpoint_decay[None, :]
+    out = tl.trans(checkpoint_out + spec_contrib)
+
+    if HAS_D:
+        x_spec_sm = tl.load(
+            x_cache_ptr
+            + offs_m[None, :] * stride_x_cache_dim
+            + phys_spec[:, None] * stride_x_cache_pos,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        D_val = tl.load(D_ptr + offs_m * stride_D_dim, mask=offs_m < dim, other=0.0).to(
+            tl.float32
+        )
+        out += x_spec_sm * D_val[None, :]
+    if HAS_Z:
+        z_val = tl.load(
+            z_ptr + offs_s[:, None] * stride_z_tok + offs_m[None, :] * stride_z_dim,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        out *= z_val * tl.sigmoid(z_val)
+    out = tl.where(spec_valid_mask[:, None], out, 0.0)
+    tl.store(
+        out_ptr + offs_s[:, None] * stride_out_tok + offs_m[None, :] * stride_out_dim,
+        out,
+        mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+    )
+
+
+# ======================================================================
+# Flush launch (flush rows): reconstruct the committed-history state S_1, store
+# it as the checkpoint, and read the output via S_1 + the intra-spec window.
+# Non-flush rows early-exit. dstate-tiled.
+# ======================================================================
+@triton.heuristics({"HAS_DT_BIAS": lambda args: args["dt_bias_ptr"] is not None})
+@triton.heuristics({"HAS_D": lambda args: args["D_ptr"] is not None})
+@triton.heuristics({"HAS_Z": lambda args: args["z_ptr"] is not None})
+@triton.heuristics(
+    {"BLOCK_SIZE_DSTATE": lambda args: triton.next_power_of_2(args["dstate"])}
+)
+@triton.jit
+def _replayssm_spec_fl_kernel(
+    state_ptr,
+    x_cache_ptr,
+    dt_cache_ptr,
+    B_cache_ptr,
+    C_src_ptr,
+    bc_pre_ptr,
+    D_ptr,
+    z_ptr,
+    dt_bias_ptr,
+    A_ptr,
+    out_ptr,
+    is_flush_flags_ptr,
+    write_pos_ptr,
+    post_origin_ptr,
+    state_batch_indices_ptr,
+    query_start_loc_ptr,
+    null_block_id,
+    batch,
+    nheads,
+    dim,
+    dstate,
+    max_cache_len,
+    nheads_ngroups_ratio,
+    stride_state_batch,
+    stride_state_head,
+    stride_state_dim,
+    stride_state_dstate,
+    stride_x_cache_batch,
+    stride_x_cache_head,
+    stride_x_cache_dim,
+    stride_x_cache_pos,
+    stride_dt_cache_batch,
+    stride_dt_cache_head,
+    stride_dt_cache_pos,
+    stride_B_cache_batch,
+    stride_B_cache_group,
+    stride_B_cache_dstate,
+    stride_B_cache_pos,
+    stride_C_src_tok,
+    stride_C_src_c,
+    stride_bc_pre_batch,
+    stride_bc_pre_group,
+    stride_bc_pre_pos,
+    stride_bc_pre_spec,
+    stride_D_head,
+    stride_D_dim,
+    stride_z_tok,
+    stride_z_head,
+    stride_z_dim,
+    stride_dt_bias_head,
+    stride_A_head,
+    stride_out_tok,
+    stride_out_head,
+    stride_out_dim,
+    stride_state_indices_batch,
+    DT_SOFTPLUS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_CACHE: tl.constexpr,
+    BLOCK_SIZE_SPEC: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    HAS_D: tl.constexpr,
+    HAS_Z: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    DSTATE_TILE: tl.constexpr,
+    NDS: tl.constexpr,
+    BLOCK_SIZE_DSTATE: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_b = tl.program_id(axis=1)
+    pid_h = tl.program_id(axis=2)
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + pid_b * stride_state_indices_batch
+    ).to(tl.int64)
+    if state_batch_idx == null_block_id:
+        return
+    if tl.load(is_flush_flags_ptr + state_batch_idx) == 0:
+        return
+    bos = tl.load(query_start_loc_ptr + pid_b).to(tl.int64)
+    eos = tl.load(query_start_loc_ptr + pid_b + 1).to(tl.int64)
+    spec_len = (eos - bos).to(tl.int32)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx).to(tl.int32)
+    post_origin = tl.load(post_origin_ptr + state_batch_idx).to(tl.int32)
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_k = tl.arange(0, BLOCK_SIZE_CACHE)
+    offs_s = tl.arange(0, BLOCK_SIZE_SPEC)
+    offs_nt = tl.arange(0, DSTATE_TILE)
+    spec_valid_mask = offs_s < spec_len
+    spec_cache_pos = write_pos + offs_s
+    phys_spec = (post_origin + spec_cache_pos) & (CACHE_BUF_LEN - 1)
+    hist_mask = offs_k < write_pos
+    phys_h = (post_origin + offs_k) & (CACHE_BUF_LEN - 1)
+
+    state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
+    x_cache_ptr += state_batch_idx * stride_x_cache_batch + pid_h * stride_x_cache_head
+    dt_cache_ptr += (
+        state_batch_idx * stride_dt_cache_batch + pid_h * stride_dt_cache_head
+    )
+    B_cache_ptr += (
+        state_batch_idx * stride_B_cache_batch
+        + (pid_h // nheads_ngroups_ratio) * stride_B_cache_group
+    )
+    C_src_ptr += (
+        bos * stride_C_src_tok
+        + (pid_h // nheads_ngroups_ratio) * dstate * stride_C_src_c
+    )
+    bc_pre_ptr += (
+        pid_b * stride_bc_pre_batch
+        + (pid_h // nheads_ngroups_ratio) * stride_bc_pre_group
+    )
+    if HAS_D:
+        D_ptr += pid_h * stride_D_head
+    if HAS_Z:
+        z_ptr += bos * stride_z_tok + pid_h * stride_z_head
+    if HAS_DT_BIAS:
+        dt_bias_ptr += pid_h * stride_dt_bias_head
+    A_ptr += pid_h * stride_A_head
+    out_ptr += bos * stride_out_tok + pid_h * stride_out_head
+    A_val = tl.load(A_ptr).to(tl.float32)
+    dt_bias_val = tl.load(dt_bias_ptr).to(tl.float32) if HAS_DT_BIAS else 0.0
+
+    # History decay (for the S_1 reconstruction) and spec-prefix decay (output).
+    dt_h = tl.load(
+        dt_cache_ptr + phys_h * stride_dt_cache_pos, mask=hist_mask, other=0.0
+    ).to(tl.float32)
+    dt_h = tl.where(hist_mask, dt_h, 0.0)
+    if HAS_DT_BIAS:
+        dt_h = tl.where(hist_mask, dt_h + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_h = tl.where(hist_mask, tl.where(dt_h <= 20.0, softplus(dt_h), dt_h), 0.0)
+    hist_cum = tl.cumsum(dt_h, axis=0)
+    hist_total = tl.sum(dt_h, axis=0)
+    hist_decay = tl.exp(tl.minimum(A_val * hist_total, 0.0))
+    hist_scale = tl.where(
+        hist_mask, dt_h * tl.exp(tl.minimum(A_val * (hist_total - hist_cum), 0.0)), 0.0
+    )
+    dt_s = tl.load(
+        dt_cache_ptr + phys_spec * stride_dt_cache_pos, mask=spec_valid_mask, other=0.0
+    ).to(tl.float32)
+    dt_s = tl.where(spec_valid_mask, dt_s, 0.0)
+    if HAS_DT_BIAS:
+        dt_s = tl.where(spec_valid_mask, dt_s + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_s = tl.where(
+            spec_valid_mask, tl.where(dt_s <= 20.0, softplus(dt_s), dt_s), 0.0
+        )
+    spec_cum = tl.cumsum(dt_s, axis=0)
+    spec_decay = tl.where(
+        spec_valid_mask, tl.exp(tl.minimum(A_val * spec_cum, 0.0)), 0.0
+    )
+    x_hist = tl.load(
+        x_cache_ptr
+        + phys_h[None, :] * stride_x_cache_pos
+        + offs_m[:, None] * stride_x_cache_dim,
+        mask=(offs_m[:, None] < dim) & hist_mask[None, :],
+        other=0.0,
+    )
+    x_hist_ty = x_hist.to(x_cache_ptr.dtype.element_ty)
+
+    # Reconstruct S_1 = S_0 * hist_decay + (x_hist @ scaled B_hist), store it, and
+    # accumulate the checkpoint readout S_1 @ C. dstate-tiled.
+    checkpoint_out = tl.zeros([BLOCK_SIZE_M, BLOCK_SIZE_SPEC], dtype=tl.float32)
+    for i in tl.static_range(NDS):
+        offs_n = i * DSTATE_TILE + offs_nt
+        nmask = offs_n < dstate
+        B_block = tl.load(
+            B_cache_ptr
+            + phys_h[:, None] * stride_B_cache_pos
+            + offs_n[None, :] * stride_B_cache_dstate,
+            mask=hist_mask[:, None] & nmask[None, :],
+            other=0.0,
+        )
+        B_hist_scaled = (
+            tl.where(hist_mask[:, None], B_block.to(tl.float32), 0.0)
+            * hist_scale[:, None]
+        ).to(x_cache_ptr.dtype.element_ty)
+        delta = tl.dot(x_hist_ty, B_hist_scaled, input_precision="tf32x3").to(
+            tl.float32
+        )
+        st_ptrs = (
+            state_ptr
+            + offs_m[:, None] * stride_state_dim
+            + offs_n[None, :] * stride_state_dstate
+        )
+        st = tl.load(st_ptrs, mask=(offs_m[:, None] < dim) & nmask[None, :], other=0.0)
+        S1 = st.to(tl.float32) * hist_decay + delta
+        if write_pos > 0:
+            tl.store(
+                st_ptrs, S1.to(st.dtype), mask=(offs_m[:, None] < dim) & nmask[None, :]
+            )
+        c_mask = spec_valid_mask[:, None] & nmask[None, :]
+        c_chunk = tl.load(
+            C_src_ptr
+            + offs_s[:, None] * stride_C_src_tok
+            + offs_n[None, :] * stride_C_src_c,
+            mask=c_mask,
+            other=0.0,
+        ).to(tl.float32)
+        if x_cache_ptr.dtype.element_ty == tl.float32:
+            checkpoint_out += tl.dot(
+                S1, tl.trans(c_chunk), input_precision="tf32x3"
+            ).to(tl.float32)
+        else:
+            checkpoint_out += tl.dot(S1, tl.trans(c_chunk), input_precision="tf32").to(
+                tl.float32
+            )
+    checkpoint_out *= spec_decay[None, :]
+
+    # Intra-spec window contribution: intra = x_spec @ factor_intra (causal T x T).
+    bc_spec = tl.load(
+        bc_pre_ptr
+        + (write_pos + offs_k)[:, None] * stride_bc_pre_pos
+        + offs_s[None, :] * stride_bc_pre_spec,
+        mask=(offs_k[:, None] < spec_len) & spec_valid_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    dt_k = tl.load(
+        dt_cache_ptr
+        + ((post_origin + write_pos + offs_k) & (CACHE_BUF_LEN - 1))
+        * stride_dt_cache_pos,
+        mask=offs_k < spec_len,
+        other=0.0,
+    ).to(tl.float32)
+    dt_k = tl.where(offs_k < spec_len, dt_k, 0.0)
+    if HAS_DT_BIAS:
+        dt_k = tl.where(offs_k < spec_len, dt_k + dt_bias_val, 0.0)
+    if DT_SOFTPLUS:
+        dt_k = tl.where(
+            offs_k < spec_len, tl.where(dt_k <= 20.0, softplus(dt_k), dt_k), 0.0
+        )
+    speccum_k = tl.cumsum(dt_k, axis=0)
+    causal = (
+        (offs_k[:, None] < spec_len)
+        & spec_valid_mask[None, :]
+        & (offs_k[:, None] <= offs_s[None, :])
+    )
+    decay_ks = tl.exp(tl.minimum(A_val * (spec_cum[None, :] - speccum_k[:, None]), 0.0))
+    factor_intra = tl.where(causal, bc_spec * dt_k[:, None] * decay_ks, 0.0)
+    x_src = tl.load(
+        x_cache_ptr
+        + ((post_origin + write_pos + offs_k)[None, :] & (CACHE_BUF_LEN - 1))
+        * stride_x_cache_pos
+        + offs_m[:, None] * stride_x_cache_dim,
+        mask=(offs_m[:, None] < dim) & (offs_k[None, :] < spec_len),
+        other=0.0,
+    ).to(x_cache_ptr.dtype.element_ty)
+    intra = tl.dot(
+        x_src, factor_intra.to(x_cache_ptr.dtype.element_ty), input_precision="tf32x3"
+    ).to(tl.float32)
+    out = tl.trans(checkpoint_out + intra)
+
+    if HAS_D:
+        x_spec_sm = tl.load(
+            x_cache_ptr
+            + offs_m[None, :] * stride_x_cache_dim
+            + phys_spec[:, None] * stride_x_cache_pos,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        D_val = tl.load(D_ptr + offs_m * stride_D_dim, mask=offs_m < dim, other=0.0).to(
+            tl.float32
+        )
+        out += x_spec_sm * D_val[None, :]
+    if HAS_Z:
+        z_val = tl.load(
+            z_ptr + offs_s[:, None] * stride_z_tok + offs_m[None, :] * stride_z_dim,
+            mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+            other=0.0,
+        ).to(tl.float32)
+        out *= z_val * tl.sigmoid(z_val)
+    out = tl.where(spec_valid_mask[:, None], out, 0.0)
+    tl.store(
+        out_ptr + offs_s[:, None] * stride_out_tok + offs_m[None, :] * stride_out_dim,
+        out,
+        mask=spec_valid_mask[:, None] & (offs_m[None, :] < dim),
+    )
+
+
+@triton.jit
+def _advance_write_pos_origin_kernel(
+    write_pos_ptr,
+    post_origin_ptr,
+    is_flush_ptr,
+    num_accepted_ptr,
+    state_batch_indices_ptr,
+    null_block_id,
+    batch,
+    stride_state_indices_batch,
+    MAX_CACHE_LEN: tl.constexpr,
+    MAX_SPEC_LEN: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK_SIZE)
+    row_mask = offs < batch
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + offs * stride_state_indices_batch,
+        mask=row_mask,
+        other=null_block_id,
+    ).to(tl.int64)
+    valid = row_mask & (state_batch_idx != null_block_id)
+    write_pos = tl.load(write_pos_ptr + state_batch_idx, mask=valid, other=0).to(
+        tl.int32
+    )
+    post_origin = tl.load(post_origin_ptr + state_batch_idx, mask=valid, other=0).to(
+        tl.int32
+    )
+    is_flush_cur = tl.load(is_flush_ptr + state_batch_idx, mask=valid, other=0).to(
+        tl.int32
+    )
+    num_accepted = tl.load(num_accepted_ptr + offs, mask=valid, other=0).to(tl.int32)
+    total_commit = tl.where(valid, num_accepted, 0).to(tl.int32)
+    flush_now = (total_commit > 0) & (is_flush_cur != 0)
+    new_origin = tl.where(
+        flush_now, (post_origin + write_pos) & (CACHE_BUF_LEN - 1), post_origin
+    ).to(tl.int32)
+    new_wp = tl.where(
+        total_commit <= 0,
+        write_pos,
+        tl.where(is_flush_cur != 0, total_commit, write_pos + total_commit),
+    ).to(tl.int32)
+    # Early-flush one window early so every verify step satisfies
+    # write_pos + spec_len <= max_cache_len (the spec window never overflows).
+    next_is_flush = ((new_wp + 2 * MAX_SPEC_LEN) > MAX_CACHE_LEN).to(tl.int8)
+    tl.store(post_origin_ptr + state_batch_idx, new_origin, mask=valid)
+    tl.store(write_pos_ptr + state_batch_idx, new_wp, mask=valid)
+    tl.store(is_flush_ptr + state_batch_idx, next_is_flush, mask=valid)
+
+
+@triton.jit
+def _reset_replayssm_spec_cursors_kernel(
+    write_pos_ptr,
+    post_origin_ptr,
+    is_flush_ptr,
+    first_decode_ptr,  # (batch,) int8 mask
+    force_flush_ptr,  # (batch,) int8 mask, subset of first_decode
+    state_batch_indices_ptr,
+    null_block_id,
+    batch,
+    stride_state_indices_batch,
+    INIT_IS_FLUSH: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK_SIZE)
+    row_mask = offs < batch
+    state_batch_idx = tl.load(
+        state_batch_indices_ptr + offs * stride_state_indices_batch,
+        mask=row_mask,
+        other=null_block_id,
+    ).to(tl.int64)
+    first = tl.load(first_decode_ptr + offs, mask=row_mask, other=0).to(tl.int32)
+    force_flush = tl.load(force_flush_ptr + offs, mask=row_mask, other=0).to(tl.int32)
+    do_reset = row_mask & (state_batch_idx != null_block_id) & (first != 0)
+    tl.store(
+        write_pos_ptr + state_batch_idx,
+        tl.zeros_like(state_batch_idx).to(tl.int32),
+        mask=do_reset,
+    )
+    tl.store(
+        post_origin_ptr + state_batch_idx,
+        tl.zeros_like(state_batch_idx).to(tl.int32),
+        mask=do_reset,
+    )
+    # A leftover single-token prompt chunk must flush this step: it appends one
+    # token to a freshly emptied ring, and without the flush the checkpoint never
+    # advances past it, so the next step's reset would drop that token.
+    init_flag = tl.zeros_like(state_batch_idx).to(tl.int32) + INIT_IS_FLUSH
+    tl.store(
+        is_flush_ptr + state_batch_idx,
+        tl.where(force_flush != 0, 1, init_flag).to(tl.int8),
+        mask=do_reset,
+    )
+
+
+def selective_state_update_replayssm_spec(
+    state_checkpoint: torch.Tensor,  # (num_blocks, H, P, N) checkpoint (flush updates in place)
+    post_conv_cache: torch.Tensor,  # (num_blocks, cache_buf_len, conv_dim) circular
+    dt_cache: torch.Tensor,  # (num_blocks, H, cache_buf_len) circular
+    conv_out: torch.Tensor,  # (total_tokens, conv_dim) packed channel-last post-conv
+    dt_spec: torch.Tensor,  # (total_tokens, H) packed raw dt
+    A: torch.Tensor,  # (H, P, N) TIE_HDIM (A.stride(-1)==A.stride(-2)==0)
+    write_pos: torch.Tensor,  # (num_state_slots,) int32 block-keyed cursor
+    post_conv_state_pos: torch.Tensor,  # (num_state_slots,) int32 circular origin
+    is_flush: torch.Tensor,  # (num_state_slots,) int8 block-keyed flag
+    query_start_loc: torch.Tensor,  # (batch + 1,) int32 packed offsets
+    state_batch_indices: torch.Tensor,  # (batch,) int32 physical block per row
+    max_cache_len: int,  # logical flush threshold L = B + max_spec_len
+    max_spec_len: int,
+    d_inner: int,
+    ngroups: int,
+    dstate: int,
+    D: torch.Tensor | None = None,
+    z: torch.Tensor | None = None,
+    dt_bias: torch.Tensor | None = None,
+    dt_softplus: bool = True,
+    out: torch.Tensor | None = None,
+    bc_pre: torch.Tensor | None = None,
+    null_block_id: int = NULL_BLOCK_ID,
+) -> torch.Tensor:
+    """One Mamba2 speculative verify step on the paged CIRCULAR post-conv cache.
+
+    Hybrid conv variant: ``conv_out`` is the post-conv output of vLLM's
+    ``causal_conv1d_update`` (packed channel-last ``[total_tokens, conv_dim]``).
+    ``max_cache_len`` is the logical flush threshold L = B + max_spec_len; the
+    physical pow2 buffer (= ``post_conv_cache.shape[1]`` = ``next_pow2(L)``) wraps
+    the ring, while the history/cache tile is ``next_pow2(L - max_spec_len)``.
+    Fuses scatter + bc-precompute in one ``(batch, ngroups)`` launch, then runs
+    two dedicated launches (verify + flush) with device-side row routing. Cursors
+    are block-keyed and advanced once per step by ``commit_replayssm_spec``.
+    """
+    num_blocks, nheads, dim, n_state = state_checkpoint.shape
+    assert n_state == dstate
+    total_tokens, conv_dim = conv_out.shape
+    buf = post_conv_cache.shape[1]
+    cache_buf_len = buf
+    assert cache_buf_len & (cache_buf_len - 1) == 0, (
+        "cache_buf_len must be a power of two"
+    )
+    assert d_inner == nheads * dim
+    cache_conv_dim = d_inner + ngroups * dstate  # x|B only (no C)
+    assert post_conv_cache.shape == (num_blocks, buf, cache_conv_dim)
+    assert dt_cache.shape == (num_blocks, nheads, buf)
+    assert dt_spec.shape == (total_tokens, nheads)
+    assert A.shape == (nheads, dim, dstate) and A.stride(-1) == 0 and A.stride(-2) == 0
+    batch = state_batch_indices.shape[0]
+    assert query_start_loc.shape[0] == batch + 1
+
+    if out is None:
+        out = torch.empty(
+            total_tokens, nheads, dim, device=conv_out.device, dtype=conv_out.dtype
+        )
+    if total_tokens == 0:
+        return out
+
+    L = max_cache_len
+    base_block = max(1, L - max_spec_len)
+    main_block = max(16, triton.next_power_of_2(base_block))  # history/cache tile
+    block_spec = max(1, triton.next_power_of_2(max_spec_len))
+    pre_block = max(16, triton.next_power_of_2(L))  # precompute window tile
+    block_dstate = triton.next_power_of_2(dstate)
+
+    bsm_v, nw_v, dt_v, ns_v = get_replayssm_config(
+        "mamba2_spec_verify", dstate=dstate, base_block=base_block
+    )
+    bsm_f, nw_f, dt_f, ns_f = get_replayssm_config(
+        "mamba2_spec_flush", dstate=dstate, base_block=base_block
+    )
+    dt_v = max(16, min(dt_v, block_dstate))
+    nds_v = triton.cdiv(block_dstate, dt_v)
+    dt_f = max(16, min(dt_f, block_dstate))
+    nds_f = triton.cdiv(block_dstate, dt_f)
+
+    if bc_pre is None:
+        bc_pre = torch.empty(
+            batch,
+            ngroups,
+            buf,
+            block_spec,
+            device=conv_out.device,
+            dtype=conv_out.dtype,
+        )
+    else:
+        # The kernels index bc_pre with its raw strides on a (batch, ngroups)
+        # grid; an under-sized group dim aliases across rows (races / OOB).
+        assert (
+            bc_pre.shape[0] >= batch
+            and bc_pre.shape[1] == ngroups
+            and bc_pre.shape[2] >= L
+            and bc_pre.shape[3] >= block_spec
+        ), (
+            f"bc_pre shape {tuple(bc_pre.shape)} incompatible with "
+            f"(batch={batch}, ngroups={ngroups}, L={L}, block_spec={block_spec})"
+        )
+    sis = state_batch_indices.stride(0)
+
+    # --- fused scatter + precompute (full-window bc over [0, L)) ---
+    ratio = nheads // ngroups
+    ratio_p = ratio * dim
+    BLOCK_CX = 256
+    NCX = triton.cdiv(ratio_p, BLOCK_CX)
+    block_hl = max(1, triton.next_power_of_2(ratio))
+    with torch.accelerator.device_index(conv_out.device.index):
+        _fused_scatter_precompute_kernel[(batch, ngroups)](
+            conv_out,
+            dt_spec,
+            post_conv_cache,
+            dt_cache,
+            write_pos,
+            post_conv_state_pos,
+            bc_pre,
+            state_batch_indices,
+            query_start_loc,
+            null_block_id,
+            batch,
+            ngroups,
+            nheads,
+            dstate,
+            d_inner,
+            conv_dim,
+            L,
+            conv_out.stride(0),
+            conv_out.stride(1),
+            dt_spec.stride(0),
+            dt_spec.stride(1),
+            post_conv_cache.stride(0),
+            post_conv_cache.stride(1),
+            post_conv_cache.stride(2),
+            dt_cache.stride(0),
+            dt_cache.stride(1),
+            dt_cache.stride(2),
+            bc_pre.stride(0),
+            bc_pre.stride(1),
+            bc_pre.stride(2),
+            bc_pre.stride(3),
+            sis,
+            RATIO=ratio,
+            RATIO_P=ratio_p,
+            NCX=NCX,
+            BLOCK_CX=BLOCK_CX,
+            CACHE_BUF_LEN=cache_buf_len,
+            BLOCK_SIZE_CACHE=pre_block,
+            BLOCK_SIZE_SPEC=block_spec,
+            BLOCK_HL=block_hl,
+            num_warps=4,
+        )
+
+    # views into the paged circular post-conv cache: x | B | C on the channel axis
+    x_view = (
+        post_conv_cache[:, :, :d_inner]
+        .view(num_blocks, buf, nheads, dim)
+        .permute(0, 2, 1, 3)
+    )
+    B_view = (
+        post_conv_cache[:, :, d_inner : d_inner + ngroups * dstate]
+        .view(num_blocks, buf, ngroups, dstate)
+        .permute(0, 2, 1, 3)
+    )
+    # C is not cached; the kernels read it fresh from this conv_out slice.
+    C_src = conv_out[:, d_inner + ngroups * dstate :]
+    z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
+
+    def _args(bsm):
+        grid = lambda META: (triton.cdiv(dim, META["BLOCK_SIZE_M"]), batch, nheads)
+        return grid, (
+            state_checkpoint,
+            x_view,
+            dt_cache,
+            B_view,
+            C_src,
+            bc_pre,
+            D,
+            z,
+            dt_bias,
+            A,
+            out,
+            is_flush,
+            write_pos,
+            post_conv_state_pos,
+            state_batch_indices,
+            query_start_loc,
+            null_block_id,
+            batch,
+            nheads,
+            dim,
+            dstate,
+            L,
+            ratio,
+            state_checkpoint.stride(0),
+            state_checkpoint.stride(1),
+            state_checkpoint.stride(2),
+            state_checkpoint.stride(3),
+            x_view.stride(0),
+            x_view.stride(1),
+            x_view.stride(3),
+            x_view.stride(2),
+            dt_cache.stride(0),
+            dt_cache.stride(1),
+            dt_cache.stride(2),
+            B_view.stride(0),
+            B_view.stride(1),
+            B_view.stride(3),
+            B_view.stride(2),
+            C_src.stride(0),
+            C_src.stride(1),
+            bc_pre.stride(0),
+            bc_pre.stride(1),
+            bc_pre.stride(2),
+            bc_pre.stride(3),
+            D.stride(0) if D is not None else 0,
+            D.stride(1) if D is not None else 0,
+            z_strides[0],
+            z_strides[1],
+            z_strides[2],
+            dt_bias.stride(0) if dt_bias is not None else 0,
+            A.stride(0),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            sis,
+            dt_softplus,
+            bsm,
+        )
+
+    with torch.accelerator.device_index(state_checkpoint.device.index):
+        grid, base = _args(bsm_v)
+        _replayssm_spec_nf_kernel[grid](
+            *base,
+            main_block,
+            block_spec,
+            CACHE_BUF_LEN=cache_buf_len,
+            DSTATE_TILE=dt_v,
+            NDS=nds_v,
+            num_warps=nw_v,
+            num_stages=ns_v,
+        )
+        grid, base = _args(bsm_f)
+        _replayssm_spec_fl_kernel[grid](
+            *base,
+            main_block,
+            block_spec,
+            CACHE_BUF_LEN=cache_buf_len,
+            DSTATE_TILE=dt_f,
+            NDS=nds_f,
+            num_warps=nw_f,
+            num_stages=ns_f,
+        )
+    return out
+
+
+def commit_replayssm_spec(
+    write_pos: torch.Tensor,
+    post_conv_state_pos: torch.Tensor,
+    is_flush: torch.Tensor,
+    num_accepted_tokens: torch.Tensor,  # (batch,) int32, INCLUDES bonus (min 1)
+    state_batch_indices: torch.Tensor,  # (batch,) int32
+    max_cache_len: int,  # logical flush threshold L
+    max_spec_len: int,
+    cache_buf_len: int | None = None,  # physical pow2 buffer next_pow2(L)
+    null_block_id: int = NULL_BLOCK_ID,
+) -> None:
+    """CUDA-graph-safe block-keyed commit. Advances ``write_pos`` and the circular
+    origin (flush = O(1) bump) per decode row, and precomputes next-step
+    ``is_flush``. Maps vLLM ``num_accepted_tokens`` (incl. bonus) to the commit."""
+    batch = state_batch_indices.shape[0]
+    if cache_buf_len is None:
+        cache_buf_len = max(1, triton.next_power_of_2(max_cache_len))
+    BLOCK = max(1, triton.next_power_of_2(batch))
+    with torch.accelerator.device_index(write_pos.device.index):
+        _advance_write_pos_origin_kernel[(1,)](
+            write_pos,
+            post_conv_state_pos,
+            is_flush,
+            num_accepted_tokens,
+            state_batch_indices,
+            null_block_id,
+            batch,
+            state_batch_indices.stride(0),
+            MAX_CACHE_LEN=max_cache_len,
+            MAX_SPEC_LEN=max_spec_len,
+            CACHE_BUF_LEN=cache_buf_len,
+            BLOCK_SIZE=BLOCK,
+            num_warps=1,
+        )
+
+
+def reset_replayssm_spec_cursors(
+    write_pos: torch.Tensor,
+    post_conv_state_pos: torch.Tensor,
+    is_flush: torch.Tensor,
+    first_decode_mask: torch.Tensor,  # (batch,) int8
+    state_batch_indices: torch.Tensor,  # (batch,) int32
+    max_cache_len: int,  # logical flush threshold L
+    max_spec_len: int,
+    force_flush_mask: torch.Tensor | None = None,  # (batch,) int8, subset of first
+    null_block_id: int = NULL_BLOCK_ID,
+) -> None:
+    """Prefill->decode reset for first-decode rows (block-keyed). Seeds the
+    initial ``is_flush`` to match the steady-state early-flush cadence, or to 1
+    for rows in ``force_flush_mask``."""
+    batch = state_batch_indices.shape[0]
+    BLOCK = max(1, triton.next_power_of_2(batch))
+    init_is_flush = 1 if 2 * max_spec_len > max_cache_len else 0
+    if force_flush_mask is None:
+        force_flush_mask = torch.zeros_like(first_decode_mask)
+    with torch.accelerator.device_index(write_pos.device.index):
+        _reset_replayssm_spec_cursors_kernel[(1,)](
+            write_pos,
+            post_conv_state_pos,
+            is_flush,
+            first_decode_mask,
+            force_flush_mask,
+            state_batch_indices,
+            null_block_id,
+            batch,
+            state_batch_indices.stride(0),
+            INIT_IS_FLUSH=init_is_flush,
+            BLOCK_SIZE=BLOCK,
+            num_warps=1,
+        )
+
+
+__all__ = [
+    "selective_state_update_replayssm_spec",
+    "commit_replayssm_spec",
+    "reset_replayssm_spec_cursors",
+]

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -745,6 +745,10 @@ class NemotronHForCausalLM(
             cache_config.mamba_cache_dtype,
             cache_config.mamba_ssm_cache_dtype,
         )
+        if cache_config.use_replayssm_spec:
+            return MambaStateDtypeCalculator.append_replayssm_spec_ring(
+                base_dtype, vllm_config.model_config.dtype
+            )
         if cache_config.use_replayssm:
             return MambaStateDtypeCalculator.append_replayssm_ring(
                 base_dtype, vllm_config.model_config.dtype
@@ -766,6 +770,8 @@ class NemotronHForCausalLM(
             - conv_state_shape: Shape for convolutional state cache
             - temporal_state_shape: Shape for state space model cache
             - x_cache/dt_cache/B_cache ring-buffer shapes (use_replayssm only)
+            - post_conv_cache/dt_cache circular ring shapes
+              (use_replayssm_spec only)
         """
         parallel_config = vllm_config.parallel_config
         cache_config = vllm_config.cache_config
@@ -782,6 +788,15 @@ class NemotronHForCausalLM(
             conv_kernel=hf_config.conv_kernel,
             num_spec=vllm_config.num_speculative_tokens,
         )
+        if cache_config.use_replayssm_spec:
+            return MambaStateShapeCalculator.append_replayssm_spec_ring(
+                base_shape,
+                intermediate_size,
+                hf_config.n_groups,
+                parallel_config.tensor_parallel_size,
+                cache_config.replayssm_buffer_len,
+                vllm_config.num_speculative_tokens,
+            )
         if cache_config.use_replayssm:
             return MambaStateShapeCalculator.append_replayssm_ring(
                 base_shape,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -294,6 +294,7 @@ class Qwen3_5ForCausalLMBase(
     nn.Module,
     HasInnerState,
     IsHybrid,
+    SupportsReplaySSM,
     SupportsEagle3,
     SupportsLoRA,
     SupportsMRoPE,

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -71,6 +71,7 @@ from .interfaces import (
     SupportsLoRA,
     SupportsMRoPE,
     SupportsPP,
+    SupportsReplaySSM,
     _require_is_multimodal,
 )
 from .qwen2_moe import Qwen2MoeMLP as Qwen3NextMLP
@@ -470,7 +471,9 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase, QwenNextMixtureOfExperts):
     info=Qwen3_5ProcessingInfo,
     dummy_inputs=Qwen3VLDummyInputsBuilder,
 )
-class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid):
+class Qwen3_5ForConditionalGeneration(
+    Qwen3VLForConditionalGeneration, IsHybrid, SupportsReplaySSM
+):
     supports_multimodal_pruning = True
 
     hf_to_vllm_mapper = (
@@ -608,18 +611,24 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
     def get_mamba_state_dtype_from_config(
         cls,
         vllm_config: "VllmConfig",
-    ) -> tuple[torch.dtype, torch.dtype]:
-        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+    ) -> tuple[torch.dtype, ...]:
+        base_dtype = MambaStateDtypeCalculator.gated_delta_net_state_dtype(
             vllm_config.model_config.dtype,
             vllm_config.cache_config.mamba_cache_dtype,
             vllm_config.cache_config.mamba_ssm_cache_dtype,
         )
+        if vllm_config.cache_config.use_replayssm_spec:
+            return MambaStateDtypeCalculator.append_gated_delta_net_replayssm_spec_ring(
+                base_dtype, vllm_config.model_config.dtype
+            )
+        return base_dtype
 
     @classmethod
     def get_mamba_state_shape_from_config(
         cls, vllm_config: "VllmConfig"
-    ) -> tuple[tuple[int, int], tuple[int, int]]:
+    ) -> tuple[tuple[int, ...], ...]:
         parallel_config = vllm_config.parallel_config
+        cache_config = vllm_config.cache_config
         hf_config = vllm_config.model_config.hf_text_config
         tp_size = parallel_config.tensor_parallel_size
         num_spec = (
@@ -627,7 +636,7 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
             if vllm_config.speculative_config
             else 0
         )
-        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+        base_shape = MambaStateShapeCalculator.gated_delta_net_state_shape(
             tp_size,
             hf_config.linear_num_key_heads,
             hf_config.linear_num_value_heads,
@@ -636,6 +645,18 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid)
             hf_config.linear_conv_kernel_dim,
             num_spec,
         )
+        if cache_config.use_replayssm_spec:
+            return MambaStateShapeCalculator.append_gated_delta_net_replayssm_spec_ring(
+                base_shape,
+                hf_config.linear_num_key_heads,
+                hf_config.linear_num_value_heads,
+                hf_config.linear_key_head_dim,
+                hf_config.linear_value_head_dim,
+                tp_size,
+                cache_config.replayssm_buffer_len,
+                num_spec,
+            )
+        return base_shape
 
     @classmethod
     def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:

--- a/vllm/third_party/flash_linear_attention/ops/gdn_replayssm_spec_decode.py
+++ b/vllm/third_party/flash_linear_attention/ops/gdn_replayssm_spec_decode.py
@@ -1,0 +1,716 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E501
+
+from __future__ import annotations
+
+import torch
+
+from vllm.model_executor.layers.mamba.ops.replayssm_config import get_replayssm_config
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def gdn_replayssm_spec_circular_kernel(
+    mixed_qkv,  # [total_tokens, qkv_dim]  packed, channel-last (q|k|v)
+    a,  # [total_tokens, HV]
+    b,  # [total_tokens, HV]
+    A_log,  # [HV] fp32
+    dt_bias,  # [HV] fp32
+    o,  # [total_tokens, HV, V]  preallocated output
+    h0,  # [num_slots, HV, V, K]  checkpoint state (== ht, in-place)
+    ht,  # [num_slots, HV, V, K]
+    d_cache,  # [num_slots, HV, L, V]
+    k_cache,  # [num_slots, H, L, K]
+    g_cache,  # [num_slots, HV, L]  fp32
+    query_start_loc,  # [B+1] int  packed cu_seqlens
+    ssm_state_indices,  # [B] int  physical block per request
+    write_pos,  # [num_slots] int32  block-keyed
+    cache_base,  # [num_slots] int32  block-keyed circular origin
+    is_flush_flags,  # [num_slots] int8  block-keyed
+    scale,
+    stride_mqkv_t: tl.constexpr,  # per-token stride of mixed_qkv
+    stride_a_t: tl.constexpr,
+    stride_b_t: tl.constexpr,
+    stride_o_t: tl.constexpr,  # per-token stride of o (= HV*V)
+    stride_state_slot: tl.constexpr,
+    stride_d_slot: tl.constexpr,
+    stride_k_slot: tl.constexpr,
+    stride_g_slot: tl.constexpr,
+    stride_qsl: tl.constexpr,
+    stride_indices: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    BS: tl.constexpr,
+    BC: tl.constexpr,
+    NK: tl.constexpr,
+    BKT: tl.constexpr,
+    MAX_CACHE_LEN: tl.constexpr,
+    SOFTPLUS_THRESHOLD: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_FLUSH: tl.constexpr,
+    NULL_BLOCK_ID: tl.constexpr,
+    DOT_PRECISION: tl.constexpr,
+):
+    i_v = tl.program_id(0)
+    i_n = tl.program_id(1)
+    i_hv = tl.program_id(2)
+    i_h = i_hv // (HV // H)
+
+    o_v = i_v * BV + tl.arange(0, BV)
+    o_s = tl.arange(0, BS)
+    o_c = tl.arange(0, BC)
+    mask_v = o_v < V
+
+    # --- per-request packed window ---
+    bos = tl.load(query_start_loc + i_n * stride_qsl).to(tl.int64)
+    eos = tl.load(query_start_loc + (i_n + 1) * stride_qsl).to(tl.int64)
+    spec_len = eos - bos  # full window length
+
+    state_idx = tl.load(ssm_state_indices + i_n * stride_indices).to(tl.int64)
+
+    # output pointer (packed): token (bos + o_s), value-head i_hv, dim o_v
+    p_o = o + (bos + o_s[:, None]) * stride_o_t + i_hv * V + o_v[None, :]
+
+    if IS_FLUSH:
+        if state_idx <= NULL_BLOCK_ID:
+            return
+        b_is_flush = tl.load(is_flush_flags + state_idx) != 0
+        if not b_is_flush:
+            return
+    else:
+        if state_idx <= NULL_BLOCK_ID:
+            full_mask = (o_s < spec_len)[:, None] & mask_v[None, :]
+            tl.store(
+                p_o,
+                tl.zeros([BS, BV], dtype=tl.float32).to(p_o.dtype.element_ty),
+                mask=full_mask,
+            )
+            return
+        b_is_flush = tl.load(is_flush_flags + state_idx) != 0
+        if b_is_flush:
+            return
+
+    b_write_pos = tl.load(write_pos + state_idx).to(tl.int64)
+    b_cache_base = tl.load(cache_base + state_idx).to(tl.int32)
+
+    mask_s = o_s < spec_len
+    out_mask = mask_s[:, None] & mask_v[None, :]
+
+    b_wp_i = b_write_pos.to(tl.int32)
+    cache_valid = o_c < b_write_pos
+
+    # CIRCULAR physical slots (addresses only; masks/cumsums stay logical).
+    phys_c = (b_cache_base + o_c) & (MAX_CACHE_LEN - 1)  # [BC] history
+    phys_spec = (b_cache_base + b_wp_i + o_s) & (MAX_CACHE_LEN - 1)  # [BS] spec
+
+    # ------------------------------------------------------------------
+    # Block 0: gates / beta / local cumsum + committed-history replay decay.
+    # ------------------------------------------------------------------
+    A_log_val = tl.load(A_log + i_hv).to(tl.float32)
+    dt_bias_val = tl.load(dt_bias + i_hv).to(tl.float32)
+    a_s = tl.load(a + (bos + o_s) * stride_a_t + i_hv, mask=mask_s, other=0.0).to(
+        tl.float32
+    )
+    b_s = tl.load(b + (bos + o_s) * stride_b_t + i_hv, mask=mask_s, other=0.0).to(
+        tl.float32
+    )
+    x = a_s + dt_bias_val
+    softplus_x = tl.where(x <= SOFTPLUS_THRESHOLD, tl.log(1.0 + tl.exp(x)), x)
+    g_s = tl.where(mask_s, -tl.exp(A_log_val) * softplus_x, 0.0)
+    beta_s = tl.where(mask_s, tl.sigmoid(b_s), 0.0)
+    G_s = tl.cumsum(g_s, axis=0)
+    expG_s = tl.exp(G_s)
+
+    # committed-history replay decay from cached g (history loads -> phys_c)
+    p_g_main = g_cache + state_idx * stride_g_slot + i_hv * MAX_CACHE_LEN + phys_c
+    b_g_all = tl.load(p_g_main, mask=cache_valid, other=0.0).to(tl.float32)
+    b_g_prefix = tl.cumsum(b_g_all, axis=0)
+    b_g_total = tl.sum(b_g_all, axis=0)
+    b_replay_decay = tl.where(cache_valid, tl.exp(b_g_total - b_g_prefix), 0.0)
+    b_total_decay = tl.exp(b_g_total)
+
+    p_d_main = d_cache + (
+        state_idx * stride_d_slot
+        + (i_hv * MAX_CACHE_LEN + phys_c[None, :]) * V
+        + o_v[:, None]
+    )
+    b_d_all = tl.load(
+        p_d_main, mask=mask_v[:, None] & cache_valid[None, :], other=0.0
+    ).to(tl.float32)
+    b_d_scaled = b_d_all * b_replay_decay[None, :]
+
+    if USE_QK_L2NORM_IN_KERNEL:
+        qnorm_acc = tl.zeros([BS], dtype=tl.float32)
+        knorm_acc = tl.zeros([BS], dtype=tl.float32)
+        for kk in range(NK):
+            o_kt = kk * BKT + tl.arange(0, BKT)
+            mask_kt = o_kt < K
+            ld = mask_s[:, None] & mask_kt[None, :]
+            qn = tl.load(
+                mixed_qkv
+                + (bos + o_s[:, None]) * stride_mqkv_t
+                + i_h * K
+                + o_kt[None, :],
+                mask=ld,
+                other=0.0,
+            ).to(tl.float32)
+            knn = tl.load(
+                mixed_qkv
+                + (bos + o_s[:, None]) * stride_mqkv_t
+                + H * K
+                + i_h * K
+                + o_kt[None, :],
+                mask=ld,
+                other=0.0,
+            ).to(tl.float32)
+            qnorm_acc += tl.sum(qn * qn, axis=1)
+            knorm_acc += tl.sum(knn * knn, axis=1)
+        q_rnorm = tl.where(mask_s, 1.0 / tl.sqrt(qnorm_acc + 1e-6), 0.0)
+        k_rnorm = tl.where(mask_s, 1.0 / tl.sqrt(knorm_acc + 1e-6), 0.0)
+    else:
+        q_rnorm = tl.where(mask_s, 1.0, 0.0)
+        k_rnorm = tl.where(mask_s, 1.0, 0.0)
+
+    # ------------------------------------------------------------------
+    # K-Tiled Fused Projection and Intra-Spec Matrices (+ flush)
+    # ------------------------------------------------------------------
+    hw_q = tl.zeros([BV, BS], dtype=tl.float32)
+    hw_k = tl.zeros([BV, BS], dtype=tl.float32)
+    if not IS_FLUSH:
+        scores_q = tl.zeros([BC, BS], dtype=tl.float32)
+        scores_k = tl.zeros([BC, BS], dtype=tl.float32)
+    kk_mat = tl.zeros([BS, BS], dtype=tl.float32)
+    kq_mat = tl.zeros([BS, BS], dtype=tl.float32)
+
+    write_k = (i_v == 0) and (i_hv == i_h * (HV // H))
+
+    for kk in range(NK):
+        o_kt = kk * BKT + tl.arange(0, BKT)
+        mask_kt = o_kt < K
+        ld_s = mask_s[:, None] & mask_kt[None, :]
+        q_tile = tl.load(
+            mixed_qkv + (bos + o_s[:, None]) * stride_mqkv_t + i_h * K + o_kt[None, :],
+            mask=ld_s,
+            other=0.0,
+        ).to(tl.float32)
+        k_tile = tl.load(
+            mixed_qkv
+            + (bos + o_s[:, None]) * stride_mqkv_t
+            + H * K
+            + i_h * K
+            + o_kt[None, :],
+            mask=ld_s,
+            other=0.0,
+        ).to(tl.float32)
+        q_tile = q_tile * (q_rnorm * scale)[:, None]
+        k_tile = k_tile * k_rnorm[:, None]
+
+        p_h0 = (
+            h0
+            + state_idx * stride_state_slot
+            + i_hv * V * K
+            + o_v[:, None] * K
+            + o_kt[None, :]
+        )
+        sc_tile = tl.load(p_h0, mask=mask_v[:, None] & mask_kt[None, :], other=0.0).to(
+            tl.float32
+        )
+        # cached-key history load -> phys_c
+        p_k = k_cache + (
+            state_idx * stride_k_slot
+            + (i_h * MAX_CACHE_LEN + phys_c[:, None]) * K
+            + o_kt[None, :]
+        )
+        khist_tile = tl.load(
+            p_k, mask=cache_valid[:, None] & mask_kt[None, :], other=0.0
+        ).to(tl.float32)
+
+        qT = tl.trans(q_tile)
+        kT = tl.trans(k_tile)
+        kk_mat += tl.dot(k_tile, kT, input_precision=DOT_PRECISION)
+        kq_mat += tl.dot(k_tile, qT, input_precision=DOT_PRECISION)
+
+        if IS_FLUSH:
+            sw_f = tl.dot(
+                b_d_scaled,
+                khist_tile,
+                acc=b_total_decay * sc_tile,
+                input_precision=DOT_PRECISION,
+            )
+            hw_q += tl.dot(sw_f, qT, input_precision=DOT_PRECISION)
+            hw_k += tl.dot(sw_f, kT, input_precision=DOT_PRECISION)
+            p_ht = (
+                ht
+                + state_idx * stride_state_slot
+                + i_hv * V * K
+                + o_v[:, None] * K
+                + o_kt[None, :]
+            )
+            # fp32 store to the fp32 checkpoint page
+            tl.store(
+                p_ht,
+                sw_f.to(p_ht.dtype.element_ty),
+                mask=mask_v[:, None] & mask_kt[None, :],
+            )
+        else:
+            hw_q += tl.dot(sc_tile, qT, input_precision=DOT_PRECISION)
+            hw_k += tl.dot(sc_tile, kT, input_precision=DOT_PRECISION)
+            scores_q += tl.dot(khist_tile, qT, input_precision=DOT_PRECISION)
+            scores_k += tl.dot(khist_tile, kT, input_precision=DOT_PRECISION)
+
+        if write_k:
+            # spec key store -> phys_spec (circular)
+            p_cur_k = k_cache + (
+                state_idx * stride_k_slot
+                + (i_h * MAX_CACHE_LEN + phys_spec[:, None]) * K
+                + o_kt[None, :]
+            )
+            tl.store(
+                p_cur_k,
+                k_tile.to(p_cur_k.dtype.element_ty),
+                mask=mask_s[:, None]
+                & mask_kt[None, :]
+                & ((b_write_pos + o_s[:, None]) < MAX_CACHE_LEN),
+            )
+
+    if not IS_FLUSH:
+        hw_q = b_total_decay * hw_q + tl.dot(
+            b_d_scaled, scores_q, input_precision=DOT_PRECISION
+        )
+        hw_k = b_total_decay * hw_k + tl.dot(
+            b_d_scaled, scores_k, input_precision=DOT_PRECISION
+        )
+
+    # ------------------------------------------------------------------
+    # strictly-lower A and T = (I + A)^{-1}.
+    # ------------------------------------------------------------------
+    lower = (o_s[:, None] > o_s[None, :]) & mask_s[:, None] & mask_s[None, :]
+    diff_ij = G_s[:, None] - G_s[None, :]
+    A_mat = tl.where(lower, beta_s[:, None] * tl.exp(diff_ij) * kk_mat, 0.0)
+
+    b_Ai = -A_mat
+    for ii in range(2, BS):
+        row = tl.sum(tl.where((o_s == ii)[:, None], -A_mat, 0.0), axis=0)
+        row = tl.where(o_s < ii, row, 0.0)
+        row = row + tl.sum(row[:, None] * b_Ai, axis=0)
+        b_Ai = tl.where((o_s == ii)[:, None], row, b_Ai)
+    T_mat = b_Ai + (o_s[:, None] == o_s[None, :]).to(tl.float32)
+
+    # ------------------------------------------------------------------
+    # R and D_spec = R @ T^T.
+    # ------------------------------------------------------------------
+    p_v = (
+        mixed_qkv
+        + (bos + o_s[None, :]) * stride_mqkv_t
+        + 2 * H * K
+        + i_hv * V
+        + o_v[:, None]
+    )
+    v_tile = tl.load(p_v, mask=mask_v[:, None] & mask_s[None, :], other=0.0).to(
+        tl.float32
+    )
+    R_mat = beta_s[None, :] * (v_tile - expG_s[None, :] * hw_k)
+    D_spec = tl.zeros([BV, BS], dtype=tl.float32)
+    for j in tl.static_range(BS):
+        Rj = tl.sum(tl.where((o_s == j)[None, :], R_mat, 0.0), axis=1)
+        Tj = tl.sum(tl.where((o_s == j)[None, :], T_mat, 0.0), axis=1)
+        D_spec += Rj[:, None] * Tj[None, :]
+
+    # ------------------------------------------------------------------
+    # outputs.
+    # ------------------------------------------------------------------
+    causalF = (o_s[:, None] <= o_s[None, :]) & mask_s[:, None] & mask_s[None, :]
+    diff_ji = G_s[None, :] - G_s[:, None]
+    F_mat = tl.where(causalF, tl.exp(diff_ji) * kq_mat, 0.0)
+    DF = tl.zeros([BV, BS], dtype=tl.float32)
+    for j in tl.static_range(BS):
+        Dj = tl.sum(tl.where((o_s == j)[None, :], D_spec, 0.0), axis=1)
+        Fj = tl.sum(tl.where((o_s == j)[:, None], F_mat, 0.0), axis=0)
+        DF += Dj[:, None] * Fj[None, :]
+    O_tile = expG_s[None, :] * hw_q + DF
+
+    tl.store(p_o, tl.trans(O_tile).to(p_o.dtype.element_ty), mask=out_mask)
+
+    # ------------------------------------------------------------------
+    # write speculative d / g at circular positions (phys_spec).
+    # ------------------------------------------------------------------
+    spec_pos = b_write_pos + o_s
+    spec_store_mask = mask_s & (spec_pos < MAX_CACHE_LEN)
+    p_cur_d = d_cache + (
+        state_idx * stride_d_slot
+        + (i_hv * MAX_CACHE_LEN + phys_spec[None, :]) * V
+        + o_v[:, None]
+    )
+    tl.store(
+        p_cur_d,
+        D_spec.to(p_cur_d.dtype.element_ty),
+        mask=mask_v[:, None] & spec_store_mask[None, :],
+    )
+    if i_v == 0:
+        p_cur_g = g_cache + state_idx * stride_g_slot + i_hv * MAX_CACHE_LEN + phys_spec
+        tl.store(p_cur_g, g_s, mask=spec_store_mask)
+
+
+@triton.jit
+def _advance_gdn_spec_cursors_kernel(
+    write_pos_ptr,
+    cache_base_ptr,
+    is_flush_ptr,
+    num_accepted_ptr,
+    state_batch_indices_ptr,
+    n_rows,
+    stride_sbi: tl.constexpr,
+    stride_na: tl.constexpr,
+    MAX_CACHE_LEN: tl.constexpr,
+    MAX_SPEC_LEN: tl.constexpr,
+    CACHE_BUF_LEN: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NULL_BLOCK_ID: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK)
+    row_mask = offs < n_rows
+    blk = tl.load(
+        state_batch_indices_ptr + offs * stride_sbi, mask=row_mask, other=NULL_BLOCK_ID
+    ).to(tl.int64)
+    valid = row_mask & (blk > NULL_BLOCK_ID)
+
+    write_pos = tl.load(write_pos_ptr + blk, mask=valid, other=0).to(tl.int32)
+    cache_base = tl.load(cache_base_ptr + blk, mask=valid, other=0).to(tl.int32)
+    is_flush_cur = tl.load(is_flush_ptr + blk, mask=valid, other=0).to(tl.int32)
+    num_acc = tl.load(num_accepted_ptr + offs * stride_na, mask=valid, other=0).to(
+        tl.int32
+    )
+
+    total_commit = num_acc
+    flush_now = (total_commit > 0) & (is_flush_cur != 0)
+
+    new_base = tl.where(
+        flush_now, (cache_base + write_pos) & (CACHE_BUF_LEN - 1), cache_base
+    )
+    new_wp = tl.where(is_flush_cur != 0, total_commit, write_pos + total_commit).to(
+        tl.int32
+    )
+    # Early-flush one window early so every verify step satisfies
+    # write_pos + spec_len <= max_cache_len (the spec window never overflows).
+    next_is_flush = ((new_wp + 2 * MAX_SPEC_LEN) > MAX_CACHE_LEN).to(tl.int8)
+
+    tl.store(write_pos_ptr + blk, new_wp, mask=valid)
+    tl.store(cache_base_ptr + blk, new_base, mask=valid)
+    tl.store(is_flush_ptr + blk, next_is_flush, mask=valid)
+
+
+@triton.jit
+def _reset_gdn_replayssm_spec_cursors_kernel(
+    write_pos_ptr,
+    cache_base_ptr,
+    is_flush_ptr,
+    do_reset_ptr,
+    state_batch_indices_ptr,
+    n_rows,
+    stride_sbi: tl.constexpr,
+    stride_reset: tl.constexpr,
+    INIT_FLUSH: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NULL_BLOCK_ID: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK)
+    row_mask = offs < n_rows
+    blk = tl.load(
+        state_batch_indices_ptr + offs * stride_sbi, mask=row_mask, other=NULL_BLOCK_ID
+    ).to(tl.int64)
+    do_reset = tl.load(do_reset_ptr + offs * stride_reset, mask=row_mask, other=0).to(
+        tl.int32
+    )
+    do = row_mask & (blk > NULL_BLOCK_ID) & (do_reset != 0)
+
+    tl.store(write_pos_ptr + blk, tl.zeros_like(blk).to(tl.int32), mask=do)
+    tl.store(cache_base_ptr + blk, tl.zeros_like(blk).to(tl.int32), mask=do)
+    tl.store(
+        is_flush_ptr + blk,
+        tl.full([BLOCK], INIT_FLUSH, dtype=tl.int8),
+        mask=do,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python wrappers.
+# ---------------------------------------------------------------------------
+def _launch_gdn_spec(
+    mixed_qkv,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    out,
+    checkpoint_state,
+    d_cache,
+    k_cache,
+    g_cache,
+    query_start_loc,
+    ssm_state_indices,
+    write_pos,
+    cache_base,
+    is_flush,
+    scale,
+    max_cache_len,
+    max_spec_len,
+    use_qk_l2norm_in_kernel,
+    is_flush_kernel,
+    block_v,
+    num_warps,
+    num_stages,
+    nk,
+    null_block_id,
+    dot_precision,
+):
+    num_slots, HV, V, K = checkpoint_state.shape
+    qkv_dim = mixed_qkv.shape[1]
+    q_dim = (qkv_dim - HV * V) // 2
+    H = q_dim // K
+    B = query_start_loc.shape[0] - 1
+    # max_cache_len is the logical flush threshold L; the physical pow2 ring is
+    # d_cache.shape[2] = next_pow2(L) and wraps addresses / per-head strides.
+    buf = d_cache.shape[2]
+    assert buf & (buf - 1) == 0, "circular cache requires power-of-two buffer"
+
+    BK = triton.next_power_of_2(K)
+    if triton.cdiv(K, BK) != 1:
+        raise ValueError(f"only NK_global=1 supported (K={K}, BK={BK}).")
+    if BK % nk != 0:
+        raise ValueError(f"nk={nk} must divide BK={BK}.")
+    BKT = BK // nk
+    if BKT < 16:
+        raise ValueError(f"BKT={BKT} must be >=16 for tl.dot.")
+    BV = block_v if block_v is not None else min(triton.next_power_of_2(V), 64)
+    BS = max(4, triton.next_power_of_2(max_spec_len))
+    # History block decoupled from the physical buffer: with L = B + max_spec_len
+    # committed history never exceeds L - max_spec_len, so BC covers it while
+    # staying small (the L=B+T win).
+    BC = max(16, triton.next_power_of_2(max(1, max_cache_len - max_spec_len)))
+
+    grid = (triton.cdiv(V, BV), B, HV)
+    gdn_replayssm_spec_circular_kernel[grid](
+        mixed_qkv,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        out,
+        checkpoint_state,
+        checkpoint_state,
+        d_cache,
+        k_cache,
+        g_cache,
+        query_start_loc,
+        ssm_state_indices,
+        write_pos,
+        cache_base,
+        is_flush,
+        scale,
+        mixed_qkv.stride(0),
+        a.stride(0),
+        b.stride(0),
+        out.stride(0),
+        checkpoint_state.stride(0),
+        d_cache.stride(0),
+        k_cache.stride(0),
+        g_cache.stride(0),
+        query_start_loc.stride(0),
+        ssm_state_indices.stride(0),
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        BS=BS,
+        BC=BC,
+        NK=nk,
+        BKT=BKT,
+        MAX_CACHE_LEN=buf,
+        SOFTPLUS_THRESHOLD=20.0,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        IS_FLUSH=is_flush_kernel,
+        NULL_BLOCK_ID=null_block_id,
+        DOT_PRECISION=dot_precision,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+
+
+def gdn_replayssm_spec_decode(
+    mixed_qkv: torch.Tensor,  # [total_tokens, qkv_dim]  post-conv packed (q|k|v)
+    a: torch.Tensor,  # [total_tokens, HV]
+    b: torch.Tensor,  # [total_tokens, HV]
+    A_log: torch.Tensor,  # [HV] fp32
+    dt_bias: torch.Tensor,  # [HV] fp32
+    checkpoint_state: torch.Tensor,  # [num_slots, HV, V, K]  (in-place h0==ht)
+    d_cache: torch.Tensor,  # [num_slots, HV, buf, V]
+    k_cache: torch.Tensor,  # [num_slots, H, buf, K]
+    g_cache: torch.Tensor,  # [num_slots, HV, buf]  fp32
+    out: torch.Tensor,  # [total_tokens, HV, V]  preallocated
+    query_start_loc: torch.Tensor,  # [B+1] int
+    ssm_state_indices: torch.Tensor,  # [B] int  physical block per request
+    write_pos: torch.Tensor,  # [num_slots] int32  block-keyed
+    cache_base: torch.Tensor,  # [num_slots] int32  block-keyed
+    is_flush: torch.Tensor,  # [num_slots] int8  block-keyed
+    max_cache_len: int,  # logical flush threshold L = B + max_spec_len
+    max_spec_len: int,
+    scale: float | None = None,
+    use_qk_l2norm_in_kernel: bool = True,
+    null_block_id: int = 0,
+    launch_mode: str = "both",
+    dot_precision: str = "tf32",
+    dot_precision_flush: str | None = None,
+):
+    """GDN cached speculative-decode on a CIRCULAR d/k/g cache (vLLM packed varlen).
+
+    ``max_cache_len`` is the logical flush threshold L = B + max_spec_len; the
+    physical pow2 buffer is ``d_cache.shape[2]`` = ``next_pow2(L)`` and the history
+    block ``BC = next_pow2(L - max_spec_len)``. Two launches (verify + flush
+    ``IS_FLUSH`` specializations) with device-side per-row routing keep the step
+    CUDA-graph capturable. Cursors are advanced by ``commit_gdn_replayssm_spec``.
+    """
+    if scale is None:
+        scale = checkpoint_state.shape[-1] ** -0.5
+    if is_flush.dtype != torch.int8:
+        is_flush = is_flush.to(torch.int8)
+    if dot_precision_flush is None:
+        dot_precision_flush = dot_precision
+    vb, vw, vnk, vns = get_replayssm_config(
+        "gdn_spec_verify",
+        max_spec_len=max_spec_len,
+        head_k_dim=checkpoint_state.shape[-1],
+    )
+    fb, fw, fnk, fns = get_replayssm_config(
+        "gdn_spec_flush",
+        max_spec_len=max_spec_len,
+        head_k_dim=checkpoint_state.shape[-1],
+    )
+
+    if launch_mode in ("both", "verify"):
+        _launch_gdn_spec(
+            mixed_qkv,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            out,
+            checkpoint_state,
+            d_cache,
+            k_cache,
+            g_cache,
+            query_start_loc,
+            ssm_state_indices,
+            write_pos,
+            cache_base,
+            is_flush,
+            scale,
+            max_cache_len,
+            max_spec_len,
+            use_qk_l2norm_in_kernel,
+            False,
+            vb,
+            vw,
+            vns,
+            vnk,
+            null_block_id,
+            dot_precision,
+        )
+    if launch_mode in ("both", "flush"):
+        _launch_gdn_spec(
+            mixed_qkv,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            out,
+            checkpoint_state,
+            d_cache,
+            k_cache,
+            g_cache,
+            query_start_loc,
+            ssm_state_indices,
+            write_pos,
+            cache_base,
+            is_flush,
+            scale,
+            max_cache_len,
+            max_spec_len,
+            use_qk_l2norm_in_kernel,
+            True,
+            fb,
+            fw,
+            fns,
+            fnk,
+            null_block_id,
+            dot_precision_flush,
+        )
+    return out
+
+
+def commit_gdn_replayssm_spec(
+    write_pos: torch.Tensor,
+    cache_base: torch.Tensor,
+    is_flush: torch.Tensor,
+    num_accepted: torch.Tensor,  # [n_rows] int  (already includes the bonus token)
+    state_batch_indices: torch.Tensor,  # [n_rows] int  physical block per row
+    max_cache_len: int,  # logical flush threshold L
+    max_spec_len: int,
+    cache_buf_len: int | None = None,  # physical pow2 buffer next_pow2(L)
+    null_block_id: int = 0,
+):
+    """Advance the block-keyed cursors once per decode step (device-only)."""
+    if cache_buf_len is None:
+        cache_buf_len = triton.next_power_of_2(max_cache_len)
+    n_rows = state_batch_indices.shape[0]
+    BLOCK = triton.next_power_of_2(max(1, n_rows))
+    _advance_gdn_spec_cursors_kernel[(1,)](
+        write_pos,
+        cache_base,
+        is_flush,
+        num_accepted,
+        state_batch_indices,
+        n_rows,
+        stride_sbi=state_batch_indices.stride(0),
+        stride_na=num_accepted.stride(0),
+        MAX_CACHE_LEN=max_cache_len,
+        MAX_SPEC_LEN=max_spec_len,
+        CACHE_BUF_LEN=cache_buf_len,
+        BLOCK=BLOCK,
+        NULL_BLOCK_ID=null_block_id,
+    )
+
+
+def reset_gdn_replayssm_spec_cursors(
+    write_pos: torch.Tensor,
+    cache_base: torch.Tensor,
+    is_flush: torch.Tensor,
+    do_reset: torch.Tensor,  # [n_rows] int/bool  1 for first-decode rows
+    state_batch_indices: torch.Tensor,  # [n_rows] int
+    max_cache_len: int,
+    max_spec_len: int,
+    null_block_id: int = 0,
+):
+    """Reset the cursors of first-decode rows (prefill->decode handoff)."""
+    n_rows = state_batch_indices.shape[0]
+    BLOCK = triton.next_power_of_2(max(1, n_rows))
+    init_flush = 1 if 2 * max_spec_len > max_cache_len else 0
+    _reset_gdn_replayssm_spec_cursors_kernel[(1,)](
+        write_pos,
+        cache_base,
+        is_flush,
+        do_reset,
+        state_batch_indices,
+        n_rows,
+        stride_sbi=state_batch_indices.stride(0),
+        stride_reset=do_reset.stride(0),
+        INIT_FLUSH=init_flush,
+        BLOCK=BLOCK,
+        NULL_BLOCK_ID=null_block_id,
+    )

--- a/vllm/third_party/flash_linear_attention/ops/gdn_replayssm_spec_decode.py
+++ b/vllm/third_party/flash_linear_attention/ops/gdn_replayssm_spec_decode.py
@@ -53,6 +53,7 @@ def gdn_replayssm_spec_circular_kernel(
     SOFTPLUS_THRESHOLD: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
     IS_FLUSH: tl.constexpr,
+    ROUTE_BOTH: tl.constexpr,
     NULL_BLOCK_ID: tl.constexpr,
     DOT_PRECISION: tl.constexpr,
 ):
@@ -76,23 +77,21 @@ def gdn_replayssm_spec_circular_kernel(
     # output pointer (packed): token (bos + o_s), value-head i_hv, dim o_v
     p_o = o + (bos + o_s[:, None]) * stride_o_t + i_hv * V + o_v[None, :]
 
-    if IS_FLUSH:
-        if state_idx <= NULL_BLOCK_ID:
-            return
-        b_is_flush = tl.load(is_flush_flags + state_idx) != 0
-        if not b_is_flush:
-            return
-    else:
-        if state_idx <= NULL_BLOCK_ID:
+    if state_idx <= NULL_BLOCK_ID:
+        if not IS_FLUSH:
             full_mask = (o_s < spec_len)[:, None] & mask_v[None, :]
             tl.store(
                 p_o,
                 tl.zeros([BS, BV], dtype=tl.float32).to(p_o.dtype.element_ty),
                 mask=full_mask,
             )
-            return
-        b_is_flush = tl.load(is_flush_flags + state_idx) != 0
-        if b_is_flush:
+        return
+    b_is_flush = tl.load(is_flush_flags + state_idx) != 0
+    if ROUTE_BOTH:
+        run_flush = b_is_flush
+    else:
+        run_flush = IS_FLUSH
+        if b_is_flush != IS_FLUSH:
             return
 
     b_write_pos = tl.load(write_pos + state_idx).to(tl.int64)
@@ -181,9 +180,10 @@ def gdn_replayssm_spec_circular_kernel(
     # ------------------------------------------------------------------
     hw_q = tl.zeros([BV, BS], dtype=tl.float32)
     hw_k = tl.zeros([BV, BS], dtype=tl.float32)
-    if not IS_FLUSH:
-        scores_q = tl.zeros([BC, BS], dtype=tl.float32)
-        scores_k = tl.zeros([BC, BS], dtype=tl.float32)
+    # Define both accumulators for the unified runtime-routed kernel.  Triton
+    # then keeps the verify/flush bodies behind a scalar per-request branch.
+    scores_q = tl.zeros([BC, BS], dtype=tl.float32)
+    scores_k = tl.zeros([BC, BS], dtype=tl.float32)
     kk_mat = tl.zeros([BS, BS], dtype=tl.float32)
     kq_mat = tl.zeros([BS, BS], dtype=tl.float32)
 
@@ -235,7 +235,7 @@ def gdn_replayssm_spec_circular_kernel(
         kk_mat += tl.dot(k_tile, kT, input_precision=DOT_PRECISION)
         kq_mat += tl.dot(k_tile, qT, input_precision=DOT_PRECISION)
 
-        if IS_FLUSH:
+        if run_flush:
             sw_f = tl.dot(
                 b_d_scaled,
                 khist_tile,
@@ -278,7 +278,7 @@ def gdn_replayssm_spec_circular_kernel(
                 & ((b_write_pos + o_s[:, None]) < MAX_CACHE_LEN),
             )
 
-    if not IS_FLUSH:
+    if not run_flush:
         hw_q = b_total_decay * hw_q + tl.dot(
             b_d_scaled, scores_q, input_precision=DOT_PRECISION
         )
@@ -461,6 +461,7 @@ def _launch_gdn_spec(
     max_spec_len,
     use_qk_l2norm_in_kernel,
     is_flush_kernel,
+    route_both,
     block_v,
     num_warps,
     num_stages,
@@ -536,6 +537,7 @@ def _launch_gdn_spec(
         SOFTPLUS_THRESHOLD=20.0,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_FLUSH=is_flush_kernel,
+        ROUTE_BOTH=route_both,
         NULL_BLOCK_ID=null_block_id,
         DOT_PRECISION=dot_precision,
         num_warps=num_warps,
@@ -593,6 +595,39 @@ def gdn_replayssm_spec_decode(
         head_k_dim=checkpoint_state.shape[-1],
     )
 
+    if launch_mode == "unified":
+        # A single per-request runtime branch replaces the two separately
+        # specialized launches.  Verify is the common case, so use its tuned
+        # launch geometry; flush rows take the alternate body in the kernel.
+        _launch_gdn_spec(
+            mixed_qkv,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            out,
+            checkpoint_state,
+            d_cache,
+            k_cache,
+            g_cache,
+            query_start_loc,
+            ssm_state_indices,
+            write_pos,
+            cache_base,
+            is_flush,
+            scale,
+            max_cache_len,
+            max_spec_len,
+            use_qk_l2norm_in_kernel,
+            False,
+            True,
+            vb,
+            vw,
+            vns,
+            vnk,
+            null_block_id,
+            dot_precision,
+        )
     if launch_mode in ("both", "verify"):
         _launch_gdn_spec(
             mixed_qkv,
@@ -614,6 +649,7 @@ def gdn_replayssm_spec_decode(
             max_cache_len,
             max_spec_len,
             use_qk_l2norm_in_kernel,
+            False,
             False,
             vb,
             vw,
@@ -644,6 +680,7 @@ def gdn_replayssm_spec_decode(
             max_spec_len,
             use_qk_l2norm_in_kernel,
             True,
+            False,
             fb,
             fw,
             fns,

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -2,8 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Backend for GatedDeltaNet attention."""
 
-from dataclasses import dataclass
-from typing import Literal
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
 
 import torch
 
@@ -16,6 +18,10 @@ from vllm.v1.attention.backend import (
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
 )
+from vllm.v1.attention.backends.recoverssm_metadata import (
+    RecoverSSMMetadata,
+    RecoverSSMPostprocessMetadata,
+)
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
     compute_causal_conv1d_metadata,
@@ -24,6 +30,11 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.kv_cache_interface import MambaSpec
 
+if TYPE_CHECKING:
+    from vllm.third_party.flash_linear_attention.ops.gdn_replayssm_prefix import (
+        GDNReplaySSMPrefixCommitContext,
+    )
+
 
 class GDNAttentionBackend(AttentionBackend):
     @staticmethod
@@ -31,7 +42,7 @@ class GDNAttentionBackend(AttentionBackend):
         return "GDN_ATTN"
 
     @staticmethod
-    def get_builder_cls() -> type["GDNAttentionMetadataBuilder"]:
+    def get_builder_cls() -> type[GDNAttentionMetadataBuilder]:
         return GDNAttentionMetadataBuilder
 
     @classmethod
@@ -40,7 +51,22 @@ class GDNAttentionBackend(AttentionBackend):
 
 
 @dataclass
-class GDNAttentionMetadata:
+class GDNReplaySSMAlignMetadata:
+    block_table: torch.Tensor
+    num_computed_tokens: torch.Tensor
+    block_size: int
+
+
+@dataclass
+class GDNReplaySSMCommitMetadata:
+    state_indices: torch.Tensor
+    query_start_loc: torch.Tensor
+    request_indices: torch.Tensor | None
+    align: GDNReplaySSMAlignMetadata
+
+
+@dataclass
+class GDNAttentionMetadata(RecoverSSMMetadata):
     num_prefills: int
     num_prefill_tokens: int
     num_decodes: int
@@ -73,6 +99,11 @@ class GDNAttentionMetadata:
     spec_cache_base_d: torch.Tensor | None = None
     spec_is_flush_d: torch.Tensor | None = None
 
+    replayssm_commit: GDNReplaySSMCommitMetadata | None = None
+    replayssm_context: GDNReplaySSMPrefixCommitContext | None = field(
+        default=None, repr=False, compare=False
+    )
+
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
     chunk_offsets: torch.Tensor | None = None
@@ -86,12 +117,40 @@ class GDNAttentionMetadata:
     batch_ptr: torch.Tensor | None = None
     token_chunk_offset_ptr: torch.Tensor | None = None
 
+    def commit_recoverssm_state(
+        self, num_accepted_tokens: torch.Tensor
+    ) -> RecoverSSMPostprocessMetadata | None:
+        commit = self.replayssm_commit
+        if commit is None:
+            return None
+        context = self.replayssm_context
+        assert context is not None
+        align = commit.align
+        reset_mask = context.commit(
+            num_accepted_tokens,
+            commit.state_indices[: self.num_spec_decodes, 0],
+            commit.query_start_loc[: self.num_spec_decodes + 1],
+            request_indices=commit.request_indices,
+            block_table=align.block_table,
+            num_computed_tokens=align.num_computed_tokens,
+            mamba_block_size=align.block_size,
+        )
+        return RecoverSSMPostprocessMetadata(
+            num_spec_decodes=self.num_spec_decodes,
+            request_indices=commit.request_indices,
+            block_table=align.block_table,
+            num_computed_tokens=align.num_computed_tokens,
+            block_size=align.block_size,
+            reset_mask=reset_mask,
+        )
+
 
 class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]):
     kv_cache_spec: MambaSpec
     _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
 
     reorder_batch_threshold: int = 1
+    mamba_aligned_state_indices: torch.Tensor | None = None
 
     def __init__(
         self,
@@ -104,6 +163,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         self.compilation_config = vllm_config.compilation_config
         self.speculative_config = vllm_config.speculative_config
         self.kv_cache_spec = kv_cache_spec
+        self.layer_names = layer_names
         from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
             _resolve_gdn_prefill_backend,
         )
@@ -120,6 +180,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         self._init_reorder_batch_threshold(1, self.use_spec_decode)
 
         self.use_replayssm_spec: bool = vllm_config.cache_config.use_replayssm_spec
+        self.use_replayssm_prefix = (
+            self.use_replayssm_spec
+            and vllm_config.cache_config.mamba_cache_mode == "align"
+        )
         self.replayssm_buffer_len: int = vllm_config.cache_config.replayssm_buffer_len
         self.max_spec_len: int = 1 + self.num_spec
         # Flush once the next window would not fit: threshold L = B + max_spec_len,
@@ -132,6 +196,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         self.spec_write_pos: torch.Tensor | None = None
         self.spec_cache_base: torch.Tensor | None = None
         self.spec_is_flush: torch.Tensor | None = None
+        self.replayssm_context: GDNReplaySSMPrefixCommitContext | None = None
 
         self.use_full_cuda_graph: bool = (
             self.compilation_config.cudagraph_mode.has_full_cudagraphs()
@@ -235,6 +300,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         common_attn_metadata: CommonAttentionMetadata,
         num_accepted_tokens: torch.Tensor | None = None,
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
+        replayssm_reset_ring_cpu: torch.Tensor | None = None,
+        replayssm_boundary_reset: torch.Tensor | None = None,
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
         m = common_attn_metadata
@@ -243,12 +310,15 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         query_start_loc_cpu = m.query_start_loc_cpu
         context_lens_tensor = m.compute_num_computed_tokens()
         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
-        block_table_tensor = mamba_get_block_table_tensor(
-            m.block_table_tensor,
-            m.seq_lens,
-            self.kv_cache_spec,
-            self.vllm_config.cache_config.mamba_cache_mode,
-        )
+        if self.mamba_aligned_state_indices is not None:
+            block_table_tensor = self.mamba_aligned_state_indices[: m.num_reqs]
+        else:
+            block_table_tensor = mamba_get_block_table_tensor(
+                m.block_table_tensor,
+                m.seq_lens,
+                self.kv_cache_spec,
+                self.vllm_config.cache_config.mamba_cache_mode,
+            )
 
         spec_sequence_masks_cpu: torch.Tensor | None = None
         if self.use_replayssm_spec and num_accepted_tokens is not None:
@@ -262,17 +332,15 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             assert is_prefilling_cpu is not None
             query_lens_cpu_all = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
             spec_sequence_masks_cpu = (
-                ~is_prefilling_cpu[: query_lens_cpu_all.shape[0]]
-            ) & (query_lens_cpu_all > 0)
+                (~is_prefilling_cpu[: query_lens_cpu_all.shape[0]])
+                & (query_lens_cpu_all > 0)
+                & (query_lens_cpu_all <= self.max_spec_len)
+            )
             num_spec_decodes = int(spec_sequence_masks_cpu.sum().item())
             if num_spec_decodes == 0:
                 spec_sequence_masks = None
                 spec_sequence_masks_cpu = None
             else:
-                assert (
-                    int(query_lens_cpu_all[spec_sequence_masks_cpu].max().item())
-                    <= self.max_spec_len
-                ), "ReplaySSM-spec decode row wider than the spec window"
                 spec_sequence_masks = async_tensor_h2d(
                     spec_sequence_masks_cpu, device=query_start_loc.device
                 )
@@ -483,6 +551,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                     num_accepted_tokens,
                     spec_sequence_masks_cpu,
                     context_lens_tensor,
+                    replayssm_reset_ring_cpu,
+                    replayssm_boundary_reset,
                 )
             )
 
@@ -558,6 +628,29 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_query_start_loc = self.non_spec_query_start_loc[: batch_size + 1]
             non_spec_query_start_loc[num_decodes + 1 :].fill_(non_spec_num_query_tokens)
 
+        replayssm_commit = None
+        if self.use_replayssm_prefix and num_spec_decodes > 0:
+            assert spec_state_indices_tensor is not None
+            assert spec_query_start_loc is not None
+            spec_request_indices = None
+            if num_prefills > 0 or num_decodes > 0:
+                assert spec_sequence_masks_cpu is not None
+                spec_request_indices = async_tensor_h2d(
+                    spec_sequence_masks_cpu.nonzero(as_tuple=True)[0],
+                    dtype=torch.int32,
+                    device=query_start_loc.device,
+                )
+            replayssm_commit = GDNReplaySSMCommitMetadata(
+                state_indices=spec_state_indices_tensor,
+                query_start_loc=spec_query_start_loc,
+                request_indices=spec_request_indices,
+                align=GDNReplaySSMAlignMetadata(
+                    block_table=m.block_table_tensor,
+                    num_computed_tokens=context_lens_tensor,
+                    block_size=self.kv_cache_spec.block_size,
+                ),
+            )
+
         attn_metadata = GDNAttentionMetadata(
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
@@ -583,11 +676,42 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_write_pos_d=spec_write_pos_d,
             spec_cache_base_d=spec_cache_base_d,
             spec_is_flush_d=spec_is_flush_d,
+            replayssm_commit=replayssm_commit,
+            replayssm_context=(
+                self._get_replayssm_prefix_context()
+                if replayssm_commit is not None
+                else None
+            ),
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
         )
         return attn_metadata
+
+    def _get_replayssm_prefix_context(self) -> GDNReplaySSMPrefixCommitContext:
+        context = self.replayssm_context
+        if context is not None:
+            return context
+        assert self.spec_write_pos is not None
+        assert self.spec_cache_base is not None
+        assert self.spec_is_flush is not None
+        from vllm.third_party.flash_linear_attention.ops.gdn_replayssm_prefix import (
+            GDNReplaySSMPrefixCommitContext,
+        )
+
+        forward_context = self.vllm_config.compilation_config.static_forward_context
+        layers = [forward_context[layer_name] for layer_name in self.layer_names]
+        context = GDNReplaySSMPrefixCommitContext.create(
+            layers,
+            write_pos=self.spec_write_pos,
+            cache_base=self.spec_cache_base,
+            is_flush=self.spec_is_flush,
+            spec_query_len=self.max_spec_len,
+            max_num_reqs=self.vllm_config.scheduler_config.max_num_seqs,
+            max_cache_len=self.spec_flush_threshold,
+        )
+        self.replayssm_context = context
+        return context
 
     def _commit_replayssm_spec_cursors(
         self,
@@ -596,6 +720,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         num_accepted_tokens: torch.Tensor,
         spec_sequence_masks_cpu: torch.Tensor,
         context_lens_tensor: torch.Tensor,
+        reset_ring_cpu: torch.Tensor | None,
+        boundary_reset: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Advance the block-keyed spec ring cursors for this step.
 
@@ -631,31 +757,44 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         # Commit first: acceptance is only known after the previous step's
         # sampling, so folding it into this build keeps every cursor update
         # on-device and avoids a device-to-host sync on num_accepted_tokens.
-        commit_gdn_replayssm_spec(
-            self.spec_write_pos,
-            self.spec_cache_base,
-            self.spec_is_flush,
-            num_accepted_tokens.to(torch.int32),
-            block_ids,
-            max_cache_len=self.spec_flush_threshold,
-            max_spec_len=self.max_spec_len,
-            cache_buf_len=self.spec_ring_len,
-        )
-
-        decode_base_cpu = m.replayssm_decode_base_cpu
-        if decode_base_cpu is None:
-            raise ValueError(
-                "--use-replayssm-spec requires the CPU decode-base counts to "
-                "reset the ring on entry to decode"
+        if not self.use_replayssm_prefix:
+            commit_gdn_replayssm_spec(
+                self.spec_write_pos,
+                self.spec_cache_base,
+                self.spec_is_flush,
+                num_accepted_tokens.to(torch.int32),
+                block_ids,
+                max_cache_len=self.spec_flush_threshold,
+                max_spec_len=self.max_spec_len,
+                cache_buf_len=self.spec_ring_len,
             )
-        # decode_base is the context at (re)admission, so a request's first
-        # verify and a resumed request both land exactly on it.
-        decode_base_d = decode_base_cpu.to(
-            context_lens_tensor.device, non_blocking=True
-        )
-        first_decode_full = (
-            context_lens_tensor[: decode_base_d.shape[0]] == decode_base_d
-        ).to(torch.int8)
+
+        if reset_ring_cpu is not None:
+            # V2 passes an explicit one-shot admission bit.  Its async context
+            # accounting can expose both prefill_len - 1 and prefill_len on the
+            # first two decode builds, so length comparisons are ambiguous.
+            reset_ring_full = reset_ring_cpu.to(device, non_blocking=True)
+        else:
+            # V1 keeps the admission origin in GPUInputBatch and has exact
+            # context accounting, so retain its established equality fallback.
+            decode_base_cpu = m.replayssm_decode_base_cpu
+            if decode_base_cpu is None:
+                raise ValueError(
+                    "--use-replayssm-spec requires an admission reset signal"
+                )
+            decode_base_d = decode_base_cpu.to(device, non_blocking=True)
+            reset_ring_full = (
+                context_lens_tensor[: decode_base_d.shape[0]] == decode_base_d
+            ).to(torch.int8)
+        if boundary_reset is not None:
+            # Generic align pre-copy migrates checkpoint/conv state but not the
+            # private ReplaySSM ring.  Reset the destination on the exact step
+            # where preprocess_state changed the running page.  A page-number
+            # lookahead remains true for several adjacent speculative windows
+            # and would repeatedly discard accepted tokens from the new ring.
+            reset_ring_full = torch.maximum(
+                reset_ring_full[: boundary_reset.shape[0]], boundary_reset
+            )
         spec_row_idx = spec_sequence_masks_cpu.nonzero(as_tuple=True)[0].to(
             device, non_blocking=True
         )
@@ -663,7 +802,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             self.spec_write_pos,
             self.spec_cache_base,
             self.spec_is_flush,
-            first_decode_full.index_select(0, spec_row_idx),
+            reset_ring_full.index_select(0, spec_row_idx),
             block_ids,
             max_cache_len=self.spec_flush_threshold,
             max_spec_len=self.max_spec_len,
@@ -692,5 +831,17 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
 
         num_accepted_tokens = torch.diff(m.query_start_loc)
         num_decode_draft_tokens_cpu = (num_accepted_tokens - 1).cpu()
+        replayssm_reset_ring_cpu = (
+            torch.zeros(m.num_reqs, dtype=torch.int8)
+            if self.use_replayssm_spec
+            else None
+        )
 
-        return self.build(0, m, num_accepted_tokens, num_decode_draft_tokens_cpu)
+        return self.build(
+            0,
+            m,
+            num_accepted_tokens,
+            num_decode_draft_tokens_cpu,
+            replayssm_reset_ring_cpu,
+            None,
+        )

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -241,6 +241,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
 
         query_start_loc = m.query_start_loc
         query_start_loc_cpu = m.query_start_loc_cpu
+        context_lens_tensor = m.compute_num_computed_tokens()
         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
         block_table_tensor = mamba_get_block_table_tensor(
             m.block_table_tensor,
@@ -445,7 +446,6 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             )
 
         if num_prefills > 0:
-            context_lens_tensor = m.compute_num_computed_tokens()
             has_initial_state = context_lens_tensor > 0
             if spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[~spec_sequence_masks_cpu]

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -8,6 +8,7 @@ from typing import Literal
 import torch
 
 from vllm.config import VllmConfig
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -65,6 +66,13 @@ class GDNAttentionMetadata:
 
     num_accepted_tokens: torch.Tensor | None = None  # shape: [batch,]
 
+    # ReplaySSM spec ring cursors: block-keyed (num_blocks,) buffers indexed by
+    # spec_state_indices_tensor[:, 0], advanced on-device once per step by
+    # commit_gdn_replayssm_spec. None unless use_replayssm_spec is enabled.
+    spec_write_pos_d: torch.Tensor | None = None
+    spec_cache_base_d: torch.Tensor | None = None
+    spec_is_flush_d: torch.Tensor | None = None
+
     # Pre-computed FLA chunk metadata (avoids GPU->CPU sync in prepare_chunk_indices)
     chunk_indices: torch.Tensor | None = None
     chunk_offsets: torch.Tensor | None = None
@@ -110,6 +118,20 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             self.num_spec = 0
         self.use_spec_decode: bool = self.num_spec > 0
         self._init_reorder_batch_threshold(1, self.use_spec_decode)
+
+        self.use_replayssm_spec: bool = vllm_config.cache_config.use_replayssm_spec
+        self.replayssm_buffer_len: int = vllm_config.cache_config.replayssm_buffer_len
+        self.max_spec_len: int = 1 + self.num_spec
+        # Flush once the next window would not fit: threshold L = B + max_spec_len,
+        # physical ring next_pow2(L). Cursors are sized from num_gpu_blocks, which
+        # is only known after profiling, so they are allocated on the first build.
+        self.spec_flush_threshold = self.replayssm_buffer_len + self.max_spec_len
+        self.spec_ring_len = MambaStateShapeCalculator.replayssm_spec_ring_len(
+            self.replayssm_buffer_len, self.num_spec
+        )
+        self.spec_write_pos: torch.Tensor | None = None
+        self.spec_cache_base: torch.Tensor | None = None
+        self.spec_is_flush: torch.Tensor | None = None
 
         self.use_full_cuda_graph: bool = (
             self.compilation_config.cudagraph_mode.has_full_cudagraphs()
@@ -228,7 +250,32 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         )
 
         spec_sequence_masks_cpu: torch.Tensor | None = None
-        if not self.use_spec_decode or num_decode_draft_tokens_cpu is None:
+        if self.use_replayssm_spec and num_accepted_tokens is not None:
+            # Every post-prefill row runs the spec kernel, a draft-less row as a
+            # T=1 window. The baseline decode path reads the checkpoint page,
+            # which lags the committed ring, so routing a decode row there
+            # corrupts the state. num_decode_draft_tokens_cpu cannot drive this
+            # mask: it is stale on draft-less steps and -1 for decode rows whose
+            # drafts were dropped.
+            is_prefilling_cpu = m.is_prefilling
+            assert is_prefilling_cpu is not None
+            query_lens_cpu_all = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+            spec_sequence_masks_cpu = (
+                ~is_prefilling_cpu[: query_lens_cpu_all.shape[0]]
+            ) & (query_lens_cpu_all > 0)
+            num_spec_decodes = int(spec_sequence_masks_cpu.sum().item())
+            if num_spec_decodes == 0:
+                spec_sequence_masks = None
+                spec_sequence_masks_cpu = None
+            else:
+                assert (
+                    int(query_lens_cpu_all[spec_sequence_masks_cpu].max().item())
+                    <= self.max_spec_len
+                ), "ReplaySSM-spec decode row wider than the spec window"
+                spec_sequence_masks = async_tensor_h2d(
+                    spec_sequence_masks_cpu, device=query_start_loc.device
+                )
+        elif not self.use_spec_decode or num_decode_draft_tokens_cpu is None:
             spec_sequence_masks = None
             num_spec_decodes = 0
         else:
@@ -422,6 +469,23 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             f"num_decodes: {num_decodes}, num_spec_decodes: {num_spec_decodes}"
         )
 
+        spec_write_pos_d = None
+        spec_cache_base_d = None
+        spec_is_flush_d = None
+        if self.use_replayssm_spec and num_spec_decodes > 0:
+            assert spec_state_indices_tensor is not None
+            assert num_accepted_tokens is not None
+            assert spec_sequence_masks_cpu is not None
+            spec_write_pos_d, spec_cache_base_d, spec_is_flush_d = (
+                self._commit_replayssm_spec_cursors(
+                    m,
+                    spec_state_indices_tensor,
+                    num_accepted_tokens,
+                    spec_sequence_masks_cpu,
+                    context_lens_tensor,
+                )
+            )
+
         # Prepare per-request tensors for cudagraph. m.num_actual_tokens is
         # token-padded for FULL graph replay, but the GDN state/query/accepted
         # metadata below is indexed by request.
@@ -516,11 +580,95 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             spec_token_indx=spec_token_indx,
             non_spec_token_indx=non_spec_token_indx,
             num_accepted_tokens=num_accepted_tokens,
+            spec_write_pos_d=spec_write_pos_d,
+            spec_cache_base_d=spec_cache_base_d,
+            spec_is_flush_d=spec_is_flush_d,
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
         )
         return attn_metadata
+
+    def _commit_replayssm_spec_cursors(
+        self,
+        m: CommonAttentionMetadata,
+        spec_state_indices_tensor: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        spec_sequence_masks_cpu: torch.Tensor,
+        context_lens_tensor: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Advance the block-keyed spec ring cursors for this step.
+
+        Commits the previous step's accepted tokens and decides this step's
+        is_flush on-device, then resets rows entering decode. Both run as fixed
+        launches so the captured graph is identical every step.
+        """
+        from vllm.third_party.flash_linear_attention.ops.gdn_replayssm_spec_decode import (  # noqa: E501
+            commit_gdn_replayssm_spec,
+            reset_gdn_replayssm_spec_cursors,
+        )
+
+        device = spec_state_indices_tensor.device
+        if self.spec_write_pos is None:
+            num_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
+            if not num_gpu_blocks:
+                raise ValueError(
+                    "--use-replayssm-spec needs num_gpu_blocks at build time to "
+                    "size the block-keyed cursor buffers"
+                )
+            self.spec_write_pos = torch.zeros(
+                num_gpu_blocks, dtype=torch.int32, device=device
+            )
+            self.spec_cache_base = torch.zeros(
+                num_gpu_blocks, dtype=torch.int32, device=device
+            )
+            self.spec_is_flush = torch.zeros(
+                num_gpu_blocks, dtype=torch.int8, device=device
+            )
+        assert self.spec_cache_base is not None and self.spec_is_flush is not None
+
+        block_ids = spec_state_indices_tensor[:, 0]
+        # Commit first: acceptance is only known after the previous step's
+        # sampling, so folding it into this build keeps every cursor update
+        # on-device and avoids a device-to-host sync on num_accepted_tokens.
+        commit_gdn_replayssm_spec(
+            self.spec_write_pos,
+            self.spec_cache_base,
+            self.spec_is_flush,
+            num_accepted_tokens.to(torch.int32),
+            block_ids,
+            max_cache_len=self.spec_flush_threshold,
+            max_spec_len=self.max_spec_len,
+            cache_buf_len=self.spec_ring_len,
+        )
+
+        decode_base_cpu = m.replayssm_decode_base_cpu
+        if decode_base_cpu is None:
+            raise ValueError(
+                "--use-replayssm-spec requires the CPU decode-base counts to "
+                "reset the ring on entry to decode"
+            )
+        # decode_base is the context at (re)admission, so a request's first
+        # verify and a resumed request both land exactly on it.
+        decode_base_d = decode_base_cpu.to(
+            context_lens_tensor.device, non_blocking=True
+        )
+        first_decode_full = (
+            context_lens_tensor[: decode_base_d.shape[0]] == decode_base_d
+        ).to(torch.int8)
+        spec_row_idx = spec_sequence_masks_cpu.nonzero(as_tuple=True)[0].to(
+            device, non_blocking=True
+        )
+        reset_gdn_replayssm_spec_cursors(
+            self.spec_write_pos,
+            self.spec_cache_base,
+            self.spec_is_flush,
+            first_decode_full.index_select(0, spec_row_idx),
+            block_ids,
+            max_cache_len=self.spec_flush_threshold,
+            max_spec_len=self.max_spec_len,
+        )
+        return self.spec_write_pos, self.spec_cache_base, self.spec_is_flush
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata

--- a/vllm/v1/attention/backends/mamba_attn.py
+++ b/vllm/v1/attention/backends/mamba_attn.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar, TypeVar
 import torch
 
 from vllm.config import VllmConfig
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
@@ -80,6 +81,15 @@ class BaseMambaAttentionMetadata:
     write_pos_d: torch.Tensor | None = None
     is_flush_d: torch.Tensor | None = None
     bc_pre_scratch: torch.Tensor | None = None
+    # ReplaySSM speculative decode: block-keyed ring cursors, shaped
+    # (num_gpu_blocks,) and indexed by physical SSM block id, plus the per-step
+    # (decode_rows, ngroups, ring_len, block_spec) fp32 scratch. The cursors are
+    # advanced on-device once per step by commit_replayssm_spec. All None when
+    # use_replayssm_spec is disabled.
+    spec_write_pos_d: torch.Tensor | None = None
+    spec_post_origin_d: torch.Tensor | None = None
+    spec_is_flush_d: torch.Tensor | None = None
+    spec_bc_pre_scratch: torch.Tensor | None = None
 
 
 class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
@@ -107,6 +117,14 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         self.use_spec_decode = self.num_spec_tokens > 0
         self.use_replayssm = vllm_config.cache_config.use_replayssm
         self.replayssm_buffer_len = vllm_config.cache_config.replayssm_buffer_len
+        self.use_replayssm_spec = vllm_config.cache_config.use_replayssm_spec
+        self.max_spec_len = 1 + self.num_spec_tokens
+        # A verify step consumes a whole window, so flush once the next window
+        # would not fit: threshold L = B + max_spec_len, physical ring next_pow2(L).
+        self.spec_flush_threshold = self.replayssm_buffer_len + self.max_spec_len
+        self.spec_ring_len = MambaStateShapeCalculator.replayssm_spec_ring_len(
+            self.replayssm_buffer_len, self.num_spec_tokens
+        )
 
         scheduler_config = vllm_config.scheduler_config
         self.decode_cudagraph_max_bs: int = scheduler_config.max_num_seqs
@@ -196,6 +214,43 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             )
         else:
             self.decode_bc_pre_scratch = None
+
+        # ReplaySSM speculative decode. The cursors are block-keyed and sized
+        # from num_gpu_blocks, which is only known after profiling, so they are
+        # allocated lazily on the first build.
+        self.spec_write_pos: torch.Tensor | None = None
+        self.spec_post_origin: torch.Tensor | None = None
+        self.spec_is_flush: torch.Tensor | None = None
+        self.decode_spec_bc_pre: torch.Tensor | None = None
+        if self.use_replayssm_spec:
+            if len(kv_cache_spec.shapes) != 4:
+                raise ValueError(
+                    "the cached-spec kernel requires the 4-tensor Mamba2 page "
+                    "(conv, ssm, post_conv_cache, dt_cache)"
+                )
+            local_nheads, head_dim, dstate = kv_cache_spec.shapes[1]
+            conv_dim_local = kv_cache_spec.shapes[2][1]
+            # post_conv_cache holds x|B only, so the width past d_inner is
+            # ngroups_local * dstate (one B block, no C).
+            ngroups_local = (conv_dim_local - local_nheads * head_dim) // dstate
+            if ngroups_local < 1:
+                raise ValueError(
+                    f"invalid ngroups_local={ngroups_local} derived from spec page "
+                    f"width {conv_dim_local} (dstate {dstate})"
+                )
+            block_spec = 1 << (max(1, self.max_spec_len) - 1).bit_length()
+            # Consumed by the scatter on every decode step, eager and captured
+            # alike, and indexed by pid_b in [0, num_decodes). Size it by
+            # max_num_seqs, not decode_cudagraph_max_bs, which is 0 under
+            # enforce_eager and would leave the scatter writing out of bounds.
+            spec_scratch_bs = max(
+                self.decode_cudagraph_max_bs, scheduler_config.max_num_seqs
+            )
+            self.decode_spec_bc_pre = torch.empty(
+                (spec_scratch_bs, ngroups_local, self.spec_ring_len, block_spec),
+                dtype=torch.float32,
+                device=device,
+            )
 
         self._init_reorder_batch_threshold(1, self.use_spec_decode)
         if self.use_spec_decode:
@@ -659,6 +714,26 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         ):
             bc_pre_scratch = self.decode_bc_pre_scratch[:num_decodes]
 
+        spec_write_pos_d = None
+        spec_post_origin_d = None
+        spec_is_flush_d = None
+        spec_bc_pre_scratch = None
+        if (
+            self.use_replayssm_spec
+            and num_decodes > 0
+            and num_accepted_tokens is not None
+        ):
+            spec_write_pos_d, spec_post_origin_d, spec_is_flush_d = (
+                self._commit_replayssm_spec_cursors(
+                    common_attn_metadata,
+                    state_indices_tensor_d,
+                    num_accepted_tokens,
+                    num_decodes,
+                )
+            )
+            if self.decode_spec_bc_pre is not None:
+                spec_bc_pre_scratch = self.decode_spec_bc_pre[:num_decodes]
+
         metadata = self.metadata_cls(
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
@@ -671,6 +746,10 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             write_pos_d=write_pos_d,
             is_flush_d=is_flush_d,
             bc_pre_scratch=bc_pre_scratch,
+            spec_write_pos_d=spec_write_pos_d,
+            spec_post_origin_d=spec_post_origin_d,
+            spec_is_flush_d=spec_is_flush_d,
+            spec_bc_pre_scratch=spec_bc_pre_scratch,
             num_accepted_tokens=num_accepted_tokens,
             query_start_loc_d=query_start_loc_d,
             block_idx_last_scheduled_token=block_idx_last_scheduled_token,
@@ -688,6 +767,92 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         )
 
         return self._update_metadata_for_cudagraph_capture(metadata)
+
+    def _commit_replayssm_spec_cursors(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        state_indices_tensor_d: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        num_decodes: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Advance the block-keyed spec ring cursors for this step.
+
+        Commits the previous step's accepted tokens and decides this step's
+        is_flush on-device, then resets rows that are entering decode. Both run
+        as fixed launches so the captured graph is identical every step.
+        """
+        from vllm.model_executor.layers.mamba.ops.selective_state_update_replayssm_spec import (  # noqa: E501
+            commit_replayssm_spec,
+            reset_replayssm_spec_cursors,
+        )
+
+        device = common_attn_metadata.query_start_loc.device
+        if self.spec_write_pos is None:
+            num_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
+            if not num_gpu_blocks:
+                raise ValueError(
+                    "--use-replayssm-spec needs num_gpu_blocks at build time to "
+                    "size the block-keyed cursor buffers"
+                )
+            self.spec_write_pos = torch.zeros(
+                num_gpu_blocks, dtype=torch.int32, device=device
+            )
+            self.spec_post_origin = torch.zeros(
+                num_gpu_blocks, dtype=torch.int32, device=device
+            )
+            self.spec_is_flush = torch.zeros(
+                num_gpu_blocks, dtype=torch.int8, device=device
+            )
+        assert self.spec_post_origin is not None and self.spec_is_flush is not None
+
+        block_ids = state_indices_tensor_d[:, 0]
+        # Commit first: acceptance is only known after the previous step's
+        # sampling, so folding it into this build keeps every cursor update
+        # on-device and avoids a device-to-host sync on num_accepted_tokens.
+        commit_replayssm_spec(
+            self.spec_write_pos,
+            self.spec_post_origin,
+            self.spec_is_flush,
+            num_accepted_tokens.to(torch.int32),
+            block_ids,
+            max_cache_len=self.spec_flush_threshold,
+            max_spec_len=self.max_spec_len,
+            cache_buf_len=self.spec_ring_len,
+        )
+
+        decode_base_cpu = common_attn_metadata.replayssm_decode_base_cpu
+        num_computed_tokens_cpu = common_attn_metadata._num_computed_tokens_cpu
+        if decode_base_cpu is None or num_computed_tokens_cpu is None:
+            raise ValueError(
+                "--use-replayssm-spec requires CPU decode-base and computed-token "
+                "counts to reset the ring on entry to decode"
+            )
+        num_computed_d = num_computed_tokens_cpu[:num_decodes]
+        decode_base_d = decode_base_cpu[:num_decodes]
+        # decode_base is the context at (re)admission, so a request's first
+        # verify and a resumed request both land exactly on it. A final
+        # single-token prompt chunk reclassified as a decode sits one token
+        # short; reset it too and force it to flush, or it would append to a
+        # recycled block's stale cursors.
+        force_flush_cpu = num_computed_d < decode_base_d
+        first_decode_cpu = (num_computed_d <= decode_base_d).to(torch.int8)
+        first_decode_d = async_tensor_h2d(
+            first_decode_cpu.tolist(), dtype=torch.int8, device=device
+        )
+        force_flush_d = async_tensor_h2d(
+            force_flush_cpu.to(torch.int8).tolist(), dtype=torch.int8, device=device
+        )
+        reset_replayssm_spec_cursors(
+            self.spec_write_pos,
+            self.spec_post_origin,
+            self.spec_is_flush,
+            first_decode_d,
+            block_ids,
+            max_cache_len=self.spec_flush_threshold,
+            max_spec_len=self.max_spec_len,
+            force_flush_mask=force_flush_d,
+        )
+        return self.spec_write_pos, self.spec_post_origin, self.spec_is_flush
 
     def _update_metadata_for_cudagraph_capture(
         self,
@@ -708,6 +873,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
         write_pos_d = metadata.write_pos_d
         is_flush_d = metadata.is_flush_d
         bc_pre_scratch = metadata.bc_pre_scratch
+        spec_bc_pre_scratch = metadata.spec_bc_pre_scratch
         if (
             metadata.num_prefills == 0
             and metadata.num_decodes <= self.decode_cudagraph_max_bs
@@ -789,6 +955,11 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
                 if self.decode_bc_pre_scratch is not None:
                     bc_pre_scratch = self.decode_bc_pre_scratch[:padded_bs]
 
+            # The spec cursors are block-keyed and full-length, so only the
+            # dense per-row scratch needs widening to the padded batch.
+            if self.use_replayssm_spec and self.decode_spec_bc_pre is not None:
+                spec_bc_pre_scratch = self.decode_spec_bc_pre[:padded_bs]
+
         return replace(
             metadata,
             state_indices_tensor_d=state_indices_tensor_d,
@@ -797,6 +968,7 @@ class BaseMambaAttentionMetadataBuilder(AttentionMetadataBuilder[M], abc.ABC):
             write_pos_d=write_pos_d,
             is_flush_d=is_flush_d,
             bc_pre_scratch=bc_pre_scratch,
+            spec_bc_pre_scratch=spec_bc_pre_scratch,
             block_idx_last_scheduled_token=block_idx_last_scheduled_token,
             block_idx_last_computed_token=block_idx_last_computed_token,
             block_idx_last_scheduled_token_prev_step=(

--- a/vllm/v1/attention/backends/recoverssm_metadata.py
+++ b/vllm/v1/attention/backends/recoverssm_metadata.py
@@ -6,6 +6,54 @@ from dataclasses import dataclass
 
 import torch
 
+from vllm.triton_utils import tl, triton
+
+
+@triton.heuristics(
+    {
+        "HAS_REQUEST_INDICES": lambda args: args["request_indices_ptr"] is not None,
+        "HAS_RESET_MASK": lambda args: args["reset_mask_ptr"] is not None,
+    }
+)
+@triton.jit
+def postprocess_recoverssm_align_kernel(
+    idx_mapping_ptr,
+    num_sampled_ptr,
+    request_indices_ptr,
+    reset_mask_ptr,
+    num_computed_ptr,
+    state_idx_ptr,
+    num_accepted_ptr,
+    HAS_REQUEST_INDICES: tl.constexpr,
+    HAS_RESET_MASK: tl.constexpr,
+    MAMBA_BLOCK_SIZE: tl.constexpr,
+    BLOCK_TABLE_WIDTH: tl.constexpr,
+):
+    """Restore align bookkeeping after accepted-state materialization."""
+    spec_idx = tl.program_id(0)
+    if HAS_RESET_MASK and not tl.load(reset_mask_ptr + spec_idx):
+        return
+    batch_idx = spec_idx
+    if HAS_REQUEST_INDICES:
+        batch_idx = tl.load(request_indices_ptr + spec_idx)
+    req_state_idx = tl.load(idx_mapping_ptr + batch_idx)
+    if req_state_idx < 0:
+        return
+    # The metadata retains the forward's batch-ordered, pre-step snapshot.
+    # post_update advances the separate persistent request-state tensor, so
+    # reconstruct the accepted post-step count here from this batch row.
+    num_computed = tl.load(num_computed_ptr + batch_idx)
+    num_sampled = tl.load(num_sampled_ptr + batch_idx)
+    total_computed = num_computed + num_sampled
+    # Match compute_aligned_state_indices(): an exact block boundary owns the
+    # completed page, not the following page.
+    state_idx = (tl.maximum(total_computed, 1) - 1) // MAMBA_BLOCK_SIZE
+    tl.store(
+        state_idx_ptr + req_state_idx,
+        tl.minimum(state_idx, BLOCK_TABLE_WIDTH - 1),
+    )
+    tl.store(num_accepted_ptr + req_state_idx, 1)
+
 
 @dataclass(frozen=True)
 class RecoverSSMPostprocessMetadata:
@@ -16,6 +64,7 @@ class RecoverSSMPostprocessMetadata:
     block_table: torch.Tensor
     num_computed_tokens: torch.Tensor
     block_size: int
+    reset_mask: torch.Tensor | None = None
 
 
 class RecoverSSMMetadata(abc.ABC):

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -34,6 +34,8 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
     is_prefilling: torch.Tensor
     num_accepted_tokens: torch.Tensor | None = None
     num_decode_draft_tokens_cpu: torch.Tensor | None = None
+    replayssm_reset_ring_cpu: torch.Tensor | None = None
+    replayssm_boundary_reset: torch.Tensor | None = None
 
     def get_extra_common_attn_kwargs(
         self,
@@ -56,7 +58,7 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             ),
         ):
             return {}
-        return {
+        result = {
             "num_accepted_tokens": None
             if self.num_accepted_tokens is None
             else self.num_accepted_tokens[:num_reqs],
@@ -64,6 +66,15 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
             if self.num_decode_draft_tokens_cpu is None
             else self.num_decode_draft_tokens_cpu[:num_reqs],
         }
+        if (
+            isinstance(attn_metadata_builder, GDNAttentionMetadataBuilder)
+            and self.replayssm_reset_ring_cpu is not None
+        ):
+            result["replayssm_reset_ring_cpu"] = self.replayssm_reset_ring_cpu[
+                :num_reqs
+            ]
+            result["replayssm_boundary_reset"] = self.replayssm_boundary_reset
+        return result
 
 
 class MambaHybridModelState(DefaultModelState):
@@ -86,8 +97,24 @@ class MambaHybridModelState(DefaultModelState):
         # kernel reusing the postprocess copy machinery, so the per-step src
         # columns and the running state_idx are kept GPU-resident.
         self._align_mode = self.cache_config.mamba_cache_mode == "align"
+        self._use_replayssm = self.cache_config.use_replayssm_spec
+        if self._use_replayssm:
+            # CPU scheduling owns request admission, so keep the one-shot reset
+            # bit there as well.  It is consumed only by the first post-prefill
+            # step.  This avoids inferring admission from async num_computed
+            # counters, whose first decode value can differ by one depending on
+            # whether a sampled prompt token has already been accounted for.
+            self._replayssm_needs_reset = np.zeros(self.max_num_reqs, dtype=np.bool_)
         self.recoverssm = (
-            RecoverSSMState() if self.cache_config.use_kda_recoverssm else None
+            RecoverSSMState()
+            if (
+                self.cache_config.use_kda_recoverssm
+                or (
+                    self.cache_config.use_replayssm_spec
+                    and self.cache_config.mamba_cache_mode == "align"
+                )
+            )
+            else None
         )
         if self._align_mode:
             self._mamba_state_idx_gpu = torch.zeros(
@@ -107,6 +134,10 @@ class MambaHybridModelState(DefaultModelState):
         super().add_request(req_index, new_req_data)
         # Must reset the speculative acceptance count in this idx which could be stale.
         self.num_accepted_tokens_gpu[req_index].fill_(1)
+        if self._use_replayssm:
+            # add_request is also called after preemption, when the restored
+            # checkpoint becomes the new ring origin.
+            self._replayssm_needs_reset[req_index] = True
         if self._align_mode:
             # Seed the running state block from the resumed/prefilled position.
             self._mamba_state_idx_gpu[req_index].fill_(
@@ -249,6 +280,8 @@ class MambaHybridModelState(DefaultModelState):
         # compute them during actual (non-capture) forward execution.
         num_accepted_tokens = None
         num_decode_draft_tokens_cpu = None
+        replayssm_reset_ring_cpu = None
+        replayssm_boundary_reset = None
         if not for_capture and self.vllm_config.num_speculative_tokens > 0:
             num_accepted_tokens = self.num_accepted_tokens_gpu.new_ones(num_reqs)
             num_accepted_tokens[: input_batch.num_reqs] = self.num_accepted_tokens_gpu[
@@ -270,6 +303,31 @@ class MambaHybridModelState(DefaultModelState):
                     spec_decode_mask, num_draft_tokens_per_req, -1
                 )
             num_decode_draft_tokens_cpu = torch.from_numpy(num_decode_draft_tokens_np)
+
+        if self._use_replayssm and not for_capture:
+            # Consume each request's admission reset exactly once, on its first
+            # post-prefill step.  Keep padded rows at zero.  In particular, do
+            # not derive this from context <= prefill_len: that relation is true
+            # for two consecutive steps on one async-spec path and would discard
+            # the first accepted token from ReplaySSM's private ring.
+            actual_num_reqs = input_batch.num_reqs
+            reset_ring_np = np.zeros(num_reqs, dtype=np.int8)
+            request_indices = input_batch.idx_mapping_np
+            decode_mask = ~input_batch.is_prefilling_np
+            reset_ring_np[:actual_num_reqs] = (
+                self._replayssm_needs_reset[request_indices] & decode_mask
+            )
+            self._replayssm_needs_reset[request_indices[decode_mask]] = False
+            replayssm_reset_ring_cpu = torch.from_numpy(reset_ring_np)
+            if self._align_mode:
+                # preprocess_state has just advanced the running page.  Unlike
+                # comparing scheduled/context page numbers, this predicate is
+                # true on exactly the one step that performed the align copy.
+                src_col = self._mamba_src_col_gpu[input_batch.idx_mapping]
+                dst_col = self._mamba_state_idx_gpu[input_batch.idx_mapping]
+                replayssm_boundary_reset = ((src_col >= 0) & (src_col != dst_col)).to(
+                    torch.int8
+                )
 
         if self._align_mode:
             mamba_group_ids, _ = self._get_mamba_group_info(kv_cache_config)
@@ -293,6 +351,8 @@ class MambaHybridModelState(DefaultModelState):
             is_prefilling=is_prefilling,
             num_accepted_tokens=num_accepted_tokens,
             num_decode_draft_tokens_cpu=num_decode_draft_tokens_cpu,
+            replayssm_reset_ring_cpu=replayssm_reset_ring_cpu,
+            replayssm_boundary_reset=replayssm_boundary_reset,
         )
         attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,

--- a/vllm/v1/worker/gpu/model_states/recoverssm.py
+++ b/vllm/v1/worker/gpu/model_states/recoverssm.py
@@ -5,8 +5,10 @@ from typing import Any
 
 import torch
 
-from vllm.triton_utils import tl, triton
-from vllm.v1.attention.backends.recoverssm_metadata import RecoverSSMMetadata
+from vllm.v1.attention.backends.recoverssm_metadata import (
+    RecoverSSMMetadata,
+    postprocess_recoverssm_align_kernel,
+)
 from vllm.v1.worker.utils import AttentionGroup
 
 
@@ -55,47 +57,14 @@ class RecoverSSMState:
             assert state_indices is not None
             # RecoverSSM already restored the accepted state. Update its running
             # column and reset the next-step copy bias to the neutral value.
-            _postprocess_recoverssm_align_kernel[(postprocess_meta.num_spec_decodes,)](
+            postprocess_recoverssm_align_kernel[(postprocess_meta.num_spec_decodes,)](
                 idx_mapping,
                 num_sampled,
                 postprocess_meta.request_indices,
+                postprocess_meta.reset_mask,
                 postprocess_meta.num_computed_tokens,
                 state_indices,
                 num_accepted_tokens,
                 MAMBA_BLOCK_SIZE=postprocess_meta.block_size,
                 BLOCK_TABLE_WIDTH=postprocess_meta.block_table.shape[1],
             )
-
-
-@triton.heuristics(
-    {"HAS_REQUEST_INDICES": lambda args: args["request_indices_ptr"] is not None}
-)
-@triton.jit
-def _postprocess_recoverssm_align_kernel(
-    idx_mapping_ptr,
-    num_sampled_ptr,
-    request_indices_ptr,
-    num_computed_ptr,
-    state_idx_ptr,
-    num_accepted_ptr,
-    HAS_REQUEST_INDICES: tl.constexpr,
-    MAMBA_BLOCK_SIZE: tl.constexpr,
-    BLOCK_TABLE_WIDTH: tl.constexpr,
-):
-    spec_idx = tl.program_id(0)
-    batch_idx = spec_idx
-    if HAS_REQUEST_INDICES:
-        batch_idx = tl.load(request_indices_ptr + spec_idx)
-    req_state_idx = tl.load(idx_mapping_ptr + batch_idx)
-    if req_state_idx < 0:
-        return
-    num_sampled = tl.load(num_sampled_ptr + batch_idx)
-    num_computed = tl.load(num_computed_ptr + batch_idx)
-    tl.store(
-        state_idx_ptr + req_state_idx,
-        tl.minimum(
-            (num_computed + num_sampled) // MAMBA_BLOCK_SIZE,
-            BLOCK_TABLE_WIDTH - 1,
-        ),
-    )
-    tl.store(num_accepted_ptr + req_state_idx, 1)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -172,7 +172,7 @@ class InputBatch:
         self.num_computed_tokens_cpu = self.num_computed_tokens_cpu_tensor.numpy()
 
         # Mamba2 ReplaySSM decode ring origin (num_computed at each request's
-        # last full-state write); populated only when the feature is on.
+        # last full-state write); populated only when a ReplaySSM mode is on.
         self.use_replayssm = use_replayssm
         self.replayssm_decode_base_cpu_tensor = torch.zeros(
             (max_num_reqs,),

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -222,6 +222,7 @@ from vllm.v1.worker.cp_utils import (
 )
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
+from vllm.v1.worker.gpu.model_states.recoverssm import RecoverSSMState
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
@@ -996,6 +997,17 @@ class GPUModelRunner(
         self.kv_connector_output: KVConnectorOutput | None = None
         self.mamba_state_idx: dict[str, int] = {}
         self._mamba_bufs: mamba_utils.MambaBuffers | None = None
+        self.replayssm_state = (
+            RecoverSSMState()
+            if self.cache_config.use_replayssm_spec
+            and self.cache_config.mamba_cache_mode == "align"
+            else None
+        )
+        self.replayssm_idx_mapping = (
+            torch.arange(self.max_num_reqs, dtype=torch.int32, device=self.device)
+            if self.replayssm_state is not None
+            else None
+        )
         self.mamba_prev_last_scheduled_idx: CpuGpuBuffer | None = None
         if self.cache_config.mamba_cache_mode == "all" and self.num_spec_tokens > 0:
             self.mamba_prev_last_scheduled_idx = self._make_buffer(
@@ -1638,12 +1650,24 @@ class GPUModelRunner(
         self.num_accepted_tokens.gpu[:num_reqs] = (output_token_ids != -1).sum(dim=1)
 
         if self.cache_config.mamba_cache_mode == "align":
+            mamba_bufs = self._get_mamba_bufs()
+            if self.replayssm_state is not None:
+                ctx = mamba_bufs.postprocess_align
+                assert ctx is not None
+                assert ctx.mamba_state_idx_buf is not None
+                assert self.replayssm_idx_mapping is not None
+                self.replayssm_state.commit_step(
+                    self.num_accepted_tokens.gpu[:num_reqs],
+                    self.replayssm_idx_mapping[:num_reqs],
+                    state_indices=ctx.mamba_state_idx_buf.gpu,
+                    num_accepted_tokens=self.num_accepted_tokens.gpu,
+                )
             # Fused GPU postprocess: state copies + per-request accepted-token
             # update without CPU-GPU sync. The metadata
             # (num_scheduled_tokens, num_draft_tokens, num_computed_tokens) is
             # pre-staged to GPU buffers in _prepare_inputs.
             mamba_utils.postprocess_mamba_align_gpu(
-                bufs=self._get_mamba_bufs(),
+                bufs=mamba_bufs,
                 num_reqs=num_reqs,
                 num_accepted_tokens_gpu=self.num_accepted_tokens.gpu,
                 num_accepted_tokens_cpu_tensor=(
@@ -2605,6 +2629,19 @@ class GPUModelRunner(
                     extra_attn_metadata_args["prev_last_scheduled_idx"] = (
                         self.mamba_prev_last_scheduled_idx.gpu[:num_reqs_padded]
                     )
+                if (
+                    self.replayssm_state is not None
+                    and isinstance(builder, GDNAttentionMetadataBuilder)
+                ):
+                    ctx = self._get_mamba_bufs().postprocess_align
+                    assert ctx is not None
+                    assert ctx.precopy_src_col_buf is not None
+                    assert ctx.mamba_state_idx_buf is not None
+                    src_col = ctx.precopy_src_col_buf.gpu[:num_reqs_padded]
+                    dst_col = ctx.mamba_state_idx_buf.gpu[:num_reqs_padded]
+                    extra_attn_metadata_args["replayssm_boundary_reset"] = (
+                        (src_col >= 0) & (src_col != dst_col)
+                    ).to(torch.int8)
 
             if for_cudagraph_capture:
                 attn_metadata_i = builder.build_for_cudagraph_capture(
@@ -4520,6 +4557,13 @@ class GPUModelRunner(
                     slot_mappings=slot_mappings_by_group,
                 )
             )
+            if self.replayssm_state is not None:
+                assert isinstance(attn_metadata, dict)
+                self.replayssm_state.record_step(
+                    attn_metadata,
+                    self.attn_groups,
+                    for_capture=False,
+                )
 
             (
                 input_ids,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -779,7 +779,8 @@ class GPUModelRunner(
                 is_pooling_model=self.is_pooling_model,
                 cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
                 reasoning_config=self.vllm_config.reasoning_config,
-                use_replayssm=self.cache_config.use_replayssm,
+                use_replayssm=self.cache_config.use_replayssm
+                or self.cache_config.use_replayssm_spec,
             )
 
         # Separate cuda stream for overlapping transfer of sampled token ids from
@@ -2490,7 +2491,7 @@ class GPUModelRunner(
             rswa_prefix_lens = num_prompt_tokens_cpu
 
         replayssm_decode_base_cpu = None
-        if self.cache_config.use_replayssm:
+        if self.cache_config.use_replayssm or self.cache_config.use_replayssm_spec:
             replayssm_decode_base_cpu = (
                 self.input_batch.replayssm_decode_base_cpu_tensor[:num_reqs_padded]
             )
@@ -2567,7 +2568,16 @@ class GPUModelRunner(
             )
 
             extra_attn_metadata_args = {}
-            if use_spec_decode and isinstance(
+            # use_spec_decode is step-level: it is False whenever the drafter
+            # proposed nothing anywhere in the batch. ReplaySSM-spec still needs
+            # the cursors on those steps, or the rows fall through to the
+            # baseline kernel and advance a checkpoint the ring has moved past.
+            needs_replayssm_spec_args = (
+                self.cache_config.use_replayssm_spec
+                and self.speculative_config is not None
+                and isinstance(builder, Mamba2AttentionMetadataBuilder)
+            )
+            if (use_spec_decode or needs_replayssm_spec_args) and isinstance(
                 builder,
                 (
                     Mamba2AttentionMetadataBuilder,
@@ -7420,7 +7430,8 @@ class GPUModelRunner(
                     is_pooling_model=self.is_pooling_model,
                     cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
                     reasoning_config=self.vllm_config.reasoning_config,
-                    use_replayssm=self.cache_config.use_replayssm,
+                    use_replayssm=self.cache_config.use_replayssm
+                    or self.cache_config.use_replayssm_spec,
                     slot_mapping_modes=slot_mapping_modes,
                 )
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2575,7 +2575,10 @@ class GPUModelRunner(
             needs_replayssm_spec_args = (
                 self.cache_config.use_replayssm_spec
                 and self.speculative_config is not None
-                and isinstance(builder, Mamba2AttentionMetadataBuilder)
+                and isinstance(
+                    builder,
+                    (Mamba2AttentionMetadataBuilder, GDNAttentionMetadataBuilder),
+                )
             )
             if (use_spec_decode or needs_replayssm_spec_args) and isinstance(
                 builder,


### PR DESCRIPTION
## Status

Draft / experimental. This is not ready to merge yet.

This branch contains a forward-port of the kernel/core portions of #49887 plus the prefix-caching prototype. It must be rebased and split after the ReplaySSM dependency settles.

## Summary

This prototype enables prefix caching for ReplaySSM speculative decoding with an in-model MTP drafter on hybrid GDN models, including the Qwen3.5/Qwen3.6 family.

Main pieces:

- extend the aligned hybrid cache layout for the ReplaySSM checkpoint and input ring;
- materialize and restore GDN recurrent state at prefix-cache boundaries;
- keep ReplaySSM metadata and cursors consistent across cache hits, block reuse and preemption;
- route fused GDN + MTP decode through the cached ReplaySSM path;
- restore context-length metadata for decode-only batches;
- preserve a fixed CUDA Graph-compatible launch structure.

No separate draft model is involved: the tested speculative method is the model's native MTP head with three draft tokens.

## Current local validation

Tested with Qwen3.6-35B-A3B, TP=2 on 2x H200, MTP=3, prefix caching enabled, ReplaySSM ring length 16 and aligned block/prefix unit 1280.

### KV-pressure and preemption test

- 360/360 requests completed;
- 1,474,560 generated tokens;
- GPU KV cache reached 100%;
- 585 real preemptions;
- zero request errors or invalid lengths;
- non-zero prefix-cache hits;
- ReplaySSM circular, materialize and postprocess kernels observed at runtime;
- running and waiting queues drained to zero.

### Correctness status

- isolated prefix-cache restore: 4/4 forced-512 generations were token-exact;
- mixed-history cache-off/cache-on comparison: 28/32 generations were token-exact;
- all four mismatches came from one numerically unstable prompt, which also changed across repeated native MTP + prefix-cache runs.

The mixed-history discrepancy still needs to be understood before this can be considered correctness-complete.

### Throughput snapshot

Under a matched continuously-backlogged 90-second workload:

- native MTP=3 + prefix cache: 15,894.6 generation tok/s;
- ReplaySSM + MTP=3 + prefix cache: 17,344.5 generation tok/s.

These are local prototype measurements, not publication-quality benchmark numbers.

## Remaining work

- rebase onto current `main`;
- separate the #49887 forward-port from the prefix-caching changes;
- add focused unit tests for prefix-boundary materialization, block reuse and preemption;
- investigate the mixed-history reproducibility case;
- run upstream kernel, scheduler and engine parity suites;
- clean up the prototype/optimization commits for review.

AI assistance was used for implementation, debugging, profiling and validation; all reported runs were executed on local hardware and inspected by the author.
