### PR TITLE
[CI] Shard Multimodal Processor 5 ways to cut it from 61m to ~15m

### DIFF
--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -99,9 +99,9 @@ steps:
     - pytest -v -s models/multimodal/processing --ignore models/multimodal/processing/test_tensor_schema.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
   parallelism: 4
 
-- label: ":nvidia: (H200 MIG 18GB) Multimodal Processor"
+- label: ":nvidia: (H200 MIG 18GB) Multimodal Processor Shard %N"
   key: multi-modal-processor
-  timeout_in_minutes: 98
+  timeout_in_minutes: 40
   device: h200_18gb
   source_file_dependencies:
   - vllm/
@@ -109,13 +109,17 @@ steps:
   - tests/models/multimodal
   - tests/models/registry.py
   commands:
-    - pytest -v -s models/multimodal/processing/test_tensor_schema.py
+    # One parametrized case per multimodal model (160 cases, ~57m of pytest at
+    # ~21s each), so sharding by case count balances well: measured p95 of the
+    # slowest shard is 16.6m at 5 shards, and the slowest single case is 1.2m.
+    - pytest -v -s models/multimodal/processing/test_tensor_schema.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
+  parallelism: 5
   mirror:
     amd:
-      label: ":amd: (MI355) Multimodal Processor"
+      label: ":amd: (MI355) Multimodal Processor Shard %N"
       dind: false
       device: mi355_1
-      timeout_in_minutes: 115
+      timeout_in_minutes: 50
       depends_on:
       - image-build-amd
 


### PR DESCRIPTION
## What

`multi-modal-processor` is the longest-running test job in the pipeline. It runs
a single parametrized function unsharded, so this shards it 5 ways: p90 drops
from **61.2m to ~21m** (≈6m setup + ≈15m pytest).

## Why 5 shards

The job is one function, `test_model_tensor_schema`, parametrized over the
multimodal model registry. Measured from build 88300:

- **160 cases**, **57.3m** of pytest, ~21s median per case
- **slowest single case 1.2m** — so the granularity floor is negligible and
  case-level sharding balances well

Simulating the real `sha256(nodeid) % N` over those per-case durations, across
2000 hash assignments (a salt models the reshuffle caused by any added or
renamed case):

| shards | p50 max | p95 max | worst | machine |
|---|---|---|---|---|
| 4 | 17.0m | 19.7m | **23.0m** ✗ | 82m |
| **5** | 14.1m | 16.6m | **19.7m** ✓ | 88m |
| 6 | 12.2m | 14.8m | 17.8m | 95m |

Five is the smallest count whose **worst** observed draw stays under a 20m
pytest budget. Four looks fine at p50 but breaches on an unlucky assignment,
which is the failure mode to avoid — the assignment re-rolls whenever a model
is added to the registry.

Cost: machine time goes 63.5m → ~88m, i.e. **0.6 GPU-minutes per wall-clock
minute saved**. Setup here is only ~6m (no source builds), which is what makes
extra shards cheap on this job.

## Old / New

```
- label: ":nvidia: (H200 MIG 18GB) Multimodal Processor"
  timeout_in_minutes: 98
  commands:
    - pytest -v -s models/multimodal/processing/test_tensor_schema.py
```

```
- label: ":nvidia: (H200 MIG 18GB) Multimodal Processor Shard %N"
  timeout_in_minutes: 40
  commands:
    - pytest -v -s models/multimodal/processing/test_tensor_schema.py --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --shard-id=$$BUILDKITE_PARALLEL_JOB
  parallelism: 5
```

## Notes

- **AMD gets the same split, and needs it.** `:amd: (MI355) Multimodal
  Processor` was p90 **54.4m** unsharded (median 53.6m over 24 runs) running the
  same 160 cases — the mirror has no `commands:` of its own, so it inherits the
  base command. It also inherits `parallelism`: the generator passes
  `parallelism=step.parallelism` from the base step and
  `_get_amd_mirror_effective_step` does not override it, so MI355 shards 5 ways
  too, landing around 11m of pytest per shard. Shard flags are already in use in
  AMD mirrors today (e.g. `models_language.yaml:94`). Timeouts drop 98m → 40m
  (NVIDIA) and 115m → 50m (AMD), both well over 2× the expected duration.
- **Known limitation, already tracked:** an `amd:` mirror cannot yet be pinned
  to a different shard count than its base step — see the note at
  `kernels.yaml:211` and ci-infra PR #473, "Honor mirror.amd.parallelism so
  NVIDIA sharding cannot multiply AMD mirrors". Not a problem here, because both
  lanes want the same split (MI355 was 54.4m unsharded). If #473 lands and MI355
  turns out to need a different count, pinning it becomes a one-line follow-up.
- **No test files moved and no selection changed.** The same 160 cases run, just
  distributed across 5 parallel instances of one job. `pytest-shard` splits a
  job across its own `parallelism:`, not between sibling jobs.
- **Deferred:** `test_tensor_schema.py` is targeted by path rather than by
  directory, because the CPU lane (`multi-modal-processor-cpu`) runs the rest of
  `models/multimodal/processing` via `--ignore` on this file. Moving it into its
  own directory would make both lanes directory-scoped, but it shifts four
  relative-import depths (`...registry`, `...utils`, `....utils`,
  `.test_common`) and is orthogonal to the duration win, so it is left for a
  follow-up.
- **Also deferred:** `multi-modal-processor-cpu` shards run 28–31m each and are
  over budget too; separate PR.

## Test plan

`yaml.safe_load` on the edited pipeline file passes. No test files or Python
code are touched, so there is nothing to run locally.

Targeted CI run for just this step (selects the step plus its dependencies):

```bash
bk build create --pipeline vllm/ci --branch agent/shard-multimodal-processor \
  --env 'RUN_ALL=1' \
  --env 'VLLM_CI_ONLY_STEP_KEYS=["multi-modal-processor"]'
```

Expect 5 shards, each ≈15m of pytest, 160 cases total across them (sum the
per-shard "Running N items in this shard" lines).

## Model evaluation

Not applicable. No vLLM runtime, serving, or model output path is touched — this
changes only how many Buildkite instances the existing test job runs on.

## AI assistance

AI assistance (Claude Code) was used to measure the per-case durations from
build 88300, simulate the shard-count trade-off, and draft this change. The
diff is a single YAML block and has been reviewed line by line by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
