### PR TITLE
[CI][Model] Rename PixtralRotaryEmbedding to PixtralVisionRotaryEmbedding

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -17,7 +17,7 @@ from transformers.models.pixtral.image_processing_pixtral import (
     _num_image_tokens as _get_pixtral_hf_num_image_tokens,
 )
 from transformers.models.pixtral.modeling_pixtral import (
-    PixtralRotaryEmbedding,
+    PixtralVisionRotaryEmbedding,
     apply_rotary_pos_emb,
     position_ids_in_meshgrid,
 )
@@ -1465,7 +1465,7 @@ class PixtralHFVisionModel(nn.Module):
 
         self.dtype = next(self.parameters()).dtype
         self.device = next(self.parameters()).device
-        self.patch_positional_embedding = PixtralRotaryEmbedding(config, self.device)
+        self.patch_positional_embedding = PixtralVisionRotaryEmbedding(config, self.device)
 
     def forward(
         self,


### PR DESCRIPTION

## Purpose

To resolve the following error in the [tpu-inference CI](https://buildkite.com/vllm/tpu-inference-ci/builds/218/canvas?sid=01a08f44-9ea4-4d6c-aea3-920025699fbd&tab=output): 

Failure Type: ImportError in Pixtral Model Registration (ImportError: cannot import name 'PixtralRotaryEmbedding' from 'transformers.models.pixtral.modeling_pixtral'). • Location: third_party/py/vllm/model_executor/models/pixtral.py (line 19) ➔ transformers.models.pixtral.modeling_pixtral. • Impacted Targets: mistralai/Mistral-Small-4-119B-2603 correctness test on TPU v7x (tpu7x_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness) in both Default and vLLM nightly variants. • Root Cause: Upstream transformers renamed PixtralRotaryEmbedding to PixtralVisionRotaryEmbedding. In vllm/model_executor/models/pixtral.py:19, PixtralRotaryEmbedding is imported directly from transformers.models.pixtral.modeling_pixtral. When vllm.model_executor.models.registry scans supported model architectures, this import fails with ImportError, causing Model architectures ['PixtralForConditionalGeneration'] failed to be inspected and raising a pydantic_core.ValidationError during ModelConfig initialization in run_mistral_small_4_correctness().

## Test Plan

N/A. The change is a simply the renaming of a class from the transformers library

## Test Result

N/A

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

