### PR TITLE
[Bugfix][QSA] Reuse bounded prefill logits workspace

### DIFF
--- a/tests/models/qwen4_exp/test_qsa_reference.py
+++ b/tests/models/qwen4_exp/test_qsa_reference.py
@@ -766,10 +766,85 @@ def test_qsa_decode_selection_correctness(
 
 
 @requires_qsa_kernels
+@pytest.mark.parametrize("logits_mb", [0, 1])
+def test_qsa_prefill_reuses_profiled_workspace(
+    workspace_init, monkeypatch: pytest.MonkeyPatch, logits_mb: int
+) -> None:
+    """Growing contexts reuse profiled storage without corrupting top-k selection."""
+    from vllm.models.qwen4_exp.nvidia import qsa as qsa_layer
+    from vllm.v1.worker.workspace import current_workspace_manager
+
+    monkeypatch.setenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", str(logits_mb))
+    max_model_len, compress_ratio, token_topk = 8192, 4, 2048
+    owner = SimpleNamespace(
+        indexer=SimpleNamespace(max_logits_width=max_model_len // compress_ratio)
+    )
+    monkeypatch.setattr(
+        qsa_layer, "get_forward_context", lambda: SimpleNamespace(attn_metadata=None)
+    )
+    dummy = torch.empty(5, 128, device="cuda")
+    qsa_layer.Qwen4ExpQSAAttention._run_qsa(
+        owner, dummy, torch.arange(5, device="cuda"), dummy, dummy, dummy, dummy
+    )
+    manager = current_workspace_manager()
+    manager.lock()
+    workspace, scratch = qsa_indexer_ops.get_qsa_prefill_workspace(
+        max_model_len // compress_ratio
+    )
+    assert workspace.data_ptr() + workspace.numel() * 4 <= scratch.data_ptr()
+    storage_ptrs = []
+    topk = qsa_indexer_ops._topk
+
+    def record_topk(logits, *args, **kwargs):
+        storage_ptrs.append(logits.data_ptr())
+        return topk(logits, *args, **kwargs)
+
+    monkeypatch.setattr(qsa_indexer_ops, "_topk", record_topk)
+    torch.manual_seed(2)
+    q = torch.randn(5, 4, 128, device="cuda", dtype=torch.bfloat16)
+    cache = torch.randn(32, 64, 1, 128, device="cuda", dtype=torch.bfloat16)
+    page_table = torch.arange(32, device="cuda", dtype=torch.int32).view(1, -1)
+    query_start_loc = torch.tensor([0, 5], device="cuda", dtype=torch.int32)
+    token_to_req = torch.zeros(5, device="cuda", dtype=torch.int32)
+    actual = torch.empty(
+        5, token_topk // compress_ratio, device="cuda", dtype=torch.int32
+    )
+    for context_len in (2048, 4096, 8192):
+        positions = torch.arange(context_len - 5, context_len, device="cuda")
+        visible = ((positions + 1) // compress_ratio).to(torch.int32)
+        workspace.fill_(float("nan"))
+        qsa_indexer_ops.qsa_select_paged_prefill(
+            q,
+            cache,
+            page_table,
+            query_start_loc,
+            visible,
+            token_topk,
+            compress_ratio,
+            5,
+            actual,
+            context_len,
+        )
+        expected = _qsa_select_paged_reference(
+            q,
+            cache,
+            page_table,
+            token_to_req,
+            positions,
+            torch.tensor([context_len], device="cuda"),
+            token_topk,
+            compress_ratio,
+        )
+        torch.testing.assert_close(actual.sort().values, expected.sort().values)
+    assert set(storage_ptrs) == {workspace.data_ptr()}
+
+
+@requires_qsa_kernels
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("seq_len_slack", [0, 1792])
 @pytest.mark.parametrize("force_chunk", [False, True])
 def test_qsa_prefill_selection_correctness(
+    workspace_init,
     monkeypatch: pytest.MonkeyPatch,
     seq_len_slack: int,
     force_chunk: bool,

--- a/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/indexer_qsa.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
 from vllm.transformers_utils.configs.qwen4_exp import (
     Qwen4ExpTextConfig,
 )
+from vllm.utils.math_utils import cdiv, round_up
 
 from ..common.qsa_cache import (
     QSACompressedKeyCache,
@@ -117,6 +118,9 @@ class QSAIndexer(nn.Module):
         self.index_head_dim = int(config.indexer_head_dim)
         self.token_topk = int(config.indexer_budget)
         self.compress_ratio = int(config.indexer_compress_ratio)
+        self.max_logits_width = round_up(
+            cdiv(vllm_config.model_config.max_model_len, self.compress_ratio), 64
+        )
         self.rotary_emb = rotary_emb
         self.use_fused_pre_indexer = _supports_fused_pre_indexer(
             rotary_emb,

--- a/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
+++ b/vllm/models/qwen4_exp/nvidia/ops/qsa_indexer.py
@@ -10,6 +10,7 @@ from vllm.model_executor.warmup.jit_warmup_triton_helper import (
 )
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
+from vllm.v1.worker.workspace import current_workspace_manager
 
 _TOPK_WORKSPACE_BYTES = 1024 * 1024
 _DECODE_BLOCK_N = 64
@@ -385,18 +386,15 @@ def _prefill_logits(
     query_start_loc: torch.Tensor,
     visible_blocks: torch.Tensor,
     max_query_len: int,
-    logits_width: int,
+    logits: torch.Tensor,
     query_offset: int,
-    num_queries: int,
-) -> torch.Tensor:
+) -> None:
+    num_queries, logits_width = logits.shape
     assert query_start_loc.shape == (page_table.shape[0] + 1,)
     assert visible_blocks.shape == (q.shape[0],)
     assert 0 <= query_offset <= query_offset + num_queries <= q.shape[0]
     assert 0 < logits_width <= page_table.shape[1] * k_cache.shape[1]
 
-    logits = torch.empty(
-        (num_queries, logits_width), dtype=torch.float32, device=q.device
-    )
     # tuned on GB300
     if k_cache.dtype == torch.float8_e4m3fn:
         TILE_R, STAGES, num_warps = 32, 2, 8
@@ -432,7 +430,6 @@ def _prefill_logits(
         STAGES=STAGES,
         num_warps=num_warps,
     )
-    return logits
 
 
 def expand_qsa_block_indices(
@@ -572,6 +569,18 @@ def qsa_select_paged_decode(
     )
 
 
+def get_qsa_prefill_workspace(logits_width: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reserve the logits budget and disjoint top-k scratch, also during profiling."""
+    max_logits_elems = max(
+        envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024 // 4, logits_width
+    )
+    logits, topk = current_workspace_manager().get_simultaneous(
+        ((max_logits_elems,), torch.float32),
+        ((_TOPK_WORKSPACE_BYTES,), torch.uint8),
+    )
+    return logits, topk
+
+
 def qsa_select_paged_prefill(
     q: torch.Tensor,
     k_cache: torch.Tensor,
@@ -612,25 +621,24 @@ def qsa_select_paged_prefill(
     logits_width = min(max(64, logits_width), page_table.shape[1] * k_cache.shape[1])
 
     # chunk the inputs to keep temp logits below VLLM_SPARSE_INDEXER_MAX_LOGITS_MB
-    max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
-    rows_per_chunk = max(1, max_logits_bytes // (logits_width * 4))
-    topk_workspace = torch.empty(
-        (_TOPK_WORKSPACE_BYTES,), dtype=torch.uint8, device=q.device
-    )
+    logits_workspace, topk_workspace = get_qsa_prefill_workspace(logits_width)
+    rows_per_chunk = logits_workspace.numel() // logits_width
 
     for query_start in range(0, rows, rows_per_chunk):
         query_end = min(query_start + rows_per_chunk, rows)
         query_slice = slice(query_start, query_end)
-        logits = _prefill_logits(
+        logits = logits_workspace[: (query_end - query_start) * logits_width].view(
+            -1, logits_width
+        )
+        _prefill_logits(
             q,
             k_cache,
             page_table,
             query_start_loc,
             visible_blocks,
             max_query_len,
-            logits_width,
+            logits,
             query_offset=query_start,
-            num_queries=query_end - query_start,
         )
         _topk(
             logits,

--- a/vllm/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm/models/qwen4_exp/nvidia/qsa.py
@@ -52,6 +52,7 @@ from vllm.v1.kv_cache_interface import (
 from ..common.qsa_cache import QSAForwardMetadata
 from . import model
 from .indexer_qsa import QSAIndexer
+from .ops.qsa_indexer import get_qsa_prefill_workspace
 
 
 class Qwen4ExpQSAMetadataBuilder(FlashAttentionMetadataBuilder):
@@ -358,6 +359,7 @@ class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
         if isinstance(metadata, list):
             metadata = metadata[0]
         if not isinstance(metadata, dict):
+            get_qsa_prefill_workspace(self.indexer.max_logits_width)
             output.zero_()
             return
         main_metadata = cast(FlashAttentionMetadata, metadata[self.layer_name])


### PR DESCRIPTION
## Purpose

Chunked QSA prefills allocate a progressively larger logits tensor as `max_seq_len` grows. The caching allocator can retain the previous sizes, so a per-tensor logits budget does not bound the memory retained across prefill steps. Addresses #56457.

Use the existing WorkspaceManager for a bounded logits buffer and disjoint top-k scratch. Reserve capacity in the QSA owner's profiling path, which returns before calling the indexer, and use compact tensor views for each inference chunk. This preserves the logical logits width, chunk sizes, kernel launches and top-k dispatch introduced by #54915. The existing manager supplies separate ubatch/workspace-lane storage; no new global cache or synchronization mechanism is added.

The reservation includes at least one logits row when the configured budget is smaller than a row. Reserving the configured budget during profiling moves that memory cost up front; it can increase live memory for short-only workloads when another operator has not already reserved a larger shared workspace.

## Validation

Base: `dc07f1638f73814b95776832b85df1cc92850416`. Local environment: RTX 4060 Laptop GPU (SM89, 8 GiB), PyTorch 2.11.0+cu130, existing prebuilt native extensions. This is not the repository's current PyTorch 2.13 CI environment.

- New regression: execute the real QSA owner profiling branch, lock the workspace, then run real prefill scoring/top-k through growing contexts with 0 MiB and 1 MiB budgets. Check storage reuse, separate scratch and reference selections after poisoning old logits. Restoring only the old allocation path makes both cases fail on the reuse assertion; the patch passes both.
- Full local sweep initially produced **96 passed, 7 failed**. Four FP8 prefill reference failures reproduce on the unmodified base with the same difference (maximum reported absolute difference 7.963e-5). Two attention cases request a 12.5 GiB input allocation on this 8 GiB GPU. One FP8 tiled pre-indexer comparison fails in the unchanged pre-indexer code.
- The final sweep explicitly excluding those seven cases: **96 passed, 7 deselected**.
- Changed-file pre-commit checks, including Ruff and mypy: passed.
- Small serving check: two-layer Qwen4Exp with real QSA, dummy weights, V1 eager runner, prefix caching off and 512-token prefill chunks. Prompt lengths 257, 2305 and 4097 each generated eight tokens; baseline and patch agreed on all 24 output tokens with the workspace locked. This is an integration smoke test, not a model-quality evaluation.

Commands for the full and final sweeps:

```bash
.venv/bin/python -m pytest \
  tests/models/qwen4_exp/test_qsa_reference.py \
  tests/models/qwen4_exp/test_qsa_pre_indexer.py \
  tests/models/qwen4_exp/test_config.py \
  tests/v1/worker/test_workspace.py -q

.venv/bin/python -m pytest \
  tests/models/qwen4_exp/test_qsa_reference.py \
  tests/models/qwen4_exp/test_qsa_pre_indexer.py \
  tests/models/qwen4_exp/test_config.py \
  tests/v1/worker/test_workspace.py -q \
  -k 'not (prefill_selection and dtype1) and not tp1_r2048 and not (tiled and indexer_dtype1)'
```

### Allocation and timing probes

Allocation-only probe: real wrapper and CUDA allocations, with scoring/top-k skipped to isolate allocation behavior; 3,200 query rows, 12 layer calls per step, 16 growing contexts from 3,200 to 51,200 tokens, default 512 MiB budget and native allocator.

| Measurement | Base | Patch |
| --- | ---: | ---: |
| Reserved memory, first → last step | 34 → 1,370 MiB | 536 → 536 MiB |
| Additional device allocations after first step | 15 | 0 |
| Peak live tensor memory | 171.90 MiB | 528.65 MiB |

The larger live reservation is intentional. These numbers establish bounded storage reuse in this probe; they are not a GB10 hang reproduction or a universal memory-saving claim.

Separate real-kernel probe: BF16, four query heads, head dimension 128, identical inputs and native top-k. Valid logits and selected score multisets were bit-exact across the two implementations. For the 3,200-token cold-prefill case, selected indices can differ at ties; repeated baseline runs also differ, consistent with the existing top-k determinism work in #55122.

Median GPU times from three alternating rounds, FlashInfer CUPTI, CUDA graphs and cold L2:

| Query rows / context tokens | Base | Patch |
| --- | ---: | ---: |
| 128 / 4,096 | 112.192 µs | 112.098 µs |
| 3,200 / 3,200 | 342.525 µs | 342.707 µs |
| 3,200 / 32,768 | 2,176.069 µs | 2,174.980 µs |

A separate warmed eager-wrapper wall-time check, including Python/allocation overhead, was approximately unchanged: median differences -0.2%, +0.0%, +1.0% for these shapes. These are local microbenchmarks, not serving-latency or model-throughput claims.

## Remaining validation and related work

- The GB10 report's full Qwen3.8-Flash-Next workload and model-quality evaluation require suitable hardware and remain pending.
- V2 integration could not start in this WSL environment: its UVA buffer constructor raises `RuntimeError: UVA is not available`, before reaching QSA.
- Keep this as a draft pending human line-by-line review and the remaining platform validation.

Duplicate checks covered the issue discussion, open PRs referencing #56457, and QSA workspace/allocation/allocator searches. No open PR implementing this storage-reuse fix was found as of 2026-09-12. #54915 is the existing compact-width optimization being preserved; #55122 concerns top-k determinism; #56240 adds a different attention backend.

AI assistance: OpenAI Codex assisted with investigation, implementation, tests, benchmarks and a second pass through the complete diff and actual call chain. No claim is made that a human has already reviewed every changed line or run these commands.
