### PR TITLE
[Bugfix][DSv4.1] Isolate sparse index state across microbatches

### DIFF
--- a/tests/v1/worker/test_gpu_ubatch_slicing.py
+++ b/tests/v1/worker/test_gpu_ubatch_slicing.py
@@ -41,7 +41,11 @@ from vllm.v1.worker.ubatch_utils import (
     maybe_create_ubatch_slices,
     split_attn_metadata,
 )
-from vllm.v1.worker.ubatching import dbo_current_ubatch_id, dbo_yield
+from vllm.v1.worker.ubatching import (
+    dbo_current_ubatch_id,
+    dbo_select_buffer,
+    dbo_yield,
+)
 
 MAX_NUM_REQS = 32
 MAX_NUM_TOKENS = 128
@@ -718,3 +722,83 @@ def test_slicing_drops_stale_dcp_metadata_when_dcp_is_off():
     ]
 
     assert all(ubatch.dcp_local_seq_lens is None for ubatch in ubatches)
+
+
+class _CrossLayerIndexModel(torch.nn.Module):
+    """Publish index state, yield at MoE, then consume it in a later layer."""
+
+    def __init__(self, device: torch.device, num_ubatches: int):
+        super().__init__()
+        self.topk = torch.empty(num_ubatches, 16, 4, dtype=torch.int32, device=device)
+        self.candidates = torch.empty(
+            num_ubatches, 16, 2, dtype=torch.int32, device=device
+        )
+
+    def forward(self, input_ids, positions, intermediate_tensors=None, **kwargs):
+        n = input_ids.numel()
+        dbo_select_buffer(self.topk)[:n].copy_(input_ids[:, None])
+        dbo_select_buffer(self.candidates)[:n].copy_(positions[:, None])
+        dbo_yield()
+        return torch.cat(
+            (dbo_select_buffer(self.topk)[:n], dbo_select_buffer(self.candidates)[:n]),
+            dim=-1,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="DBO needs a GPU")
+def test_ubatch_runner_preserves_cross_layer_index_state():
+    """Another microbatch must not overwrite indices needed after an MoE yield."""
+    config = _make_dbo_config()
+    device = torch.device("cuda:0")
+    runner = _make_execution_runner(config)
+    model = _CrossLayerIndexModel(device, config.parallel_config.num_ubatches)
+    state = _make_ubatch_state(
+        config,
+        [
+            UBatchSlice(slice(0, 4), slice(0, 8)),
+            UBatchSlice(slice(4, 8), slice(8, 16)),
+        ],
+    )
+    inputs = _make_model_inputs(16, device)
+    for offset in (0, 100):
+        inputs["input_ids"].add_(offset)
+        output = runner.run(model, inputs, state)
+        expected = torch.cat(
+            (
+                inputs["input_ids"][:, None].expand(-1, 4),
+                inputs["positions"][:, None].expand(-1, 2),
+            ),
+            dim=-1,
+        ).to(torch.int32)
+        torch.testing.assert_close(output, expected)
+
+
+def test_dbo_select_buffer_preserves_unbatched_storage():
+    buffer = torch.empty(16, 4, dtype=torch.int32)
+    assert dbo_select_buffer(buffer) is buffer
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA graphs")
+def test_microbatch_buffer_selection_is_stable_across_graph_replay(monkeypatch):
+    """Replay retains each captured slot even without an active Python microbatch."""
+    import vllm.v1.worker.ubatching as ubatching
+
+    storage = torch.empty(2, 8, 4, dtype=torch.int32, device="cuda")
+    inputs = torch.arange(32, dtype=torch.int32, device="cuda").view(8, 4)
+    active = 0
+    monkeypatch.setattr(ubatching, "dbo_current_ubatch_id", lambda: active)
+    graphs = [torch.cuda.CUDAGraph(), torch.cuda.CUDAGraph()]
+    outputs = []
+    torch.accelerator.synchronize()
+    for active, graph in enumerate(graphs):
+        with torch.cuda.graph(graph):
+            dbo_select_buffer(storage).copy_(inputs + active)
+            outputs.append(dbo_select_buffer(storage).clone())
+    active = 0
+    for increment in (100, 200):
+        inputs.add_(increment)
+        for graph in reversed(graphs):
+            graph.replay()
+        for slot, output in enumerate(outputs):
+            torch.testing.assert_close(storage[slot], inputs + slot)
+            torch.testing.assert_close(output, inputs + slot)

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -41,6 +41,7 @@ from vllm.v1.attention.backends.mla.indexer import (
 )
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
 from vllm.v1.attention.ops.pcp import maybe_gather_indexer_k
