### PR TITLE
[Test][EC Connector] Add the no-NIXL import test the docs refer to

### DIFF
--- a/docs/features/ec_cpu_connector.md
+++ b/docs/features/ec_cpu_connector.md
@@ -8,7 +8,7 @@ Setting `ec_enable_nixl: true` in `ec_connector_extra_config` additionally enabl
 ## Prerequisites
 
 - `ECCPUConnector` requires the V2 model runner: `VLLM_USE_V2_MODEL_RUNNER=1`. It raises `ValueError` at construction otherwise.
-- Local CPU-tier offload (`ec_enable_nixl` unset or `false`) needs no extra packages — the gate-off code path (`cpu/connector.py`, `cpu/scheduler/`, `cpu/worker/`, `cpu/common.py`) imports no `nixl`/`zmq`/`msgspec`, enforced by a repo test (`tests/v1/ec_connector/unit/test_no_nixl_imports.py`).
+- Local CPU-tier offload (`ec_enable_nixl` unset or `false`) needs no extra packages — the gate-off code path (`cpu/connector.py`, `cpu/scheduler/`, `cpu/worker/`, `cpu/common.py`) imports neither `nixl` nor the P2P transport modules, enforced by a repo test (`tests/v1/ec_connector/unit/test_no_nixl_imports.py`).
 - P2P NIXL mode (`ec_enable_nixl: true`) requires the `nixl` package: `uv pip install nixl` (pinned to `nixl==1.3.2` in `requirements/kv_connectors.txt`, shared with `NixlConnector`). Refer to the [NIXL repository](https://github.com/ai-dynamo/nixl) for platform-specific installation. If `nixl` isn't importable, the connector raises `RuntimeError: ec_enable_nixl requires NIXL; install the nixl package or remove ec_enable_nixl from ec_connector_extra_config.`
 
 ## Basic Usage

--- a/tests/v1/ec_connector/unit/test_no_nixl_imports.py
+++ b/tests/v1/ec_connector/unit/test_no_nixl_imports.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""With ec_enable_nixl off, ECCPUConnector must not import NIXL or the P2P
+transport modules. ECCPUScheduler._setup_nixl imports them lazily."""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = pytest.mark.cpu_test
+
+_CPU = "vllm.distributed.ec_transfer.ec_connector.cpu"
+
+GATE_OFF_MODULES = [
+    f"{_CPU}.connector",
+    f"{_CPU}.common",
+    f"{_CPU}.scheduler",
+    f"{_CPU}.worker",
+]
+
+P2P_MODULES = [
+    f"{_CPU}.control.zmq",
+    f"{_CPU}.data.nixl",
+    f"{_CPU}.protocol",
+    f"{_CPU}.session",
+]
+
+
+def test_gate_off_path_does_not_import_nixl():
+    # Fresh interpreter, since other tests in the session import NIXL.
+    script = textwrap.dedent(f"""
+        import importlib
+        import importlib.abc
+        import sys
+
+        attempted = []
+
+        class RecordNixl(importlib.abc.MetaPathFinder):
+            # Catches the attempt even when NIXL is not installed and the
+            # caller swallows the ImportError.
+            def find_spec(self, name, path, target=None):
+                if name.partition(".")[0] in ("nixl", "nixl_rocm"):
+                    attempted.append(name)
+                return None
+
+        sys.meta_path.insert(0, RecordNixl())
+        for mod in {GATE_OFF_MODULES!r}:
+            importlib.import_module(mod)
+
+        assert not attempted, f"NIXL imported: {{attempted}}"
+        leaked = [m for m in {P2P_MODULES!r} if m in sys.modules]
+        assert not leaked, f"P2P modules imported: {{leaked}}"
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Purpose

Closes #56507.

`docs/features/ec_cpu_connector.md` says NIXL is kept off the gate-off path of `ECCPUConnector`, and that a repo test enforces this: `tests/v1/ec_connector/unit/test_no_nixl_imports.py`. That test was never added, so nothing would catch someone hoisting the lazy imports in `ECCPUScheduler._setup_nixl` to module level.

This PR adds it. The test imports `cpu.connector`, `cpu.common`, `cpu.scheduler` and `cpu.worker` in a fresh interpreter. It fails if a `nixl`/`nixl_rocm` import is attempted, or if any P2P module (`control.zmq`, `data.nixl`, `protocol`, `session`) gets loaded. It records import attempts with a meta-path finder instead of looking at `sys.modules`, because the CPU CI image has no NIXL and `nixl_utils` swallows the ImportError.

The doc sentence also listed `zmq` and `msgspec`, but these modules do load `zmq` via `vllm.distributed.parallel_state`. Both packages are core deps, so the sentence now names only `nixl` and the P2P modules.

No open PR or issue touches this test (searched `test_no_nixl_imports`, `no_nixl`, `ECCPUConnector nixl import`).

cc @omerpaz95

## Test Plan

```bash
pytest tests/v1/ec_connector/unit/test_no_nixl_imports.py -v
# Each of these mutations must make the test fail:
#   1. hoist the cpu.session import in cpu/scheduler/__init__.py to module level
#   2. resolve nixl_utils.NixlWrapper when cpu/connector.py is imported
cd tests && pytest -m cpu_test v1/ec_connector/unit
pre-commit run --files tests/v1/ec_connector/unit/test_no_nixl_imports.py docs/features/ec_cpu_connector.md
```

## Test Result

Ran on a CPU-only node (torch 2.13.0+cpu, NIXL not installed):

- new test: 1 passed
- mutation 1: fails with `P2P modules imported: ['...cpu.control.zmq', '...cpu.protocol', '...cpu.session']`
- mutation 2: fails with `NIXL imported: ['nixl']`
- `pytest -m cpu_test v1/ec_connector/unit`: 11 passed, 279 deselected
- pre-commit: all hooks passed

After importing the four gate-off modules, `zmq` is in `sys.modules` and `msgspec` isn't.

AI assistance (Claude) was used; I reviewed every changed line and ran the tests above.
