### PR TITLE
[Perf][Kimi-K3] Make GEMM-AR SM margin configurable

### DIFF
--- a/tests/kernels/test_kimi_k3_gemm_rs_ar.py
+++ b/tests/kernels/test_kimi_k3_gemm_rs_ar.py
@@ -130,7 +130,7 @@ def _run_mode(
         assert first_output.data_ptr() != second_output.data_ptr()
         torch.testing.assert_close(first_output, first_snapshot, rtol=0, atol=0)
 
-    graph_M, graph_K = 1025, 4224
+    graph_M, graph_K = 4097, 4224
     input_generator.manual_seed(3000)
     graph_x = torch.randn(
         graph_M,

--- a/tests/kernels/test_kimi_k3_gemm_rs_ar.py
+++ b/tests/kernels/test_kimi_k3_gemm_rs_ar.py
@@ -23,7 +23,7 @@ _SHAPES = (
     (1024, 4224),
     (8191, 4224),
 )
-_N = 512
+_N = 1024
 
 
 def _reference(
@@ -201,6 +201,15 @@ def _worker(local_rank: int, world_size: int, master_port: int) -> None:
     group = dist.group.WORLD
     rank = dist.get_rank(group)
 
+    from vllm.models.kimi_k3.nvidia.ops.cute_dsl.gemm_rs_ar import GemmRsAr
+
+    num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    with pytest.MonkeyPatch.context() as patch:
+        for invalid_margin in (-1, num_sms - 1, num_sms):
+            patch.setenv("VLLM_KIMI_K3_GEMM_AR_SM_MARGIN", str(invalid_margin))
+            with pytest.raises(ValueError, match="must leave at least two SMs"):
+                GemmRsAr(max_M=1024, N=_N, all_reduce=True)
+
     weight_generator = torch.Generator(device=device)
     weights = {}
     for K in {K for _, K in _SHAPES}:
@@ -228,17 +237,21 @@ def _worker(local_rank: int, world_size: int, master_port: int) -> None:
 
 
 @pytest.mark.distributed(num_gpus=2)
+@pytest.mark.parametrize("sm_margin", [0, 7, 8])
 @pytest.mark.skipif(
     not current_platform.is_device_capability_family(100),
     reason="Kimi-K3 GEMM-RS/AR requires SM100",
 )
-def test_kimi_k3_gemm_rs_ar(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_kimi_k3_gemm_rs_ar(monkeypatch: pytest.MonkeyPatch, sm_margin: int) -> None:
     world_size = 2
     if torch.accelerator.device_count() < world_size:
         pytest.skip("GEMM-RS/AR requires two GPUs")
 
     monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
     monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
+    # Exercise capped grids, odd margins rounded for 2-CTA clusters, and
+    # unchanged RS behavior through the existing eager/graph reuse checks.
+    monkeypatch.setenv("VLLM_KIMI_K3_GEMM_AR_SM_MARGIN", str(sm_margin))
     try:
         mp.spawn(
             _worker,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -211,6 +211,7 @@ if TYPE_CHECKING:
     VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT: bool = False
     VLLM_KIMI_K3_AUX_ATTN_RES_STREAM: bool = False
     VLLM_KIMI_K3_GEMM_AR: bool = True
+    VLLM_KIMI_K3_GEMM_AR_SM_MARGIN: int = 0
     VLLM_KIMI_K3_GEMM_RS: bool = False
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
@@ -1610,6 +1611,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use the SM100 BF16 GEMM-AR kernel for eligible Kimi-K3 row-parallel
     # attention projections. All TP ranks must belong to one NVLink domain.
     "VLLM_KIMI_K3_GEMM_AR": lambda: bool(int(os.getenv("VLLM_KIMI_K3_GEMM_AR", "1"))),
+    # Reduce the persistent GEMM-AR CTA budget to leave room for concurrent
+    # kernels (for example PP communication). Does not affect GEMM-RS.
+    "VLLM_KIMI_K3_GEMM_AR_SM_MARGIN": lambda: int(
+        os.getenv("VLLM_KIMI_K3_GEMM_AR_SM_MARGIN", "0")
+    ),
     # Use the SM100 BF16 GEMM-RS kernel for eligible Kimi-K3 sequence-parallel
     # row-parallel projections. All TP ranks must belong to one NVLink domain.
     "VLLM_KIMI_K3_GEMM_RS": lambda: bool(int(os.getenv("VLLM_KIMI_K3_GEMM_RS", "0"))),

--- a/vllm/models/kimi_k3/nvidia/ops/cute_dsl/gemm_rs_ar.py
+++ b/vllm/models/kimi_k3/nvidia/ops/cute_dsl/gemm_rs_ar.py
@@ -20,6 +20,7 @@ from cutlass.cute.runtime import make_fake_stream, make_fake_tensor, make_ptr, n
 from cutlass.cutlass_dsl import dsl_user_op
 from cutlass.utils import get_smem_capacity_in_bytes
 
+from vllm import envs
 from vllm.cute_utils import _tcgen05, mbarrier, simple_tma_copy, to_cta0_smem
 from vllm.distributed import get_tp_group
 from vllm.logger import init_logger
@@ -728,6 +729,16 @@ class GemmRsAr:
         self.device = device
         self.all_reduce = all_reduce
 
+        num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+        sm_margin = envs.VLLM_KIMI_K3_GEMM_AR_SM_MARGIN if all_reduce else 0
+        if not 0 <= sm_margin <= num_sms - 2:
+            raise ValueError(
+                "VLLM_KIMI_K3_GEMM_AR_SM_MARGIN must leave at least two SMs "
+                f"for a 2-CTA cluster; got {sm_margin} on a {num_sms}-SM GPU"
+            )
+        # This caps the CTA grid; it does not reserve particular physical SMs.
+        self.num_sms = num_sms - sm_margin
+
         self.partial = symm_mem.empty((max_M, N), dtype=torch.bfloat16, device=device)
         self.partial_handle = symm_mem.rendezvous(self.partial, group)
         if self.partial_handle.multicast_ptr == 0:
@@ -742,8 +753,7 @@ class GemmRsAr:
         grid_m = (max_M + 127) // 128
         cta_group = 2 if max_M >= 1024 or grid_m % 2 == 0 else 1
         grid_m = (grid_m + cta_group - 1) // cta_group * cta_group
-        self.num_sms = torch.cuda.get_device_properties(device).multi_processor_count
-        max_flags = grid_m * (N // 128) + self.num_sms
+        max_flags = grid_m * (N // 128) + num_sms
         self.flags = symm_mem.empty(max_flags, dtype=torch.int32, device=device)
         self.flags_handle = symm_mem.rendezvous(self.flags, group)
         if self.flags_handle.multicast_ptr == 0:


### PR DESCRIPTION
## Purpose

Kimi-K3 fused GEMM-AR can be faster in isolation but slower during TP8 + PP2 serving. Add `VLLM_KIMI_K3_GEMM_AR_SM_MARGIN` to reduce its persistent CTA budget so concurrent kernels have room to run. The default is 0; setting it to 8 on B200 caps the grid at 140 CTAs instead of 148. Existing 2-CTA cluster rounding is preserved, invalid margins are rejected before workspace allocation, and GEMM-RS is unchanged. This limits the grid; it does not reserve specific physical SMs.

Related to #55261, but independent of its Lamport backend and crossover work. Searches found no open PR providing this SM-margin control. This PR does not change the crossover or claim that PP contention is the only source of latency. The environment-variable documentation includes the new setting through its existing `envs.py` inclusion.

## Test Plan

```bash
pre-commit run --files vllm/envs.py \
  vllm/models/kimi_k3/nvidia/ops/cute_dsl/gemm_rs_ar.py \
  tests/kernels/test_kimi_k3_gemm_rs_ar.py

# Pending on the PR checkout; requires two SM100 GPUs.
.venv/bin/python -m pytest tests/kernels/test_kimi_k3_gemm_rs_ar.py -v
```

The existing distributed numerical test is extended to margins 0, 7, and 8, invalid margins, alternating shapes, output lifetime, CUDA Graph replay, and unaffected RS behavior. N is increased to 1024 so the largest shape actually reaches the CTA cap.

### Deploy

Run on both nodes, setting `NODE_RANK=0` on the API node and `NODE_RANK=1` on the worker. Set `MODEL`, `DRAFT_MODEL`, and `HEAD_IP` to the local model paths and head address. Compare AR off, AR on with margin 0, and AR on with margin 8.

```bash
export VLLM_USE_V2_MODEL_RUNNER=1 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1
export GLOO_SOCKET_IFNAME=bond0 NCCL_SOCKET_IFNAME=bond0
export VLLM_KIMI_K3_GEMM_AR=1 VLLM_KIMI_K3_GEMM_AR_SM_MARGIN=8
export VLLM_SERVER_DEV_MODE=1
NODE_ARGS=(--host 0.0.0.0 --port 8008)
if [[ "$NODE_RANK" == 1 ]]; then NODE_ARGS=(--headless); fi

vllm serve "$MODEL" --trust-remote-code --seed 0 --served-model-name k3 \
  --tensor-parallel-size 8 --pipeline-parallel-size 2 --nnodes 2 \
  --node-rank "$NODE_RANK" --distributed-executor-backend mp \
  --master-addr "$HEAD_IP" --master-port 29521 \
  --attention-backend FLASHINFER_MLA \
  --attention-config '{"mla_prefill_backend":"FLASHINFER","use_prefill_query_quantization":true}' \
  --kv-cache-dtype fp8 --no-enable-flashinfer-autotune \
  --max-model-len 1048576 --max-num-batched-tokens 16000 --max-num-seqs 96 \
  --gpu-memory-utilization 0.90 --enable-prompt-tokens-details \
  --mamba-backend triton --mamba-cache-mode align --enable-prefix-caching \
  --additional-config '{"kda_decode_backend":"triton"}' \
  --speculative-config "{\"method\":\"dspark\",\"model\":\"$DRAFT_MODEL\",\"num_speculative_tokens\":8,\"enable_adaptive_verification\":false,\"rejection_sample_method\":\"synthetic\",\"synthetic_acceptance_length\":4}" \
  "${NODE_ARGS[@]}"
```

### Benchmark

Warm up with 96 requests and 128 output tokens, then run the following twice. Reset the prefix cache before each run. Loading and warmup are excluded from the reported throughput.

```bash
curl --fail -X POST http://127.0.0.1:8008/reset_prefix_cache
vllm bench serve --backend vllm --base-url http://127.0.0.1:8008 \
  --endpoint /v1/completions --model k3 --tokenizer "$MODEL" --trust-remote-code \
  --dataset-name random --random-input-len 8192 --random-output-len 1024 \
  --random-range-ratio 0 --random-prefix-len 0 --num-prompts 960 \
  --max-concurrency 96 --request-rate inf --ignore-eos --temperature 0 --seed 42 \
  --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 50,95,99 \
  --save-result
```

## Test Result

Two nodes, 8 × B200 each; TP8, PP2, DCP1; full Kimi-K3 with DSpark 8, synthetic acceptance length 4, snapshot state recovery. Each row summarizes two 960-request runs at concurrency 96 with fixed 8192-token input and 1024-token output. Every request succeeded and produced the requested token count. These are controlled performance measurements, not a quality or real-acceptance evaluation.

| Configuration | Output tokens/s, run 1 / run 2 | Mean output tokens/s | vs. AR off | Mean TTFT (ms) | Mean TPOT (ms) |
|---|---:|---:|---:|---:|---:|
| AR off | 2266.8 / 2282.5 | 2274.7 | baseline | 6573.2 | 35.00 |
| AR on, margin 0 | 1776.1 / 1783.6 | 1779.8 | -21.8% | 9339.5 | 44.04 |
| AR on, margin 8 | 2320.3 / 2337.5 | 2328.9 | +2.4% | 6488.4 | 34.11 |

Margin 8 recovers the large regression versus margin 0 (+30.8%), but the incremental gain over disabling fusion is only +2.4%. The two AR-on configurations had identical KV cache capacity; AR off had about 0.32% more. A later two-run AR-off recheck measured 2268.6 / 2283.6 output tokens/s (mean 2276.1, +0.06% versus the initial baseline), supporting the stability of this small gain.

Isolated BF16 GEMM-AR sweeps on both nodes covered M=128 through 16000, K=1536/4224, N=7168, margins 0/8, with numerical checks against GEMM + all-reduce. Most shapes changed little; the large dense shape (M=16000, K=4224) regressed by about 4–5% with margin 8. This is why the setting remains opt-in rather than selecting a hardware-wide default.

Provenance: serving measurements used source `30aa0ade39ab6625674865f578fae19a49cf3e43`, Torch 2.13.0+cu130 and FlashInfer 0.6.18.post1, with an experimental wrapper applying the same CTA cap. The underlying GEMM-RS/AR file matches this PR's base. All arms shared a DSpark draft-loader configuration fix and an isolated current-source grouped-FP8-cache operator to bridge the older image's native ABI. Measured startup used fastsafetensors for the main model and auto for the draft; the reproduction command above uses the default loader, which changes startup rather than the timed inference path. Focused GPU checks loaded this PR's exact kernel and environment-variable implementation into the established runtime on all 16 GPUs. The PR test's numerical, output-lifetime and CUDA Graph checks passed for RS and AR at margins 0/7/8; invalid margins -1/147/148 were rejected. These checks reused the test function bodies directly; the full pytest command on the complete PR checkout remains pending.

A controlled TP8+PP2 overlap probe delayed one PP sender by 5 ms. At M=16000, K=1536, N=7168, the original kernel at margin 0 increased from 585.8 us without PP traffic to 4712.1 us with the delayed PP operation; margin 8 measured 585.8 us in both cases (50-sample median of maximum TP-rank CUDA-event latency). This supports a concurrent-resource contention explanation, without identifying the exact limiting per-SM resource.

Local pre-commit checks passed, including Ruff, spelling, mypy, and repository checks. AI assistance was used for implementation, analysis, and test execution. Human review is pending; no human-run validation is claimed.
