### PR TITLE
[Docs] Move russellb to emeritus committer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,9 +34,9 @@
 
 # Entrypoints
 /vllm/entrypoints/anthropic @mgoin @DarkLight1337
-/vllm/entrypoints/cli @hmellor @mgoin @DarkLight1337 @russellb
+/vllm/entrypoints/cli @hmellor @mgoin @DarkLight1337
 /vllm/entrypoints/mcp @heheda12345
-/vllm/entrypoints/openai @aarnphm @chaunceyjiang @DarkLight1337 @russellb
+/vllm/entrypoints/openai @aarnphm @chaunceyjiang @DarkLight1337
 /vllm/entrypoints/speech_to_text/realtime @njhill
 /vllm/entrypoints/speech_to_text @NickLucche
 /vllm/entrypoints/pooling @noooop
@@ -73,7 +73,7 @@
 /vllm/v1/core @WoosukKwon @robertgshaw2-redhat @njhill @ywang96 @alexm-redhat @heheda12345 @ApostaC @orozery @ivanium
 /vllm/v1/sample @22quinn @houseroad @njhill
 /vllm/v1/spec_decode @benchislett @luccafong @MatthewBonanni
-/vllm/v1/structured_output @mgoin @russellb @aarnphm @benchislett
+/vllm/v1/structured_output @mgoin @aarnphm @benchislett
 /vllm/v1/kv_cache_interface.py @heheda12345 @ivanium
 /vllm/v1/kv_offload @ApostaC @orozery
 /vllm/v1/simple_kv_offload @ivanium
@@ -107,8 +107,8 @@
 /tests/multimodal @DarkLight1337 @ywang96 @NickLucche @shen-shanshan
 /tests/multimodal/media @Isotr0py
 /tests/quantization @mgoin @robertgshaw2-redhat @yewentao256 @pavanimajety @zyongye @AndreasKaratzas
-/tests/entrypoints/llm/test_struct_output_generate.py @mgoin @russellb @aarnphm
-/tests/v1/structured_output @mgoin @russellb @aarnphm
+/tests/entrypoints/llm/test_struct_output_generate.py @mgoin @aarnphm
+/tests/v1/structured_output @mgoin @aarnphm
 /tests/v1/core @WoosukKwon @robertgshaw2-redhat @njhill @ywang96 @alexm-redhat @heheda12345 @ApostaC @orozery @ivanium
 /tests/weight_loading @mgoin @youkaichao @yewentao256
 /tests/lora @jeejeelee
@@ -232,6 +232,6 @@ mkdocs.yaml @hmellor
 /docs/training/weight_transfer @aoshen02
 
 # Security guide and policies
-/docs/usage/security.md @russellb @jperezdealgaba
-/SECURITY.md @russellb @jperezdealgaba
-/docs/contributing/vulnerability_management.md @russellb @jperezdealgaba
+/docs/usage/security.md @jperezdealgaba
+/SECURITY.md @jperezdealgaba
+/docs/contributing/vulnerability_management.md @jperezdealgaba

--- a/docs/contributing/vulnerability_management.md
+++ b/docs/contributing/vulnerability_management.md
@@ -33,9 +33,7 @@ on GitHub. However, if you need to contact the VMT directly for an urgent issue,
 you may contact the following individuals:
 
 - Simon Mo - <simon.mo@hey.com>
-- Russell Bryant - <rbryant@redhat.com>
 - Juan Pérez de Algaba - <jperezde@redhat.com>
-- Huzaifa Sidhpurwala - <huzaifas@redhat.com>
 
 ## Slack Discussion
 

