### PR TITLE
[bugfix][kernel] honor leading strides in sm100 standard and blockwise fp8 gemm

### DIFF
--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm100_fp8_dispatch.cuh
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm100_fp8_dispatch.cuh
@@ -162,6 +162,11 @@ void cutlass_gemm_caller_blockwise(torch::stable::Tensor& out, torch::stable::Te
   c_stride =
       cutlass::make_cute_packed_stride(StrideC{}, swap_ab ? cute::make_shape(n, m, 1) : cute::make_shape(m, n, 1));
 
+  cute::get<0>(a_stride) = a.stride(0);
+  cute::get<0>(b_stride) = b.stride(1);
+  // Swapping A and B transposes the output layout.
+  cute::get<swap_ab ? 1 : 0>(c_stride) = out.stride(0);
+
   LayoutSFA layout_SFA = swap_ab ? 
       ScaleConfig::tile_atom_to_shape_SFA(make_shape(n, m, k, 1)) :
       ScaleConfig::tile_atom_to_shape_SFA(make_shape(m, n, k, 1));

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_sm100_fp8_dispatch.cuh
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_sm100_fp8_dispatch.cuh
@@ -219,6 +219,11 @@ void cutlass_gemm_caller_sm100_fp8(torch::stable::Tensor& out,
       StrideC{},
       swap_ab ? cute::make_shape(n, m, 1) : cute::make_shape(m, n, 1));
 
+  cute::get<0>(a_stride) = a.stride(0);
+  cute::get<0>(b_stride) = b.stride(1);
+  // Swapping A and B transposes the output layout.
+  cute::get<swap_ab ? 1 : 0>(c_stride) = out.stride(0);
+
   auto a_ptr = static_cast<ElementAB*>(a.data_ptr());
   auto b_ptr = static_cast<ElementAB*>(b.data_ptr());
   auto c_ptr = static_cast<ElementD*>(out.data_ptr());

--- a/tests/kernels/quantization/test_cutlass_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutlass_scaled_mm.py
@@ -259,6 +259,62 @@ def test_cutlass_fp8_blockwise_scale_gemm(
     cutlass_fp8_gemm_helper(m, n, k, a_scale_group_shape, b_scale_group_shape, use_bias)
 
 
+@pytest.mark.parametrize("m", [8, 16])
+@pytest.mark.parametrize("padded", ["packed", "a", "b", "out"])
+@pytest.mark.skipif(
+    not 100 <= capability < 120,
+    reason="Requires the SM100 blockwise FP8 CUTLASS caller.",
+)
+def test_cutlass_fp8_sm100_blockwise_leading_strides(m: int, padded: str):
+    """Block scaling must preserve logical values across aligned leading padding."""
+    # M=8 swaps A/B; M=16 uses the normal layout and TMA epilogue.
+    n, k, padding = 256, 256, 128
+    generator = torch.Generator(device="cuda").manual_seed(0)
+    a_packed = torch.randint(-2, 3, (m, k), device="cuda", generator=generator).to(
+        torch.float8_e4m3fn
+    )
+    b_packed = (
+        torch.randint(-2, 3, (n, k), device="cuda", generator=generator)
+        .to(torch.float8_e4m3fn)
+        .t()
+    )
+    a = a_packed
+    b = b_packed
+    if padded == "a":
+        a = torch.zeros((m, k + padding), dtype=a.dtype, device="cuda")[:, :k]
+        a.copy_(a_packed)
+    if padded == "b":
+        b = torch.zeros((n, k + padding), dtype=b.dtype, device="cuda")[:, :k].t()
+        b.copy_(b_packed)
+
+    scale_a = torch.tensor(
+        [[0.25, 0.5], [0.5, 0.125]], dtype=torch.float32, device="cuda"
+    ).repeat(m // 2, 1)
+    scale_b = torch.tensor(
+        [[0.5, 0.25], [0.125, 1.0]], dtype=torch.float32, device="cuda"
+    )
+    scale_a = scale_a.t().contiguous().t()
+    scale_b = scale_b.t().contiguous().t()
+    out_dtype = torch.bfloat16
+    sentinel = -1024
+    out_storage = torch.full(
+        (m, n + (padding if padded == "out" else 0)),
+        sentinel,
+        dtype=out_dtype,
+        device="cuda",
+    )
+    out = out_storage[:, :n]
+    expected = baseline_scaled_mm(a_packed, b_packed, scale_a, scale_b, out_dtype)
+    packed_out = ops.cutlass_scaled_mm(a_packed, b_packed, scale_a, scale_b, out_dtype)
+    torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b, None)
+
+    # Integer operands and dyadic block scales keep the FP32 reference exact.
+    torch.testing.assert_close(packed_out, expected, rtol=0, atol=0)
+    torch.testing.assert_close(out, packed_out, rtol=0, atol=0)
+    if padded == "out":
+        assert torch.all(out_storage[:, n:] == sentinel)
+
+
 @pytest.mark.parametrize("m,n,k", MNK_FACTORS)
 @pytest.mark.parametrize(
     "a_scale_group_shape", [PER_TOKEN_GROUP_SHAPE, TENSORWISE_GROUP_SHAPE]

--- a/tests/kernels/quantization/test_cutlass_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutlass_scaled_mm.py
@@ -591,6 +591,56 @@ def test_cutlass_subset():
     torch.testing.assert_close(out, baseline, rtol=1e-1, atol=1e0)
 
 
+@pytest.mark.parametrize("m", [16, 64])
+@pytest.mark.parametrize("padded", ["packed", "a", "b", "out"])
+@pytest.mark.skipif(
+    not 100 <= capability < 120,
+    reason="Requires the SM100 FP8 CUTLASS caller.",
+)
+def test_cutlass_fp8_sm100_leading_strides(m: int, padded: str):
+    """Aligned leading padding must preserve values and output guard columns."""
+    # Without batch invariance, M=16 swaps A/B; M=64, K<4096 does not.
+    n, k, padding = 256, 256, 16
+    generator = torch.Generator(device="cuda").manual_seed(0)
+    a_packed = torch.randint(-2, 3, (m, k), device="cuda", generator=generator).to(
+        torch.float8_e4m3fn
+    )
+    b_packed = (
+        torch.randint(-2, 3, (n, k), device="cuda", generator=generator)
+        .to(torch.float8_e4m3fn)
+        .t()
+    )
+    a = a_packed
+    b = b_packed
+    if padded == "a":
+        a = torch.zeros((m, k + padding), dtype=a.dtype, device="cuda")[:, :k]
+        a.copy_(a_packed)
+    if padded == "b":
+        b = torch.zeros((n, k + padding), dtype=b.dtype, device="cuda")[:, :k].t()
+        b.copy_(b_packed)
+
+    scale_a = torch.full((1, 1), 0.5, device="cuda")
+    scale_b = torch.full((1, 1), 0.25, device="cuda")
+    out_dtype = torch.bfloat16
+    sentinel = -1024
+    out_storage = torch.full(
+        (m, n + (padding if padded == "out" else 0)),
+        sentinel,
+        dtype=out_dtype,
+        device="cuda",
+    )
+    out = out_storage[:, :n]
+    expected = baseline_scaled_mm(a_packed, b_packed, scale_a, scale_b, out_dtype)
+    packed_out = ops.cutlass_scaled_mm(a_packed, b_packed, scale_a, scale_b, out_dtype)
+    torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b, None)
+
+    # Small integer operands and dyadic scales make the FP32 reference exact.
+    torch.testing.assert_close(packed_out, expected, rtol=0, atol=0)
+    torch.testing.assert_close(out, packed_out, rtol=0, atol=0)
+    if padded == "out":
+        assert torch.all(out_storage[:, n:] == sentinel)
+
+
 # Test to make sure cuda graphs work
 class CutlassLayer(torch.nn.Module):
     def __init__(self, b, scale_a, scale_b, out_dtype):


### PR DESCRIPTION
## purpose

aligned tensor views with padded leading dimensions produce incorrect results in the sm100 standard and blockwise fp8 callers. for example, a blockwise a view shaped `(8, 256)` with stride `(384, 1)` is addressed as if its row stride were 256.

use `a.stride(0)`, `b.stride(1)` and `out.stride(0)` for both callers. when `swap_ab` transposes the output layout, its leading stride belongs in component 1. no copies added; block-scale layouts stay unchanged.

partially addresses #55534. #55537 covers common/sm90 standard scaling and #56248 covers sm90 blockwise. neither changes these sm100 callers. issue references, all-state sm100/blockwise/stride searches and the affected files were checked on 2026-09-11. sm120 callers remain outside this patch.

## test plan

add 16 cases to the existing cutlass test file: standard m=16/64 and blockwise m=8/16, n=k=256, each with packed storage or independent padding on a, b or output. both matrices exercise swapped and ordinary output layouts. the blockwise cases use distinct fp32 block scales in canonical storage. compare exactly against packed operands and the existing dequantized reference, then check output guard columns. integer fp8 operands and dyadic scales keep reference arithmetic exact.

native builds use source `a2bc2ffb2c8bf46759c4bbeb88e2f4dc32968762`. the standard baseline is the unchanged native source; its candidate adds the standard fix. the blockwise baseline reuses that standard-fixed library with the blockwise header unchanged; its candidate adds the blockwise fix. tests are present in both arms of each comparison. build/install `_C_stable_libtorch` through the incremental compilation workflow and run each arm in a fresh process.

executed standard regression and surrounding checks:

```sh
VLLM_BATCH_INVARIANT=0 .venv/bin/python -m pytest \
  tests/kernels/quantization/test_cutlass_scaled_mm.py -v -k sm100_leading_strides

VLLM_BATCH_INVARIANT=0 .venv/bin/python -m pytest -v \
  tests/kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_gemm \
  tests/kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_gemm_output_dtype \
  tests/kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_gemm_padded
```

executed blockwise baseline:

```sh
VLLM_BATCH_INVARIANT=0 .venv/bin/python -m pytest \
  tests/kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_sm100_blockwise_leading_strides \
  -v --junitxml=/root/vllm-blockwise-evidence/regression-base.xml \
  > /root/vllm-blockwise-evidence/regression-base.log 2>&1
```

executed combined candidate regression and existing blockwise selection:

```sh
VLLM_BATCH_INVARIANT=0 .venv/bin/python -m pytest \
  tests/kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_sm100_leading_strides \
  tests/kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_sm100_blockwise_leading_strides \
  tests/kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_blockwise_scale_gemm \
  tests/kernels/quantization/test_cutlass_scaled_mm.py::test_cutlass_fp8_blockwise_scale_gemm_dtype \
  -v -ra --junitxml=/root/vllm-blockwise-evidence/combined-regressions.xml
```

## test result

one nvidia b300, capability 10.3, driver 580.126.09, cuda compiler 13.0.88, torch 2.13.0+cu130, python 3.12.3. same build configuration and `10.0f` target. loaded/staged native hashes match for each installation, and each candidate library differs from its baseline.

| check | baseline | candidate |
| --- | --- | --- |
| standard stride regression | 6 padded failures, 2 packed passes | 8 passed |
| existing standard fp8 checks | — | 216 passed on standard-fixed library |
| blockwise stride regression | 6 padded failures, 2 packed passes | 8 passed in combined selection |
| combined regression + existing blockwise checks | — | 39 passed in 13.62s; 35 active checks, 4 early returns |
| packed opt model preservation | reference captured | exact match on standard-fixed library |
| qwen blockwise padded vs packed weights | layout mismatch, repeats stable | exact match; packed outputs preserved across builds |

all baseline kernel failures occur at padded-versus-packed numerical assertions after packed/reference controls pass. both candidate stride matrices and output guards pass. the combined run has no skips; four existing blockwise cases return before invoking the kernel because their k dimension is incompatible with block scaling. all applicable pre-commit hooks passed, including mypy, ruff, clang-format, spdx and sign-off checks.

standard model preservation: `facebook/opt-125m` revision `27dcfa74d334bc871f3234de431e71c6eeba5dd6`, online fp8, forced cutlass, bf16, eager, tp1, seed 0 and prefix caching disabled. all 48 targeted layers use `CutlassFP8ScaledMMLinearKernel`. eight repository prompts, up to 32 greedy tokens, two repeats per build: token ids, text and returned logprobs match exactly.

blockwise model probe: `Qwen/Qwen3-0.6B-FP8` revision `e5be08033360965ceca7b0ffd72d521a51331ce0`, forced cutlass, bf16, eager, tp1, seed 0 and prefix caching disabled, retaining the supported default chunked-prefill setting. the probe verifies 112 `CutlassFp8BlockScaledMMKernel` layers execute, then adds 128 elements of weight-row padding while checking logical weight bytes are unchanged. batch sizes 1/3/4, up to 32 greedy tokens, repeated packed and padded controls. baseline captures a layout mismatch with stable repeats. the final candidate restores exact token ids, text and log probabilities; packed outputs also match across builds. observed kernel m values are 1/3/4/5/25/34, all on the swapped path. the m=16 operator case independently covers the ordinary/tma path.

external blockwise model commands, executed with both native builds:

```sh
HF_HOME=/mnt/vllm-build/hf-cache HF_HUB_OFFLINE=1 VLLM_BATCH_INVARIANT=0 \
  .venv/bin/python /root/vllm-blockwise-evidence/validate_qwen_blockwise.py capture \
  --repo /mnt/vllm-build/vllm --label base \
  --output /root/vllm-blockwise-evidence/model-base.json
```

the candidate uses the same command with `--label patch` and output `/root/vllm-blockwise-evidence/model-patch.json`. baseline exits 1 after capturing the layout mismatch; candidate exits 0. the following exact comparison also exits 0:

```sh
.venv/bin/python /root/vllm-blockwise-evidence/validate_qwen_blockwise.py compare \
  /root/vllm-blockwise-evidence/model-base.json \
  /root/vllm-blockwise-evidence/model-patch.json
```

these model checks measure packed-output preservation and deliberately constructed weight-layout equivalence. they are not task-accuracy benchmarks or reports of ordinary contiguous qwen inference failing. raw logs, native-library provenance and external model probes are retained locally in the evidence bundle.

## ai assistance

i led this contribution and used openai codex to help investigate, implement and design the regressions, execute the gpu tests, and draft this description.
