### PR TITLE
[Doc] Fix prompt_lookup_min/max defaults in SpeculativeConfig docstrings

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2758,6 +2758,24 @@ def test_draft_sample_method_probabilistic_is_accepted():
     assert speculative_config.draft_sample_method == "probabilistic"
 
 
+@pytest.mark.parametrize(
+    ("lookup_min", "lookup_max", "expected"),
+    [(None, None, (5, 5)), (None, 3, (3, 3)), (2, None, (2, 2)), (2, 4, (2, 4))],
+)
+def test_ngram_prompt_lookup_defaults(lookup_min, lookup_max, expected):
+    """An omitted bound mirrors the other one; both omitted gives 5."""
+    speculative_config = SpeculativeConfig(
+        method="ngram",
+        num_speculative_tokens=1,
+        prompt_lookup_min=lookup_min,
+        prompt_lookup_max=lookup_max,
+    )
+    assert (
+        speculative_config.prompt_lookup_min,
+        speculative_config.prompt_lookup_max,
+    ) == expected
+
+
 @pytest.mark.parametrize("disable_eagle_block_drop", [False, True])
 def test_eagle_block_drop_can_be_disabled_without_disabling_eagle(
     disable_eagle_block_drop: bool,

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -456,11 +456,13 @@ class SpeculativeConfig:
 
     # Ngram proposer configuration
     prompt_lookup_max: int | None = Field(default=None, ge=1)
-    """Maximum size of ngram token window when using Ngram proposer, required
-    when method is set to ngram."""
+    """Maximum size of ngram token window when using Ngram proposer. If
+    omitted, it defaults to `prompt_lookup_min`, or to 5 when both are
+    omitted."""
     prompt_lookup_min: int | None = Field(default=None, ge=1)
-    """Minimum size of ngram token window when using Ngram proposer, if
-    provided. Defaults to 1."""
+    """Minimum size of ngram token window when using Ngram proposer. If
+    omitted, it defaults to `prompt_lookup_max`, or to 5 when both are
+    omitted."""
 
     # Alternative drafting strategies
     parallel_drafting: bool = False


### PR DESCRIPTION
## Purpose

Closes #56516.

The `SpeculativeConfig` docstrings give the wrong defaults. The `prompt_lookup_max` one says it's required for ngram, and the `prompt_lookup_min` one says it defaults to 1. What `__post_init__` actually does:

- if both are omitted, it sets both to 5
- if only one is given, it copies that value into the other

The table in `docs/features/speculative_decoding/README.md` already describes this correctly.

With the current wording, `{"method": "ngram", "prompt_lookup_max": 4}` looks like it matches 1- to 4-grams, but it only matches 4-grams.

This PR rewords both docstrings and adds a parametrized test for the defaults, which had no coverage.

No open PR or issue covers this. I searched for `prompt_lookup_min`, `prompt_lookup_max`, `ngram docstring` and `ngram default prompt_lookup`.

## Test Plan

```bash
pytest tests/test_config.py -k "ngram_prompt_lookup_defaults"
pytest tests/test_config.py -k "draft_sample_method or ngram or speculative"
pre-commit run --files tests/test_config.py vllm/config/speculative.py
```

## Test Result

Ran on a CPU-only node with torch 2.13.0+cpu.

- `-k ngram_prompt_lookup_defaults`: 4 passed
- `-k "draft_sample_method or ngram or speculative"`: 33 passed
- With `__post_init__` changed so that an omitted `prompt_lookup_min` becomes 1, which is what the old docstring says, the new test fails with `assert (1, 3) == (3, 3)`.
- pre-commit: all hooks passed

AI assistance (Claude) was used; I reviewed every changed line and ran the tests above.
