### PR TITLE
[Bugfix] Remove activation override in test_flashinfer_cutedsl_fp4_moe

### DIFF
--- a/tests/kernels/moe/test_flashinfer_cutedsl_nvfp4_moe.py
+++ b/tests/kernels/moe/test_flashinfer_cutedsl_nvfp4_moe.py
@@ -193,7 +193,6 @@ def test_flashinfer_cutedsl_fp4_moe(
             hidden_states, score, topk, renormalize=False
         )
 
-        activation = MoEActivation.RELU2_NO_MUL
         moe_config = FusedMoEConfig(
             num_experts=e,
             experts_per_token=topk,


### PR DESCRIPTION
## Summary

- Fixes #56504
- `test_flashinfer_cutedsl_fp4_moe` is parametrized over 5 activations (`silu`, `silu-clamp`, `relu2_no_mul`, `swigluoai`, `swigluoai_uninterleave`), but an unconditional `activation = MoEActivation.RELU2_NO_MUL` reassignment (introduced in #48355) overwrote the parametrized value before it reached the kernel call or the reference comparison. Every case has actually been exercising `RELU2_NO_MUL` since then, regardless of its test ID -- zero real coverage for the other 4 cases.
- `activation` was already correctly bound from the function's own `@pytest.mark.parametrize`; the reassignment served no purpose and looks like leftover local-debugging code that wasn't removed before merge.

## Why this isn't duplicating existing work

Searched open issues/PRs for `test_flashinfer_cutedsl_nvfp4_moe`, `RELU2_NO_MUL cutedsl`, and related terms before filing #56504 and this PR -- no existing report or fix found.

## Test plan

- Removed the override line and re-ran all 5 parametrize cases on a live GPU.
- Each case now exercises its own distinct activation and produces its own distinct result, instead of all non-`relu2_no_mul` cases converging on `relu2_no_mul` behavior as before the fix.
- `silu` now passes cleanly where it previously silently ran the wrong activation.

This is a one-line test-only change (no model-output-affecting code touched), so no model eval was run.

## AI assistance disclosure

Found, root-caused, and fixed with AI assistance (Claude Code) while investigating an unrelated test failure. The change was reviewed line-by-line and verified manually on a live GPU by a human (me) before submission.
