### PR TITLE
[9/N][Attention] Support adaptive verification in FlashMLA Sparse

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -57,6 +57,7 @@ from vllm.model_executor.layers.attention.sparse_mla_attention import (
 )
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import current_stream
+from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.mla import index_group as index_group_module
 from vllm.v1.attention.backends.mla.flashattn_mla_sparse import (
     FlashAttnMLASparseImpl,
@@ -2966,77 +2967,46 @@ def test_hisparse_gather_prefill_cache_prefers_resident_rows():
         torch.testing.assert_close(staged_flat[i], expected)
 
 
-def test_hisparse_fp8_decode_resolves_steps_then_runs_batched_attention(monkeypatch):
-    """FP8 decode must use active dimensions when common metadata is padded."""
+def test_hisparse_fp8_decode_preserves_packed_varlen_rows():
+    """Uneven decode rows must not be reshaped into uniform request spans."""
     device = torch.device("cpu")
     num_decodes = 2
     query_len = 3
-    num_tokens = num_decodes * query_len
+    num_tokens = 4
     q = torch.randn(num_tokens, 2, 4, device=device)
     topk = (
         torch.arange(num_tokens, dtype=torch.int32, device=device)
         .view(-1, 1)
         .expand(-1, 4)
     )
-    steps: list[int] = []
     kernel_shapes: list[torch.Size] = []
 
-    def swap_in(req_ids, *, logical_topk_indices, **kwargs):  # noqa: ARG001
-        steps.append(int(logical_topk_indices[0, 0]))
-        output = kwargs["attention_indices_out"]
-        if output is not None:
-            output.copy_(logical_topk_indices + 10)
-        return topk[:num_decodes]
+    def convert_decode(layer_index, logical_topk_indices, metadata, **kwargs):
+        assert layer_index == 0
+        assert metadata.query_start_loc.tolist() == [0, 3, 4]
+        return logical_topk_indices + 10
 
     def run_kernel(self, *, q, **kwargs):  # noqa: ARG001
         kernel_shapes.append(q.shape)
         return q[..., :1], None
 
-    runtime = SimpleNamespace(
-        hot=SimpleNamespace(attention_cache=torch.empty(1, device=device))
-    )
-    leader_cache = SimpleNamespace(
-        runtime=runtime,
-        source_block_table=torch.empty(
-            num_decodes, 1, dtype=torch.int32, device=device
-        ),
-        swap_in=MagicMock(side_effect=swap_in),
-    )
-    follower_cache = SimpleNamespace(
-        runtime=runtime,
-        source_block_table=torch.empty(
-            num_decodes, 1, dtype=torch.int32, device=device
-        ),
-        swap_in=MagicMock(side_effect=swap_in),
-    )
     index_group = object.__new__(HiSparseMLAIndexGroup)
-    index_group.caches = [leader_cache, follower_cache]
-    index_group.physical_topk_indices = torch.empty(
-        (num_tokens + 1, 4), dtype=torch.int32, device=device
+    index_group.convert_decode_logical_to_physical_topk = MagicMock(
+        side_effect=convert_decode
     )
-    index_group.valid_topk_counts = torch.empty(
-        num_tokens + 1, dtype=torch.int32, device=device
-    )
-    index_group.request_ids = torch.arange(
-        num_decodes, dtype=torch.int32, device=device
+    index_group.physical_kv_cache = MagicMock(
+        return_value=torch.empty(1, 64, 1, dtype=torch.uint8, device=device)
     )
     impl = SimpleNamespace(
-        kv_lora_rank=1,
         index_group=index_group,
         index_group_index=0,
     )
     impl._fp8_flash_mla_kernel = MethodType(run_kernel, impl)
     metadata = SimpleNamespace(
-        num_decodes=num_tokens,
+        num_decodes=num_decodes,
         num_decode_tokens=num_tokens,
-        decode_max_query_len=1,
-        query_start_loc=torch.arange(
-            0,
-            num_tokens + 1,
-            query_len,
-            dtype=torch.int32,
-            device=device,
-        ),
+        decode_max_query_len=query_len,
+        query_start_loc=torch.tensor([0, 3, 4], dtype=torch.int32, device=device),
         block_table=torch.empty(num_decodes, 1, dtype=torch.int32, device=device),
         block_size=64,
     )
@@ -3047,27 +3017,21 @@ def test_hisparse_fp8_decode_resolves_steps_then_runs_batched_attention(monkeypa
         topk,
         metadata,
         SimpleNamespace(),
-        num_decodes,
-        query_len,
     )
 
-    assert steps == [0, 1, 2]
-    assert kernel_shapes == [(num_decodes, query_len, 2, 4)]
+    index_group.convert_decode_logical_to_physical_topk.assert_called_once()
+    assert kernel_shapes == [(1, num_tokens, 2, 4)]
     assert output.shape == (num_tokens, 2, 1)
-    torch.testing.assert_close(
-        index_group.physical_topk_indices[:num_tokens], topk + 10
-    )
+    torch.testing.assert_close(output, q[..., :1])
 
-    follower_indices = index_group.convert_decode_logical_to_physical_topk(
-        1,
-        topk,
-        metadata,
-        return_valid_counts=False,
-        num_decodes=num_decodes,
-        decode_query_len=query_len,
+
+def test_flashmla_hisparse_reports_varlen_cudagraph_support():
+    config = SimpleNamespace(attention_config=SimpleNamespace(hisparse_config=object()))
+
+    assert (
+        FlashMLASparseMetadataBuilder.get_cudagraph_support(config, None)
+        == AttentionCGSupport.ALWAYS
     )
-    assert steps == [0, 1, 2, 0, 1, 2]
-    torch.testing.assert_close(follower_indices, topk + 10)
 
 
 def test_hisparse_varlen_decode_uses_canonical_request_rows():
@@ -3352,6 +3316,7 @@ def test_flashmla_fp8_metadata_excludes_zero_token_decode_padding(monkeypatch):
     )
     builder = SimpleNamespace(
         device=torch.device(DEVICE_TYPE),
+        use_hisparse=False,
         dummy_block_table=torch.zeros(7, 1, device=DEVICE_TYPE),
         max_model_len_tensor=torch.zeros(7, device=DEVICE_TYPE),
     )

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -162,7 +162,7 @@ T = TypeVar("T", bound=SparseMLACommonMetadata)
 
 class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
     metadata_cls: type[T]
-    require_uniform_decodes: ClassVar[bool] = False
+    require_uniform_decodes: bool = False
     hisparse_supports_multi_token_decode: ClassVar[bool] = False
 
     def __init__(
@@ -288,17 +288,7 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
         self,
         common_attn_metadata: "CommonAttentionMetadata",
     ) -> torch.Tensor:
-        num_tokens = common_attn_metadata.num_actual_tokens
-        starts = np.asarray(common_attn_metadata.query_start_loc_cpu, dtype=np.int32)
-        seg_lengths = np.diff(starts)
-        req_id_per_token = np.repeat(
-            np.arange(seg_lengths.shape[0], dtype=np.int32), seg_lengths
-        )
-        self.req_id_per_token_buffer.fill_(0)
-        self.req_id_per_token_buffer[: req_id_per_token.shape[0]].copy_(
-            np_to_pinned_tensor(req_id_per_token), non_blocking=True
-        )
-        return self.req_id_per_token_buffer[:num_tokens]
+        return common_attn_metadata.token_to_req_indices(self.req_id_per_token_buffer)
 
     def _build_chunked_context_fields(
         self,

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -42,7 +42,7 @@ from vllm.v1.attention.ops.flashmla import (
     flash_mla_with_kvcache,
     get_mla_metadata,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheSpec
 from vllm.v1.worker.workspace import current_workspace_manager
 
 if TYPE_CHECKING:
@@ -242,9 +242,19 @@ class FlashMLASparseMetadataBuilder(
     SparseMLACommonMetadataBuilder[FlashMLASparseMetadata]
 ):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
-    require_uniform_decodes: ClassVar[bool] = True
+    require_uniform_decodes: bool = True
     hisparse_supports_multi_token_decode: ClassVar[bool] = True
     metadata_cls = FlashMLASparseMetadata
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: KVCacheSpec,
+    ) -> AttentionCGSupport:
+        if vllm_config.attention_config.hisparse_config is not None:
+            return AttentionCGSupport.ALWAYS
+        return super().get_cudagraph_support(vllm_config, kv_cache_spec)
 
     def __init__(
         self,
@@ -267,6 +277,7 @@ class FlashMLASparseMetadataBuilder(
         self.use_hisparse = vllm_config.attention_config.hisparse_config is not None
         if self.use_hisparse:
             threshold = 1
+            self.require_uniform_decodes = False
         # Varlen decodes are safe under DCP: causality comes from the
         # indexer's top-k indices, not from the kernel metadata.
         self._init_reorder_batch_threshold(
@@ -403,11 +414,17 @@ class FlashMLASparseMetadataBuilder(
         decode_query_len = 0
         active_num_decodes = num_decodes
         if num_decodes > 0:
-            query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
-            decode_query_len = (query_start_loc_cpu[1] - query_start_loc_cpu[0]).item()
+            if self.use_hisparse:
+                decode_query_len = metadata.decode_max_query_len
+            else:
+                query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+                decode_query_len = (
+                    query_start_loc_cpu[1] - query_start_loc_cpu[0]
+                ).item()
             assert decode_query_len > 0
-            active_num_decodes = num_decode_tokens // decode_query_len
-            assert active_num_decodes * decode_query_len == num_decode_tokens
+            if not self.use_hisparse:
+                active_num_decodes = num_decode_tokens // decode_query_len
+                assert active_num_decodes * decode_query_len == num_decode_tokens
 
         FP8Meta = FlashMLASparseMetadata.FP8SeparatePrefillDecode
         fp8_metadata = FP8Meta(
@@ -518,11 +535,12 @@ class FlashMLASparseMetadataBuilder(
         if num_decodes > 0:
             # Use padded head count since that's what the kernel will see
             scheduler_metadata, _ = get_mla_metadata()
+            kernel_batch_size = 1 if self.use_hisparse else active_num_decodes
 
             kernel_meta = FlashMLASparseMetadata.FP8KernelMetadata(
                 scheduler_metadata=scheduler_metadata,
-                dummy_block_table=self.dummy_block_table[:active_num_decodes],
-                cache_lens=self.max_model_len_tensor[:active_num_decodes],
+                dummy_block_table=self.dummy_block_table[:kernel_batch_size],
+                cache_lens=self.max_model_len_tensor[:kernel_batch_size],
             )
             fp8_metadata.decode = FP8Meta.Decode(
                 seq_lens=common_attn_metadata.seq_lens[:active_num_decodes],
@@ -818,8 +836,6 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
                     topk_indices,
                     attn_metadata,
                     fp8_metadata.decode.kernel_metadata,
-                    num_decodes,
-                    fp8_metadata.decode.decode_query_len,
                 )
             # Reshape q: (num_decode_tokens, num_heads, head_dim)
             #         -> (num_decodes, seq_len, num_heads, head_dim)
@@ -1046,8 +1062,6 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
         topk_indices: torch.Tensor,
         attn_metadata: FlashMLASparseMetadata,
         kernel_metadata: FlashMLASparseMetadata.FP8KernelMetadata,
-        num_decodes: int,
-        decode_query_len: int,
     ) -> torch.Tensor:
         assert isinstance(self.index_group, HiSparseMLAIndexGroup)
         physical_topk = self.index_group.convert_decode_logical_to_physical_topk(
@@ -1055,21 +1069,17 @@ class FlashMLASparseImpl(SparseMLACommonImpl[FlashMLASparseMetadata]):
             topk_indices,
             attn_metadata,
             return_valid_counts=False,
-            num_decodes=num_decodes,
-            decode_query_len=decode_query_len,
         )
         assert isinstance(physical_topk, torch.Tensor)
-        q = reshape_query_for_spec_decode(q, num_decodes)
-        physical_topk = physical_topk.view(num_decodes, q.shape[1], -1)
         output, _ = self._fp8_flash_mla_kernel(
-            q=q,
+            q=q.unsqueeze(0),
             kv_c_and_k_pe_cache=self.index_group.physical_kv_cache(
                 self.index_group_index
             ),
-            topk_indices=physical_topk,
+            topk_indices=physical_topk.unsqueeze(0),
             kernel_metadata=kernel_metadata,
         )
-        return reshape_attn_output_for_spec_decode(output)
+        return output.squeeze(0)
 
     def _bf16_flash_mla_kernel(
         self,


### PR DESCRIPTION
## Summary

- allow HiSparse-backed FlashMLA Sparse to capture nonuniform adaptive-verification batches
- preserve packed variable-length decode rows as one MQA batch instead of inventing uniform request boundaries
- derive request rows from device metadata without a device-to-host synchronization

This is split from the core HiSparse PR because FlashMLA Sparse does not support adaptive verification on main; HiSparse can otherwise use the existing FlashInfer Sparse MLA support.

## Duplicate work

I searched open PRs for FlashMLA Sparse adaptive-verification support and found no duplicate. #52988 concerns Kimi-K3 rather than FlashMLA Sparse or HiSparse.

## Validation

- `pre-commit run --files tests/v1/attention/test_sparse_mla_backends.py vllm/model_executor/layers/attention/sparse_mla_attention.py vllm/v1/attention/backends/mla/flashmla_sparse.py`
- `python -m pytest -q tests/v1/attention/test_sparse_mla_backends.py::test_hisparse_fp8_decode_preserves_packed_varlen_rows tests/v1/attention/test_sparse_mla_backends.py::test_flashmla_hisparse_reports_varlen_cudagraph_support tests/v1/attention/test_sparse_mla_backends.py::test_hisparse_flashmla_reorders_full_speculative_window_as_decode`
  - 3 passed on one B300 GPU
- GLM TP4 end-to-end smoke with `FULL_AND_PIECEWISE` and forced adaptive rejection:
  - 25 requests completed
  - 7,105 drafted tokens, 0 accepted
  - 0 errors

AI assistance was used. Every changed line and the validation results were reviewed by the human submitter.