### PR TITLE
[ROCm][CI] Extend timeout for `Basic Models (other)`

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1973,7 +1973,7 @@ steps:
   - pytest -v -s models/test_initialization.py::test_can_initialize_small_subset
 
 - label: ":amd: (MI300) Basic Models (Other)" # TBD
-  timeout_in_minutes: 55
+  timeout_in_minutes: 65
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
   dind: false
   agent_pool: mi300_1

--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -56,7 +56,7 @@ steps:
       label: ":amd: (MI300) Basic Models (Other)"
       dind: false
       device: mi300_1
-      timeout_in_minutes: 50
+      timeout_in_minutes: 65
       depends_on:
       - image-build-amd
       source_file_dependencies:


### PR DESCRIPTION

Extend timeout for `(MI300) Basic Models (Other)` to improve reliability. e.g. https://buildkite.com/vllm/ci/builds/88384/list?jid=01a091a3-10b3-4296-8709-383fe1c768da&tab=output
