### PR TITLE
[Perf][Marlin] Group full-K tiles for wide block-FP8 GEMMs on SM89

### DIFF
--- a/csrc/libtorch_stable/quantization/marlin/kernel.h
+++ b/csrc/libtorch_stable/quantization/marlin/kernel.h
@@ -16,7 +16,7 @@
       const float *__restrict__ global_scale_ptr,                          \
       const int4 *__restrict__ zp_ptr, int prob_m, int prob_n, int prob_k, \
       int lda, int *locks, bool has_bias, bool use_atomic_add,             \
-      bool use_fp32_reduce, int max_shared_mem
+      bool use_fp32_reduce, int max_shared_mem, bool group_m_tiles
 
 namespace MARLIN_NAMESPACE_NAME {
 template <const vllm::ScalarTypeId a_type_id,  // A ScalarType id

--- a/csrc/libtorch_stable/quantization/marlin/marlin.cu
+++ b/csrc/libtorch_stable/quantization/marlin/marlin.cu
@@ -401,12 +401,18 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* b_bias,
     bool part_use_atomic_add =
         use_atomic_add && div_ceil(prob_m_split, 64) * prob_n <= 2048;
 
+    bool group_m_tiles = major_capability == 8 && minor_capability == 9 &&
+                         a_type == vllm::kBFloat16 &&
+                         b_type == vllm::kFE4M3fn && group_blocks == 8 &&
+                         !has_bias && use_fp32_reduce && prob_m_split >= 256 &&
+                         prob_n >= 24576 && prob_k >= 4096 && prob_k <= 8192;
+
     // avoid ">>>" being formatted to "> > >"
     // clang-format off
     kernel<<<blocks, num_threads, max_shared_mem_new, stream>>>(
         A_ptr, B_ptr, C_ptr, C_tmp_ptr, bias_ptr, a_s_ptr, b_s_ptr, g_s_ptr, zp_ptr,
         prob_m_split, prob_n, prob_k, lda, locks, has_bias, part_use_atomic_add,
-        use_fp32_reduce, max_shared_mem_new);
+        use_fp32_reduce, max_shared_mem_new, group_m_tiles);
     // clang-format on
 
     bool is_a_8bit = a_type.size_bits() == 8;

