### PR TITLE
[Bugfix][KV Cache] Exclude KpoolTailSpec from the generic slot-mapping kernel

### DIFF
--- a/tests/v1/worker/test_gpu_slot_mapping_classification.py
+++ b/tests/v1/worker/test_gpu_slot_mapping_classification.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Regression tests for #56380 (problem 2): builder-managed KV cache groups
+must be excluded from the generic position-indexed slot-mapping kernel.
+
+``KpoolTailSpec`` rows hold one circular block per request. The generic
+``_compute_slot_mappings_kernel`` computes ``pos // kernel_block_size``
+against that one-column row and reads past it on chunked prefill, poisoning
+the block ids used by every kpool consumer. The circular mapping is owned by
+``KpoolTailMetadataBuilder``.
+"""
+
+import pytest
+import torch
+
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    CircularBufferSpec,
+    FullAttentionSpec,
+    KpoolTailSpec,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+    uses_generic_slot_mapping,
+)
+
+# Pure spec-classification tests: no accelerator, no dist env — skip the
+# global teardown so the suite runs on CPU-only machines.
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _kpool_tail_spec() -> KpoolTailSpec:
+    return KpoolTailSpec(
+        block_size=4,
+        num_kv_heads=2,
+        head_size=128,
+        head_size_v=0,
+        dtype=torch.bfloat16,
+        sliding_window=4,
+    )
+
+
+def _circular_buffer_spec() -> CircularBufferSpec:
+    return CircularBufferSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=128,
+        head_size_v=0,
+        dtype=torch.bfloat16,
+    )
+
+
+def _mamba_spec() -> MambaSpec:
+    return MambaSpec(
+        block_size=640,
+        shapes=((1, 8, 128), (1, 8, 128, 3)),
+        dtypes=(torch.float32, torch.float32),
+    )
+
+
+@pytest.mark.parametrize(
+    "spec_factory",
+    [_kpool_tail_spec, _circular_buffer_spec],
+    ids=["kpool_tail", "circular_buffer"],
+)
+def test_builder_managed_groups_excluded_from_generic_slot_mapping(spec_factory):
+    # The bug: KpoolTailSpec used to pass the CircularBufferSpec-only check,
+    # so the generic position-indexed kernel indexed its one-column
+    # block-table row with pos // kpool on chunked prefill.
+    assert not uses_generic_slot_mapping(spec_factory())
+
+
+def test_position_indexed_groups_included():
+    full = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        head_size_v=128,
+        dtype=torch.bfloat16,
+    )
+    attention = AttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=128,
+        head_size_v=128,
+        dtype=torch.bfloat16,
+    )
+    assert uses_generic_slot_mapping(full)
+    assert uses_generic_slot_mapping(attention)
+    assert uses_generic_slot_mapping(_mamba_spec())
+
+
+def test_uniform_type_wrapper_unwraps_to_member_spec():
+    # A UniformTypeKVCacheSpecs collection must be classified by its member
+    # specs: a kpool-tail-only group must stay excluded through the wrapper,
+    # mirroring is_full_attention_spec's handling of the wrapper.
+    spec = UniformTypeKVCacheSpecs(
+        block_size=4,
+        kv_cache_specs={
+            "decoder.layers.0.kpool_tail": _kpool_tail_spec(),
+            "decoder.layers.1.kpool_tail": _kpool_tail_spec(),
+        },
+    )
+    assert not uses_generic_slot_mapping(spec)
+
+    full_group = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={
+            "decoder.layers.0.self_attn": FullAttentionSpec(
+                block_size=16,
+                num_kv_heads=8,
+                head_size=128,
+                head_size_v=128,
+                dtype=torch.bfloat16,
+            )
+        },
+    )
+    assert uses_generic_slot_mapping(full_group)

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -1304,6 +1304,22 @@ def is_full_attention_spec(kv_cache_spec: KVCacheSpec) -> bool:
     )
 
 
+def uses_generic_slot_mapping(kv_cache_spec: KVCacheSpec) -> bool:
+    """Whether the generic position-indexed slot-mapping kernel may serve a
+    KV cache group.
+
+    Builder-managed groups are excluded: ``CircularBufferSpec`` and
+    ``KpoolTailSpec`` rows hold a single block per request whose slot mapping
+    is computed by their own attention metadata builders, so the generic
+    ``pos // kernel_block_size`` column lookup would index past the row and
+    read unmaterialized block ids (#56380).
+    """
+    layer_specs = iter_layer_specs(kv_cache_spec)
+    return not any(
+        isinstance(spec, (CircularBufferSpec, KpoolTailSpec)) for spec in layer_specs
+    )
+
+
 def get_kv_cache_spec_kind(kv_cache_spec: KVCacheSpec) -> KVCacheSpecKind:
     if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
         inner_kinds = {

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -69,7 +69,7 @@ from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     MambaSpec,
-    UniformTypeKVCacheSpecs,
+    uses_generic_slot_mapping,
 )
 from vllm.v1.outputs import (
     DraftTokenIds,
@@ -603,10 +603,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         for kv_cache_group in kv_cache_config.kv_cache_groups:
             spec = kv_cache_group.kv_cache_spec
             block_sizes.append(spec.block_size)
-            layer_spec = (
-                spec.first_spec if isinstance(spec, UniformTypeKVCacheSpecs) else spec
-            )
-            slot_mapping_enabled.append(layer_spec.uses_slot_mapping)
+            # Builder-managed groups (CircularBufferSpec, KpoolTailSpec) hold
+            # one circular block per request and compute their slot mapping
+            # in their own attention metadata builder; the generic
+            # position-indexed kernel would index past their one-column
+            # block-table rows on chunked prefill (#56380).
+            slot_mapping_enabled.append(uses_generic_slot_mapping(spec))
             # Let each cache type account for CP. Attention KV is DCP-sharded,
             # while Mamba/GDN recurrent state is replicated across DCP ranks.
             max_num_blocks = spec.max_num_blocks_per_req(


### PR DESCRIPTION
## Purpose

Addresses problem 2 of #56380 (the kpool-tail slot-mapping fault; problem 1 — the MLA storage-page granularity — is handled separately in #56381).

`KpoolTailSpec` reserves exactly **one circular block per request** (`max_num_blocks_per_req == 1`, `block_size == index_kpool`, e.g. 4). Its slot mapping is produced by `KpoolTailMetadataBuilder` (`own_block * kpool + pos % kpool`). However, the group was not excluded from the generic `_compute_slot_mappings_kernel`, which maps `block_indices = position // kernel_block_size` against the group's one-column block-table row. On chunked prefill (e.g. a 16000-token chunk) the column index reaches thousands, reads past the row, and poisons the block id used to form `slot_ids = block_numbers * kernel_block_size + block_offsets`. Downstream kpool consumers then dereference a wild physical id:

```
Memory access fault by GPU node-2 ... on address 0x7f2274000000. Reason: Unknown.
EngineDeadError: EngineCore encountered an issue.
```

With `HIP_LAUNCH_BLOCKING=1`, the faulting stack lands on `_compute_slot_mappings_kernel` — matching what #56380 reports for problem 2.

## Changes

- Add `uses_generic_slot_mapping()` to `kv_cache_interface.py`, next to the existing `is_full_attention_spec()` helper, classifying whether the generic position-indexed slot-mapping kernel may serve a group. Builder-managed groups (`CircularBufferSpec`, `KpoolTailSpec` — both hold one circular block per request and compute their mapping in their own attention metadata builder) return False, unwrapping `UniformTypeKVCacheSpecs` the same way `is_full_attention_spec` does.
- `GPUModelRunner.initialize_kv_cache` uses the helper for `slot_mapping_enabled` instead of the bare `CircularBufferSpec` isinstance check. With mapping disabled the generic kernel writes `PAD_SLOT_ID` for the group (`slot_ids = tl.where(mapping_enabled, slot_ids, PAD_ID)`), and the correct circular mapping continues to come from `KpoolTailMetadataBuilder`. No consumer reads the padded entries (kpool reads only the builder's mapping; the Mooncake connector reads `kv_block_len`, not this tensor).
- Regression tests asserting the classification for kpool-tail, circular-buffer, full-attention/attention/mamba, and the `UniformTypeKVCacheSpecs` wrapper path.

## Test Plan

```bash
pytest tests/v1/worker/test_gpu_slot_mapping_classification.py -v
```

plus the hardware reproducer from #56380's environment: GLM-5.3-Flash on 8x MI308X (gfx942), TP8, MTP N=1, chunked prefill (16000-token chunks), a 40032-token prompt with `max_tokens=512`:

```bash
python3 - <<'EOF'
import json, urllib.request
payload = json.load(open("probe40k.json"))
body = {"model": "glm53-flash",
        "messages": [{"role": "user", "content": payload["messages"][0]["content"]}],
        "max_tokens": 512, "temperature": 0, "ignore_eos": True,
        "chat_template_kwargs": {"thinking": False}}
req = urllib.request.Request("http://127.0.0.1:30001/v1/chat/completions",
                             data=json.dumps(body).encode(),
                             headers={"Content-Type": "application/json"})
print(json.load(urllib.request.urlopen(req, timeout=1800))["usage"])
EOF
```

## Test Result

Unit tests (CPU-only, no accelerator needed):

```
tests/v1/worker/test_gpu_slot_mapping_classification.py::test_builder_managed_groups_excluded_from_generic_slot_mapping[kpool_tail] PASSED
tests/v1/worker/test_gpu_slot_mapping_classification.py::test_builder_managed_groups_excluded_from_generic_slot_mapping[circular_buffer] PASSED
tests/v1/worker/test_gpu_slot_mapping_classification.py::test_position_indexed_groups_included PASSED
tests/v1/worker/test_gpu_slot_mapping_classification.py::test_uniform_type_wrapper_unwraps_to_member_spec PASSED
======================== 4 passed in 0.01s ========================
```

Negative control: reverting the exclusion makes the kpool-tail and wrapper tests fail.

Hardware A/B on 8x MI308X (gfx942), GLM-5.3-Flash, TP8 + MTP N=1, same 40032-token probe, only the classification toggled:

| Build | Probe result |
|---|---|
| unfixed | HTTP 500 at ~300 s; GPU memory faults on 5 nodes; EngineDeadError |
| fixed | HTTP 200 in 7–15 s (3 independent runs incl. `HIP_LAUNCH_BLOCKING=1`) |

GSM8K spot-check after the fix: 4/4. Decode throughput unchanged (c1-short 47.5 tok/s watermark before and after).

## Notes

- Related: #55219 replaces this cache layout and may supersede this fix together with #56381.

AI assistance was used for investigation, implementation, and this description.
