### PR TITLE
[Profiler] Synchronize iteration windows across DP ranks

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -233,6 +233,19 @@ readiness field to the existing coordination only while the option is enabled;
 it does not add a profiling-only collective. Independent data-parallel replicas
 without a shared forward cadence retain rank-local iteration counting.
 
+All model-runner dummy forwards that occur while the session is armed count as
+execution boundaries, not only dummy work caused by an idle DP rank. Startup
+warmup and graph-capture runs occur before the session is armed and do not
+count. The first captured synchronized boundary may not include the outer
+worker-level iteration annotation because readiness is agreed inside the model
+runner; subsequent captured boundaries retain their annotations. This does not
+affect the iteration window itself.
+
+For a DP-aligned bounded stop, use `max_iterations`. An explicit stop remains
+immediate on the worker receiving it; peers observe the de-armed state before
+their next shared forward. As a result, trailing non-forward activity can differ
+between ranks after an explicit stop.
+
 #### Analysis
 
 You can view these profiles either as summaries in the CLI, using `nsys stats [profile-file]`, or in the GUI by installing Nsight [locally following the directions here](https://developer.nvidia.com/nsight-systems/get-started).

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -215,6 +215,24 @@ vllm bench serve \
 
 With `--profile`, vLLM will capture a profile for each run of `vllm bench serve`. Once the server is killed, the profiles will all be saved.
 
+To align iteration-bounded captures across ranks that share a data-parallel
+model-forward cadence, enable synchronized profiler iterations on every rank:
+
+```bash
+vllm serve mistralai/Mixtral-8x7B-Instruct-v0.1 \
+    --data-parallel-size 2 \
+    --enable-expert-parallel \
+    --profiler-config '{"profiler":"cuda","delay_iterations":100,"max_iterations":20,"synchronize_iterations_across_dp":true}'
+```
+
+Arm profiling on every participating rank before sending traffic. The profiler
+starts after all ranks report ready through vLLM's existing DP coordination.
+`delay_iterations` and `max_iterations` then count those shared execution
+boundaries, including dummy model forwards on locally idle ranks. This adds one
+readiness field to the existing coordination only while the option is enabled;
+it does not add a profiling-only collective. Independent data-parallel replicas
+without a shared forward cadence retain rank-local iteration counting.
+
 #### Analysis
 
 You can view these profiles either as summaries in the CLI, using `nsys stats [profile-file]`, or in the GUI by installing Nsight [locally following the directions here](https://developer.nvidia.com/nsight-systems/get-started).

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
 from contextlib import nullcontext
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock, Mock, call, patch
 from uuid import UUID
 
@@ -10,6 +10,7 @@ import pytest
 import torch
 from pydantic import ValidationError
 
+import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
 from vllm.config import (
     CompilationConfig,
     CUDAGraphMode,
@@ -22,6 +23,12 @@ from vllm.profiler.wrapper import ProtonProfilerWrapper, WorkerProfiler
 from vllm.v1.core.sched.output import CachedRequestData
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_worker import Worker
+
+
+def _bind_profiler_mode_helper(worker) -> None:
+    worker._use_dp_synchronized_profiler_iterations = MethodType(
+        Worker._use_dp_synchronized_profiler_iterations, worker
+    )
 
 
 class ConcreteWorkerProfiler(WorkerProfiler):
@@ -310,6 +317,7 @@ class TestAnnotateProfile:
         worker.profiler_config.synchronize_iterations_across_dp = False
         worker.parallel_config.data_parallel_size = 1
         worker.profiler = MagicMock()
+        _bind_profiler_mode_helper(worker)
 
         ctx_req = MagicMock(req_id="ctx1", num_computed_tokens=0)
         cached = CachedRequestData(
@@ -346,6 +354,7 @@ class TestAnnotateProfile:
         worker.profiler_config.synchronize_iterations_across_dp = False
         worker.parallel_config.data_parallel_size = 1
         worker.profiler.is_running = False
+        _bind_profiler_mode_helper(worker)
 
         context = Worker.annotate_profile(worker, scheduler_output=None)
 
@@ -358,6 +367,7 @@ class TestAnnotateProfile:
         worker.profiler_config.synchronize_iterations_across_dp = True
         worker.parallel_config.data_parallel_size = 2
         worker.profiler.is_running = False
+        _bind_profiler_mode_helper(worker)
 
         Worker.annotate_profile(worker, scheduler_output=None)
 
@@ -393,6 +403,7 @@ class TestDPSynchronizedProfiler:
         worker.profiler_config.synchronize_iterations_across_dp = True
         worker.parallel_config.data_parallel_size = 2
         worker._dp_profiler_requested = False
+        _bind_profiler_mode_helper(worker)
 
         with patch(
             "vllm.distributed.utils.get_worker_rank_suffix",
@@ -423,7 +434,7 @@ class TestDPSynchronizedProfiler:
         Worker._advance_dp_synchronized_profiler(worker, True)
         Worker._advance_dp_synchronized_profiler(worker, True)
 
-        assert not profiler.is_active
+        assert not profiler.is_armed
         assert profiler.stop_call_count == 1
         assert worker._dp_profiler_requested is False
         assert worker._dp_profiler_session_started is False
@@ -451,6 +462,83 @@ class TestDPSynchronizedProfiler:
         assert profiler.stop_call_count == 1
         assert worker._dp_profiler_requested is False
         assert worker._dp_profiler_session_started is False
+
+
+class _BoundaryObserved(Exception):
+    pass
+
+
+class _StopAfterBoundaryBatch:
+    @property
+    def num_tokens(self):
+        raise _BoundaryObserved
+
+
+def _v1_boundary_result():
+    return (
+        CUDAGraphMode.NONE,
+        _StopAfterBoundaryBatch(),
+        False,
+        None,
+        None,
+        True,
+    )
+
+
+def test_v1_execute_model_advances_profiler_once_after_dp_agreement():
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.execute_model_state = None
+    runner.speculative_config = None
+    runner.synchronize_input_prep = nullcontext
+    runner._update_states = Mock()
+    runner.cache_config = SimpleNamespace(kv_sharing_fast_prefill=False)
+    runner.num_prompt_logprobs = 0
+    runner.input_batch = SimpleNamespace(num_reqs=1, req_ids=["request"])
+    runner._prepare_inputs = Mock(return_value=(None, None, None))
+    runner.cascade_attn_enabled = False
+    runner.parallel_config = SimpleNamespace(use_ubatching=False)
+    runner._allow_microbatching = Mock(return_value=False)
+    runner._determine_batch_execution_and_padding = Mock(
+        return_value=_v1_boundary_result()
+    )
+    runner.dp_profiler_advance = Mock()
+    scheduler_output = MagicMock(
+        total_num_scheduled_tokens=1,
+        num_scheduled_tokens={"request": 1},
+        scheduled_encoder_inputs={},
+    )
+
+    with (
+        patch.object(
+            gpu_model_runner_module,
+            "has_kv_transfer_group",
+            return_value=False,
+        ),
+        pytest.raises(_BoundaryObserved),
+    ):
+        GPUModelRunner.execute_model(runner, scheduler_output)
+
+    runner.dp_profiler_advance.assert_called_once_with(True)
+
+
+def test_v1_dummy_run_advances_profiler_once_after_dp_agreement():
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(multimodal_config=None)
+    )
+    runner.max_num_tokens = 4
+    runner.max_num_reqs = 4
+    runner.scheduler_config = SimpleNamespace(max_num_seqs=4)
+    runner.uniform_decode_query_len = 1
+    runner._determine_batch_execution_and_padding = Mock(
+        return_value=_v1_boundary_result()
+    )
+    runner.dp_profiler_advance = Mock()
+
+    with pytest.raises(_BoundaryObserved):
+        GPUModelRunner._dummy_run(runner, 1, skip_eplb=True)
+
+    runner.dp_profiler_advance.assert_called_once_with(True)
 
 
 @pytest.mark.parametrize(
@@ -769,6 +857,7 @@ def test_gpu_worker_creates_proton_profiler():
     worker.profiler_config.profiler = "proton"
     worker.profiler_config.synchronize_iterations_across_dp = False
     worker.parallel_config.data_parallel_size = 1
+    _bind_profiler_mode_helper(worker)
 
     with (
         patch(
@@ -791,6 +880,7 @@ def test_gpu_worker_recreates_proton_profiler_for_each_run():
     worker.profiler_config.profiler = "proton"
     worker.profiler_config.synchronize_iterations_across_dp = False
     worker.parallel_config.data_parallel_size = 1
+    _bind_profiler_mode_helper(worker)
 
     with (
         patch(

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 from uuid import UUID
 
 import pytest
+import torch
 from pydantic import ValidationError
 
 from vllm.config import (
@@ -249,6 +250,24 @@ def test_mixed_delay_and_stop(default_profiler_config):
     assert profiler.start_call_count == 0
 
 
+def test_synchronized_iterations_disabled_by_default():
+    assert ProfilerConfig().synchronize_iterations_across_dp is False
+
+
+def test_synchronized_iterations_accept_cuda_profiler():
+    config = ProfilerConfig(
+        profiler="cuda",
+        synchronize_iterations_across_dp=True,
+    )
+
+    assert config.synchronize_iterations_across_dp is True
+
+
+def test_synchronized_iterations_require_profiler():
+    with pytest.raises(ValueError, match="requires profiler to be set"):
+        ProfilerConfig(synchronize_iterations_across_dp=True)
+
+
 class TestIsUriPath:
     """Tests for the _is_uri_path helper function."""
 
@@ -288,6 +307,8 @@ class TestAnnotateProfile:
     def _annotate(self, detailed: bool) -> str:
         worker = MagicMock()
         worker.vllm_config.profiler_config.detailed_trace_annotation = detailed
+        worker.profiler_config.synchronize_iterations_across_dp = False
+        worker.parallel_config.data_parallel_size = 1
         worker.profiler = MagicMock()
 
         ctx_req = MagicMock(req_id="ctx1", num_computed_tokens=0)
@@ -322,6 +343,8 @@ class TestAnnotateProfile:
 
     def test_skips_annotation_work_after_profiler_stops(self):
         worker = MagicMock()
+        worker.profiler_config.synchronize_iterations_across_dp = False
+        worker.parallel_config.data_parallel_size = 1
         worker.profiler.is_running = False
 
         context = Worker.annotate_profile(worker, scheduler_output=None)
@@ -329,6 +352,140 @@ class TestAnnotateProfile:
         worker.profiler.step.assert_called_once_with()
         worker.profiler.annotate_context_manager.assert_not_called()
         assert isinstance(context, nullcontext)
+
+    def test_synchronized_mode_suppresses_rank_local_step(self):
+        worker = MagicMock()
+        worker.profiler_config.synchronize_iterations_across_dp = True
+        worker.parallel_config.data_parallel_size = 2
+        worker.profiler.is_running = False
+
+        Worker.annotate_profile(worker, scheduler_output=None)
+
+        worker.profiler.step.assert_not_called()
+
+
+class TestDPSynchronizedProfiler:
+    def _worker(self, profiler):
+        worker = MagicMock()
+        worker.profiler = profiler
+        worker._dp_profiler_requested = True
+        worker._dp_profiler_session_started = False
+        return worker
+
+    def test_waits_until_every_rank_is_ready(self, default_profiler_config):
+        profiler = ConcreteWorkerProfiler(default_profiler_config)
+        worker = self._worker(profiler)
+
+        Worker._advance_dp_synchronized_profiler(worker, False)
+
+        assert profiler.start_call_count == 0
+        assert profiler._active_iteration_count == 0
+
+        Worker._advance_dp_synchronized_profiler(worker, True)
+
+        assert profiler.start_call_count == 1
+        assert profiler._active_iteration_count == 1
+
+    def test_profile_request_arms_without_starting_locally(self):
+        worker = MagicMock()
+        worker.rank = 0
+        worker.profiler = MagicMock()
+        worker.profiler_config.synchronize_iterations_across_dp = True
+        worker.parallel_config.data_parallel_size = 2
+        worker._dp_profiler_requested = False
+
+        with patch(
+            "vllm.distributed.utils.get_worker_rank_suffix",
+            return_value="rank0",
+        ):
+            Worker.profile(worker)
+
+        assert worker._dp_profiler_requested is True
+        worker.profiler.start.assert_not_called()
+
+    def test_delayed_start_counts_shared_boundaries(self, default_profiler_config):
+        default_profiler_config.delay_iterations = 2
+        profiler = ConcreteWorkerProfiler(default_profiler_config)
+        worker = self._worker(profiler)
+
+        Worker._advance_dp_synchronized_profiler(worker, True)
+        assert not profiler.is_running
+
+        Worker._advance_dp_synchronized_profiler(worker, True)
+        assert profiler.is_running
+        assert profiler.start_call_count == 1
+
+    def test_auto_stop_resets_synchronized_session(self, default_profiler_config):
+        default_profiler_config.max_iterations = 1
+        profiler = ConcreteWorkerProfiler(default_profiler_config)
+        worker = self._worker(profiler)
+
+        Worker._advance_dp_synchronized_profiler(worker, True)
+        Worker._advance_dp_synchronized_profiler(worker, True)
+
+        assert not profiler.is_active
+        assert profiler.stop_call_count == 1
+        assert worker._dp_profiler_requested is False
+        assert worker._dp_profiler_session_started is False
+
+    def test_restart_after_auto_stop(self, default_profiler_config):
+        default_profiler_config.max_iterations = 1
+        profiler = ConcreteWorkerProfiler(default_profiler_config)
+        worker = self._worker(profiler)
+
+        Worker._advance_dp_synchronized_profiler(worker, True)
+        Worker._advance_dp_synchronized_profiler(worker, True)
+        worker._dp_profiler_requested = True
+        Worker._advance_dp_synchronized_profiler(worker, True)
+
+        assert profiler.start_call_count == 2
+        assert worker._dp_profiler_session_started is True
+
+    def test_peer_stop_ends_local_capture(self, default_profiler_config):
+        profiler = ConcreteWorkerProfiler(default_profiler_config)
+        worker = self._worker(profiler)
+        Worker._advance_dp_synchronized_profiler(worker, True)
+
+        Worker._advance_dp_synchronized_profiler(worker, False)
+
+        assert profiler.stop_call_count == 1
+        assert worker._dp_profiler_requested is False
+        assert worker._dp_profiler_session_started is False
+
+
+@pytest.mark.parametrize(
+    ("readiness", "expected"),
+    [([1, 0], False), ([1, 1], True)],
+)
+def test_legacy_dp_sync_carries_profiler_readiness(readiness, expected):
+    from vllm.v1.worker import dp_utils
+
+    reduced = torch.tensor(
+        [
+            [64, 64],
+            [64, 64],
+            [0, 0],
+            [0, 0],
+            readiness,
+        ],
+        dtype=torch.int32,
+    )
+    parallel_config = SimpleNamespace(
+        disable_nccl_for_dp_synchronization=True,
+        num_ubatches=1,
+    )
+
+    with patch.object(dp_utils, "_run_ar", return_value=reduced):
+        *_, profiler_ready = dp_utils._synchronize_dp_ranks(
+            num_tokens_unpadded=64,
+            num_tokens_padded=64,
+            should_attempt_ubatching=False,
+            cudagraph_mode=0,
+            parallel_config=parallel_config,
+            profiler_ready=True,
+        )
+
+    assert profiler_ready is expected
 
 
 def test_profiler_entered_during_capture():
@@ -610,6 +767,8 @@ def test_gpu_worker_creates_proton_profiler():
     worker.rank = 1
     worker.profiler = None
     worker.profiler_config.profiler = "proton"
+    worker.profiler_config.synchronize_iterations_across_dp = False
+    worker.parallel_config.data_parallel_size = 1
 
     with (
         patch(
@@ -630,6 +789,8 @@ def test_gpu_worker_recreates_proton_profiler_for_each_run():
     worker.rank = 1
     worker.profiler = None
     worker.profiler_config.profiler = "proton"
+    worker.profiler_config.synchronize_iterations_across_dp = False
+    worker.parallel_config.data_parallel_size = 1
 
     with (
         patch(

--- a/tests/v1/worker/test_gpu_ubatch_slicing.py
+++ b/tests/v1/worker/test_gpu_ubatch_slicing.py
@@ -272,6 +272,7 @@ def _sync_dp(
     num_tokens_per_rank: list[int],
     uniform_token_count_per_rank: list[int] | None = None,
     allow_ubatching: bool = True,
+    profiler_ready_per_rank: list[bool] | None = None,
 ) -> tuple[BatchExecutionDescriptor, dp_utils.DPSyncState | None]:
     """Run the DP handshake with the all-reduce stubbed out.
 
@@ -282,19 +283,26 @@ def _sync_dp(
     """
     dp_size = len(num_tokens_per_rank)
     uniform_token_counts = uniform_token_count_per_rank or [0] * dp_size
-    reduced = torch.zeros(6, dp_size, dtype=torch.int32)
+    num_fields = 7 if profiler_ready_per_rank is not None else 6
+    reduced = torch.zeros(num_fields, dp_size, dtype=torch.int32)
     reduced[0] = torch.tensor(num_tokens_per_rank, dtype=torch.int32)
     reduced[1] = CUDAGraphMode.NONE.value
     reduced[2] = torch.tensor(uniform_token_counts, dtype=torch.int32)
     reduced[3] = -1  # max_query_len, -1 means None
     reduced[4] = int(allow_ubatching)
     reduced[5] = 8  # num_reqs
+    if profiler_ready_per_rank is not None:
+        reduced[6] = torch.tensor(profiler_ready_per_rank, dtype=torch.int32)
 
     with (
-        patch.object(dp_utils.dist, "all_reduce", lambda t, group: t.copy_(reduced)),
+        patch.object(
+            dp_utils.dist,
+            "all_reduce",
+            side_effect=lambda t, group: t.copy_(reduced),
+        ) as all_reduce,
         patch.object(dp_utils, "get_dp_group", lambda: SimpleNamespace(cpu_group=None)),
     ):
-        return dp_utils.sync_cudagraph_and_dp_padding(
+        result = dp_utils.sync_cudagraph_and_dp_padding(
             cudagraph_manager=None,
             desired_batch_desc=BatchExecutionDescriptor(
                 cg_mode=CUDAGraphMode.NONE,
@@ -313,7 +321,14 @@ def _sync_dp(
             ),
             allow_ubatching=allow_ubatching,
             uniform_decode=uniform_token_counts[0] == DECODE_QUERY_LEN,
+            profiler_ready=(
+                profiler_ready_per_rank[0]
+                if profiler_ready_per_rank is not None
+                else None
+            ),
         )
+    all_reduce.assert_called_once()
+    return result
 
 
 def test_every_dp_rank_must_agree_to_microbatch():
@@ -342,6 +357,28 @@ def test_microbatching_pads_all_ranks_to_the_largest():
     assert desc.num_tokens == 256
     assert dp_sync is not None
     assert dp_sync.num_tokens_across_dp.tolist() == [256, 256]
+
+
+def test_profiler_readiness_uses_existing_dp_agreement():
+    _, waiting = _sync_dp([64, 64], profiler_ready_per_rank=[True, False])
+    _, ready = _sync_dp([64, 64], profiler_ready_per_rank=[True, True])
+
+    assert waiting is not None and waiting.profiler_ready is False
+    assert ready is not None and ready.profiler_ready is True
+
+
+def test_profiler_readiness_includes_locally_idle_rank():
+    _, dp_sync = _sync_dp([0, 64], profiler_ready_per_rank=[True, True])
+
+    assert dp_sync is not None
+    assert dp_sync.num_tokens_across_dp.tolist() == [0, 64]
+    assert dp_sync.profiler_ready is True
+
+
+def test_all_rank_idle_poll_is_not_a_profiler_boundary():
+    _, dp_sync = _sync_dp([0, 0], profiler_ready_per_rank=[True, True])
+
+    assert dp_sync is None
 
 
 def test_microbatching_survives_a_rank_that_cannot_fill_it():

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -125,6 +125,16 @@ class ProfilerConfig:
     Defaults to 0, meaning no limit.
     """
 
+    synchronize_iterations_across_dp: bool = False
+    """If `True`, count profiler iterations at DP execution boundaries.
+
+    This makes `delay_iterations` and `max_iterations` count the shared
+    model-forward cadence, including dummy execution on locally idle ranks.
+    The existing DP coordination carries profiler readiness, so this does not
+    add a profiling-only collective. This option has no effect when data
+    parallel size is one.
+    """
+
     warmup_iterations: int = Field(default=0, ge=0)
     """Number of warmup iterations for PyTorch profiler schedule.
     During warmup, the profiler runs but data is discarded. This helps reduce
@@ -232,6 +242,11 @@ class ProfilerConfig:
             raise ValueError(
                 "capture_torch_profiler is only applicable when profiler is "
                 "set to 'torch'"
+            )
+
+        if self.synchronize_iterations_across_dp and self.profiler is None:
+            raise ValueError(
+                "synchronize_iterations_across_dp requires profiler to be set"
             )
 
         return self

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -296,7 +296,7 @@ def set_forward_context(
         ):
             assert ubatch_slices is None
             assert num_tokens is not None
-            _, num_tokens_across_dp, _ = coordinate_batch_across_dp(
+            _, num_tokens_across_dp, _, _ = coordinate_batch_across_dp(
                 num_tokens_unpadded=num_tokens,
                 parallel_config=vllm_config.parallel_config,
                 allow_microbatching=False,

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -56,7 +56,7 @@ class WorkerProfiler(ABC):
         return self._running
 
     @property
-    def is_active(self) -> bool:
+    def is_armed(self) -> bool:
         """Whether a start request is active, including a delayed start."""
         return self._active
 

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -55,6 +55,11 @@ class WorkerProfiler(ABC):
         """Whether the underlying profiler is currently collecting data."""
         return self._running
 
+    @property
+    def is_active(self) -> bool:
+        """Whether a start request is active, including a delayed start."""
+        return self._active
+
     @abstractmethod
     def _start(self) -> None:
         """Start the profiler."""

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -208,7 +208,7 @@ class ExtractHiddenStatesProposer:
         # TODO(Flechman): support DBO ubatching
         should_ubatch, num_tokens_across_dp = False, None
         if self.vllm_config.parallel_config.data_parallel_size > 1:
-            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
+            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode, _ = (
                 coordinate_batch_across_dp(
                     num_tokens_unpadded=num_tokens,
                     parallel_config=self.vllm_config.parallel_config,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1794,7 +1794,7 @@ class SpecDecodeBaseProposer:
         # TODO(Flechman): support DBO ubatching
         should_ubatch, num_tokens_across_dp = False, None
         if self.vllm_config.parallel_config.data_parallel_size > 1:
-            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
+            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode, _ = (
                 coordinate_batch_across_dp(
                     num_tokens_unpadded=num_tokens,
                     parallel_config=self.vllm_config.parallel_config,

--- a/vllm/v1/worker/dp_utils.py
+++ b/vllm/v1/worker/dp_utils.py
@@ -132,6 +132,8 @@ def _synchronize_dp_ranks(
         num_tokens_after_padding: A tensor containing the total number of
         tokens per-microbatch for each DP rank including any DP padding.
         synced_cudagraph_mode: The synchronized cudagraph mode (min across ranks)
+        synced_profiler_ready: Whether all DP ranks have armed synchronized
+            profiler stepping, or None when readiness was not included.
     ]
 
     """

--- a/vllm/v1/worker/dp_utils.py
+++ b/vllm/v1/worker/dp_utils.py
@@ -43,17 +43,23 @@ def _run_ar(
     padded_num_tokens_per_ubatch: int,
     cudagraph_mode: int,
     parallel_config: ParallelConfig,
+    profiler_ready: bool | None,
 ) -> torch.Tensor:
     dp_size = parallel_config.data_parallel_size
     dp_rank = parallel_config.data_parallel_rank
     device, group = _get_device_and_group(parallel_config)
     # Populate this rank's contribution on CPU to reduce GPU syncs.
     pin_memory = PIN_MEMORY and torch.device(device).type == "cuda"
-    tensor_cpu = torch.zeros(4, dp_size, dtype=torch.int32, pin_memory=pin_memory)
+    num_fields = 5 if profiler_ready is not None else 4
+    tensor_cpu = torch.zeros(
+        num_fields, dp_size, dtype=torch.int32, pin_memory=pin_memory
+    )
     tensor_cpu[0][dp_rank] = orig_num_tokens_per_ubatch
     tensor_cpu[1][dp_rank] = padded_num_tokens_per_ubatch
     tensor_cpu[2][dp_rank] = 1 if should_ubatch else 0
     tensor_cpu[3][dp_rank] = cudagraph_mode
+    if profiler_ready is not None:
+        tensor_cpu[4][dp_rank] = int(profiler_ready)
     tensor = tensor_cpu.to(device, non_blocking=True)
     dist.all_reduce(tensor, group=group)
     return tensor
@@ -109,7 +115,8 @@ def _synchronize_dp_ranks(
     should_attempt_ubatching: bool,
     cudagraph_mode: int,
     parallel_config: ParallelConfig,
-) -> tuple[bool, torch.Tensor | None, int]:
+    profiler_ready: bool | None,
+) -> tuple[bool, torch.Tensor | None, int, bool | None]:
     """
     1. Decides if each DP rank is going to microbatch. Either all ranks
     run with microbatching or none of them do.
@@ -139,6 +146,7 @@ def _synchronize_dp_ranks(
         padded_num_tokens_per_ubatch=num_tokens_padded,
         cudagraph_mode=cudagraph_mode,
         parallel_config=parallel_config,
+        profiler_ready=profiler_ready,
     )
 
     # Only the NCCL path leaves `tensor` on device. With Gloo -- the default
@@ -169,7 +177,18 @@ def _synchronize_dp_ranks(
         # should_dp_pad is True
         num_tokens_after_padding = _post_process_dp_padding(tensor, should_dp_pad)
 
-    return should_ubatch, num_tokens_after_padding, synced_cudagraph_mode
+        synced_profiler_ready = (
+            bool(torch.all(tensor[4] == 1).item())
+            if profiler_ready is not None
+            else None
+        )
+
+    return (
+        should_ubatch,
+        num_tokens_after_padding,
+        synced_cudagraph_mode,
+        synced_profiler_ready,
+    )
 
 
 def coordinate_batch_across_dp(
@@ -179,7 +198,8 @@ def coordinate_batch_across_dp(
     num_tokens_padded: int | None = None,
     uniform_decode: bool | None = None,
     cudagraph_mode: int = 0,
-) -> tuple[bool, torch.Tensor | None, int]:
+    profiler_ready: bool | None = None,
+) -> tuple[bool, torch.Tensor | None, int, bool | None]:
     """
     Coordinates amongst all DP ranks to determine if and how the full batch
     should be split into microbatches.
@@ -194,6 +214,8 @@ def coordinate_batch_across_dp(
             only contains single token decodes
         cudagraph_mode: The cudagraph mode for this rank (0=NONE, 1=PIECEWISE, 2=FULL).
             DP padding is enabled when synced cudagraph mode across ranks is not NONE.
+        profiler_ready: Whether this rank has armed synchronized profiler
+            stepping. When set, the result reports whether every rank is ready.
 
     Returns: tuple[
         ubatch_slices: if this is set then all DP ranks have agreed to
@@ -202,12 +224,14 @@ def coordinate_batch_across_dp(
         tokens per-microbatch for each DP rank including padding. Will be
         padded up to the max value across all DP ranks when cudagraph is enabled.
         synced_cudagraph_mode: The synchronized cudagraph mode (min across ranks)
+        synced_profiler_ready: Whether all DP ranks have armed synchronized
+            profiler stepping, or None when not requested.
     ]
 
     """
     if parallel_config.data_parallel_size == 1:
         # Early exit.
-        return False, None, cudagraph_mode
+        return False, None, cudagraph_mode, profiler_ready
 
     # If the caller has explicitly enabled microbatching.
     should_attempt_ubatching = False
@@ -223,14 +247,23 @@ def coordinate_batch_across_dp(
     if num_tokens_padded is None:
         num_tokens_padded = num_tokens_unpadded
 
-    (should_ubatch, num_tokens_after_padding, synced_cudagraph_mode) = (
-        _synchronize_dp_ranks(
-            num_tokens_unpadded,
-            num_tokens_padded,
-            should_attempt_ubatching,
-            cudagraph_mode,
-            parallel_config,
-        )
+    (
+        should_ubatch,
+        num_tokens_after_padding,
+        synced_cudagraph_mode,
+        synced_profiler_ready,
+    ) = _synchronize_dp_ranks(
+        num_tokens_unpadded,
+        num_tokens_padded,
+        should_attempt_ubatching,
+        cudagraph_mode,
+        parallel_config,
+        profiler_ready,
     )
 
-    return (should_ubatch, num_tokens_after_padding, synced_cudagraph_mode)
+    return (
+        should_ubatch,
+        num_tokens_after_padding,
+        synced_cudagraph_mode,
+        synced_profiler_ready,
+    )

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -63,6 +63,8 @@ def sync_cudagraph_and_dp_padding(
 
     `parallel_config` is only needed to decide whether to microbatch, so callers
     that never do (`allow_ubatching=False`) can leave it out.
+    When `profiler_ready` is set, its readiness bit is carried by the same
+    all-reduce and returned in `DPSyncState`.
 
     Returns (synced_batch_desc, sync). `sync` is None when no rank has work.
     """

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -38,6 +38,9 @@ class DPSyncState:
     # Agreed upper bound on any rank's request count. Holds the padded count when
     # a FULL descriptor imposed one, else the most any rank scheduled.
     num_reqs: int
+    # Whether every rank has armed synchronized profiler stepping. None when
+    # profiler readiness was not included in this agreement.
+    profiler_ready: bool | None = None
 
 
 def sync_cudagraph_and_dp_padding(
@@ -53,6 +56,7 @@ def sync_cudagraph_and_dp_padding(
     parallel_config: ParallelConfig | None = None,
     allow_ubatching: bool = False,
     uniform_decode: bool = False,
+    profiler_ready: bool | None = None,
 ) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
     """
     Coordinates the batch descriptor and DP padding across all ranks.
@@ -64,13 +68,16 @@ def sync_cudagraph_and_dp_padding(
     """
     assert dp_size > 1, "DP size must be greater than 1"
     group = get_dp_group().cpu_group
-    tensor = torch.zeros(6, dp_size, dtype=torch.int32, device="cpu")
+    num_fields = 7 if profiler_ready is not None else 6
+    tensor = torch.zeros(num_fields, dp_size, dtype=torch.int32, device="cpu")
     tensor[0][dp_rank] = num_tokens
     tensor[1][dp_rank] = desired_batch_desc.cg_mode.value
     tensor[2][dp_rank] = uniform_token_count or 0  # (0 means None)
     tensor[3][dp_rank] = max_query_len or -1  # (-1 means None)
     tensor[4][dp_rank] = int(allow_ubatching)
     tensor[5][dp_rank] = num_reqs
+    if profiler_ready is not None:
+        tensor[6][dp_rank] = int(profiler_ready)
     dist.all_reduce(tensor, group=group)
 
     num_tokens_across_dp = tensor[0]
@@ -79,6 +86,9 @@ def sync_cudagraph_and_dp_padding(
     max_query_lens_across_dp = tensor[3]
     allow_ubatching_across_dp = tensor[4]
     num_reqs_across_dp = tensor[5]
+    synced_profiler_ready = (
+        bool(torch.all(tensor[6] == 1).item()) if profiler_ready is not None else None
+    )
 
     # If ranks disagree on the uniform token count, or its 0 (means None) set to None
     synced_uniform_token_count: int | None = int(uniform_token_counts_across_dp[0])
@@ -125,6 +135,7 @@ def sync_cudagraph_and_dp_padding(
                 uniform_token_count=synced_uniform_token_count,
                 eager=True,
                 num_reqs=int(num_reqs_across_dp.max()),
+                profiler_ready=synced_profiler_ready,
             )
 
     synced_cg_mode = CUDAGraphMode(int(cg_mode_across_dp.min().item()))
@@ -143,6 +154,7 @@ def sync_cudagraph_and_dp_padding(
                 uniform_token_count=synced_uniform_token_count,
                 eager=True,
                 num_reqs=int(num_reqs_across_dp.max()),
+                profiler_ready=synced_profiler_ready,
             ),
         )
 
@@ -182,6 +194,7 @@ def sync_cudagraph_and_dp_padding(
             and synced_desc.num_reqs is not None
             else int(num_reqs_across_dp.max())
         ),
+        profiler_ready=synced_profiler_ready,
     )
 
 
@@ -199,6 +212,7 @@ def dispatch_cg_and_sync_dp(
     allow_ubatching: bool = False,
     uniform_decode: bool = False,
     dp_sync: DPSyncState | None = None,
+    profiler_ready: bool | None = None,
 ) -> tuple[BatchExecutionDescriptor, DPSyncState | None]:
     """Pick a cudagraph descriptor for this batch, agreeing it across DP ranks.
 
@@ -227,6 +241,9 @@ def dispatch_cg_and_sync_dp(
             same `uniform_token_count`; `num_reqs` may differ, as neither
             depends on it. Passing a sync from a different batch is a caller
             error and trips an assert.
+        profiler_ready: Whether this rank has armed synchronized profiler
+            stepping. When set, the existing DP agreement also reports whether
+            every rank is ready.
 
     Returns:
         (batch_desc, sync), where `sync` is this batch's agreement for a later
@@ -289,4 +306,5 @@ def dispatch_cg_and_sync_dp(
         parallel_config=parallel_config,
         allow_ubatching=allow_ubatching,
         uniform_decode=uniform_decode,
+        profiler_ready=profiler_ready,
     )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -200,8 +200,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.speculative_config is not None and self.speculative_config.use_dspark()
         )
         self.observability_config = vllm_config.observability_config
-        self.dp_profiler_state: Callable[[], bool] | None = None
-        self.dp_profiler_step: Callable[[bool], None] | None = None
+        self.dp_profiler_is_ready: Callable[[], bool] | None = None
+        self.dp_profiler_advance: Callable[[bool], None] | None = None
         self.jit_warmup_registry = JitWarmupRegistry(vllm_config)
 
         self.device = device
@@ -1660,13 +1660,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             ),
             uniform_decode=uniform_tok_count == self.decode_query_len,
             profiler_ready=(
-                self.dp_profiler_state() if self.dp_profiler_state else None
+                self.dp_profiler_is_ready() if self.dp_profiler_is_ready else None
             ),
         )
 
-        if self.dp_profiler_step is not None and dp_sync is not None:
+        if self.dp_profiler_advance is not None and dp_sync is not None:
             assert dp_sync.profiler_ready is not None
-            self.dp_profiler_step(dp_sync.profiler_ready)
+            self.dp_profiler_advance(dp_sync.profiler_ready)
 
         if batch_desc.num_tokens == 0:
             # All DP ranks have zero tokens to run.

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -20,6 +20,7 @@ instead of embedding feature-specific logic directly.
 import functools
 import gc
 import time
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from copy import deepcopy
 from typing import Any, NamedTuple
@@ -199,6 +200,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.speculative_config is not None and self.speculative_config.use_dspark()
         )
         self.observability_config = vllm_config.observability_config
+        self.dp_profiler_state: Callable[[], bool] | None = None
+        self.dp_profiler_step: Callable[[bool], None] | None = None
         self.jit_warmup_registry = JitWarmupRegistry(vllm_config)
 
         self.device = device
@@ -1656,7 +1659,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.ubatch_runner is not None and not skip_attn_for_dummy_run
             ),
             uniform_decode=uniform_tok_count == self.decode_query_len,
+            profiler_ready=(
+                self.dp_profiler_state() if self.dp_profiler_state else None
+            ),
         )
+
+        if self.dp_profiler_step is not None and dp_sync is not None:
+            assert dp_sync.profiler_ready is not None
+            self.dp_profiler_step(dp_sync.profiler_ready)
 
         if batch_desc.num_tokens == 0:
             # All DP ranks have zero tokens to run.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -514,8 +514,8 @@ class GPUModelRunner(
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
-        self.dp_profiler_state: Callable[[], bool] | None = None
-        self.dp_profiler_step: Callable[[bool], None] | None = None
+        self.dp_profiler_is_ready: Callable[[], bool] | None = None
+        self.dp_profiler_advance: Callable[[bool], None] | None = None
         self.jit_warmup_registry = JitWarmupRegistry(vllm_config)
 
         model_config = self.model_config
@@ -4041,7 +4041,7 @@ class GPUModelRunner(
                 uniform_decode=uniform_decode,
                 cudagraph_mode=cudagraph_mode.value,
                 profiler_ready=(
-                    self.dp_profiler_state() if self.dp_profiler_state else None
+                    self.dp_profiler_is_ready() if self.dp_profiler_is_ready else None
                 ),
             )
 
@@ -4310,9 +4310,11 @@ class GPUModelRunner(
                 ),
             )
 
-            if self.dp_profiler_step is not None:
+            if self.dp_profiler_advance is not None:
+                # All-rank idle polls return above. V1 reaches this agreement
+                # only for nonempty real or dummy forwards.
                 assert profiler_ready is not None
-                self.dp_profiler_step(profiler_ready)
+                self.dp_profiler_advance(profiler_ready)
 
             logger.debug(
                 "Running batch with cudagraph_mode: %s, batch_descriptor: %s, "
@@ -5988,9 +5990,11 @@ class GPUModelRunner(
             # need to capture graphs for specific num_active_loras counts
             force_num_active_loras=num_active_loras,
         )
-        if self.dp_profiler_step is not None:
+        if self.dp_profiler_advance is not None:
+            # Dummy runs always contain at least one token, so this is a shared
+            # execution boundary rather than an all-rank idle poll.
             assert profiler_ready is not None
-            self.dp_profiler_step(profiler_ready)
+            self.dp_profiler_advance(profiler_ready)
 
         if cudagraph_runtime_mode is None:
             cudagraph_runtime_mode = _cudagraph_mode

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -514,6 +514,8 @@ class GPUModelRunner(
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
+        self.dp_profiler_state: Callable[[], bool] | None = None
+        self.dp_profiler_step: Callable[[bool], None] | None = None
         self.jit_warmup_registry = JitWarmupRegistry(vllm_config)
 
         model_config = self.model_config
@@ -3972,6 +3974,7 @@ class GPUModelRunner(
         bool,
         torch.Tensor | None,
         CUDAGraphStat | None,
+        bool | None,
     ]:
         uniform_decode = self._is_uniform_decode(
             max_num_scheduled_tokens=max_num_scheduled_tokens,
@@ -4023,16 +4026,23 @@ class GPUModelRunner(
         # Extra coordination when running data-parallel since we need to coordinate
         # across ranks
         should_ubatch, num_tokens_across_dp = False, None
+        synced_profiler_ready = None
         if self.vllm_config.parallel_config.data_parallel_size > 1:
-            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
-                coordinate_batch_across_dp(
-                    num_tokens_unpadded=num_tokens,
-                    parallel_config=self.parallel_config,
-                    allow_microbatching=allow_microbatching,
-                    num_tokens_padded=num_tokens_padded,
-                    uniform_decode=uniform_decode,
-                    cudagraph_mode=cudagraph_mode.value,
-                )
+            (
+                should_ubatch,
+                num_tokens_across_dp,
+                synced_cudagraph_mode,
+                synced_profiler_ready,
+            ) = coordinate_batch_across_dp(
+                num_tokens_unpadded=num_tokens,
+                parallel_config=self.parallel_config,
+                allow_microbatching=allow_microbatching,
+                num_tokens_padded=num_tokens_padded,
+                uniform_decode=uniform_decode,
+                cudagraph_mode=cudagraph_mode.value,
+                profiler_ready=(
+                    self.dp_profiler_state() if self.dp_profiler_state else None
+                ),
             )
 
             # Extract DP-synced values
@@ -4063,6 +4073,7 @@ class GPUModelRunner(
             should_ubatch,
             num_tokens_across_dp,
             cudagraph_stats,
+            synced_profiler_ready,
         )
 
     def _register_layerwise_nvtx_hooks(self) -> None:
@@ -4286,6 +4297,7 @@ class GPUModelRunner(
                 should_ubatch,
                 num_tokens_across_dp,
                 cudagraph_stats,
+                profiler_ready,
             ) = self._determine_batch_execution_and_padding(
                 num_tokens=num_tokens_unpadded,
                 num_reqs=num_reqs,
@@ -4297,6 +4309,10 @@ class GPUModelRunner(
                     num_reqs, num_scheduled_tokens_np
                 ),
             )
+
+            if self.dp_profiler_step is not None:
+                assert profiler_ready is not None
+                self.dp_profiler_step(profiler_ready)
 
             logger.debug(
                 "Running batch with cudagraph_mode: %s, batch_descriptor: %s, "
@@ -5944,30 +5960,37 @@ class GPUModelRunner(
 
         num_sampled_tokens = np.ones(num_reqs, dtype=np.int32)
 
-        _cudagraph_mode, batch_desc, should_ubatch, num_tokens_across_dp, _ = (
-            self._determine_batch_execution_and_padding(
-                num_tokens=num_tokens_unpadded,
-                num_reqs=num_reqs,
-                num_scheduled_tokens_np=num_scheduled_tokens,
-                max_num_scheduled_tokens=max_query_len,
-                use_cascade_attn=False,
-                allow_microbatching=allow_microbatching,
-                force_eager=is_profile
-                or (cudagraph_runtime_mode == CUDAGraphMode.NONE),
-                # `force_uniform_decode` is used for cudagraph capture; because for
-                # capturing mixed prefill-decode batches, we sometimes use
-                # num_tokens == num_reqs which looks like a uniform decode batch to the
-                # dispatcher; but we actually want to capture a piecewise cudagraph
-                force_uniform_decode=uniform_decode,
-                # `force_has_lora` is used for cudagraph capture; because LoRA is
-                # activated later in the context manager, but we need to know the
-                # LoRA state when determining the batch descriptor for capture
-                force_has_lora=num_active_loras > 0,
-                # `force_num_active_loras` is used for cudagraph capture; because we
-                # need to capture graphs for specific num_active_loras counts
-                force_num_active_loras=num_active_loras,
-            )
+        (
+            _cudagraph_mode,
+            batch_desc,
+            should_ubatch,
+            num_tokens_across_dp,
+            _,
+            profiler_ready,
+        ) = self._determine_batch_execution_and_padding(
+            num_tokens=num_tokens_unpadded,
+            num_reqs=num_reqs,
+            num_scheduled_tokens_np=num_scheduled_tokens,
+            max_num_scheduled_tokens=max_query_len,
+            use_cascade_attn=False,
+            allow_microbatching=allow_microbatching,
+            force_eager=is_profile or (cudagraph_runtime_mode == CUDAGraphMode.NONE),
+            # `force_uniform_decode` is used for cudagraph capture; because for
+            # capturing mixed prefill-decode batches, we sometimes use
+            # num_tokens == num_reqs which looks like a uniform decode batch to the
+            # dispatcher; but we actually want to capture a piecewise cudagraph
+            force_uniform_decode=uniform_decode,
+            # `force_has_lora` is used for cudagraph capture; because LoRA is
+            # activated later in the context manager, but we need to know the
+            # LoRA state when determining the batch descriptor for capture
+            force_has_lora=num_active_loras > 0,
+            # `force_num_active_loras` is used for cudagraph capture; because we
+            # need to capture graphs for specific num_active_loras counts
+            force_num_active_loras=num_active_loras,
         )
+        if self.dp_profiler_step is not None:
+            assert profiler_ready is not None
+            self.dp_profiler_step(profiler_ready)
 
         if cudagraph_runtime_mode is None:
             cudagraph_runtime_mode = _cudagraph_mode

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -218,6 +218,8 @@ class Worker(WorkerBase):
         # so we have all the information needed for proper trace naming.
         self.profiler: Any | None = None
         self.profiler_config = vllm_config.profiler_config
+        self._dp_profiler_requested = False
+        self._dp_profiler_session_started = False
 
         self.use_v2_model_runner = vllm_config.use_v2_model_runner
 
@@ -483,6 +485,10 @@ class Worker(WorkerBase):
             )
 
             self.model_runner = GPUModelRunnerV1(self.vllm_config, self.device)
+
+        if self._use_dp_synchronized_profiler_iterations():
+            self.model_runner.dp_profiler_state = self._dp_profiler_is_ready
+            self.model_runner.dp_profiler_step = self._advance_dp_synchronized_profiler
 
         if self.rank == 0:
             # If usage stat is enabled, collect relevant info.
@@ -997,6 +1003,36 @@ class Worker(WorkerBase):
         """Get encoder timing stats from model runner."""
         return self.model_runner.get_encoder_timing_stats()
 
+    def _use_dp_synchronized_profiler_iterations(self) -> bool:
+        return (
+            self.profiler_config.synchronize_iterations_across_dp
+            and self.parallel_config.data_parallel_size > 1
+        )
+
+    def _dp_profiler_is_ready(self) -> bool:
+        return self._dp_profiler_requested
+
+    def _advance_dp_synchronized_profiler(self, all_ranks_ready: bool) -> None:
+        """Advance once when all DP ranks have armed the same profile session."""
+        profiler = self.profiler
+        if not all_ranks_ready:
+            if self._dp_profiler_session_started:
+                assert profiler is not None
+                profiler.stop()
+                self._dp_profiler_session_started = False
+                self._dp_profiler_requested = False
+            return
+
+        assert profiler is not None
+        if not self._dp_profiler_session_started:
+            profiler.start()
+            self._dp_profiler_session_started = True
+
+        profiler.step()
+        if not profiler.is_active:
+            self._dp_profiler_session_started = False
+            self._dp_profiler_requested = False
+
     def annotate_profile(self, scheduler_output):
         # add trace annotation so that we can easily distinguish
         # context/generation request numbers in each iteration.
@@ -1004,7 +1040,8 @@ class Worker(WorkerBase):
         if not self.profiler:
             return nullcontext()
 
-        self.profiler.step()
+        if not Worker._use_dp_synchronized_profiler_iterations(self):
+            self.profiler.step()
         if not self.profiler.is_running:
             return nullcontext()
 
@@ -1150,7 +1187,7 @@ class Worker(WorkerBase):
             # TODO(lucas): This is pretty gross; ideally we should only ever call
             # `_determine_batch_execution_and_padding` once (will get called again
             # in `execute_model`) but this requires a larger refactor of PP.
-            _, batch_desc, _, _, _ = (
+            _, batch_desc, _, _, _, _ = (
                 self.model_runner._determine_batch_execution_and_padding(
                     num_tokens=num_scheduled_tokens,
                     num_reqs=len(num_scheduled_tokens_np),
@@ -1267,11 +1304,20 @@ class Worker(WorkerBase):
                         f"Invalid profiler value of {self.profiler_config.profiler}"
                     )
 
-            self.profiler.start()
+            if Worker._use_dp_synchronized_profiler_iterations(self):
+                self._dp_profiler_requested = True
+                logger.info(
+                    "DP-synchronized profiler armed; capture will follow the "
+                    "next execution boundary agreed by all DP ranks."
+                )
+            else:
+                self.profiler.start()
         else:
             if self.profiler is None:
                 logger.warning("Profiler was not started, nothing to stop.")
                 return
+            self._dp_profiler_requested = False
+            self._dp_profiler_session_started = False
             try:
                 self.profiler.stop()
             finally:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -487,8 +487,10 @@ class Worker(WorkerBase):
             self.model_runner = GPUModelRunnerV1(self.vllm_config, self.device)
 
         if self._use_dp_synchronized_profiler_iterations():
-            self.model_runner.dp_profiler_state = self._dp_profiler_is_ready
-            self.model_runner.dp_profiler_step = self._advance_dp_synchronized_profiler
+            self.model_runner.dp_profiler_is_ready = self._dp_profiler_is_ready
+            self.model_runner.dp_profiler_advance = (
+                self._advance_dp_synchronized_profiler
+            )
 
         if self.rank == 0:
             # If usage stat is enabled, collect relevant info.
@@ -1029,7 +1031,7 @@ class Worker(WorkerBase):
             self._dp_profiler_session_started = True
 
         profiler.step()
-        if not profiler.is_active:
+        if not profiler.is_armed:
             self._dp_profiler_session_started = False
             self._dp_profiler_requested = False
 
@@ -1040,7 +1042,7 @@ class Worker(WorkerBase):
         if not self.profiler:
             return nullcontext()
 
-        if not Worker._use_dp_synchronized_profiler_iterations(self):
+        if not self._use_dp_synchronized_profiler_iterations():
             self.profiler.step()
         if not self.profiler.is_running:
             return nullcontext()
@@ -1304,7 +1306,7 @@ class Worker(WorkerBase):
                         f"Invalid profiler value of {self.profiler_config.profiler}"
                     )
 
-            if Worker._use_dp_synchronized_profiler_iterations(self):
+            if self._use_dp_synchronized_profiler_iterations():
                 self._dp_profiler_requested = True
                 logger.info(
                     "DP-synchronized profiler armed; capture will follow the "
@@ -1316,6 +1318,8 @@ class Worker(WorkerBase):
             if self.profiler is None:
                 logger.warning("Profiler was not started, nothing to stop.")
                 return
+            # Keep the explicit stop synchronous. Other DP ranks observe the
+            # de-armed state at their next existing execution agreement.
             self._dp_profiler_requested = False
             self._dp_profiler_session_started = False
             try:


### PR DESCRIPTION
## Summary

Add an opt-in `synchronize_iterations_across_dp` profiler setting so
`delay_iterations` and `max_iterations` count the same distributed model
execution boundaries on every data-parallel rank.

This makes bounded CUDA/Nsight captures comparable when some DP ranks execute
real tokens while others participate through dummy work.

## Design

- Preserve the existing rank-local profiler behavior and collective payload by
  default.
- Arm profiling on each participant and carry one readiness field in the
  existing DP batch agreement only when enabled. This does not add a
  profiling-only collective.
- Start and advance the profiler only after every DP rank is armed.
- Advance once per target-model boundary in both model-runner implementations,
  including asymmetric real/dummy execution.
- Do not count an all-rank idle poll as a model execution boundary.
- Keep automatically bounded stops synchronized and preserve profiler restart
  after automatic stop.

Worker RPCs execute serially in the worker loop, so profiler state transitions
and model execution callbacks share a single execution context.

For an aligned bounded stop, use `max_iterations`. An explicit stop remains
synchronous on the receiving worker; peers observe the de-armed state before
their next shared forward, so trailing non-forward activity can differ. The
first captured synchronized boundary may also omit the outer worker-level
iteration annotation because readiness is agreed inside the model runner. Both
behaviors are documented.

## Duplicate check

I searched open PRs and issues for `synchronize_iterations_across_dp`,
DP-synchronized profiling, `delay_iterations` with data parallelism, and Nsight
DP profiling. I did not find an implementation of this feature.

Related work is complementary:

- #28987 introduced iteration-bounded profiling using local worker steps.
- #51839 fixed restart after an iteration-bounded automatic stop; this PR
  preserves that behavior.
- #35340 adds runtime step-window parameters but not a DP-shared clock.
- #44535 adds multiple worker-step windows but not DP synchronization.

## Validation

- `pre-commit run --files <changed files>`: passed, including ruff, mypy,
  markdownlint, SPDX, and profiler-config validation.
- `.venv/bin/python -m pytest -q tests/v1/worker/test_gpu_profiler.py tests/v1/worker/test_gpu_ubatch_slicing.py tests/v1/spec_decode/test_extract_hidden_states.py tests/v1/spec_decode/test_llm_base_proposer.py tests/v1/spec_decode/test_llm_base_proposer_sampling.py`:
  82 passed, 39 skipped.

The tests cover disabled/default behavior, configuration validation, readiness
agreement, asymmetric zero-token participation, all-rank idle behavior, delayed
start, bounded stop, peer stop, restart, the absence of an additional
all-reduce, and direct V1 real/dummy runner boundary invocation.

Distributed asymmetric-DP CUDA/Nsight validation has not been run yet. The PR
is intentionally draft pending that run and submitter review.

## Model evaluation

Not applicable. This changes profiler control state only and does not alter
model execution, sampling, or output tensors.

## AI assistance

OpenAI Codex assisted with implementation and testing. This draft is pending
the submitter's line-by-line review and distributed validation before it is
marked ready for review.
