### PR TITLE
[Bugfix][CI] Give cpu_test a gloo dist_init so it cannot poison forked engines

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,8 @@ from vllm.config.model import ConvertOption, RunnerOption, _get_and_verify_dtype
 from vllm.connections import global_http_connection
 from vllm.distributed import (
     cleanup_dist_env_and_memory,
+    destroy_distributed_environment,
+    destroy_model_parallel,
     init_distributed_environment,
     initialize_model_parallel,
 )
@@ -224,8 +226,17 @@ def init_test_http_connection():
 
 
 @pytest.fixture
-def dist_init():
+def dist_init(request):
     from tests.utils import ensure_current_vllm_config
+
+    # A cpu_test gets a gloo group and no accelerator teardown, so it leaves
+    # the CUDA driver untouched. An NCCL group initializes the driver in the
+    # pytest process without setting torch.cuda.is_initialized(), so vLLM's
+    # fork/spawn guard (_maybe_force_spawn) still selects fork and the next
+    # test that launches an EngineCore subprocess dies with
+    # cudaErrorInitializationError.
+    cpu_only = request.node.get_closest_marker("cpu_test") is not None
+    backend = "gloo" if cpu_only else "nccl"
 
     # Close the fd returned by mkstemp; FileStore opens the path itself.
     # Leaving it open leaks one FD per test and eventually exhausts the
@@ -241,11 +252,15 @@ def dist_init():
                 rank=0,
                 distributed_init_method=f"file://{temp_file}",
                 local_rank=0,
-                backend="nccl",
+                backend=backend,
             )
-            initialize_model_parallel(1, 1)
+            initialize_model_parallel(1, 1, backend=backend)
             yield
-        cleanup_dist_env_and_memory()
+        if cpu_only:
+            destroy_model_parallel()
+            destroy_distributed_environment()
+        else:
+            cleanup_dist_env_and_memory()
     finally:
         with contextlib.suppress(OSError):
             os.unlink(temp_file)

--- a/tests/model_executor/model_loader/test_weight_tying.py
+++ b/tests/model_executor/model_loader/test_weight_tying.py
@@ -84,3 +84,16 @@ def test_no_retie_without_checkpoint_override():
     maybe_retie_word_embeddings(model, make_model_config())
 
     assert model.lm_head.weight is not model.embed_tokens.weight
+
+
+@pytest.mark.cpu_test
+@pytest.mark.usefixtures("dist_init")
+def test_cpu_test_dist_init_avoids_nccl():
+    """A cpu_test gets a gloo group so the CUDA driver stays untouched.
+
+    An NCCL group initializes the driver without setting
+    torch.cuda.is_initialized(), so vLLM's fork/spawn guard still selects fork
+    and the next test to launch an EngineCore subprocess fails with
+    cudaErrorInitializationError.
+    """
+    assert torch.distributed.get_backend() == "gloo"


### PR DESCRIPTION
## What

`dist_init` always creates an **NCCL** process group. For a test marked
`cpu_test` that is both unnecessary and harmful: it initializes the CUDA driver
in the pytest process while leaving `torch.cuda.is_initialized()` `False`.

`_maybe_force_spawn()` (`vllm/utils/system_utils.py:126`) gates on that flag, so
it keeps the default `fork` start method. The next test that launches an
EngineCore subprocess **without** first initializing CUDA in the parent then
inherits a dirty driver and dies:

```
torch.AcceleratorError: CUDA error: initialization error   (cudaErrorInitializationError)
  at torch._C._cuda_init()   <-  vllm/v1/worker/gpu_worker.py:421 init_device
```

This change makes `dist_init` honour the marker the test already carries: a
`cpu_test` gets a `gloo` group and skips the accelerator teardown, so it leaves
the CUDA driver untouched.

```python
cpu_only = request.node.get_closest_marker("cpu_test") is not None
backend = "gloo" if cpu_only else "nccl"
```

## Why it is invisible today