--- a/docs/governance/committers.md
+++ b/docs/governance/committers.md
@@ -32,6 +32,7 @@ Sorted alphabetically by GitHub handle:
 - [@ivanium](https://github.com/ivanium): KV Connector and offload
 - [@jeejeelee](https://github.com/jeejeelee): LoRA, new model support
 - [@jikunshang](https://github.com/jikunshang): Intel CPU/XPU integration
+- [@jperezdealgaba](https://github.com/jperezdealgaba): Security
 - [@khluu](https://github.com/khluu): CI infrastructure
 - [@LucasWilkinson](https://github.com/LucasWilkinson): Kernels and performance
 - [@markmc](https://github.com/markmc): Observability
@@ -44,7 +45,6 @@ Sorted alphabetically by GitHub handle:
 - [@pavanimajety](https://github.com/pavanimajety): NVIDIA GPU integration
 - [@ProExpertProg](https://github.com/ProExpertProg): Compilation, startup UX
 - [@robertgshaw2-redhat](https://github.com/robertgshaw2-redhat): Core, distributed, disagg
-- [@russellb](https://github.com/russellb): Structured output, engine core, security
 - [@sfeng33](https://github.com/sfeng33): Tool use and reasoning parser
 - [@shen-shanshan](https://github.com/shen-shanshan): AMD GPU / ROCm integration, multimodality, ViT CUDA graph
 - [@simon-mo](https://github.com/simon-mo): Project lead, API entrypoints, community
@@ -82,6 +82,7 @@ Committers who have contributed to vLLM significantly in the past (thank you!) b
 - [@pcmoritz](https://github.com/pcmoritz): MoE
 - [@rkooo567](https://github.com/rkooo567): Chunked prefill
 - [@ruisearch42](https://github.com/ruisearch42): Pipeline parallelism, Ray Support
+- [@russellb](https://github.com/russellb): Structured output, engine core, security
 - [@sighingnow](https://github.com/sighingnow): Qwen models, new model support
 - [@sroy745](https://github.com/sroy745): Speculative decoding
 - [@Yard1](https://github.com/Yard1): kernels and performance
@@ -100,7 +101,7 @@ If you have PRs touching the area, please feel free to ping the area owner for r
 - KV Cache Manager: memory management layer within scheduler maintaining KV cache logical block data
     - @heheda12345, @WoosukKwon
 - AsyncLLM: the zmq based protocol hosting engine core and making it accessible for entrypoints
-    - @robertgshaw2-redhat, @njhill, @russellb
+    - @robertgshaw2-redhat, @njhill
 - ModelRunner, Executor, Worker: the abstractions for engine wrapping model implementation
     - @WoosukKwon, @tlrmchlsmth, @heheda12345, @LucasWilkinson, @ProExpertProg, @MatthewBonanni
 - KV Connector: Connector interface and implementation for KV cache offload and transfer
@@ -153,7 +154,7 @@ If you have PRs touching the area, please feel free to ping the area owner for r
 - Spec Decode: Covers model definition, attention, sampler, and scheduler related to n-grams, EAGLE, and MTP.
     - @WoosukKwon, @benchislett, @MatthewBonanni
 - Structured Output: The structured output implementation
-    - @russellb, @aarnphm
+    - @aarnphm
 - RL: The RL related features such as collective rpc, sleep mode, etc.
     - @youkaichao, @zhuohan123
 - LoRA: @jeejeelee
@@ -167,7 +168,7 @@ If you have PRs touching the area, please feel free to ping the area owner for r
 - Documentation: @hmellor, @DarkLight1337, @simon-mo
 - Benchmarks: @ywang96, @simon-mo
 - CI, Build, Release Process: @khluu, @njhill, @simon-mo, @Harry-Chen, @vadiklyutiy
-- Security: @russellb
+- Security: @jperezdealgaba
 
 ### External Kernels Integration
 


### PR DESCRIPTION
Move @russellb from active to emeritus committers and drop the
corresponding CODEOWNERS and area-owner entries.

Associated housekeeping while touching these files:

- Add @jperezdealgaba to the committers doc. They already own the
  security policy paths in CODEOWNERS; the doc was just out of date.
  They take over as the Security area owner.
- Trim the Vulnerability Management Team contact list to the members
  who are currently active.

AI assistance (Claude Code) was used to prepare this change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Russell Bryant <rbryant@redhat.com>
