### PR TITLE
docs(batch_invariance): add Granite MoE SWA to validated models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -135,6 +135,7 @@ Batch invariance has been tested and verified on the following models:
 - **Granite 3.1 (Dense)**: `ibm-granite/granite-3.1-2b-instruct`, `ibm-granite/granite-3.1-8b-instruct`
 - **EXAONE 4.0 series**: `LGAI-EXAONE/EXAONE-4.0-1.2B`, `LGAI-EXAONE/EXAONE-4.0.1-32B`, `LGAI-EXAONE/EXAONE-4.0-32B`
 - **OLMo 2**: `allenai/OLMo-2-0425-1B-Instruct`
+- **Granite MoE SWA**: `ibm-granite/granite-swash-3b-a600m` (MoE + sliding-window attention; FLASH_ATTN and TRITON_ATTN backends; FLEX_ATTENTION and decode-vs-prefill test excluded due to per-layer SWA KV window differences)
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm/issues/new/choose).
 


### PR DESCRIPTION
## Why this is not duplicating an existing PR

No existing PR covers `ibm-granite/granite-swash-3b-a600m` (GraniteMoeSWAForCausalLM) batch invariance validation. The related PR #55138 covers GraniteSWA (dense, `granite-swash-2b`); this is the MoE variant.

```
gh pr list --repo vllm-project/vllm --state open --search "granite-swash-3b"
```
→ no results.

## Changes

- `docs/features/batch_invariance.md`: add `ibm-granite/granite-swash-3b-a600m` to the validated models list

## Test run (H100 NVL, SM90, vllm/vllm-openai:nightly)

```
NVIDIA H100 NVL, 9.0, 95830 MiB
Torch: 2.13.0+cu130 | CUDA: 13.0
vLLM: 0.28.1rc1.dev580+g385dce36b

VLLM_TEST_MODEL=ibm-granite/granite-swash-3b-a600m python3 -m pytest -v \
  tests/v1/determinism/test_batch_invariance.py \
  -k "not FLEX_ATTENTION and not decode_logprobs" \
  --tb=short -p no:cacheprovider

============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
rootdir: /tmp/det
plugins: anyio-4.15.1
collecting ... collected 19 items / 7 deselected / 12 selected

test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[default-FLASH_ATTN] PASSED [  8%]
test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[default-TRITON_ATTN] PASSED [ 16%]
test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[vllm_c-FLASH_ATTN] PASSED [ 25%]
test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[vllm_c-TRITON_ATTN] PASSED [ 33%]
test_batch_invariance.py::test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[16-16-FLASH_ATTN] PASSED [ 41%]
test_batch_invariance.py::test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[16-16-TRITON_ATTN] PASSED [ 50%]
test_batch_invariance.py::test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[8-16-FLASH_ATTN] PASSED [ 58%]
test_batch_invariance.py::test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[8-16-TRITON_ATTN] PASSED [ 66%]
test_batch_invariance.py::test_simple_generation[FLASH_ATTN] PASSED      [ 75%]
test_batch_invariance.py::test_simple_generation[TRITON_ATTN] PASSED     [ 83%]
test_batch_invariance.py::test_logprobs_without_batch_invariance_should_fail[FLASH_ATTN] PASSED [ 91%]
test_batch_invariance.py::test_logprobs_without_batch_invariance_should_fail[TRITON_ATTN] PASSED [100%]

========== 12 passed, 7 deselected, 28 warnings in 652.15s (0:10:52) ===========
```

**Note on exclusions:** `GraniteMoeSWAForCausalLM` uses per-layer sliding-window attention with attention sinks. FLEX_ATTENTION's block-sparse allocator is incompatible (same as the dense GraniteSWA variant, see PR #55138). The decode-vs-prefill consistency test is excluded because per-layer SWA means decode and prefill operate over different KV windows by design. FLASH_ATTN and TRITON_ATTN are fully batch-invariant.

## AI assistance disclosure

This validation was performed with AI assistance (Claude Code). I reviewed all changes and ran the tests on real H100 NVL hardware.

Signed-off-by: Yuval Luria <yluria@redhat.com>