### PR TITLE
[Bugfix][KV Offload] Ignore pending chunks in invalid sliding windows

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -74,7 +74,7 @@ from vllm.v1.kv_offload.base import (
     make_offload_key,
 )
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
-from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.outputs import KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import RequestStatus
 
 
@@ -1665,6 +1665,15 @@ class TestMaximalPrefixLookup:
 
 
 class TestSlidingWindowLookup:
+    def test_pending_chunk_behind_gap_does_not_defer(self):
+        """A pending suffix too short for the window cannot improve the hit."""
+        sched = _make_scheduler_with_lookup(
+            {1: LookupResult.HIT, 2: LookupResult.HIT, 4: LookupResult.HIT_PENDING}
+        )
+        assert (
+            sched._sliding_window_lookup(to_keys([1, 2, 3, 4]), 2, _EMPTY_REQ_CTX) == 2
+        )
+
     def test_all_hit_exact_window(self):
         sched = _make_scheduler_with_lookup({1: LookupResult.HIT, 2: LookupResult.HIT})
         assert sched._sliding_window_lookup(to_keys([1, 2]), 2, _EMPTY_REQ_CTX) == 2
@@ -1781,6 +1790,73 @@ class TestSlidingWindowLookup:
 # ---------------------------------------------------------------------------
 # Tests for SWA store pruning vs. load demand
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("async_scheduling", [False, True])
+def test_swa_load_does_not_wait_for_unusable_pending_suffix(
+    request_runner, async_scheduling
+):
+    """A CPU store beyond a missing SWA chunk must not block a ready prefix."""
+    groups = [
+        KVCacheGroupSpec(
+            ["full"],
+            FullAttentionSpec(
+                block_size=4, num_kv_heads=1, head_size=1, dtype=torch.float32
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["swa"],
+            SlidingWindowSpec(
+                block_size=4,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                sliding_window=8,
+            ),
+        ),
+    ]
+    runner = request_runner(
+        block_size=4,
+        num_gpu_blocks=32,
+        async_scheduling=async_scheduling,
+        kv_cache_groups=groups,
+    )
+    sched = runner.connector_scheduler
+    manager = CPUOffloadingManager(num_chunks=16)
+    sched.manager = manager
+    runner.new_request(token_ids=list(range(17)))
+    state = sched._req_status["0"]
+    state.update_offload_keys()
+    full, swa = (g.offload_keys for g in state.group_states)
+    ready = manager.prepare_store(full[:4] + swa[:2], state.req_context)
+    assert ready is not None
+    manager.complete_store(ready.keys_to_store, state.req_context)
+    pending = manager.prepare_store(swa[3:4], state.req_context)
+    assert pending is not None
+
+    # The last SWA chunk is still being written; the preceding one is missing.
+    output = runner.scheduler.schedule()
+    metadata = output.kv_connector_metadata
+    assert isinstance(metadata, OffloadingConnectorMetadata)
+    [(job_id, load)] = metadata.load_jobs.items()
+    assert isinstance(load.dst_spec, GPULoadStoreSpec)
+    assert load.dst_spec.group_sizes == [2, 2]
+    assert manager.lookup(swa[3], state.req_context) is LookupResult.HIT_PENDING
+
+    runner.scheduler.update_from_output(
+        output,
+        ModelRunnerOutput.with_kv_conn_output_only(
+            KVConnectorOutput(
+                finished_recving={"0"},
+                kv_connector_worker_meta=OffloadingWorkerMetadata(
+                    completed_jobs={job_id: 1}
+                ),
+            )
+        ),
+    )
+    resumed = runner.scheduler.schedule()
+    assert resumed.num_scheduled_tokens == {"0": 9}
+    assert manager.lookup(swa[3], state.req_context) is LookupResult.HIT_PENDING
 
 
 @pytest.mark.parametrize("alignment_chunk_count", [4, 8, 64])

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -680,6 +680,7 @@ class OffloadingConnectorScheduler:
         The first run may need a larger window for a partial rightmost chunk.
         Returns 0 on miss, None if the backend deferred a lookup."""
         defer_lookup = False
+        pending_in_window = False
         consecutive_hits = 0
         required_window = initial_window_size or sliding_window_size
         for idx in range(len(keys) - 1, -1, -1):
@@ -690,7 +691,7 @@ class OffloadingConnectorScheduler:
                     # Block is in cache, just not readable yet — counts
                     # as hit for the consecutive streak. Don't break:
                     # keep scanning to let manager kick off async lookups.
-                    defer_lookup = True
+                    pending_in_window = True
                     consecutive_hits += 1
                 case LookupResult.RETRY:
                     # Block location uncertain — does not count as hit.
@@ -698,13 +699,18 @@ class OffloadingConnectorScheduler:
                     # async lookups.
                     defer_lookup = True
                     consecutive_hits = 0
+                    pending_in_window = False
                     required_window = sliding_window_size
                 case LookupResult.MISS:
                     consecutive_hits = 0
+                    # This gap rules out the incomplete window to its right.
+                    pending_in_window = False
                     required_window = sliding_window_size
             if consecutive_hits == required_window:
-                return idx + required_window if not defer_lookup else None
-        return consecutive_hits if not defer_lookup else None
+                return (
+                    None if defer_lookup or pending_in_window else idx + required_window
+                )
+        return None if defer_lookup or pending_in_window else consecutive_hits
 
     def _touch(self, req_status: RequestOffloadState):
         for group_config, group_state in zip(


### PR DESCRIPTION
## Purpose

A pending CPU KV write can unnecessarily defer a request even when an earlier sliding window is ready to load. For a two-chunk window, `[HIT, HIT, MISS, HIT_PENDING]` currently returns `None`: the reverse scan keeps the pending flag after the miss has already ruled out that incomplete suffix. The core scheduler therefore submits no load for the ready prefix.

Track pending writes within the current consecutive window and clear that state when a miss invalidates the window. A pending chunk inside a usable window still defers lookup, and `RETRY` retains its existing conservative behavior. No timeout, transfer ownership, or external API changes are introduced.

## Why this is not duplicate work

I checked #49829 and #53087 discussions and searched open PRs for `_sliding_window_lookup`, `HIT_PENDING gap`, and related offload/window/defer terms on 2026-09-11. #53087 addresses bounded waits, #53330 addresses P2P supply/demand coverage, and #51787 addresses cache recency. This change fixes the stale pending flag for an already-invalid sliding window. It does not claim to fix the production stalls reported in #49829 or an underlying stalled transfer.

## Test Plan

The regressions fail against the unchanged base: the scanner returns `None`, and the real core scheduler plus CPU manager submits zero loads. With the fix, both synchronous and asynchronous scheduling load the earlier prefix and resume the remaining prompt while the unrelated CPU write is still pending.

```bash
.venv/bin/python -m pytest \
  tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py \
  tests/v1/kv_offload/cpu/test_manager.py -q --disable-warnings

pre-commit run --files \
  vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py \
  tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
```

## Test Result

Tested on base `22258a26bc090bccf5473cf681bbe9bac41bd035` plus this patch. The two test files pass: **249 passed** in 81.88 seconds. Pre-commit passes, including the configured mypy check, and `git diff --check` is clean.

GPU output check: a two-layer Gemma2 with dummy weights, BF16, and native CPU KV offload on an RTX 4060 Laptop. After warming the earlier window and clearing the GPU prefix cache, the backend lookup boundary is made to report a missing chunk followed by a pending chunk. The actual CPU/GPU worker reloads 32 prefix tokens, and all 8 generated tokens match the reference run. This is a controlled output-consistency check, not a trained-model accuracy evaluation, real stalled-copy experiment, or throughput/TTFT benchmark.

Local environment: Python 3.12.13, PyTorch 2.11.0+cu130, Transformers 5.17.0, current Python source plus precompiled extensions. This is not an exact-commit source build; standard CI with the main branch's PyTorch 2.13.0 dependency remains necessary. The optional DeepGEMM extension was unavailable due to local ABI mismatch; the exercised model uses FlashAttention 2.

## AI assistance

OpenAI Codex assisted with investigation, implementation, test execution, and drafting. The submitting human has reviewed the change. The test results reported above were run by Codex.