### PR TITLE
[kernel][perf][minimax m3] adds flashinfer MSA backend for sm100

### DIFF
--- a/tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
+++ b/tests/kernels/attention/test_minimax_m3_msa_cutlass_sparse_decode.py
@@ -31,6 +31,10 @@ from vllm.models.minimax_m3.nvidia.msa_cutlass_sparse_decode import (
     prepare_decode_metadata,
     should_prepare_decode_metadata,
 )
+from vllm.models.minimax_m3.nvidia.msa_flashinfer_sparse_decode import (
+    msa_flashinfer_sparse_decode,
+    supports_flashinfer_sparse_decode,
+)
 from vllm.models.minimax_m3.nvidia.sparse_attention_msa import (
     MiniMaxM3SparseMSABackend,
     MiniMaxM3SparseMSADecodeMetadata,
@@ -165,9 +169,41 @@ def test_msa_cutlass_decode_static_dispatch_requires_sm100(
 
 
 @pytest.mark.parametrize(
+    ("decode_backend", "num_q_heads", "num_kv_heads", "kv_cache_dtype", "expected"),
+    [
+        ("flashinfer", 16, 1, "fp8_e4m3", True),
+        ("flashinfer", 16, 1, "fp8", True),
+        ("triton", 16, 1, "fp8_e4m3", False),
+        ("flashinfer", 16, 1, "bfloat16", False),
+        ("flashinfer", 17, 1, "fp8_e4m3", False),
+        ("flashinfer", 16, 3, "fp8_e4m3", False),
+    ],
+)
+def test_msa_flashinfer_decode_static_dispatch(
+    decode_backend: str,
+    num_q_heads: int,
+    num_kv_heads: int,
+    kv_cache_dtype: str,
+    expected: bool,
+) -> None:
+    assert (
+        supports_flashinfer_sparse_decode(
+            decode_backend=decode_backend,  # type: ignore[arg-type]
+            num_q_heads=num_q_heads,
+            num_kv_heads=num_kv_heads,
+            kv_cache_dtype=kv_cache_dtype,
+            page_size=BLOCK_SIZE,
+            topk_blocks=TOPK,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
     ("backend", "expected"),
     [
         (AttentionBackendEnum.CUTLASS_MSA, "cutlass"),
+        (AttentionBackendEnum.FLASHINFER_MSA, "flashinfer"),
         (AttentionBackendEnum.TRITON_MSA, "triton"),
     ],
 )
@@ -416,6 +452,185 @@ def _make_topk(
                 visible_pages, dtype=torch.int32, device="cuda"
             )
     return topk
+
+
+def _reference_sparse_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    q2k_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: list[int],
+    query_len: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    output = torch.empty_like(query)
+    lse = torch.empty(query.shape[:2], dtype=torch.float32, device=query.device)
+    group_size = query.shape[1] // key_cache.shape[1]
+    for request, seq_len in enumerate(seq_lens):
+        for local_query in range(query_len):
+            token = request * query_len + local_query
+            query_position = seq_len - query_len + local_query
+            for query_head in range(query.shape[1]):
+                kv_head = query_head // group_size
+                keys = []
+                values = []
+                for logical_page in q2k_indices[kv_head, token].tolist():
+                    if logical_page < 0:
+                        break
+                    physical_page = int(block_table[request, logical_page])
+                    page_start = logical_page * BLOCK_SIZE
+                    page_end = min(
+                        page_start + BLOCK_SIZE,
+                        seq_len,
+                        query_position + 1,
+                    )
+                    if page_end <= page_start:
+                        continue
+                    page_tokens = page_end - page_start
+                    keys.append(key_cache[physical_page, kv_head, :page_tokens])
+                    values.append(value_cache[physical_page, kv_head, :page_tokens])
+                selected_keys = torch.cat(keys).to(torch.float32)
+                selected_values = torch.cat(values).to(torch.float32)
+                scores = (
+                    selected_keys @ query[token, query_head].to(torch.float32)
+                ) * SM_SCALE
+                probabilities = torch.softmax(scores, dim=0)
+                output[token, query_head] = probabilities @ selected_values
+                lse[token, query_head] = torch.logsumexp(scores, dim=0)
+    return output, lse
+
+
+@pytest.mark.parametrize("query_len", [1, 4])
+def test_msa_flashinfer_decode_matches_triton_and_lse_reference(
+    query_len: int,
+) -> None:
+    torch.manual_seed(1)
+    num_q_heads = 16
+    num_kv_heads = 4
+    seq_lens_list = [257, 513]
+    seq_lens = torch.tensor(seq_lens_list, dtype=torch.int32, device="cuda")
+    pages_per_request = [math.ceil(length / BLOCK_SIZE) for length in seq_lens_list]
+    num_pages = sum(pages_per_request)
+    max_pages = max(pages_per_request)
+    block_table = torch.zeros(
+        len(seq_lens_list), max_pages, dtype=torch.int32, device="cuda"
+    )
+    physical_pages = torch.randperm(num_pages, dtype=torch.int32, device="cuda")
+    offset = 0
+    for request, request_pages in enumerate(pages_per_request):
+        block_table[request, :request_pages] = physical_pages[
+            offset : offset + request_pages
+        ]
+        offset += request_pages
+
+    key_cache = (
+        torch.randn(
+            num_pages,
+            num_kv_heads,
+            BLOCK_SIZE,
+            HEAD_DIM,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        * 0.25
+    ).to(torch.float8_e4m3fn)
+    value_cache = (torch.randn_like(key_cache, dtype=torch.bfloat16) * 0.25).to(
+        torch.float8_e4m3fn
+    )
+    assert key_cache.is_contiguous() and value_cache.is_contiguous()
+
+    total_q = len(seq_lens_list) * query_len
+    query = torch.randn(
+        total_q,
+        num_q_heads,
+        HEAD_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    query_scale_float = 0.75
+    query_scale = torch.tensor(query_scale_float, dtype=torch.float32, device="cuda")
+    query_fp8 = torch.empty_like(query, dtype=torch.float8_e4m3fn)
+    ops.scaled_fp8_quant(
+        query.view(total_q, -1),
+        scale=query_scale,
+        output=query_fp8.view(total_q, -1),
+    )
+    query_dequantized = query_fp8.to(torch.bfloat16) * query_scale
+    topk_token_major = _make_topk(seq_lens_list, num_kv_heads, query_len)
+    q2k_indices = topk_token_major.transpose(0, 1)
+    assert not q2k_indices.is_contiguous()
+
+    packed_cache = torch.cat((key_cache, value_cache), dim=-1)
+    triton_output = torch.empty_like(query)
+    minimax_m3_sparse_attn_decode(
+        query_dequantized,
+        packed_cache,
+        q2k_indices,
+        block_table,
+        seq_lens,
+        num_kv_heads,
+        SM_SCALE,
+        triton_output,
+        query_len,
+        k_scale=None,
+        v_scale=None,
+    )
+    reference_output, reference_lse = _reference_sparse_attention(
+        query_dequantized,
+        key_cache,
+        value_cache,
+        q2k_indices,
+        block_table,
+        seq_lens_list,
+        query_len,
+    )
+
+    provided_output = torch.empty_like(query)
+    provided_lse = torch.empty(
+        query.shape[0], query.shape[1], dtype=torch.float32, device=query.device
+    )
+    capture_stream = torch.cuda.Stream()
+    with torch.cuda.stream(capture_stream):
+        actual, actual_lse = msa_flashinfer_sparse_decode(
+            query_fp8,
+            packed_cache,
+            q2k_indices,
+            block_table,
+            seq_lens,
+            query_len,
+            scale=SM_SCALE,
+            q_scale_float=query_scale_float,
+            out=provided_output,
+            lse_out=provided_lse,
+        )
+    capture_stream.synchronize()
+
+    assert actual.data_ptr() == provided_output.data_ptr()
+    assert actual_lse.data_ptr() == provided_lse.data_ptr()
+    torch.testing.assert_close(actual, triton_output, atol=0.02, rtol=0.02)
+    torch.testing.assert_close(actual, reference_output, atol=0.02, rtol=0.02)
+    torch.testing.assert_close(actual_lse, reference_lse, atol=0.02, rtol=0.02)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        captured_output, captured_lse = msa_flashinfer_sparse_decode(
+            query_fp8,
+            packed_cache,
+            q2k_indices,
+            block_table,
+            seq_lens,
+            query_len,
+            scale=SM_SCALE,
+            q_scale_float=query_scale_float,
+            out=provided_output,
+            lse_out=provided_lse,
+        )
+    assert captured_output.data_ptr() == actual.data_ptr()
+    assert captured_lse.data_ptr() == actual_lse.data_ptr()
+    graph.replay()
+    current_platform.synchronize()
+    torch.testing.assert_close(captured_output, reference_output, atol=0.02, rtol=0.02)
+    torch.testing.assert_close(captured_lse, reference_lse, atol=0.02, rtol=0.02)
 
 
 @pytest.mark.parametrize(

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -14,7 +14,7 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 logger = init_logger(__name__)
 
 IndexerKVDType = Literal["auto", "bf16", "fp8", "mxfp4", "nvfp4"]
-MiniMaxM3MSADecodeBackend = Literal["triton", "cutlass"]
+MiniMaxM3MSADecodeBackend = Literal["triton", "cutlass", "flashinfer"]
 
 
 @config
@@ -108,6 +108,7 @@ class AttentionConfig:
     def __post_init__(self) -> None:
         msa_aliases: dict[AttentionBackendEnum, MiniMaxM3MSADecodeBackend] = {
             AttentionBackendEnum.CUTLASS_MSA: "cutlass",
+            AttentionBackendEnum.FLASHINFER_MSA: "flashinfer",
             AttentionBackendEnum.TRITON_MSA: "triton",
         }
         if self.backend in msa_aliases:

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -565,7 +565,10 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         )
 
     def _allocate_query_fp8(self, qkv: torch.Tensor) -> torch.Tensor | None:
-        if not getattr(self.impl, "use_cutlass_decode", False):
+        if not (
+            getattr(self.impl, "use_cutlass_decode", False)
+            or getattr(self.impl, "use_flashinfer_decode", False)
+        ):
             return None
         return torch.empty(
             (qkv.shape[0], self.q_size),

--- a/vllm/models/minimax_m3/nvidia/msa_flashinfer_sparse_decode.py
+++ b/vllm/models/minimax_m3/nvidia/msa_flashinfer_sparse_decode.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FlashInfer sparse decode adapter for MiniMax M3 on SM100."""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.config.attention import MiniMaxM3MSADecodeBackend
+from vllm.platforms import current_platform
+
+_HEAD_DIM = 128
+_PAGE_SIZE = 128
+_TOPK = 16
+
+
+def supports_flashinfer_sparse_decode(
+    *,
+    decode_backend: MiniMaxM3MSADecodeBackend,
+    num_q_heads: int,
+    num_kv_heads: int,
+    kv_cache_dtype: str,
+    page_size: int,
+    topk_blocks: int,
+) -> bool:
+    """Return whether static geometry supports packed FlashInfer MSA decode."""
+
+    return (
+        decode_backend == "flashinfer"
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability_family(100)
+        and kv_cache_dtype in ("fp8", "fp8_e4m3")
+        and 0 < num_kv_heads <= num_q_heads
+        and num_q_heads % num_kv_heads == 0
+        and num_q_heads // num_kv_heads <= 16
+        and page_size == _PAGE_SIZE
+        and topk_blocks == _TOPK
+    )
+
+
+def _validate_inputs(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    q2k_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    decode_query_len: int,
+) -> None:
+    if query.ndim != 3 or query.shape[-1] != _HEAD_DIM:
+        raise ValueError("query must have shape (total_q, num_q_heads, 128)")
+    if query.dtype != torch.float8_e4m3fn:
+        raise ValueError("FlashInfer packed MSA decode requires an FP8 E4M3 query")
+    if query.shape[0] % decode_query_len != 0:
+        raise ValueError("query rows must be divisible by decode_query_len")
+    if kv_cache.ndim != 4 or kv_cache.shape[2:] != (
+        _PAGE_SIZE,
+        2 * _HEAD_DIM,
+    ):
+        raise ValueError("kv_cache must have shape (num_pages, num_kv_heads, 128, 256)")
+    if kv_cache.dtype != torch.float8_e4m3fn or not kv_cache.is_contiguous():
+        raise ValueError("kv_cache must be a contiguous FP8 E4M3 packed cache")
+
+    total_q, num_q_heads, _ = query.shape
+    num_kv_heads = kv_cache.shape[1]
+    if num_q_heads % num_kv_heads != 0 or num_q_heads // num_kv_heads > 16:
+        raise ValueError("FlashInfer MSA requires a GQA group size of at most 16")
+    if q2k_indices.shape != (num_kv_heads, total_q, _TOPK):
+        raise ValueError("q2k_indices must have shape (num_kv_heads, total_q, 16)")
+    if q2k_indices.dtype != torch.int32 or (
+        not q2k_indices.is_contiguous()
+        and q2k_indices.stride() != (16, num_kv_heads * 16, 1)
+    ):
+        raise ValueError(
+            "q2k_indices must be compact head-major int32 or an exact compact "
+            "token-major transpose"
+        )
+
+    batch_size = total_q // decode_query_len
+    if (
+        block_table.ndim != 2
+        or block_table.shape[0] != batch_size
+        or block_table.dtype != torch.int32
+        or not block_table.is_contiguous()
+    ):
+        raise ValueError(
+            "block_table must be contiguous int32 with one row per request"
+        )
+    if (
+        seq_lens.shape != (batch_size,)
+        or seq_lens.dtype != torch.int32
+        or not seq_lens.is_contiguous()
+    ):
+        raise ValueError("seq_lens must be contiguous int32 with one entry per request")
+
+    tensors = (
+        kv_cache,
+        q2k_indices,
+        block_table,
+        seq_lens,
+    )
+    if any(tensor.device != query.device for tensor in tensors):
+        raise ValueError("all FlashInfer MSA inputs must be on the query device")
+
+
+@torch.no_grad()
+def msa_flashinfer_sparse_decode(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    q2k_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    decode_query_len: int,
+    *,
+    scale: float,
+    q_scale_float: float = 1.0,
+    k_scale_float: float = 1.0,
+    v_scale_float: float = 1.0,
+    out: torch.Tensor,
+    lse_out: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run paged MSA decode directly on vLLM's packed K/V cache."""
+    if decode_query_len <= 0:
+        raise ValueError("decode_query_len must be positive")
+    _validate_inputs(
+        query,
+        kv_cache,
+        q2k_indices,
+        block_table,
+        seq_lens,
+        decode_query_len,
+    )
+
+    from flashinfer.msa_ops import msa_sparse_decode_attention
+
+    key_cache, value_cache = kv_cache.split(_HEAD_DIM, dim=-1)
+
+    result = msa_sparse_decode_attention(
+        query,
+        key_cache,
+        value_cache,
+        q2k_indices,
+        page_table=block_table,
+        seqused_k=seq_lens,
+        seqlen_q=decode_query_len,
+        causal=True,
+        softmax_scale=scale * q_scale_float,
+        return_softmax_lse=True,
+        k_global_scale=k_scale_float,
+        v_global_scale=v_scale_float,
+        force_fused=True,
+        out=out,
+        lse_out=lse_out,
+    )
+    assert isinstance(result, tuple)
+    output, lse = result
+    return output, lse

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_msa.py
@@ -3,8 +3,8 @@
 """MSA (SM100/Blackwell) block-sparse attention for MiniMax M3.
 
 Prefill attends with ``fmha_sm100`` (``build_k2q_csr`` + ``sparse_atten_func``).
-Decode uses Triton split-K by default, with an opt-in CUTLASS ``fmha_sm100``
-path for regular decode and speculative verification.
+Decode uses Triton split-K by default, with opt-in CUTLASS ``fmha_sm100`` or
+FlashInfer MSA paths for regular decode and speculative verification.
 """
 
 from dataclasses import dataclass
@@ -34,6 +34,10 @@ from vllm.models.minimax_m3.nvidia.msa_cutlass_sparse_decode import (
     should_prepare_decode_metadata,
     supports_cutlass_sparse_decode,
 )
+from vllm.models.minimax_m3.nvidia.msa_flashinfer_sparse_decode import (
+    msa_flashinfer_sparse_decode,
+    supports_flashinfer_sparse_decode,
+)
 from vllm.v1.attention.backend import (
     AttentionLayer,
     CommonAttentionMetadata,
@@ -57,6 +61,14 @@ class MiniMaxM3SparseCutlassBackend(MiniMaxM3SparseMSABackend):
     @staticmethod
     def get_name() -> str:
         return "CUTLASS_MSA"
+
+
+class MiniMaxM3SparseFlashInferBackend(MiniMaxM3SparseMSABackend):
+    """Attention-backend alias selecting FlashInfer MSA sparse decode."""
+
+    @staticmethod
+    def get_name() -> str:
+        return "FLASHINFER_MSA"
 
 
 class MiniMaxM3SparseTritonBackend(MiniMaxM3SparseMSABackend):
@@ -174,13 +186,30 @@ class MiniMaxM3SparseMSAImpl(MiniMaxM3SparseImpl):
             page_size=self.block_size,
             topk_blocks=self.topk_blocks,
         )
+        self.use_flashinfer_decode = supports_flashinfer_sparse_decode(
+            decode_backend=msa_decode_backend,
+            num_q_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            kv_cache_dtype=self.kv_cache_dtype,
+            page_size=self.block_size,
+            topk_blocks=self.topk_blocks,
+        )
+        selected_backend = (
+            "FlashInfer"
+            if self.use_flashinfer_decode
+            else "CUTLASS"
+            if self.use_cutlass_decode
+            else "Triton"
+        )
         logger.info_once(
             "MiniMax M3 MSA sparse decode selected %s",
-            "CUTLASS" if self.use_cutlass_decode else "Triton",
+            selected_backend,
         )
 
     def should_use_msa_decode(self, layer_name: str) -> bool:
-        if not self.use_cutlass_decode:
+        use_cutlass_decode = getattr(self, "use_cutlass_decode", False)
+        use_flashinfer_decode = getattr(self, "use_flashinfer_decode", False)
+        if not (use_cutlass_decode or use_flashinfer_decode):
             return False
         attn_metadata = get_forward_context().attn_metadata
         if not isinstance(attn_metadata, dict):
@@ -189,6 +218,8 @@ class MiniMaxM3SparseMSAImpl(MiniMaxM3SparseImpl):
         if not isinstance(main_md, MiniMaxM3SparseMetadata):
             return False
         decode = main_md.decode
+        if use_flashinfer_decode:
+            return isinstance(decode, MiniMaxM3SparseMSADecodeMetadata)
         return (
             isinstance(decode, MiniMaxM3SparseMSADecodeMetadata)
             and decode.msa_cutlass is not None
@@ -233,7 +264,27 @@ class MiniMaxM3SparseMSAImpl(MiniMaxM3SparseImpl):
                 if isinstance(d, MiniMaxM3SparseMSADecodeMetadata)
                 else None
             )
-            if self.use_cutlass_decode and msa_metadata is not None:
+            if getattr(self, "use_flashinfer_decode", False):
+                assert query_fp8 is not None
+                flashinfer_lse = torch.empty(
+                    (nd, self.num_heads), dtype=torch.float32, device=query.device
+                )
+                flashinfer_output, _ = msa_flashinfer_sparse_decode(
+                    query_fp8[:nd].view(-1, self.num_heads, hd),
+                    kv_cache,
+                    topk[:nd].transpose(0, 1),
+                    d.block_table,
+                    d.seq_lens,
+                    d.decode_query_len,
+                    scale=self.scale,
+                    q_scale_float=getattr(layer, "_q_scale_float", 1.0),
+                    k_scale_float=getattr(layer, "_k_scale_float", 1.0),
+                    v_scale_float=getattr(layer, "_v_scale_float", 1.0),
+                    out=out[:nd],
+                    lse_out=flashinfer_lse,
+                )
+                assert flashinfer_output.data_ptr() == out[:nd].data_ptr()
+            elif self.use_cutlass_decode and msa_metadata is not None:
                 assert query_fp8 is not None
                 msa_cutlass_sparse_decode(
                     query_fp8[:nd].view(-1, self.num_heads, hd),

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -110,6 +110,10 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
         "vllm.models.minimax_m3.nvidia.sparse_attention_msa."
         "MiniMaxM3SparseCutlassBackend"
     )
+    FLASHINFER_MSA = (
+        "vllm.models.minimax_m3.nvidia.sparse_attention_msa."
+        "MiniMaxM3SparseFlashInferBackend"
+    )
     TRITON_MSA = (
         "vllm.models.minimax_m3.nvidia.sparse_attention_msa."
         "MiniMaxM3SparseTritonBackend"


### PR DESCRIPTION
## Purpose

Add a FlashInfer MSA decode backend for MiniMax M3 on SM100/GB200. The new
backend consumes vLLM's packed FP8 K/V cache and compact token-major top-k
indices directly, writes into vLLM-owned output and LSE buffers, and supports
CUDA graph capture and replay without per-step K/V or top-k materialization.

The backend is selectable through `minimax_m3_msa_decode_backend="flashinfer"`
or the `FLASHINFER_MSA` attention-backend alias. Unsupported geometry and cache
dtypes retain the existing backend behavior.

This backend is also a prerequisite for enabling DCP for MiniMax M3 on GB200.
The DCP integration itself remains separate from this PR.

### Dependency

**Do not merge this PR before
[flashinfer-ai/flashinfer#5094](https://github.com/flashinfer-ai/flashinfer/pull/5094).**
That PR provides the packed-FP8 paged MSA kernel, token-major top-k support, and
caller-owned `out`/`lse_out` API used here.

### Duplicate-work check

This does not duplicate
[vllm-project/vllm#48994](https://github.com/vllm-project/vllm/pull/48994).
That PR targets the SM120/SM121 consumer-Blackwell path and couples a
FlashInfer indexer with its attention implementation. This PR targets the
existing SM100/GB200 NVIDIA MSA path, preserves the current indexer, and adds a
direct packed-FP8 decode integration for the kernel introduced by FlashInfer
#5094.

AI assistance was used to implement, test, and prepare this change. The human
submitter reviewed the changed code and validation results.

## Test Plan

- Run vLLM's staged-file pre-commit suite.
- Validate backend selection and unsupported-geometry fallback cases.
- Compare Q1 and Q4 FlashInfer output/LSE against both the existing Triton
  implementation and a direct PyTorch sparse-attention reference on GB200.
- Capture and replay the FlashInfer decode path with caller-owned output and
  LSE buffers.
- Run matched 1,000-request end-to-end Mooncake benchmarks for FlashInfer and
  CUTLASS MSA.

## Test Result

### Correctness and CUDA graphs

- `pre-commit run`: passed all staged-file hooks, including ruff, mypy, SPDX,
  forbidden-import, configuration-default, and sign-off checks.
- Fresh-source FlashInfer GB200 validation: 4 passed.
- vLLM FlashInfer-focused GB200 suite: 9 passed, 32 deselected.
- Q1 and Q4 output/LSE parity passed against Triton and PyTorch references.
- CUDA graph capture and replay passed with caller-owned `out` and `lse_out`
  buffers.

### GB200 performance

Both runs used the same immutable image, MiniMax-M3-NVFP4 model, TP4/K=3,
`FULL_AND_PIECEWISE` CUDA graphs, local argmax, four GB200 GPUs, and the same
1,000-request Mooncake trace with 64K-class inputs, 400 OSL, and 90% prefix
reuse.

| Metric | FlashInfer MSA (E18) | CUTLASS MSA (E21) | FlashInfer improvement |
|---|---:|---:|---:|
| Input throughput | 49,475 tok/s | 46,220 tok/s | +7.04% |
| Input throughput/GPU | 12,368.81 tok/s | 11,554.90 tok/s | +7.04% |
| Output throughput | 1,967.71 tok/s | 1,838.23 tok/s | +7.04% |
| Output throughput/GPU | 491.93 tok/s | 459.56 tok/s | +7.04% |
| Request throughput | 0.746 req/s | 0.697 req/s | +7.04% |
| p50 output tok/s/user | 57.09 | 55.15 | +3.51% |
| p50 TPOT | 17.52 ms | 18.13 ms | 3.39% lower |
| p90 TPOT | 32.02 ms | 35.22 ms | 9.09% lower |
| p50 TTFT | 373.09 ms | 485.54 ms | 23.16% lower |
| p90 TTFT | 36.23 s | 38.87 s | 6.79% lower |
| p50 request latency | 26.72 s | 27.52 s | 2.90% lower |
| p90 request latency | 160.94 s | 174.49 s | 7.76% lower |
| Benchmark duration | 1,338.68 s | 1,432.98 s | 6.58% lower |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, including dependencies and duplicate-work analysis.
- [x] The test plan and commands/checks used.
- [x] Correctness, CUDA-graph, and end-to-end performance results.
- [x] Documentation impact considered; this adds an internal model backend and
  requires no supported-model-list change.
</details>