+from vllm.v1.worker.ubatching import dbo_select_buffer
 from vllm.v1.worker.workspace import current_workspace_manager
 
 logger = init_logger(__name__)
@@ -839,13 +840,13 @@ class SparseAttnIndexer(CustomOp):
         self.head_dim = head_dim
         self.max_model_len = max_model_len
         self.max_total_seq_len = max_total_seq_len
-        self.topk_indices_buffer = topk_indices_buffer
+        self._topk_indices_buffer = topk_indices_buffer
         self.skip_k_cache_insert = skip_k_cache_insert
         self.use_fp4_cache = use_fp4_cache
         self.compress_ratio = compress_ratio
         # v4.1 two-level selection: the candidate source indexer writes the
         # top candidate blocks here; later indexers mask their scores with it.
-        self.candidate_blocks = candidate_blocks
+        self._candidate_blocks = candidate_blocks
         self.candidate_block_size = candidate_block_size
         self.candidate_write = candidate_write
         self.dense_mha_metadata_layer_name = ""
@@ -886,6 +887,20 @@ class SparseAttnIndexer(CustomOp):
 
                 _PACK_DCP_TOPK_CANDIDATES_KERNEL.register_warmup()
                 _STABLE_TOPK_FROM_GATHERED_CANDIDATES_KERNEL.register_warmup()
+
+    @property
+    def topk_indices_buffer(self) -> torch.Tensor:
+        return dbo_select_buffer(self._topk_indices_buffer)
+
+    @topk_indices_buffer.setter
+    def topk_indices_buffer(self, buffer: torch.Tensor) -> None:
+        self._topk_indices_buffer = buffer
+
+    @property
+    def candidate_blocks(self) -> torch.Tensor | None:
+        if self._candidate_blocks is None:
+            return None
+        return dbo_select_buffer(self._candidate_blocks)
 
     @property
     def cp_kv_cache_interleave_size(self) -> int:

--- a/vllm/models/deepseek_v4_1/amd/model.py
+++ b/vllm/models/deepseek_v4_1/amd/model.py
@@ -380,8 +380,14 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # the default stream.
         aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
 
-        # Reserved topk indices buffer for all Indexer layers to reuse.
+        # Keep cross-layer index state separate for each microbatch.
+        ubatch_shape = (
+            (self.parallel_config.num_ubatches,)
+            if self.parallel_config.use_ubatching
+            else ()
+        )
         self.topk_indices_buffer = torch.empty(
+            *ubatch_shape,
             vllm_config.scheduler_config.max_num_batched_tokens,
             config.index_topk,
             dtype=torch.int32,
@@ -395,6 +401,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         candidate_topk_blocks = getattr(config, "candidate_topk_blocks", 0)
         if candidate_source_layer >= 0 and candidate_topk_blocks > 0:
             self.candidate_block_buffer = torch.empty(
+                *ubatch_shape,
                 vllm_config.scheduler_config.max_num_batched_tokens,
                 candidate_topk_blocks,
                 dtype=torch.int32,

--- a/vllm/models/deepseek_v4_1/attention.py
+++ b/vllm/models/deepseek_v4_1/attention.py
@@ -68,6 +68,7 @@ from vllm.v1.kv_cache_interface import (
     MLAAttentionSpec,
     get_kv_quant_mode,
 )
+from vllm.v1.worker.ubatching import dbo_select_buffer
 
 logger = init_logger(__name__)
 
@@ -352,7 +353,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             compress_ratio=self.compress_ratio,
         )
         self.indexer_rotary_emb = self.rotary_emb
-        self.topk_indices_buffer = topk_indices_buffer
+        self._topk_indices_buffer = topk_indices_buffer
         self.candidate_block_buffer = candidate_block_buffer
 
         # Register with compilation context for metadata lookup. Done before
@@ -541,6 +542,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
                 )
 
                 _COMBINE_TOPK_SWA_INDICES_KERNEL.register_warmup()
