### PR TITLE
Optimize atomic MiniMax M3 marker lookup

### DIFF
--- a/tests/reasoning/test_minimax_m3_reasoning_parser.py
+++ b/tests/reasoning/test_minimax_m3_reasoning_parser.py
@@ -157,6 +157,14 @@ def test_parser_registration():
     assert parser_cls is MiniMaxM3ReasoningParser
 
 
+def test_contains_atomic_and_split_token_sequences():
+    contains = MiniMaxM3ReasoningParser._contains_token_sequence
+
+    assert contains([1, 2, 3], [2])
+    assert not contains([1, 2, 3], [4])
+    assert contains([1, 2, 3, 4], [2, 3])
+
+
 def test_nonstreaming_extracts_explicit_reasoning_block():
     parser, _ = make_parser()
     request = ChatCompletionRequest(messages=[], model="test-model")

--- a/vllm/reasoning/minimax_m3_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m3_reasoning_parser.py
@@ -87,6 +87,8 @@ class MiniMaxM3ReasoningParser(BaseThinkingReasoningParser):
     ) -> bool:
         if not marker_ids or len(marker_ids) > len(token_ids):
             return False
+        if len(marker_ids) == 1:
+            return marker_ids[0] in token_ids
         marker_len = len(marker_ids)
         return any(
             tuple(token_ids[i : i + marker_len]) == tuple(marker_ids)


### PR DESCRIPTION
## Summary

Use native sequence membership for MiniMax-M3 reasoning markers that encode to
one token. Keep the existing sequence-window fallback unchanged for tokenizers
that split a marker.

During structured-output decoding, `is_reasoning_end_streaming` checks the full
generated history until reasoning ends. MiniMax-M3's official tokenizer encodes
`<mm:think>` and `</mm:think>` as the single IDs 200059 and 200060. The current
generic loop therefore allocates one-element tuple slices at every history
position even though `marker_id in token_ids` is equivalent for this case.

No parser state is added, so speculative draft probes continue to be stateless.

## Performance

Python 3.12.13, exact official tokenizer revision, alternating fresh parser
loops:

| Generated reasoning tokens | Baseline | This change | Speedup |
| ---: | ---: | ---: | ---: |
| 2,048 | 187.65 ms | 11.61 ms | 16.17x |
| 8,192 | 2,999.57 ms | 157.19 ms | 19.08x |

These numbers isolate the cumulative reasoning-boundary predicate cost. They
are not a full-model throughput or latency claim, and ordinary generation
without structured output does not use this path.

## Correctness and tests

- `python -m pytest -q tests/reasoning/test_minimax_m3_reasoning_parser.py`
  - 23 passed
- `ruff check` and `ruff format --check` on both changed files
- `git diff --check`
- Loaded the official `MiniMaxAI/MiniMax-M3-MXFP8` tokenizer at revision
  `1c4e6a69f3278df8dd6c9693fcca241efe439b7d` with local files only:
  - `<mm:think>` encodes as `[200059]`
  - `</mm:think>` encodes as `[200060]`
- Existing split-marker streaming tests remain unchanged and pass.

The change does not alter generated tokens, parser output, or model math, so no
model accuracy evaluation is applicable.

## Duplicate-work check

Repository history and open PR searches found no MiniMax-M3 optimization for
this token-sequence helper. Related work changes different behavior:

- #54454 targets Muse-Glimmer text-channel classification.
- #50594 targets MiniMax-M3 prompt reasoning initialization correctness.

## Contribution disclosure

- [x] The human submitter reviewed every changed line and can explain the
  optimization, fallback behavior, benchmark boundary, and tests.
- AI assistance was used for repository analysis, implementation, tests, and
  benchmark preparation.
