### PR TITLE
[CI] Limit retries to PRs within 50 commits of the target branch

### DIFF
--- a/.github/workflows/scripts/run_ci_command.py
+++ b/.github/workflows/scripts/run_ci_command.py
@@ -59,6 +59,7 @@ RETRY_COMMANDS = frozenset({COMMAND_RETRY_FAILED, COMMAND_RETRY_AMD_FAILED})
 CANCEL_COMMANDS = frozenset({COMMAND_CANCEL_CI, COMMAND_CANCEL_AMD_CI})
 ALL_CI_COMMANDS = UPSTREAM_CI_COMMANDS | AMD_CI_COMMANDS
 CI_AUTHORIZED_COMMENT_MARKER = "<!-- vllm-ci-authorized -->"
+MAX_RETRY_COMMITS_BEHIND_BASE = 50
 READY_LABELS = {"ready", "ready-run-all-tests"}
 TRUSTED_PERMISSIONS = {"admin", "maintain", "write"}
 ACTIVE_BUILD_STATES = {
@@ -775,6 +776,8 @@ def notify_authorized(
             "target branch. Merge or rebase onto the latest target branch, then "
             "rerun the command. Append `--allow-stale` to a run command to test "
             "an outdated branch at your own risk.\n"
+            f"- Retries allow at most {MAX_RETRY_COMMITS_BEHIND_BASE} commits "
+            "behind the upstream target branch.\n"
             "- `/ci retry` retries failed jobs in the CI build for the current "
             "PR head. If the current head has no CI build, it starts a new CI "
             "build for the current head containing only jobs that failed in "
@@ -828,7 +831,11 @@ def prepare_pr_for_ci(
     command: str,
 ) -> tuple[dict[str, Any], str]:
     base_ref = pr["base"]["ref"]
-    no_action = "No new CI build was started."
+    no_action = (
+        "No CI build was started or retried."
+        if command in RETRY_COMMANDS
+        else "No new CI build was started."
+    )
     try:
         behind = github.get_commits_behind_base(base_ref, pr["head"]["sha"])
         current_pr = github.get_pr(pr["number"])
@@ -861,13 +868,24 @@ def prepare_pr_for_ci(
             print(warning)
         return current_pr, warning
 
-    if behind:
-        raise CiPreparationError(
-            f"{lag} Your branch must contain every commit currently on upstream "
-            f"`{base_ref}`. {no_action} "
-            f"Merge or rebase onto the latest `{base_ref}`, then rerun `{command}`."
+    max_behind = MAX_RETRY_COMMITS_BEHIND_BASE if command in RETRY_COMMANDS else 0
+    if behind > max_behind:
+        requirement = (
+            f"Retries allow at most {max_behind} commits behind the target branch."
+            if command in RETRY_COMMANDS
+            else f"Your branch must contain every commit currently on upstream "
+            f"`{base_ref}`."
+        )
+        override_hint = (
             " To test this branch at your own risk, "
             f"use `{command}{ALLOW_STALE_SUFFIX}`."
+            if command in RUN_CI_COMMAND_ENV
+            else ""
+        )
+        raise CiPreparationError(
+            f"{lag} {requirement} {no_action} "
+            f"Merge or rebase onto the latest `{base_ref}`, then rerun `{command}`."
+            f"{override_hint}"
         )
     return current_pr, ""
 
@@ -944,6 +962,7 @@ def handle_retry_failed(
                 f"{ci_name} was already requested by this comment: {build['web_url']}"
             )
 
+        prepare_pr_for_ci(github, pr, command)
         retried = buildkite.retry_failed_jobs(build["number"], RETRY_STATES)
         if retried["retried_jobs_count"] == 0:
             return (
@@ -1012,12 +1031,7 @@ def handle_retry_failed(
             f"({source_build['web_url']})."
         )
 
-    current_pr = github.get_pr(pr["number"])
-    if current_pr["state"] != "open" or current_pr["head"]["sha"] != pr["head"]["sha"]:
-        return (
-            "The PR head changed while processing the command. "
-            f"Comment `{retry_command}` again."
-        )
+    current_pr, _ = prepare_pr_for_ci(github, pr, retry_command)
 
     retry_build = buildkite.create_build(
         create_retry_build_payload(

--- a/.github/workflows/scripts/test_run_ci_command.py
+++ b/.github/workflows/scripts/test_run_ci_command.py
@@ -678,17 +678,23 @@ class RunCiCommandTest(unittest.TestCase):
                     )
                     self.assertEqual(transport.calls[0]["method"], "GET")
 
-    def test_unknown_lag_or_changed_pr_prevents_runs(self) -> None:
+    def test_unknown_lag_or_changed_pr_prevents_runs_and_retries(self) -> None:
         for command in (
             COMMAND_RUN_CI,
             COMMAND_RUN_AMD_CI,
             f"{COMMAND_RUN_CI} --allow-stale",
             f"{COMMAND_RUN_AMD_CI} --allow-stale",
+            COMMAND_RETRY_FAILED,
+            COMMAND_RETRY_AMD_FAILED,
         ):
             for fault in ("api", "head", "closed", "base"):
                 with self.subTest(command=command, fault=fault):
                     github = FakeGitHub()
-                    buildkite = FakeBuildkite([[], []])
+                    buildkite = FakeBuildkite(
+                        [[{"number": 123, "pull_request": {"id": 42}}]]
+                        if " retry" in command
+                        else [[], []]
+                    )
 
                     def check(
                         base_ref: str,
@@ -716,6 +722,55 @@ class RunCiCommandTest(unittest.TestCase):
                     self.assertEqual(buildkite.retry_calls, [])
                     self.assertTrue(github.comments[0].startswith("❌ "))
                     self.assertNotIn("Triggered", github.comments[0])
+
+    def test_retries_allow_at_most_50_commits_behind_base(self) -> None:
+        source = {
+            "number": 122,
+            "commit": "earlier-head",
+            "pull_request": {"id": 42},
+            "state": "failed",
+            "finished_at": "2026-07-28T02:00:00Z",
+            "web_url": "https://buildkite.example/builds/122",
+        }
+        for command, new_head in (
+            (COMMAND_RETRY_FAILED, False),
+            (COMMAND_RETRY_AMD_FAILED, False),
+            (COMMAND_RETRY_FAILED, True),
+        ):
+            for behind in (0, 50, 51, 100):
+                with self.subTest(command=command, new_head=new_head, behind=behind):
+                    github = FakeGitHub(
+                        behind=behind, pr=make_pr(base={"ref": "release/1.0"})
+                    )
+                    buildkite = FakeBuildkite(
+                        [[], [source]] if new_head else [[source]],
+                        [[{"type": "script", "step_key": "cpu-tests"}]],
+                    )
+                    run(make_event(command), github, buildkite)
+
+                    self.assertEqual(
+                        github.lag_queries,
+                        [("release/1.0", github.pr["head"]["sha"])],
+                    )
+                    if behind <= 50:
+                        if new_head:
+                            self.assertEqual(len(buildkite.created_builds), 1)
+                            self.assertEqual(
+                                buildkite.created_builds[0]["commit"],
+                                github.pr["head"]["sha"],
+                            )
+                        else:
+                            self.assertEqual(
+                                buildkite.retry_calls, [(122, RETRY_STATES)]
+                            )
+                    else:
+                        self.assertEqual(buildkite.created_builds, [])
+                        self.assertEqual(buildkite.retry_calls, [])
+                        self.assertIn(
+                            f"{behind} commits behind upstream `release/1.0`",
+                            github.comments[0],
+                        )
+                        self.assertIn("50", github.comments[0])
 
     def test_amd_run_ignores_blocked_builds(self) -> None:
         for metadata in ({}, {"github-comment-id": "98"}):
@@ -1036,7 +1091,6 @@ class RunCiCommandTest(unittest.TestCase):
 
     def test_ci_retry_retries_failed_jobs_while_build_is_running(self) -> None:
         github = FakeGitHub(
-            behind=100,
             permission="read",
             pr=make_pr(labels=[{"name": "ready"}]),
         )
@@ -1056,12 +1110,11 @@ class RunCiCommandTest(unittest.TestCase):
         run(make_event(COMMAND_RETRY_FAILED, "author"), github, buildkite)
 
         self.assertEqual(buildkite.retry_calls, [(123, RETRY_STATES)])
-        self.assertEqual(github.lag_queries, [])
+        self.assertEqual(github.lag_queries, [("main", "0123456789abcdef")])
         self.assertIn("Queued 3 failed job", github.comments[0])
 
     def test_amd_ci_retry_retries_only_the_current_head_build(self) -> None:
         github = FakeGitHub(
-            behind=100,
             permission="read",
             pr=make_pr(labels=[{"name": "ready"}]),
         )
@@ -1082,7 +1135,7 @@ class RunCiCommandTest(unittest.TestCase):
         run(make_event(COMMAND_RETRY_AMD_FAILED, "author"), github, buildkite)
 
         self.assertEqual(buildkite.retry_calls, [(321, RETRY_STATES)])
-        self.assertEqual(github.lag_queries, [])
+        self.assertEqual(github.lag_queries, [("main", "0123456789abcdef")])
         self.assertIn("Buildkite AMD CI #321", github.comments[0])
 
     def test_amd_ci_retry_requires_a_build_for_the_current_head(self) -> None:
@@ -1104,7 +1157,6 @@ class RunCiCommandTest(unittest.TestCase):
 
     def test_ci_retry_creates_filtered_build_for_new_head(self) -> None:
         github = FakeGitHub(
-            behind=100,
             permission="read",
             pr=make_pr(labels=[{"name": "ready"}]),
         )
@@ -1146,7 +1198,7 @@ class RunCiCommandTest(unittest.TestCase):
         self.assertEqual(len(buildkite.created_builds), 1)
         payload = buildkite.created_builds[0]
         self.assertEqual(payload["commit"], "0123456789abcdef")
-        self.assertEqual(github.lag_queries, [])
+        self.assertEqual(github.lag_queries, [("main", "0123456789abcdef")])
         self.assertEqual(payload["message"], "PR #42 /ci retry by @author")
         self.assertEqual(
             json.loads(payload["env"]["VLLM_CI_ONLY_STEP_KEYS"]),

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -329,7 +329,11 @@ review process:
   The bot reports the lag and warns that outdated CI configuration may cause
   failures. Before merging, merge or rebase onto the latest target branch and
   rerun CI without `--allow-stale` on the latest PR commit.
-- Retrying or cancelling builds does not check branch freshness.
+- `/ci retry` and `/amd-ci retry` allow **at most 50 commits behind** the target
+  branch. This limit applies both to retries of jobs in an existing build and
+  to new builds that retry selected failed jobs. At 51 or more commits behind,
+  update your branch and rerun CI. Retry commands do not accept `--allow-stale`.
+  Cancelling builds does not check branch freshness.
 - These commands do not modify your branch or enforce merge requirements.
   Direct Buildkite launches are outside this workflow. No additional token is
   needed.


### PR DESCRIPTION
`/ci retry` and `/amd-ci retry` can currently rerun jobs on branches arbitrarily far behind their target branch. This change allows retries up to 50 commits behind and rejects requests at 51 or more, asking the contributor to merge or rebase onto the latest target branch.

- Check freshness before retrying jobs in an existing upstream or AMD build, and before creating an upstream build of previously failed tests on a new PR head.
- Compare against the PR's actual target branch, including release and stacked branches. Reject retries if the comparison fails or the PR changes during the check.
- Keep retry commands without a `--allow-stale` override, and document the limit in contributor guidance and CI authorization notifications.

Extracted from #56169, which now covers run-command freshness and its explicit stale override. This PR is stacked on `ci/update-pr-before-ci` to reuse its comparison helper; merge #56169 first, then retarget this PR to `main`. Its diff contains only the retry guardrail. Searches found no separate freshness-limit PR; #55413 concerns setup failures and #51239 concerns command reliability and rerun controls.

Validation:

- `.venv/bin/python -m unittest discover -s .github/workflows/scripts -p 'test_run_ci_command.py' -q` — 53 tests passed, including 0/50/51/100-commit retry boundaries, both pipelines, filtered builds, and failure/race checks.
- `.venv/bin/pre-commit run --files .github/workflows/scripts/run_ci_command.py .github/workflows/scripts/test_run_ci_command.py docs/contributing/README.md` — passed.
- The combined file tree matches #56169's pre-split commit `cf39d6d2e39aba41affde7f7238dac96e33e14b2` exactly.

AI assistance from OpenAI Codex was used for the implementation, tests, and split.
