### PR TITLE
[Kimi Perf] Fuse the three Kimi-K3 latent-MoE front projections, 1.1~1.4x kernel performance improvement

### DIFF
--- a/tests/models/kimi_k3/test_latent_moe_tail.py
+++ b/tests/models/kimi_k3/test_latent_moe_tail.py
@@ -8,6 +8,7 @@ import ray
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+from torch import nn
 
 from tests.utils import (
     init_test_distributed_environment,
@@ -21,7 +22,7 @@ from vllm.model_executor.layers.fused_moe.experts.trtllm_mxfp4_moe import (
 from vllm.model_executor.layers.fused_moe.moe_output import UnfinalizedMoEOutput
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 from vllm.model_executor.warmup.cutedsl_warmup import cutedsl_warmup
-from vllm.models.kimi_k3.nvidia import latent_moe_runner
+from vllm.models.kimi_k3.nvidia import latent_moe_runner, model
 from vllm.models.kimi_k3.nvidia.ops.latent_moe_tail import KimiK3LatentMoETailOp
 from vllm.platforms import current_platform
 
@@ -29,6 +30,36 @@ HIDDEN_SIZE = 7168
 LATENT_SIZE = 3584
 EPS = 0.1
 TOP_K = 8
+
+
+class _Linear(nn.Linear):
+    def forward(self, x: torch.Tensor):
+        return super().forward(x), None
+
+
+def test_kimi_mlp_accepts_precomputed_gate_up(default_vllm_config) -> None:
+    mlp = object.__new__(model.KimiMLP)
+    nn.Module.__init__(mlp)
+    mlp.gate_up_proj = _Linear(5, 4, bias=False)
+    mlp.down_proj = _Linear(4, 3, bias=False)
+    mlp.act_fn = nn.Identity()
+    mlp.gemm_rs_ar = None
+    mlp.shard_sequence_parallel = False
+    gate_up = torch.randn(6, 4)
+
+    torch.testing.assert_close(mlp(gate_up), F.linear(gate_up, mlp.down_proj.weight))
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+def test_fused_moe_front_matches_separate_router() -> None:
+    sizes = (300, 257, 513)
+    hidden_states = torch.randn(7, 128, dtype=torch.bfloat16, device="cuda")
+    merged_weight = torch.randn(sum(sizes), 128, dtype=torch.bfloat16, device="cuda")
+
+    actual = model._fused_moe_front(hidden_states, merged_weight, sizes)
+    expected = torch.mm(hidden_states, merged_weight.t(), out_dtype=torch.float32)
+    shared, router, routed = expected.split(sizes, dim=-1)
+    torch.testing.assert_close(actual, (shared.bfloat16(), router, routed.bfloat16()))
 
 
 def test_deferred_finalize_enabled_before_moe_kernel_setup(

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -135,6 +135,17 @@ logger = init_logger(__name__)
 _ROUTED_DOWN_PROJ_STREAM_TOKEN_THRESHOLD = 256
 
 
+def _fused_moe_front(
+    hidden_states: torch.Tensor,
+    merged_weight: torch.Tensor,
+    sizes: tuple[int, int, int],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    output = torch.mm(hidden_states, merged_weight.t(), out_dtype=torch.float32)
+    shared, router, routed = output.split(sizes, dim=-1)
+    dtype = hidden_states.dtype
+    return shared.to(dtype), router.contiguous(), routed.to(dtype)
+
+
 def shard_sequence_parallel_mlp(
     hidden_size: int,
     intermediate_size: int,
@@ -299,13 +310,15 @@ class KimiMLP(nn.Module):
             )
 
     def forward(self, x):
+        gate_up = None if x.shape[-1] == self.gate_up_proj.weight.shape[1] else x
         if self.shard_sequence_parallel:
             # Each rank holds a weight shard but only its own tokens, so it
             # cannot finish those tokens alone: gather the full token set,
             # compute this rank's partial for all of them, then reduce-scatter,
             # which sums across TP and restores the sequence sharding.
             x = sp_all_gather(x)
-        gate_up, _ = self.gate_up_proj(x)
+        if gate_up is None:
+            gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
 
         if self.gemm_rs_ar is not None and self.gemm_rs_ar.should_run(x):
@@ -599,6 +612,12 @@ class KimiMoE(nn.Module):
         self.use_mega_moe = (
             vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
         )
+        self._fused_front_weight: torch.Tensor | None = None
+        self._fused_front_config_eligible = (
+            not use_sequence_parallel
+            and not vllm_config.parallel_config.enable_expert_parallel
+            and not vllm_config.model_config.enable_sleep_mode
+        )
         if self.use_mega_moe and not vllm_config.parallel_config.enable_expert_parallel:
             raise NotImplementedError(
                 "Kimi K3 MegaMoE requires expert parallel. Enable it with "
@@ -775,6 +794,39 @@ class KimiMoE(nn.Module):
                 moe_intermediate_size // self.tp_size
             )
 
+    def merge_fused_front_weights(self) -> None:
+        down_proj = self.routed_expert_down_proj
+        if (
+            not self._fused_front_config_eligible
+            or self.shared_experts is None
+            or down_proj is None
+            or not isinstance(self.experts, LatentMoERunner)
+            or not self.experts._use_fused_path()
+            or self.experts.do_naive_dispatch_combine
+            or self.experts.moe_config.pcp_size > 1
+            or self.experts.moe_config.hidden_dim != self.moe_hidden_size
+            or self.experts._quant_method.has_unpadded_output
+        ):
+            return
+        weights = [
+            self.shared_experts.gate_up_proj.weight,
+            self.gate.weight,
+            down_proj.weight,
+        ]
+        if (
+            any(
+                weight.ndim != 2 or weight.dtype != torch.bfloat16 or not weight.is_cuda
+                for weight in weights
+            )
+            or len({weight.shape[1] for weight in weights}) != 1
+        ):
+            return
+
+        merged = torch.cat([weight.data for weight in weights])
+        for weight, view in zip(weights, merged.split([w.shape[0] for w in weights])):
+            weight.data = view
+        self._fused_front_weight = merged
+
     def _maybe_overlap_router_and_down_proj(
         self, hidden_states: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
@@ -835,6 +887,27 @@ class KimiMoE(nn.Module):
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_size = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_size)
+        down_proj = self.routed_expert_down_proj
+        if (
+            self._fused_front_weight is not None
+            and down_proj is not None
+            and 0 < num_tokens <= _ROUTED_DOWN_PROJ_STREAM_TOKEN_THRESHOLD
+        ):
+            sizes = (
+                self.shared_experts.gate_up_proj.weight.shape[0],
+                self.gate.weight.shape[0],
+                down_proj.weight.shape[0],
+            )
+            shared_gate_up, router_logits, routed_hidden_states = _fused_moe_front(
+                hidden_states, self._fused_front_weight, sizes
+            )
+            final_hidden_states = self.experts(
+                routed_hidden_states,
+                router_logits,
+                shared_experts_input=shared_gate_up,
+            )
+            return final_hidden_states.view(num_tokens, hidden_size)
+
         # Overlap the gate with the routed down projection; the returned hidden
         # states are already down-projected. Keep the original ``hidden_states``
         # for the shared experts.
@@ -1732,6 +1805,9 @@ class KimiLinearForCausalLM(
         # A parent AutoWeightsLoader may invoke load_weights repeatedly for
         # non-contiguous streamed prefixes. Finalize only after the full stream.
         self.model.finalize_mega_moe_weights()
+        for module in self.model.modules():
+            if isinstance(module, KimiMoE):
+                module.merge_fused_front_weights()
         # The fused MultiHeadLatentAttention's process_weights_after_loading
         # (W_UK_T / W_UV absorption) is driven by the loader's generic post-load
         # hook for any AttentionLayerBase, so no manual trigger is needed here.


### PR DESCRIPTION
## Purpose

Before

```bash
hidden_states [M, 7168]
 ├─ shared gate/up proj → [M, 1536]
 ├─ router proj         → [M, 896] → TopK
 └─ routed down proj    → [M, 3584]
```

Now

```bash
output = hidden_states @ merged_weight.T
shared, router, routed = output.split((1536, 896, 3584), dim=-1)
```

## Test

Acc covered in current unit test

Perf can be seen in this AI generated script

```bash
import torch
import triton

from vllm.model_executor.kernels.linear.cute_dsl.ll_bf16 import ll_bf16_gemm
from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
    fused_grouped_topk,
)
from vllm.models.kimi_k3.nvidia.low_latency_gemm import try_low_latency_gemm
from vllm.models.kimi_k3.nvidia.model import _fused_moe_front

HIDDEN_SIZE = 7168
NUM_EXPERTS = 896
OUTPUT_SIZES = (1536, NUM_EXPERTS, 3584)
TOP_K = 16
TOKEN_COUNTS = (1, 2, 4, 8, 16, 32, 64, 128, 256)


def projection(hidden_states: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
    output = try_low_latency_gemm(hidden_states, weight)
    if output is not None:
        return output
    return torch.mm(hidden_states, weight.t())


def benchmark_token_count(
    num_tokens: int,
    merged_weight: torch.Tensor,
    correction_bias: torch.Tensor,
) -> None:
    shared_weight, router_weight, latent_weight = merged_weight.split(OUTPUT_SIZES)
    hidden_states = torch.randn(
        num_tokens,
        HIDDEN_SIZE,
        device=merged_weight.device,
        dtype=torch.bfloat16,
    )

    def topk_ids(router_logits: torch.Tensor) -> torch.Tensor:
        return fused_grouped_topk(
            hidden_states,
            router_logits,
            TOP_K,
            True,
            correction_bias,
            1,
            1,
            "sigmoid",
            1.0,
        )[1]

    def separate() -> torch.Tensor:
        projection(hidden_states, shared_weight)
        router_logits = (
            ll_bf16_gemm(hidden_states, router_weight)
            if num_tokens <= 16
            else torch.mm(hidden_states, router_weight.t(), out_dtype=torch.float32)
        )
        projection(hidden_states, latent_weight)
        return topk_ids(router_logits)

    def fused() -> torch.Tensor:
        _, router_logits, _ = _fused_moe_front(
            hidden_states, merged_weight, OUTPUT_SIZES
        )
        return topk_ids(router_logits)

    expected = separate()
    actual = fused()
    torch.cuda.synchronize()

    mismatch = expected.ne(actual).any(dim=1).float().mean().item()
    separate_ms = triton.testing.do_bench(separate, warmup=50, rep=200)
    fused_ms = triton.testing.do_bench(fused, warmup=50, rep=200)

    print(
        f"{num_tokens:6d}  {separate_ms * 1e3:11.3f}  "
        f"{fused_ms * 1e3:8.3f}  {separate_ms / fused_ms:7.3f}  "
        f"{mismatch:13.6f}"
    )


def main() -> None:
    torch.manual_seed(1)
    merged_weight = torch.randn(
        sum(OUTPUT_SIZES),
        HIDDEN_SIZE,
        device="cuda",
        dtype=torch.bfloat16,
    )
    merged_weight.mul_(HIDDEN_SIZE**-0.5)
    correction_bias = torch.randn(NUM_EXPERTS, device="cuda", dtype=torch.float32).mul_(
        0.01
    )

    print(f"GPU: {torch.cuda.get_device_name()}")
    print("tokens  separate_us  fused_us  speedup  topk_mismatch")

    for num_tokens in TOKEN_COUNTS:
        benchmark_token_count(num_tokens, merged_weight, correction_bias)


if __name__ == "__main__":
    main()

```

And we can get

```bash
tokens  separate_us  fused_us  speedup  topk_mismatch
     1       51.354    37.080    1.385       0.000000
     2       52.005    43.024    1.209       0.000000
     4       60.213    42.414    1.420       0.000000
     8       60.362    41.831    1.443       0.000000
    16       58.526    42.194    1.387       0.000000
    32       52.218    43.547    1.199       0.000000
    64       49.983    45.264    1.104       0.000000
   128       51.248    42.972    1.193       0.000000
   256       59.335    50.742    1.169       0.000000
```