--- a/csrc/libtorch_stable/quantization/marlin/marlin_template.h
+++ b/csrc/libtorch_stable/quantization/marlin/marlin_template.h
@@ -238,7 +238,7 @@ __global__ void Marlin(
     bool has_bias,
     bool use_atomic_add,   // whether to use atomic add to reduce
     bool use_fp32_reduce,  // whether to use fp32 global reduce
-    int max_shared_mem) {
+    int max_shared_mem, bool group_m_tiles) {
   // Each threadblock processes one "stripe" of the B matrix with (roughly) the
   // same size, which might involve multiple column "slices" (of width 16 *
   // `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM
@@ -466,6 +466,21 @@ __global__ void Marlin(
       part1_mn_iters--;
       par_id = slice_col_par / n_tiles;
       slice_col = slice_col_par % n_tiles;
+      if constexpr (a_type == vllm::kBFloat16 && b_type == vllm::kFE4M3fn &&
+                    group_blocks == 8) {
+        if (group_m_tiles) {
+          // Reorder only complete M rows; leave the Stream-K tail unchanged.
+          int full_m = (global_mn_tiles - part2_mn_tiles) / n_tiles;
+          if (full_m > 1 && slice_col_par < full_m * n_tiles) {
+            constexpr int group_size_m = 8;
+            int group = slice_col_par / (group_size_m * n_tiles);
+            int group_m = min(group_size_m, full_m - group * group_size_m);
+            int tile = slice_col_par - group * group_size_m * n_tiles;
+            par_id = group * group_size_m + tile % group_m;
+            slice_col = tile / group_m;
+          }
+        }
+      }
       slice_iters = k_tiles;
       A = A0 + 16 * thread_m_blocks / (is_a_8bit ? 16 : 8) * par_id * lda;
       C = C0 + 16 * thread_m_blocks / 8 * par_id * prob_n;

--- a/tests/kernels/quantization/test_marlin_gemm.py
+++ b/tests/kernels/quantization/test_marlin_gemm.py
@@ -477,18 +477,33 @@ def test_marlin_gemm(
     assert max_diff < 0.04
 
 
-def test_marlin_gemm_subset_input():
-    quant_type = scalar_types.uint4b8
+@pytest.mark.parametrize(
+    "quant_type,dtype,size_m,size_k,size_n",
+    [
+        (scalar_types.uint4b8, torch.float16, 32, 1024, 2048),
+        (scalar_types.float8_e4m3fn, torch.bfloat16, 255, 4096, 24576),
+        (scalar_types.float8_e4m3fn, torch.bfloat16, 256, 4096, 24576),
+        (scalar_types.float8_e4m3fn, torch.bfloat16, 257, 4096, 24576),
+        (scalar_types.float8_e4m3fn, torch.bfloat16, 511, 5120, 34816),
+        (scalar_types.float8_e4m3fn, torch.bfloat16, 1025, 8192, 32768),
+    ],
+)
+def test_marlin_gemm_subset_input(quant_type, dtype, size_m, size_k, size_n):
+    """Cover strided inputs, partial tiles, and the large-M launch boundary."""
     group_size = 128
 
-    size_m, size_k, size_n = 32, 1024, 2048
-    big_m = size_m * 2
-    big_k = size_k * 2
+    big_m = size_m + 8
+    big_k = size_k + 16
 
-    a_input = rand_data((big_m, big_k))[8 : size_m + 8, 8 : size_k + 8]
-    b_weight = rand_data((size_k, size_n))
+    a_input = rand_data((big_m, big_k), dtype)[8 : size_m + 8, 8 : size_k + 8]
+    b_weight = rand_data((size_k, size_n), dtype)
 
-    w_ref, marlin_q_w, marlin_s = marlin_quantize(b_weight, quant_type, group_size)
+    if quant_type == scalar_types.float8_e4m3fn:
+        w_ref, marlin_q_w, marlin_s = marlin_quant_fp8_torch(
+            b_weight.T, group_size, input_dtype=dtype
+        )
+    else:
+        w_ref, marlin_q_w, marlin_s = marlin_quantize(b_weight, quant_type, group_size)
 
     marlin_zp = marlin_make_empty(marlin_s.device)
     workspace = marlin_make_workspace_new(a_input.device)


### PR DESCRIPTION
## Purpose

Group complete M tile rows in Marlin's full-K region (group size 8) to improve weight-tile reuse. The partial-row remainder, Stream-K tail, reduction order and public operator interface stay unchanged.

Limited to SM89, BF16 activations, FP8 block128 weights, no bias, FP32 reduction, M split >=256, N >=24576 and K in [4096,8192]. No runtime autotuning or model-name checks.

## Test Plan

```bash
.venv/bin/python -m pytest \
  tests/kernels/quantization/test_marlin_gemm.py \
  tests/kernels/quantization/test_marlin_tile_padding.py \
  -v -p no:cacheprovider
```

**621 passed, 13 skipped.** Includes five added FP8 strided-input and large-M boundary cases. Ruff, formatting, mypy 3.12, typos and applicable source checks passed.

## Test Result

One L40S, TP1, 27B block-FP8 checkpoint (`Qwen3_5ForConditionalGeneration`), CUDA graphs enabled, max batched tokens 2048. Four independent processes in baseline/candidate/candidate/baseline order, two samples per workload per process, fixed compilation cache. Offline engine latency, not HTTP latency.

| Input/output tokens, B=1 | Request latency, baseline → patched | TTFT change |
|---|---:|---:|
| 8192/256 | 13.810 → 13.228 s (−4.21%) | −16.66% |
| 16384/64 | 9.713 → 8.601 s (−11.45%) | −15.60% |
| 2048/1024 | 41.684 → 41.521 s (−0.39%) | −18.59% |

TPOT is effectively unchanged; no TP2 or cross-architecture speedup claim.

- Full output hashes match baseline for 112 GEMM shapes, including eager/graph replay. All 10,752 generated tokens match in the final model comparison; no prefix-cache hits or preemptions.
- GSM8K smoke: first 16 questions, 5-shot. Chat/thinking-off/max512: both 15/16, one identical truncation. Completion/max256: both 7/16, eight truncations and one empty output. All tokens match; saved baseline outputs were reused for the final comparison. This is not a full accuracy evaluation.
- Tested base `5ff50f3996`; 15 relevant baseline paths match main `9a35c081e8`. `_C_stable_libtorch` rebuilt; ancillary native libraries reuse an older wheel. Python 3.12.13, Torch 2.13.0+cu129, CUDA 12.9.86.

## Not a duplicate

Open-PR searches for `Marlin tile order`, `Marlin cache locality` and
`Marlin prefill` were refreshed on 2026-09-13; no matching dense FP8 traversal
change was found. #38054 tunes MXFP4 MoE tile sizes, #50096 changes W4A8 loads,
and #56697 reduces SM90 MoE padding. This PR changes only complete full-K tile
traversal for the stated SM89 dense FP8 path.

AI assistance was used for implementation and validation. I reviewed the changed
lines and ran the relevant tests.
