### PR TITLE
[Security] Keep live MoRIIO transfer IDs bound to the first owner

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_unmap.py
+++ b/tests/v1/kv_connector/unit/test_moriio_unmap.py
@@ -106,6 +106,23 @@ def test_colliding_unmap_does_not_clear_live_owner():
     assert s.request_id_to_transfer_id == {"rid-a": "tid-shared"}
 
 
+def test_prefixed_colliding_unmap_does_not_clear_live_owner():
+    """A colliding request id that only starts with the owner id is not
+    the input_processor ``-{8 hex}`` suffix and must not unmap the owner."""
+    s = _sched()
+    assert _map(s, "cmpl-owner", "tid-shared") is True
+    assert _map(s, "cmpl-owner-attacker-12345678", "tid-shared") is False
+
+    _unmap(
+        s,
+        "cmpl-owner-attacker-12345678",
+        transfer_id="tid-shared",
+    )
+
+    assert s.transfer_id_to_request_id == {"tid-shared": "cmpl-owner"}
+    assert s.request_id_to_transfer_id == {"cmpl-owner": "tid-shared"}
+
+
 def test_colliding_alloc_does_not_stage_producer_save():
     s = _sched()
     s._reqs_need_save = {}

--- a/tests/v1/kv_connector/unit/test_moriio_unmap.py
+++ b/tests/v1/kv_connector/unit/test_moriio_unmap.py
@@ -11,14 +11,19 @@ The map/unmap methods touch only the two id<->id dicts, so we bind them to a
 lightweight stand-in rather than constructing a full scheduler.
 """
 
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
+    MoRIIOMode,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
     MoRIIOConnectorScheduler,
+    MoRIIOConnectorWorker,
 )
 
 _map = MoRIIOConnectorScheduler.map_request_id
 _unmap = MoRIIOConnectorScheduler.unmap_request_id
+_update_state_after_alloc = MoRIIOConnectorScheduler.update_state_after_alloc
 
 
 def _sched():
@@ -66,3 +71,126 @@ def test_exact_match_preferred_over_transfer_id_fallback():
     _unmap(s, "rid-1", transfer_id="tid-1")
     assert s.request_id_to_transfer_id == {}
     assert s.transfer_id_to_request_id == {}
+
+
+def test_duplicate_transfer_id_keeps_first_owner():
+    s = _sched()
+    assert _map(s, "rid-a", "tid-shared") is True
+    assert _map(s, "rid-b", "tid-shared") is False
+    assert s.transfer_id_to_request_id == {"tid-shared": "rid-a"}
+    assert s.request_id_to_transfer_id == {"rid-a": "tid-shared"}
+
+
+def test_same_request_transfer_id_map_is_idempotent():
+    s = _sched()
+    assert _map(s, "rid-a", "tid-a") is True
+    assert _map(s, "rid-a", "tid-a") is True
+    assert s.transfer_id_to_request_id == {"tid-a": "rid-a"}
+    assert s.request_id_to_transfer_id == {"rid-a": "tid-a"}
+
+
+def test_transfer_id_can_be_reused_after_owner_unmaps():
+    s = _sched()
+    _map(s, "rid-a", "tid-shared")
+    _unmap(s, "rid-a")
+    assert _map(s, "rid-b", "tid-shared") is True
+    assert s.transfer_id_to_request_id == {"tid-shared": "rid-b"}
+    assert s.request_id_to_transfer_id == {"rid-b": "tid-shared"}
+
+
+def test_colliding_unmap_does_not_clear_live_owner():
+    s = _sched()
+    _map(s, "rid-a", "tid-shared")
+    _unmap(s, "rid-b", transfer_id="tid-shared")
+    assert s.transfer_id_to_request_id == {"tid-shared": "rid-a"}
+    assert s.request_id_to_transfer_id == {"rid-a": "tid-shared"}
+
+
+def test_colliding_alloc_does_not_stage_producer_save():
+    s = _sched()
+    s._reqs_need_save = {}
+    s._req_kv_params = {}
+    s.map_request_id = MethodType(_map, s)
+    _map(s, "rid-a", "tid-shared")
+    request = SimpleNamespace(
+        request_id="rid-b",
+        kv_transfer_params={
+            "transfer_id": "tid-shared",
+            "do_remote_decode": True,
+        },
+    )
+    blocks = SimpleNamespace(get_block_ids=lambda: [[7, 8]])
+
+    _update_state_after_alloc(s, request, blocks, 0)
+
+    assert s.transfer_id_to_request_id == {"tid-shared": "rid-a"}
+    assert "rid-b" not in s.request_id_to_transfer_id
+    assert s._reqs_need_save == {}
+    assert s._req_kv_params == {}
+
+
+def test_colliding_alloc_does_not_stage_consumer_recv():
+    s = _sched()
+    s._reqs_need_recv = {}
+    s._req_kv_params = {}
+    s.map_request_id = MethodType(_map, s)
+    _map(s, "rid-a", "tid-shared")
+    request = SimpleNamespace(
+        request_id="rid-b",
+        kv_transfer_params={
+            "transfer_id": "tid-shared",
+            "do_remote_prefill": True,
+            "remote_block_ids": [1, 2],
+            "remote_engine_id": "eng",
+        },
+    )
+    blocks = SimpleNamespace(get_block_ids=lambda: [[1, 2]])
+
+    _update_state_after_alloc(s, request, blocks, 16)
+
+    assert s.transfer_id_to_request_id == {"tid-shared": "rid-a"}
+    assert s._reqs_need_recv == {}
+
+
+def test_unique_transfer_id_still_stages_producer_save():
+    s = _sched()
+    s._reqs_need_save = {}
+    s._req_kv_params = {}
+    s.map_request_id = MethodType(_map, s)
+    request = SimpleNamespace(
+        request_id="rid-a",
+        kv_transfer_params={
+            "transfer_id": "tid-a",
+            "do_remote_decode": True,
+        },
+    )
+    blocks = SimpleNamespace(get_block_ids=lambda: [[7, 8]])
+
+    _update_state_after_alloc(s, request, blocks, 0)
+
+    assert s.transfer_id_to_request_id == {"tid-a": "rid-a"}
+    assert s._reqs_need_save["rid-a"][1] == [7, 8]
+    assert s._req_kv_params["rid-a"]["transfer_id"] == "tid-a"
+
+
+def test_producer_completion_stays_on_first_transfer_owner():
+    class FakeWrapper:
+        def pop_finished_req_ids(self):
+            return ["tid-shared"]
+
+        def shutdown(self):
+            pass
+
+    worker = MoRIIOConnectorWorker.__new__(MoRIIOConnectorWorker)
+    worker.is_producer = True
+    worker.mode = MoRIIOMode.READ
+    worker.world_size = 1
+    worker.moriio_wrapper = FakeWrapper()
+    worker.transfer_id_to_request_id = {"tid-shared": "rid-a"}
+    worker._consumer_notification_counts = {}
+    worker._completed_consumer_notifications = set()
+    worker._pending_unmapped_acks = []
+
+    done_sending, done_recving = worker.get_finished()
+    assert done_sending == {"rid-a"}
+    assert done_recving == set()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -442,9 +442,20 @@ class MoRIIOConnectorScheduler:
         self.transfer_id_to_request_id: dict[TransferId, ReqId] = {}
         self.request_id_to_transfer_id: dict[ReqId, TransferId] = {}
 
-    def map_request_id(self, request_id: ReqId, transfer_id: TransferId):
+    def map_request_id(self, request_id: ReqId, transfer_id: TransferId) -> bool:
+        """Bind transfer_id to request_id. False if another live request owns it."""
+        owner = self.transfer_id_to_request_id.get(transfer_id)
+        if owner is not None and owner != request_id:
+            logger.warning(
+                "MoRI-IO keeping transfer_id=%r bound to %r; ignoring request %r",
+                transfer_id,
+                owner,
+                request_id,
+            )
+            return False
         self.transfer_id_to_request_id[transfer_id] = request_id
         self.request_id_to_transfer_id[request_id] = transfer_id
+        return True
 
     def unmap_request_id(
         self, request_id: ReqId, transfer_id: TransferId | None = None
@@ -454,7 +465,7 @@ class MoRIIOConnectorScheduler:
         if request_id in self.request_id_to_transfer_id:
             tid = self.request_id_to_transfer_id[request_id]
             del self.request_id_to_transfer_id[request_id]
-            if tid in self.transfer_id_to_request_id:
+            if self.transfer_id_to_request_id.get(tid) == request_id:
                 del self.transfer_id_to_request_id[tid]
             return
 
@@ -462,6 +473,23 @@ class MoRIIOConnectorScheduler:
         if transfer_id is not None and transfer_id in self.transfer_id_to_request_id:
             original_rid = self.transfer_id_to_request_id[transfer_id]
             if original_rid != request_id:
+                # input_processor appends a suffix after map. A different
+                # request that reused transfer_id must not clear the owner.
+                mutated = (
+                    isinstance(request_id, str)
+                    and isinstance(original_rid, str)
+                    and request_id.startswith(original_rid)
+                    and len(request_id) > len(original_rid)
+                )
+                if not mutated:
+                    logger.debug(
+                        "MoRI-IO unmap skip: rid=%r is not owner of "
+                        "transfer_id=%r (owner=%r)",
+                        request_id,
+                        transfer_id,
+                        original_rid,
+                    )
+                    return
                 logger.debug(
                     "MoRI-IO unmap via transfer_id: %r -> %r", request_id, original_rid
                 )
@@ -640,7 +668,8 @@ class MoRIIOConnectorScheduler:
         transfer_id = params.get("transfer_id") or f"sidecar-{request.request_id}"
         params.setdefault("transfer_id", transfer_id)
         request_id = request.request_id
-        self.map_request_id(request_id, transfer_id)
+        if not self.map_request_id(request_id, transfer_id):
+            return
         if params.get("do_remote_decode"):
             local_block_ids = blocks.get_block_ids()[0]
             self._reqs_need_save[request.request_id] = (request, local_block_ids)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 import msgpack
 import msgspec
 import numpy as np
+import regex as re
 import torch
 import zmq
 
@@ -101,6 +102,24 @@ except ImportError:
 
 def is_moriio_available() -> bool:
     return MoRIIO_enabled
+
+
+# input_processor.assign_request_id appends ``-{random_uuid():.8}``.
+_INPUT_PROCESSOR_RID_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$", re.IGNORECASE)
+
+
+def _is_input_processor_request_id(request_id: str, original_rid: str) -> bool:
+    """True if *request_id* is *original_rid* plus the 8-hex randomization.
+
+    A different request whose id merely starts with the owner id must
+    not be treated as the same request.
+    """
+    if not isinstance(request_id, str) or not isinstance(original_rid, str):
+        return False
+    if not request_id.startswith(original_rid):
+        return False
+    extra = request_id[len(original_rid) :]
+    return bool(_INPUT_PROCESSOR_RID_SUFFIX_RE.fullmatch(extra))
 
 
 def get_moriio_remote_tp_rank(
@@ -473,15 +492,10 @@ class MoRIIOConnectorScheduler:
         if transfer_id is not None and transfer_id in self.transfer_id_to_request_id:
             original_rid = self.transfer_id_to_request_id[transfer_id]
             if original_rid != request_id:
-                # input_processor appends a suffix after map. A different
-                # request that reused transfer_id must not clear the owner.
-                mutated = (
-                    isinstance(request_id, str)
-                    and isinstance(original_rid, str)
-                    and request_id.startswith(original_rid)
-                    and len(request_id) > len(original_rid)
-                )
-                if not mutated:
+                # input_processor appends ``-{8 hex}`` after map. A different
+                # request whose id only starts with the owner id must not
+                # clear the live mapping.
+                if not _is_input_processor_request_id(request_id, original_rid):
                     logger.debug(
                         "MoRI-IO unmap skip: rid=%r is not owner of "
                         "transfer_id=%r (owner=%r)",


### PR DESCRIPTION
## Summary

MoRIIO stored `transfer_id` → `request_id` with last-write-wins semantics. If two overlapping requests presented the same `transfer_id`, the later request stole the mapping, so the first request's completion was reported as `finished_sending` for the later request and the scheduler freed that request's live KV blocks. This change keeps the first live owner, skips connector staging for the colliding request, and refuses to unmap a transfer that still belongs to a different request.

`unmap_request_id`'s input-processor fallback now requires the real `assign_request_id` suffix (`-{8 hex}`). A colliding request whose id only starts with the owner id must not erase the live mapping.

## Changes
- `moriio_connector.py`: `map_request_id` returns false instead of overwriting a live owner; `update_state_after_alloc` returns without staging save/recv; `unmap_request_id` only clears a mapping it still owns, and only treats `owner-{8 hex}` as the randomized internal id.
- `tests/v1/kv_connector/unit/test_moriio_unmap.py`: collision, reuse-after-unmap, alloc skip, completion-translation, and prefixed-unmap coverage.

## Codepath coverage
- Producer `update_state_after_alloc` (`do_remote_decode` save path): colliding request is not mapped and not staged.
- Consumer `update_state_after_alloc` (`do_remote_prefill` recv path): same early return.
- Worker `get_finished` `finished_sending` translation: uses the scheduler mapping, so the first owner stays the completed request.
- Consumer `request_finished` unmap with a colliding `transfer_id`: no longer clears the live owner.
- Unmap with a request id that only prefixes the owner: does not clear the live owner.
- Unmap with `owner-{8 hex}` (input_processor mutation): still clears.
- Same request remapped with the same id remains idempotent (chunked prefill / TP fan-in ACKs).
- Unique `transfer_id` still stages a producer save.
- All HTTP/gRPC inference entry points that allocate a MoRIIO request go through `update_state_after_alloc`.

## Duplicate-work check
Searched open and merged PRs for `map_request_id`, `transfer_id_to_request_id`, MoRIIO transfer mapping, and duplicate transfer IDs.
- https://github.com/vllm-project/vllm/pull/43541 accumulates many request ids per transfer for `best_of_n`; that would still complete every mapped request on one ACK and does not keep a single live owner.
- https://github.com/vllm-project/vllm/pull/46874 logs a collision and still overwrites the mapping.
- https://github.com/vllm-project/vllm/pull/56465 holds deferred sends until ACK; different trigger (timeout), same connector.
- https://github.com/vllm-project/vllm/pull/49796 rejects duplicate Mooncake transfer IDs; different connector.

## Tests
- `test_duplicate_transfer_id_keeps_first_owner`
- `test_same_request_transfer_id_map_is_idempotent`
- `test_transfer_id_can_be_reused_after_owner_unmaps`
- `test_colliding_unmap_does_not_clear_live_owner`
- `test_prefixed_colliding_unmap_does_not_clear_live_owner`
- `test_colliding_alloc_does_not_stage_producer_save`
- `test_colliding_alloc_does_not_stage_consumer_recv`
- `test_unique_transfer_id_still_stages_producer_save`
- `test_producer_completion_stays_on_first_transfer_owner`

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_moriio_unmap.py tests/v1/kv_connector/unit/test_moriio_tp_ack.py -q
```

34 passed.

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)