+
+    @property
+    def topk_indices_buffer(self) -> torch.Tensor | None:
+        if self._topk_indices_buffer is None:
+            return None
+        return dbo_select_buffer(self._topk_indices_buffer)
 
     def forward(
         self,
@@ -1079,7 +1086,7 @@ class DeepseekV4Indexer(nn.Module):
 
         self.scale_fmt = "ue8m0"
         self.quant_block_size = 128  # TODO: get from config
-        self.topk_indices_buffer = topk_indices_buffer
+        self._topk_indices_buffer = topk_indices_buffer
 
         self.max_model_len = (
             vllm_config.model_config.max_model_len // self.compress_ratio
@@ -1112,7 +1119,7 @@ class DeepseekV4Indexer(nn.Module):
             self.head_dim,
             self.max_model_len,
             self.max_total_seq_len,
-            self.topk_indices_buffer,
+            topk_indices_buffer,
             skip_k_cache_insert=True,
             use_fp4_cache=self.use_fp4_kv,
             compress_ratio=self.compress_ratio,
@@ -1120,6 +1127,12 @@ class DeepseekV4Indexer(nn.Module):
             candidate_block_size=candidate_block_size,
             candidate_write=candidate_write,
         )
+
+    @property
+    def topk_indices_buffer(self) -> torch.Tensor | None:
+        if self._topk_indices_buffer is None:
+            return None
+        return dbo_select_buffer(self._topk_indices_buffer)
 
     def _produce_k(
         self,

--- a/vllm/models/deepseek_v4_1/nvidia/model.py
+++ b/vllm/models/deepseek_v4_1/nvidia/model.py
@@ -414,8 +414,14 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # the default stream.
         aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
 
-        # Reserved topk indices buffer for all Indexer layers to reuse.
+        # Keep cross-layer index state separate for each microbatch.
+        ubatch_shape = (
+            (self.parallel_config.num_ubatches,)
+            if self.parallel_config.use_ubatching
+            else ()
+        )
         self.topk_indices_buffer = torch.empty(
+            *ubatch_shape,
             vllm_config.scheduler_config.max_num_batched_tokens,
             config.index_topk,
             dtype=torch.int32,
@@ -429,6 +435,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         candidate_topk_blocks = getattr(config, "candidate_topk_blocks", 0)
         if candidate_source_layer >= 0 and candidate_topk_blocks > 0:
             self.candidate_block_buffer = torch.empty(
+                *ubatch_shape,
                 vllm_config.scheduler_config.max_num_batched_tokens,
                 candidate_topk_blocks,
                 dtype=torch.int32,

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -157,6 +157,16 @@ def dbo_current_ubatch_id() -> int:
     return _THREAD_ID_TO_CONTEXT[threading.get_ident()]
 
 
+def dbo_select_buffer(buffer: torch.Tensor) -> torch.Tensor:
+    """Select a microbatch's persistent 2D buffer from optional 3D storage.
+
+    A 2D buffer is used unchanged by callers without microbatch-local storage.
+    The selection must happen at use time, including during graph capture,
+    rather than during model construction when no microbatch is active.
+    """
+    return buffer[dbo_current_ubatch_id()] if buffer.ndim == 3 else buffer
+
+
 def _register_ubatch_function(func):
     def wrapper(*args, **kwargs):
         if len(_THREAD_ID_TO_CONTEXT) > 0:


### PR DESCRIPTION
## Summary

DeepSeek V4.1 keeps top-k token indices and candidate blocks across multiple decoder layers. DBO microbatches currently write the same model-global buffers. A source layer in microbatch 1 can overwrite state before a later consumer layer in microbatch 0 reads it.

Allocate persistent index storage per microbatch on NVIDIA and AMD, and select the active microbatch's view when the short-context indexer, general sparse indexer, or attention consumer accesses it. Keep the existing 2D allocation for non-microbatched execution and the shared indexer's runtime buffer-rebinding API.

```text
ASIS
uBatch 0 source --write--> [shared top-k / candidates] --read--> uBatch 0 consumer
uBatch 1 source --overwrite---------^
```

```text
PR
uBatch 0 source --write--> [uBatch 0 top-k / candidates] --read--> uBatch 0 consumer
uBatch 1 source --write--> [uBatch 1 top-k / candidates] --read--> uBatch 1 consumer
```

## Scope and duplicate check

Related to #56400 and the unresolved shared-top-k overwrite reported in #56440. #56440 repairs input positions and Engram histories; it explicitly leaves sparse-index storage unfixed. Open PR searches for DBO, sparse/microbatch, topk/DBO and `56440 in:body` found no equivalent buffer fix. This change repairs persistent index ownership; it does not claim to resolve the reported NaNs or establish general DBO support.

Index state remains model-owned because it must survive across layers; it is not transient scratch workspace. With two microbatches, the additional storage is `max_num_batched_tokens * (index_topk + candidate_topk_blocks) * 4` bytes per worker (20 MiB at 2048 scheduled tokens, top-k 512, and 2048 candidate blocks).

## Validation

- `CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest tests/v1/worker/test_gpu_ubatch_slicing.py -q`: 26 passed on GB200 with both PyTorch 2.11 and 2.13; final exact-base native/pinned-runtime rerun also passed all 26 tests, including actual threaded UBatchRunner interleaving and separate CUDA graph capture/replay.
- Negative control forcing both microbatches to slot 0 fails the new cross-layer regression: 48/96 output elements mismatch. This reproduces shared-storage corruption in the runner harness, not a full-model NaN.
- White-box CPU probe of actual V4.1 attention, short-context indexer and generic sparse-indexer buffer properties: correct per-microbatch views, candidate lifetime, and legacy buffer rebinding.
- Changed-file pre-commit, including mypy: passed on the final patch.
- Model smoke: **5/5 expected answers**, official DeepSeek-V4.1-Flash revision `dba1be0a40aa45a94ad051997016db3960a90277`, TP4 GB200, text-only, eager, max context 2048, no prefix cache, greedy max 32 output tokens. Includes a long prompt to exercise general sparse indexing. Used native extensions for exact base `7ef4d9bfe` and pinned dependencies. This is a non-DBO smoke test, not a model-accuracy benchmark. Additional full-model eager DBO qualification is described below. No performance or model-accuracy improvement is claimed.


## Full-model eager DBO qualification

On integration commit `8276917` (this feature plus #56440 input/history corrections), DP2 x TP2 + EP on four GB200 GPUs, DeepEP LL with local NVLink transport:

- Twelve long fixed-answer prompts passed with microbatching disabled by runtime thresholds, then passed with DBO active in the same engine. Output token IDs match exactly.
- Both microbatch IDs ran on all four EP ranks. Each worker passed 8 top-k checks between layers 2 and 3 and 8 candidate-block checks between layers 20 and 24.
- Aliasing only the persistent index storage back to slot 0 then reproduced a top-k overwrite on all four workers: 179830-179834 mismatched entries over 1024 rows in microbatch 0, recorded before layer 3 consumed the buffer.

Configuration: eager, synchronous scheduling, no prefix cache, 2048 max context/scheduled tokens, 16 max sequences, 1 GiB KV per worker, greedy max 32 output tokens. DeepEP `d4f41e4`, NCCL 2.30.7, NVSHMEM 3.4.5, `NVSHMEM_QP_DEPTH=8192`, `NVSHMEM_REMOTE_TRANSPORT=none`. Hooks synchronize comparisons; these are correctness diagnostics, not performance measurements. Full-model CUDA graphs and inter-node transport remain unvalidated. #56440 is a validation dependency and is not bundled in this feature diff.

## Reproducibility

[Validation report, exact executed harness, outputs, collision records, and checksums](https://github.com/foraxe/vllm/tree/f22ceb1fe9916ef58ca3ef7b0abbc917a24b5407/evidence/dsv41-dbo-index-state). The [integration source](https://github.com/foraxe/vllm/tree/827691787a3c29ffa3b28ebe8dc9cbd151a70bff) adds only #56440's input/history changes to this feature.

Model diagnostic command (environment and local model path described in the report):

```bash
.venv/bin/python dbo_model_eval.py --dbo --paired --negative-control --output dbo-qualified.json
```

AI assistance: implementation and validation used OpenAI Codex. The human submitter confirmed review of feature commit `ec24188` and rerunning relevant tests before submission.