Unsharded runs mask it. In nightly build 88259 the poisoner
(`test_gemma.py::test_checkpoint_lm_head_can_override_tied_config`) is test #21
of 43, behind 20 `test_common.py::test_models` cases. Those use `hf_runner`,
which loads a transformers model onto the GPU **in the parent** — CUDA becomes
initialized, `_maybe_force_spawn()` switches to spawn, and every later engine
launch is safe.

A 30-day scan of failed jobs (10,669) found **zero** occurrences in the
unsharded configuration:

| step | failures | this signature |
|---|---|---|
| `language-models-test-extended-generation`, unsharded | 26 | **0** (ordinary regressions) |
| same, build 88240 shard 4/5 | 1 | **1 — only occurrence** |
| `language-models-tests-hybrid` | 197 (12 sampled) | 0 (`-m hybrid_model` never selects it) |

Once the suite is sharded it stops being masked. The poisoner and the three
`test_dummy_loader` cases all live in `test_gemma.py`, so whenever they share a
shard they run effectively adjacent with no `hf_runner` test ahead of them:

| shards | 4 | 5 | 6 | 8 |
|---|---|---|---|---|
| chance they collide | 57% | **49%** | **42%** | 33% |

Both observed draws match: build 88240 (N=5) collided and failed; build 88231
(N=8) separated and passed.

Only `test_dummy_loader` is vulnerable — it uses `load_format="dummy"` and goes
straight to `vllm_runner`, so nothing initializes CUDA in the parent first. In
88231 shard 2 the poisoner was also test #1, followed immediately by
`test_granite.py::test_models`, and that passed because of its `hf_runner`.

## Scope

Seven tests carry both `cpu_test` and `dist_init` (found by AST scan). All are
CPU-only weight-loading/tying unit tests with no GPU collectives, so `gloo` at
`world_size=1` is equivalent:

```
tests/models/test_utils.py::test_module_skip_tied_weights
tests/models/test_utils.py::test_module_skip_tied_weights_without_canonical
tests/model_executor/model_loader/test_weight_tying.py::test_retie_only_when_identical
tests/model_executor/model_loader/test_weight_tying.py::test_quantized_lm_head_is_left_alone
tests/model_executor/model_loader/test_weight_tying.py::test_no_retie_without_checkpoint_override
tests/models/language/generation/test_gemma.py::test_checkpoint_lm_head_can_override_tied_config
```

`tests/v1/attention/test_mla_backends.py` and
`tests/v1/kv_connector/unit/test_bidirectional_kv_transfer.py` use both markers
but on *different* tests, so they are unaffected. Non-`cpu_test` users of
`dist_init` keep NCCL and the full teardown — unchanged.

Adds one guard test asserting the backend is `gloo`.

## Not a duplicate

`gh pr list --repo vllm-project/vllm --state open --search "dist_init"`,
`"cpu_test cuda initialization"` and `"cudaErrorInitializationError"` return no
PR touching this fixture or this failure mode. Related prior art: #53170, which
introduced the `cpu_test` + `dist_init` combination on `test_gemma.py`.

## Tests run

```
ruff check    tests/conftest.py tests/model_executor/model_loader/test_weight_tying.py   # pass (pinned v0.14.0)
ruff format   (same files)                                                               # pass
py_compile    (same files)                                                               # pass
```

**Not yet run on GPU** — no CUDA available to the author's local environment.
The reproducer is one command, and both tests sit in one file in the failing
order (line 24 before line 121), so it is deterministic:

```bash
pytest -v tests/models/language/generation/test_gemma.py
```

Expected: fails on `main`, passes with this change. Please confirm on a GPU
runner before merge.

## Model evaluation

Not applicable. Test-fixture-only change; no vLLM runtime, serving, or model
output path is touched.

## AI assistance

AI assistance (Claude Code) was used to diagnose the failure from Buildkite
logs, to scan 30 days of job history, and to draft this change. The diff is
small and has been reviewed line by line by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
