### PR TITLE
[custom op] complete custom op args validation

### DIFF
--- a/tests/model_executor/test_enabled_custom_ops.py
+++ b/tests/model_executor/test_enabled_custom_ops.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections import Counter
+
 import pytest
 import torch
 
+import vllm.config.compilation as compilation
+import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import (
     CompilationConfig,
@@ -11,7 +15,9 @@ from vllm.config import (
     get_cached_compilation_config,
     set_current_vllm_config,
 )
+from vllm.model_executor import custom_op as classic_custom_op
 from vllm.model_executor.custom_op import CustomOp, op_registry
+from vllm.model_executor.hw_agnostic import custom_op as hw_agnostic_custom_op
 from vllm.model_executor.layers.activation import (
     GeluAndMul,
     ReLUSquaredActivation,
@@ -33,6 +39,20 @@ RMS_NORM_SUPPORTED_DTYPES = [torch.float16, torch.bfloat16]
 @CustomOp.register("relu3")
 class Relu3(ReLUSquaredActivation):
     pass
+
+
+# Dummy class used as a registry value. Only the keys matter here.
+class DummyOp:
+    pass
+
+
+# Names held by only one registry. The real hw-agnostic layers use rms_norm and
+# silu_and_mul, which the classic stack also has, so those cannot show which
+# registry a name came from. The oot registries stay empty without a plugin, so
+# the tests fill them in.
+HW_ONLY_IN_TREE = "hw_only_op"
+HW_ONLY_OOT = "HwOnlyOotOp"
+CLASSIC_OOT_ONLY = "ClassicOotOnlyOp"
 
 
 @pytest.mark.parametrize(
@@ -125,6 +145,65 @@ def test_enabled_ops_invalid(env: str):
         )
         with set_current_vllm_config(vllm_config):
             RMSNorm(1024).enabled()
+
+
+def _add_hw_only_ops(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(hw_agnostic_custom_op.op_registry, HW_ONLY_IN_TREE, DummyOp)
+    monkeypatch.setitem(hw_agnostic_custom_op.op_registry_oot, HW_ONLY_OOT, DummyOp)
+    monkeypatch.setitem(classic_custom_op.op_registry_oot, CLASSIC_OOT_ONLY, DummyOp)
+    # Read the flag live, even if the envs cache is enabled.
+    envs.disable_envs_cache()
+
+
+@pytest.mark.parametrize("hw_agnostic", [False, True])
+def test_get_known_op_names_reads_registry_keys(
+    monkeypatch: pytest.MonkeyPatch, hw_agnostic: bool
+):
+    _add_hw_only_ops(monkeypatch)
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1" if hw_agnostic else "0")
+
+    names = classic_custom_op.get_known_op_names()
+
+    # Classic keys always count, from both of its registries.
+    assert "rms_norm" in names
+    assert CLASSIC_OOT_ONLY in names
+
+    # hw-agnostic keys count only when the flag is on, from both registries.
+    hw_names = {HW_ONLY_IN_TREE, HW_ONLY_OOT}
+    if hw_agnostic:
+        assert hw_names <= names
+    else:
+        assert hw_names.isdisjoint(names)
+
+
+@pytest.mark.parametrize(
+    "hw_agnostic,expected",
+    [
+        (False, "doesn't exist (or wasn't imported/registered)"),
+        (True, "not present in model"),
+    ],
+)
+def test_custom_op_log_check_uses_hw_agnostic_names(
+    monkeypatch: pytest.MonkeyPatch, hw_agnostic: bool, expected: str
+):
+    _add_hw_only_ops(monkeypatch)
+    monkeypatch.setenv("VLLM_USE_HW_AGNOSTIC", "1" if hw_agnostic else "0")
+
+    compilation_config = CompilationConfig(custom_ops=["all", f"+{HW_ONLY_IN_TREE}"])
+    # The op is registered but unused by this model, so the warning wording
+    # shows whether the hw-agnostic keys were visible.
+    compilation_config.enabled_custom_ops = Counter({"rms_norm": 1})
+
+    warnings: list[tuple] = []
+    monkeypatch.setattr(
+        compilation.logger, "warning_once", lambda *args: warnings.append(args)
+    )
+
+    compilation_config.custom_op_log_check()
+
+    assert len(warnings) == 1
+    # args are (message, op_name, missing_str, enable_str, op)
+    assert warnings[0][2] == expected
 
 
 @pytest.mark.parametrize(

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1340,13 +1340,13 @@ class CompilationConfig:
             # check if op name exists in model
             op_name = op[1:]
             if op_name not in all_ops_in_model:
-                from vllm.model_executor.custom_op import op_registry
+                from vllm.model_executor.custom_op import get_known_op_names
 
-                # Does op exist at all or is it just not present in this model?
-                # Note: Only imported op classes appear in the registry.
+                known_op_names = get_known_op_names()
+
                 missing_str = (
                     "doesn't exist (or wasn't imported/registered)"
-                    if op_name not in op_registry
+                    if op_name not in known_op_names
                     else "not present in model"
                 )
 

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -6,6 +6,7 @@ import inspect
 import torch
 import torch.nn as nn
 
+import vllm.envs as envs
 from vllm.config import get_cached_compilation_config
 from vllm.logger import init_logger
 from vllm.model_executor.utils import maybe_disable_graph_partition
@@ -27,6 +28,18 @@ def maybe_get_oot_by_class(class_type: type) -> type:
     if class_name in op_registry_oot:
         return op_registry_oot[class_name]
     return class_type
+
+
+def get_known_op_names() -> set[str]:
+    # The hw-agnostic keys count only when VLLM_USE_HW_AGNOSTIC is set. Both
+    # sets are kept, since the classic stack still provides all other ops.
+    names = op_registry.keys() | op_registry_oot.keys()
+    if envs.VLLM_USE_HW_AGNOSTIC:
+        from vllm.model_executor.hw_agnostic import custom_op as hw_agnostic_custom_op
+
+        names |= hw_agnostic_custom_op.op_registry.keys()
+        names |= hw_agnostic_custom_op.op_registry_oot.keys()
+    return names
 
 
 class PluggableLayer(nn.Module):


### PR DESCRIPTION



## Purpose
custom_op argument value validation should be against all the known ops, including in-tree ops and oot ops. Also, hw_agnostic in-tree ops and oot ops should also be included when enabled.

## Test Plan
Add new ut.
## Test Result
Passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

