### PR TITLE
[MoE] Complete transition of packed mxfp4 quantization methods to the mxfp4 oracle

### DIFF
--- a/tests/kernels/moe/test_b12x.py
+++ b/tests/kernels/moe/test_b12x.py
@@ -501,17 +501,12 @@ def test_compressed_tensors_mxfp4_preserves_checkpoint_packing(
     )
 
     monkeypatch.setattr(
-        ct_mxfp4.CutlassExpertsMxfp4,
-        "_supports_current_device",
-        lambda: False,
+        ct_mxfp4,
+        "select_packed_mxfp4_moe_backend",
+        lambda moe, method_name: (Mxfp4MoeBackend.B12X_MXFP4_MXFP8, B12xExperts),
     )
     monkeypatch.setattr(
-        ct_mxfp4,
-        "select_mxfp4_moe_backend",
-        lambda moe: (Mxfp4MoeBackend.B12X_MXFP4_MXFP8, B12xExperts),
-    )
-    monkeypatch.setattr(
-        ct_mxfp4,
+        "vllm.model_executor.layers.quantization.utils.marlin_utils_fp4."
         "prepare_moe_fp4_layer_for_marlin",
         lambda layer: pytest.fail("b12x must not use Marlin packing"),
     )

--- a/tests/kernels/moe/test_b12x.py
+++ b/tests/kernels/moe/test_b12x.py
@@ -502,13 +502,13 @@ def test_compressed_tensors_mxfp4_preserves_checkpoint_packing(
 
     monkeypatch.setattr(
         ct_mxfp4,
-        "select_packed_mxfp4_moe_backend",
-        lambda moe, method_name: (Mxfp4MoeBackend.B12X_MXFP4_MXFP8, B12xExperts),
+        "select_mxfp4_moe_backend",
+        lambda moe, candidates: (Mxfp4MoeBackend.B12X_MXFP4_MXFP8, B12xExperts),
     )
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.utils.marlin_utils_fp4."
-        "prepare_moe_fp4_layer_for_marlin",
-        lambda layer: pytest.fail("b12x must not use Marlin packing"),
+        "prepare_moe_mxfp4_layer_for_marlin",
+        lambda *args: pytest.fail("b12x must not use Marlin packing"),
     )
     moe_config = SimpleNamespace(w13_num_shards=2, moe_backend="b12x")
     method = ct_mxfp4.CompressedTensorsW4A4Mxfp4MoEMethod(moe_config)

--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -1081,13 +1081,13 @@ def test_inc_mxfp4_moe_method_preserves_checkpoint_packing(
 
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_moe."
-        "select_packed_mxfp4_moe_backend",
-        lambda moe, method_name: (mxfp4_backend, expected_experts_cls),
+        "select_mxfp4_moe_backend",
+        lambda moe, candidates: (mxfp4_backend, expected_experts_cls),
     )
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.utils.marlin_utils_fp4."
-        "prepare_moe_fp4_layer_for_marlin",
-        lambda layer: pytest.fail("packed backends must not use Marlin packing"),
+        "prepare_moe_mxfp4_layer_for_marlin",
+        lambda *args: pytest.fail("packed backends must not use Marlin packing"),
     )
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_moe."

--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -1057,16 +1057,15 @@ def test_inc_mxfp4_linear_method_registers_and_processes_weights(
 
 
 @pytest.mark.parametrize(
-    ("moe_backend", "is_xpu", "mxfp4_backend"),
+    ("moe_backend", "mxfp4_backend"),
     [
-        ("auto", True, Mxfp4MoeBackend.XPU),
-        ("b12x", False, Mxfp4MoeBackend.B12X_MXFP4_MXFP8),
+        ("auto", Mxfp4MoeBackend.XPU),
+        ("b12x", Mxfp4MoeBackend.B12X_MXFP4_MXFP8),
     ],
 )
 def test_inc_mxfp4_moe_method_preserves_checkpoint_packing(
     monkeypatch,
     moe_backend: str,
-    is_xpu: bool,
     mxfp4_backend: Mxfp4MoeBackend,
 ) -> None:
     captured = {}
@@ -1082,14 +1081,13 @@ def test_inc_mxfp4_moe_method_preserves_checkpoint_packing(
 
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_moe."
-        "CutlassExpertsMxfp4._supports_current_device",
-        lambda: False,
-    )
-    monkeypatch.setattr(current_platform, "is_xpu", lambda: is_xpu)
-    monkeypatch.setattr(
-        "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_moe."
         "select_mxfp4_moe_backend",
         lambda moe: (mxfp4_backend, expected_experts_cls),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_moe."
+        "select_mxfp4_moe_backend_from",
+        lambda moe, candidates: (mxfp4_backend, expected_experts_cls),
     )
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_moe."

--- a/tests/quantization/test_auto_round.py
+++ b/tests/quantization/test_auto_round.py
@@ -1081,16 +1081,11 @@ def test_inc_mxfp4_moe_method_preserves_checkpoint_packing(
 
     monkeypatch.setattr(
         "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_moe."
-        "select_mxfp4_moe_backend",
-        lambda moe: (mxfp4_backend, expected_experts_cls),
+        "select_packed_mxfp4_moe_backend",
+        lambda moe, method_name: (mxfp4_backend, expected_experts_cls),
     )
     monkeypatch.setattr(
-        "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_moe."
-        "select_mxfp4_moe_backend_from",
-        lambda moe, candidates: (mxfp4_backend, expected_experts_cls),
-    )
-    monkeypatch.setattr(
-        "vllm.model_executor.layers.quantization.inc.schemes.inc_mxfp4_moe."
+        "vllm.model_executor.layers.quantization.utils.marlin_utils_fp4."
         "prepare_moe_fp4_layer_for_marlin",
         lambda layer: pytest.fail("packed backends must not use Marlin packing"),
     )

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Union
 
@@ -65,7 +66,7 @@ if has_triton_kernels():
         )
 
 
-def _pack_deepgemm_mxfp4_scales(
+def pack_deepgemm_mxfp4_scales(
     w13_weight: torch.Tensor,
     w2_weight: torch.Tensor,
     w13_weight_scale: torch.Tensor,
@@ -112,6 +113,8 @@ class Mxfp4MoeBackend(Enum):
     # FlashInfer CUTLASS backends
     FLASHINFER_CUTLASS_MXFP4_MXFP8 = "FLASHINFER_CUTLASS_MXFP4_MXFP8"
     FLASHINFER_CUTLASS_MXFP4_BF16 = "FLASHINFER_CUTLASS_MXFP4_BF16"
+    # vLLM's own CUTLASS W4A4 kernel (not the FlashInfer CUTLASS ones above)
+    CUTLASS_MXFP4_MXFP4 = "CUTLASS_MXFP4_MXFP4"
     # Marlin
     BATCHED_MARLIN = "BATCHED_MARLIN"
     MARLIN = "MARLIN"
@@ -192,6 +195,13 @@ def backend_to_kernel_cls(
         )
 
         return [FlashInferExperts]
+
+    elif backend == Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4:
+        from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+            CutlassExpertsMxfp4,
+        )
+
+        return [CutlassExpertsMxfp4]
 
     elif backend == Mxfp4MoeBackend.TRITON:
         from vllm.model_executor.layers.fused_moe.experts.gpt_oss_triton_kernels_moe import (  # noqa: E501
@@ -329,6 +339,33 @@ def map_mxfp4_backend(runner_backend: MoEBackend) -> list[Mxfp4MoeBackend]:
     )
 
 
+def narrow_mxfp4_candidates(
+    runner_backend: MoEBackend,
+    candidates: Sequence[Mxfp4MoeBackend],
+) -> list[Mxfp4MoeBackend]:
+    """Narrow ``candidates`` to the backends a non-auto ``moe_backend`` names.
+
+    ``map_mxfp4_backend`` deliberately omits ``"cutlass"``: the shared weight
+    converters do not swizzle scales for it, so honoring the flag would give
+    those callers silently wrong results. Quant methods that do their own
+    CUTLASS weight preparation call this instead.
+
+    Args:
+        runner_backend: Requested ``moe_backend``; never ``"auto"``.
+        candidates: Backends the caller prepares weights for, in preference
+            order.
+
+    Returns:
+        The subset of ``candidates`` the request names, order preserved. Empty
+        if the request names no backend the caller implements.
+    """
+    if runner_backend == "cutlass":
+        requested = [Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4]
+    else:
+        requested = map_mxfp4_backend(runner_backend)
+    return [b for b in candidates if b in requested]
+
+
 def _get_priority_backends_for_gpt_oss() -> list[Mxfp4MoeBackend]:
     """Available backends in priority order, BF16-act variant before
     activation-quantized variant within each vendor family."""
@@ -391,7 +428,10 @@ def _backend_activation_key(backend: Mxfp4MoeBackend) -> QuantKey | None:
         return kMxfp8Dynamic
     if backend == Mxfp4MoeBackend.AITER_MXFP4_FP8:
         return kFp8StaticTensorSym
-    if backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
+    if backend in (
+        Mxfp4MoeBackend.AITER_MXFP4_MXFP4,
+        Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4,
+    ):
         return kMxfp4Dynamic
     return None  # BF16 activation
 
@@ -450,6 +490,59 @@ def _return_or_raise(
             logger.info_once(_make_log_backend(backend), scope=scope)
             return backend, k_cls
     raise ValueError(_make_log_unsupported(backend, reason))
+
+
+def select_mxfp4_moe_backend_from(
+    config: FusedMoEConfig,
+    candidates: list[Mxfp4MoeBackend],
+    activation_key: QuantKey | None = None,
+) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
+    """Select the first candidate backend whose kernel supports ``config``.
+
+    Args:
+        config: MoE configuration.
+        candidates: Backends in preference order. ``MARLIN`` is swapped for
+            ``BATCHED_MARLIN`` when the activation format is batched.
+        activation_key: Activation quantization key for ``EMULATION``; every
+            other backend uses its own default key.
+
+    Returns:
+        The selected backend and the expert class that serves it.
+
+    Raises:
+        ValueError: No candidate supports the deployment configuration.
+    """
+    activation_format = (
+        mk.FusedMoEActivationFormat.BatchedExperts
+        if config.moe_parallel_config.use_batched_activation_format
+        else mk.FusedMoEActivationFormat.Standard
+    )
+
+    if activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
+        candidates = [
+            Mxfp4MoeBackend.BATCHED_MARLIN if b == Mxfp4MoeBackend.MARLIN else b
+            for b in candidates
+        ]
+
+    last_error: Exception | None = None
+    for backend in candidates:
+        act_key = (
+            activation_key
+            if backend == Mxfp4MoeBackend.EMULATION
+            else _backend_activation_key(backend)
+        )
+        try:
+            return _return_or_raise(
+                backend,
+                config,
+                kMxfp4Static,
+                act_key,
+                activation_format,
+            )
+        except ValueError as e:
+            last_error = e
+    assert last_error is not None
+    raise last_error
 
 
 def _filter_by_activation(
@@ -557,25 +650,9 @@ def select_mxfp4_moe_backend(
                 f"moe_backend={runner_backend!r} does not support "
                 f"activation={requested_activation_key}"
             )
-        last_error: Exception | None = None
-        for requested_backend in requested_backends:
-            act_key = (
-                requested_activation_key
-                if requested_backend == Mxfp4MoeBackend.EMULATION
-                else _backend_activation_key(requested_backend)
-            )
-            try:
-                return _return_or_raise(
-                    requested_backend,
-                    config,
-                    kMxfp4Static,
-                    act_key,
-                    activation_format,
-                )
-            except ValueError as e:
-                last_error = e
-        assert last_error is not None
-        raise last_error
+        return select_mxfp4_moe_backend_from(
+            config, requested_backends, requested_activation_key
+        )
 
     if _requires_qwen38_tep8_emulation(config, requested_activation_key):
         backend = Mxfp4MoeBackend.EMULATION
@@ -809,7 +886,7 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
     """Convert loaded weights into backend-specific kernel format."""
 
     if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
-        w13_weight_scale, w2_weight_scale = _pack_deepgemm_mxfp4_scales(
+        w13_weight_scale, w2_weight_scale = pack_deepgemm_mxfp4_scales(
             w13_weight,
             w2_weight,
             w13_weight_scale,
@@ -1402,7 +1479,7 @@ def convert_weight_to_mxfp4_moe_kernel_format(
         )
 
     if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
-        w13_weight_scale, w2_weight_scale = _pack_deepgemm_mxfp4_scales(
+        w13_weight_scale, w2_weight_scale = pack_deepgemm_mxfp4_scales(
             w13_weight,
             w2_weight,
             w13_weight_scale,
@@ -1900,7 +1977,10 @@ def make_mxfp4_moe_quant_config(
             block_shape=None,
             gemm1_clamp_limit=swiglu_limit,
         )
-    elif mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_MXFP4:
+    elif mxfp4_backend in (
+        Mxfp4MoeBackend.AITER_MXFP4_MXFP4,
+        Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4,
+    ):
         return ocp_mx_moe_quant_config(
             quant_dtype="mxfp4",
             w1_bias=w1_bias,

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -805,6 +805,60 @@ def select_deepseek_v4_mxfp4_moe_backend(
     )
 
 
+# Candidate backends, in preference order, for quant methods that load the
+# packed MXFP4 checkpoint layout (uint8 `w13/w2_weight_packed` plus uint8 E8M0
+# `weight_scale`, group_size=32): compressed-tensors W4A4 and AutoRound/INC.
+# Must stay in sync with `convert_packed_weight_to_mxfp4_moe_kernel_format`:
+# CUTLASS swizzles scales, DeepGEMM packs them, XPU consumes the checkpoint
+# packing, and Marlin repacks weights and scales.
+PACKED_MXFP4_CANDIDATE_BACKENDS = (
+    Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4,
+    Mxfp4MoeBackend.DEEPGEMM_MXFP4,
+    Mxfp4MoeBackend.XPU,
+    Mxfp4MoeBackend.MARLIN,
+)
+
+
+def select_packed_mxfp4_moe_backend(
+    config: FusedMoEConfig,
+    method_name: str,
+) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
+    """Select the backend for a packed-MXFP4-checkpoint MoE method.
+
+    Candidates come from `PACKED_MXFP4_CANDIDATE_BACKENDS`; the oracle drops
+    the ones the deployment cannot use (device, expert parallelism, activation
+    format), which is how DeepEP V2's PaddedStandard dispatch reaches
+    `DeepGemmFP4Experts` instead of a Standard-only kernel.
+
+    Args:
+        config: MoE configuration.
+        method_name: Quant method name used in the error message.
+
+    Returns:
+        The selected backend and the expert class that serves it.
+
+    Raises:
+        ValueError: The requested ``moe_backend`` names no candidate, or no
+            candidate supports the deployment configuration.
+    """
+    if config.moe_backend == "b12x":
+        # b12x has its own precision policy (VLLM_B12X_MOE_FP4_FORCE_A16).
+        backend, experts_cls = select_mxfp4_moe_backend(config)
+        assert experts_cls is not None
+        return backend, experts_cls
+
+    candidates = list(PACKED_MXFP4_CANDIDATE_BACKENDS)
+    if config.moe_backend != "auto":
+        candidates = narrow_mxfp4_candidates(config.moe_backend, candidates)
+        if not candidates:
+            raise ValueError(
+                f"moe_backend={config.moe_backend!r} is not supported for "
+                f"{method_name} MXFP4 MoE; expected one of "
+                f"{[b.value for b in PACKED_MXFP4_CANDIDATE_BACKENDS]}."
+            )
+    return select_mxfp4_moe_backend_from(config, candidates)
+
+
 def mxfp4_round_up_hidden_size_and_intermediate_size(
     backend: Mxfp4MoeBackend,
     hidden_size: int,
@@ -1896,6 +1950,97 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             "Expected TRTLLM, FlashInfer CUTLASS, Triton, AITER, XPU, or "
             "emulation backend."
         )
+
+
+def _process_weights_cutlass(layer: torch.nn.Module) -> None:
+    """Swizzle weight scales from the flat checkpoint layout [E, N, K//32] to
+    the CUTLASS tiled layout [E, numMTiles*numKTiles*512]."""
+    from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+        swizzle_mxfp4_scales,
+    )
+
+    E = layer.w13_weight_scale.shape[0]
+    w13_N = layer.w13_weight_scale.shape[1]
+    w13_scale_K = layer.w13_weight_scale.shape[2]
+    w13_K = w13_scale_K * 32
+
+    w2_M = layer.w2_weight_scale.shape[1]
+    w2_scale_N = layer.w2_weight_scale.shape[2]
+    w2_N = w2_scale_N * 32
+
+    swizzled_w13 = []
+    swizzled_w2 = []
+    for e_idx in range(E):
+        s13 = layer.w13_weight_scale[e_idx]
+        sw13 = swizzle_mxfp4_scales(s13, w13_N, w13_K)
+        swizzled_w13.append(sw13.reshape(w13_N, w13_scale_K))
+        s2 = layer.w2_weight_scale[e_idx]
+        sw2 = swizzle_mxfp4_scales(s2, w2_M, w2_N)
+        swizzled_w2.append(sw2.reshape(w2_M, w2_scale_N))
+
+    layer.w13_weight_scale = torch.nn.Parameter(
+        torch.stack(swizzled_w13), requires_grad=False
+    )
+    layer.w2_weight_scale = torch.nn.Parameter(
+        torch.stack(swizzled_w2), requires_grad=False
+    )
+
+
+def _process_weights_deepgemm(layer: torch.nn.Module) -> None:
+    w13_scale, w2_scale = pack_deepgemm_mxfp4_scales(
+        layer.w13_weight,
+        layer.w2_weight,
+        layer.w13_weight_scale,
+        layer.w2_weight_scale,
+    )
+    layer.w13_weight_scale = torch.nn.Parameter(w13_scale, requires_grad=False)
+    layer.w2_weight_scale = torch.nn.Parameter(w2_scale, requires_grad=False)
+
+
+def convert_packed_weight_to_mxfp4_moe_kernel_format(
+    mxfp4_backend: Mxfp4MoeBackend,
+    layer: torch.nn.Module,
+) -> None:
+    """Convert a packed MXFP4 checkpoint into backend-specific kernel format.
+
+    Renames the ``w13/w2_weight_packed`` parameters registered by the
+    packed-checkpoint quant methods (compressed-tensors W4A4, AutoRound/INC) to
+    the ``w13/w2_weight`` the kernels read, then rewrites the scales in place
+    for ``mxfp4_backend``. Handles every backend in
+    ``PACKED_MXFP4_CANDIDATE_BACKENDS``; XPU consumes the checkpoint layout
+    directly and so needs no scale conversion.
+
+    Args:
+        mxfp4_backend: The selected backend.
+        layer: The layer whose parameters are being prepared, modified in
+            place.
+    """
+    layer.w13_weight = torch.nn.Parameter(
+        layer.w13_weight_packed.data, requires_grad=False
+    )
+    delattr(layer, "w13_weight_packed")
+
+    layer.w2_weight = torch.nn.Parameter(
+        layer.w2_weight_packed.data, requires_grad=False
+    )
+    delattr(layer, "w2_weight_packed")
+
+    if mxfp4_backend == Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4:
+        _process_weights_cutlass(layer)
+    elif mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
+        _process_weights_deepgemm(layer)
+    elif mxfp4_backend in (Mxfp4MoeBackend.MARLIN, Mxfp4MoeBackend.BATCHED_MARLIN):
+        from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+            prepare_moe_fp4_layer_for_marlin,
+        )
+
+        logger.warning_once(
+            "Your GPU does not have native support for FP4 computation "
+            "but FP4 quantization is being used. Weight-only FP4 "
+            "compression will be used leveraging the Marlin kernel. "
+            "This may degrade performance for compute-heavy workloads."
+        )
+        prepare_moe_fp4_layer_for_marlin(layer)
 
 
 def make_mxfp4_moe_quant_config(

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -158,6 +158,16 @@ B12X_BACKENDS = (
     Mxfp4MoeBackend.B12X_MXFP4_BF16,
 )
 
+# Candidate backends, in preference order, for quant methods that load the
+# packed MXFP4 checkpoint layout (uint8 `w13/w2_weight_packed` plus uint8 E8M0
+# `weight_scale`, group_size=32): compressed-tensors W4A4 and AutoRound/INC.
+PACKED_MXFP4_CANDIDATE_BACKENDS = (
+    Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4,
+    Mxfp4MoeBackend.DEEPGEMM_MXFP4,
+    Mxfp4MoeBackend.XPU,
+    Mxfp4MoeBackend.MARLIN,
+)
+
 
 def backend_to_kernel_cls(
     backend: Mxfp4MoeBackend,
@@ -339,16 +349,15 @@ def map_mxfp4_backend(runner_backend: MoEBackend) -> list[Mxfp4MoeBackend]:
     )
 
 
-def narrow_mxfp4_candidates(
+def _narrow_mxfp4_candidates(
     runner_backend: MoEBackend,
     candidates: Sequence[Mxfp4MoeBackend],
 ) -> list[Mxfp4MoeBackend]:
     """Narrow ``candidates`` to the backends a non-auto ``moe_backend`` names.
 
-    ``map_mxfp4_backend`` deliberately omits ``"cutlass"``: the shared weight
-    converters do not swizzle scales for it, so honoring the flag would give
-    those callers silently wrong results. Quant methods that do their own
-    CUTLASS weight preparation call this instead.
+    ``map_mxfp4_backend`` deliberately omits ``"cutlass"``, which names vLLM's
+    own W4A4 kernel rather than either FlashInfer CUTLASS backend, so resolve
+    that spelling here.
 
     Args:
         runner_backend: Requested ``moe_backend``; never ``"auto"``.
@@ -492,9 +501,9 @@ def _return_or_raise(
     raise ValueError(_make_log_unsupported(backend, reason))
 
 
-def select_mxfp4_moe_backend_from(
+def _select_mxfp4_moe_backend_from(
     config: FusedMoEConfig,
-    candidates: list[Mxfp4MoeBackend],
+    candidates: Sequence[Mxfp4MoeBackend],
     activation_key: QuantKey | None = None,
 ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
     """Select the first candidate backend whose kernel supports ``config``.
@@ -615,7 +624,8 @@ def _requires_qwen38_tep8_emulation(
 def select_mxfp4_moe_backend(
     config: FusedMoEConfig,
     activation_key: QuantKey | None = None,
-) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts] | None]:
+    candidates: Sequence[Mxfp4MoeBackend] | None = None,
+) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
     """
     Select the primary MXFP4 MoE backend.
 
@@ -624,6 +634,12 @@ def select_mxfp4_moe_backend(
         activation_key: Optional activation quantization key. If provided,
             overrides the default activation key for backend selection.
             Use kFp8StaticTensorSym for W4A8 scheme.
+        candidates: Restrict the selection to these backends, in preference
+            order. Quant methods whose checkpoint can only be converted for a
+            subset of the backends pass that subset (e.g.
+            `PACKED_MXFP4_CANDIDATE_BACKENDS`); ``None`` considers every
+            backend. Ignored for ``moe_backend="b12x"``, which picks its own
+            precision.
 
     Note: Shape-specific fallbacks may still occur at runtime.
     """
@@ -637,21 +653,30 @@ def select_mxfp4_moe_backend(
     )
 
     if runner_backend != "auto":
-        requested_backends = _get_requested_backends(
-            runner_backend, requested_activation_key
-        )
-        if activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
-            requested_backends = [
-                Mxfp4MoeBackend.BATCHED_MARLIN if b == Mxfp4MoeBackend.MARLIN else b
-                for b in requested_backends
-            ]
-        if not requested_backends:
-            raise ValueError(
-                f"moe_backend={runner_backend!r} does not support "
-                f"activation={requested_activation_key}"
+        if candidates is not None and runner_backend != "b12x":
+            requested_backends = _narrow_mxfp4_candidates(runner_backend, candidates)
+            if not requested_backends:
+                raise ValueError(
+                    f"moe_backend={runner_backend!r} is not supported for this "
+                    f"MXFP4 MoE checkpoint; expected one of "
+                    f"{[b.value for b in candidates]}."
+                )
+        else:
+            requested_backends = _get_requested_backends(
+                runner_backend, requested_activation_key
             )
-        return select_mxfp4_moe_backend_from(
+            if not requested_backends:
+                raise ValueError(
+                    f"moe_backend={runner_backend!r} does not support "
+                    f"activation={requested_activation_key}"
+                )
+        return _select_mxfp4_moe_backend_from(
             config, requested_backends, requested_activation_key
+        )
+
+    if candidates is not None:
+        return _select_mxfp4_moe_backend_from(
+            config, candidates, requested_activation_key
         )
 
     if _requires_qwen38_tep8_emulation(config, requested_activation_key):
@@ -803,60 +828,6 @@ def select_deepseek_v4_mxfp4_moe_backend(
     raise NotImplementedError(
         "No MXFP4 MoE backend supports the deployment configuration."
     )
-
-
-# Candidate backends, in preference order, for quant methods that load the
-# packed MXFP4 checkpoint layout (uint8 `w13/w2_weight_packed` plus uint8 E8M0
-# `weight_scale`, group_size=32): compressed-tensors W4A4 and AutoRound/INC.
-# Must stay in sync with `convert_packed_weight_to_mxfp4_moe_kernel_format`:
-# CUTLASS swizzles scales, DeepGEMM packs them, XPU consumes the checkpoint
-# packing, and Marlin repacks weights and scales.
-PACKED_MXFP4_CANDIDATE_BACKENDS = (
-    Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4,
-    Mxfp4MoeBackend.DEEPGEMM_MXFP4,
-    Mxfp4MoeBackend.XPU,
-    Mxfp4MoeBackend.MARLIN,
-)
-
-
-def select_packed_mxfp4_moe_backend(
-    config: FusedMoEConfig,
-    method_name: str,
-) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
-    """Select the backend for a packed-MXFP4-checkpoint MoE method.
-
-    Candidates come from `PACKED_MXFP4_CANDIDATE_BACKENDS`; the oracle drops
-    the ones the deployment cannot use (device, expert parallelism, activation
-    format), which is how DeepEP V2's PaddedStandard dispatch reaches
-    `DeepGemmFP4Experts` instead of a Standard-only kernel.
-
-    Args:
-        config: MoE configuration.
-        method_name: Quant method name used in the error message.
-
-    Returns:
-        The selected backend and the expert class that serves it.
-
-    Raises:
-        ValueError: The requested ``moe_backend`` names no candidate, or no
-            candidate supports the deployment configuration.
-    """
-    if config.moe_backend == "b12x":
-        # b12x has its own precision policy (VLLM_B12X_MOE_FP4_FORCE_A16).
-        backend, experts_cls = select_mxfp4_moe_backend(config)
-        assert experts_cls is not None
-        return backend, experts_cls
-
-    candidates = list(PACKED_MXFP4_CANDIDATE_BACKENDS)
-    if config.moe_backend != "auto":
-        candidates = narrow_mxfp4_candidates(config.moe_backend, candidates)
-        if not candidates:
-            raise ValueError(
-                f"moe_backend={config.moe_backend!r} is not supported for "
-                f"{method_name} MXFP4 MoE; expected one of "
-                f"{[b.value for b in PACKED_MXFP4_CANDIDATE_BACKENDS]}."
-            )
-    return select_mxfp4_moe_backend_from(config, candidates)
 
 
 def mxfp4_round_up_hidden_size_and_intermediate_size(
@@ -1493,6 +1464,22 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
         )
 
 
+def _swizzle_cutlass_mxfp4_scales(scale: torch.Tensor) -> torch.Tensor:
+    """Swizzle block scales from the flat checkpoint layout ``[E, M, K // 32]``
+    into the CUTLASS tiled layout, preserving the original shape."""
+    from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+        swizzle_mxfp4_scales,
+    )
+
+    num_experts, m, scale_k = scale.shape
+    return torch.stack(
+        [
+            swizzle_mxfp4_scales(scale[e], m, scale_k * 32).reshape(m, scale_k)
+            for e in range(num_experts)
+        ]
+    )
+
+
 def convert_weight_to_mxfp4_moe_kernel_format(
     mxfp4_backend: Mxfp4MoeBackend,
     layer: torch.nn.Module,
@@ -1514,7 +1501,8 @@ def convert_weight_to_mxfp4_moe_kernel_format(
 ]:
     """Convert loaded weights into backend-specific kernel format.
 
-    Supports DeepGEMM, FlashInfer, TRTLLM MXFP8, Triton and Marlin backends.
+    Supports CUTLASS, DeepGEMM, FlashInfer, TRTLLM MXFP8, Triton and Marlin
+    backends.
     """
     is_gfx1250 = False
     if current_platform.is_rocm():
@@ -1549,6 +1537,16 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
 
+    if mxfp4_backend == Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4:
+        return (
+            w13_weight.data,
+            w2_weight.data,
+            _swizzle_cutlass_mxfp4_scales(w13_weight_scale),
+            _swizzle_cutlass_mxfp4_scales(w2_weight_scale),
+            w13_bias,
+            w2_bias,
+        )
+
     if mxfp4_backend == Mxfp4MoeBackend.HUMMING:
         from vllm.model_executor.layers.quantization.utils.humming_utils import (
             convert_to_humming_moe_kernel_format,
@@ -1571,6 +1569,12 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             prepare_moe_mxfp4_layer_for_marlin,
         )
 
+        logger.warning_once(
+            "Your GPU does not have native support for FP4 computation but "
+            "FP4 quantization is being used. Weight-only FP4 compression will "
+            "be used leveraging the Marlin kernel. This may degrade "
+            "performance for compute-heavy workloads."
+        )
         return prepare_moe_mxfp4_layer_for_marlin(
             layer,
             w13_weight,
@@ -1950,97 +1954,6 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             "Expected TRTLLM, FlashInfer CUTLASS, Triton, AITER, XPU, or "
             "emulation backend."
         )
-
-
-def _process_weights_cutlass(layer: torch.nn.Module) -> None:
-    """Swizzle weight scales from the flat checkpoint layout [E, N, K//32] to
-    the CUTLASS tiled layout [E, numMTiles*numKTiles*512]."""
-    from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
-        swizzle_mxfp4_scales,
-    )
-
-    E = layer.w13_weight_scale.shape[0]
-    w13_N = layer.w13_weight_scale.shape[1]
-    w13_scale_K = layer.w13_weight_scale.shape[2]
-    w13_K = w13_scale_K * 32
-
-    w2_M = layer.w2_weight_scale.shape[1]
-    w2_scale_N = layer.w2_weight_scale.shape[2]
-    w2_N = w2_scale_N * 32
-
-    swizzled_w13 = []
-    swizzled_w2 = []
-    for e_idx in range(E):
-        s13 = layer.w13_weight_scale[e_idx]
-        sw13 = swizzle_mxfp4_scales(s13, w13_N, w13_K)
-        swizzled_w13.append(sw13.reshape(w13_N, w13_scale_K))
-        s2 = layer.w2_weight_scale[e_idx]
-        sw2 = swizzle_mxfp4_scales(s2, w2_M, w2_N)
-        swizzled_w2.append(sw2.reshape(w2_M, w2_scale_N))
-
-    layer.w13_weight_scale = torch.nn.Parameter(
-        torch.stack(swizzled_w13), requires_grad=False
-    )
-    layer.w2_weight_scale = torch.nn.Parameter(
-        torch.stack(swizzled_w2), requires_grad=False
-    )
-
-
-def _process_weights_deepgemm(layer: torch.nn.Module) -> None:
-    w13_scale, w2_scale = pack_deepgemm_mxfp4_scales(
-        layer.w13_weight,
-        layer.w2_weight,
-        layer.w13_weight_scale,
-        layer.w2_weight_scale,
-    )
-    layer.w13_weight_scale = torch.nn.Parameter(w13_scale, requires_grad=False)
-    layer.w2_weight_scale = torch.nn.Parameter(w2_scale, requires_grad=False)
-
-
-def convert_packed_weight_to_mxfp4_moe_kernel_format(
-    mxfp4_backend: Mxfp4MoeBackend,
-    layer: torch.nn.Module,
-) -> None:
-    """Convert a packed MXFP4 checkpoint into backend-specific kernel format.
-
-    Renames the ``w13/w2_weight_packed`` parameters registered by the
-    packed-checkpoint quant methods (compressed-tensors W4A4, AutoRound/INC) to
-    the ``w13/w2_weight`` the kernels read, then rewrites the scales in place
-    for ``mxfp4_backend``. Handles every backend in
-    ``PACKED_MXFP4_CANDIDATE_BACKENDS``; XPU consumes the checkpoint layout
-    directly and so needs no scale conversion.
-
-    Args:
-        mxfp4_backend: The selected backend.
-        layer: The layer whose parameters are being prepared, modified in
-            place.
-    """
-    layer.w13_weight = torch.nn.Parameter(
-        layer.w13_weight_packed.data, requires_grad=False
-    )
-    delattr(layer, "w13_weight_packed")
-
-    layer.w2_weight = torch.nn.Parameter(
-        layer.w2_weight_packed.data, requires_grad=False
-    )
-    delattr(layer, "w2_weight_packed")
-
-    if mxfp4_backend == Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4:
-        _process_weights_cutlass(layer)
-    elif mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
-        _process_weights_deepgemm(layer)
-    elif mxfp4_backend in (Mxfp4MoeBackend.MARLIN, Mxfp4MoeBackend.BATCHED_MARLIN):
-        from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
-            prepare_moe_fp4_layer_for_marlin,
-        )
-
-        logger.warning_once(
-            "Your GPU does not have native support for FP4 computation "
-            "but FP4 quantization is being used. Weight-only FP4 "
-            "compression will be used leveraging the Marlin kernel. "
-            "This may degrade performance for compute-heavy workloads."
-        )
-        prepare_moe_fp4_layer_for_marlin(layer)
 
 
 def make_mxfp4_moe_quant_config(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
@@ -13,23 +13,15 @@ from vllm.model_executor.layers.fused_moe import (
 )
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
-    mxfp4_moe_quant_config,
-)
-from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
-    CutlassExpertsMxfp4,
-)
-from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
-    MarlinExperts,
-)
-from vllm.model_executor.layers.fused_moe.experts.xpu_moe import (
-    XPUExpertsMxFp4,
 )
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
-    B12X_BACKENDS,
     Mxfp4MoeBackend,
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
+    narrow_mxfp4_candidates,
+    pack_deepgemm_mxfp4_scales,
     select_mxfp4_moe_backend,
+    select_mxfp4_moe_backend_from,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
@@ -38,36 +30,47 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
     prepare_moe_fp4_layer_for_marlin,
 )
 from vllm.model_executor.utils import set_weight_attrs
-from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
 
 class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
+    # Candidate backends in preference order. Must stay in sync with the weight
+    # preparation below: CUTLASS swizzles scales, DeepGEMM packs them, XPU
+    # consumes the checkpoint packing, and Marlin repacks weights and scales.
+    # The oracle drops candidates the deployment cannot use (device, expert
+    # parallelism, activation format), which is how DeepEP V2's PaddedStandard
+    # dispatch reaches DeepGemmFP4Experts instead of a Standard-only kernel.
+    CANDIDATE_BACKENDS = (
+        Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4,
+        Mxfp4MoeBackend.DEEPGEMM_MXFP4,
+        Mxfp4MoeBackend.XPU,
+        Mxfp4MoeBackend.MARLIN,
+    )
+
     def __init__(self, moe):
         super().__init__(moe)
         self.group_size = 32
-        self.mxfp4_backend = Mxfp4MoeBackend.MARLIN
-        # Backend selection must match the weight preparation below: CUTLASS
-        # swizzles scales, b12x and XPU consume checkpoint packing, and Marlin
-        # repacks weights and scales.
-        self.use_cutlass_mxfp4 = CutlassExpertsMxfp4._supports_current_device()
         self.experts_cls: type[mk.FusedMoEExperts]
         if moe.moe_backend == "b12x":
+            # b12x has its own precision policy (VLLM_B12X_MOE_FP4_FORCE_A16).
             self.mxfp4_backend, experts_cls = select_mxfp4_moe_backend(moe)
             assert experts_cls is not None
             self.experts_cls = experts_cls
-            self.use_cutlass_mxfp4 = False
-        elif self.use_cutlass_mxfp4:
-            logger.info_once("Using CutlassExpertsMxfp4 for MXFP4 MoE")
-            self.experts_cls = CutlassExpertsMxfp4
-        elif current_platform.is_xpu():
-            self.mxfp4_backend = Mxfp4MoeBackend.XPU
-            self.experts_cls = XPUExpertsMxFp4
-            logger.info_once("Using XPUExpertsMxFp4 for MXFP4 MoE on XPU platform")
-        else:
-            logger.info_once("Using MarlinExperts for MXFP4 MoE")
-            self.experts_cls = MarlinExperts
+            return
+
+        candidates = list(self.CANDIDATE_BACKENDS)
+        if moe.moe_backend != "auto":
+            candidates = narrow_mxfp4_candidates(moe.moe_backend, candidates)
+            if not candidates:
+                raise ValueError(
+                    f"moe_backend={moe.moe_backend!r} is not supported for "
+                    "compressed-tensors MXFP4 MoE; expected one of "
+                    f"{[b.value for b in self.CANDIDATE_BACKENDS]}."
+                )
+        self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend_from(
+            moe, candidates
+        )
 
     def create_weights(
         self,
@@ -140,20 +143,14 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:
-        if self.use_cutlass_mxfp4:
-            # W4A4: both weights and activations quantized to MXFP4
-            return mxfp4_moe_quant_config(
-                w1_scale=layer.w13_weight_scale,
-                w2_scale=layer.w2_weight_scale,
-            )
-        else:
-            # b12x selects W4A8 or W4A16; XPU uses W4A4; Marlin uses W4A16.
-            return make_mxfp4_moe_quant_config(
-                mxfp4_backend=self.mxfp4_backend,
-                w1_scale=layer.w13_weight_scale,
-                w2_scale=layer.w2_weight_scale,
-                layer=layer,
-            )
+        # CUTLASS and XPU use W4A4; DeepGEMM W4A8; b12x W4A8 or W4A16;
+        # Marlin W4A16.
+        return make_mxfp4_moe_quant_config(
+            mxfp4_backend=self.mxfp4_backend,
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            layer=layer,
+        )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         layer.w13_weight = torch.nn.Parameter(
@@ -166,7 +163,7 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
         )
         delattr(layer, "w2_weight_packed")
 
-        if self.use_cutlass_mxfp4:
+        if self.mxfp4_backend == Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4:
             # Swizzle weight scales from flat checkpoint layout [E, N, K//32]
             # to CUTLASS tiled layout [E, numMTiles*numKTiles*512].
             from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
@@ -197,9 +194,19 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
             layer.w2_weight_scale = torch.nn.Parameter(
                 torch.stack(swizzled_w2), requires_grad=False
             )
-        elif self.mxfp4_backend in B12X_BACKENDS or current_platform.is_xpu():
-            pass
-        else:
+        elif self.mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
+            w13_scale, w2_scale = pack_deepgemm_mxfp4_scales(
+                layer.w13_weight,
+                layer.w2_weight,
+                layer.w13_weight_scale,
+                layer.w2_weight_scale,
+            )
+            layer.w13_weight_scale = torch.nn.Parameter(w13_scale, requires_grad=False)
+            layer.w2_weight_scale = torch.nn.Parameter(w2_scale, requires_grad=False)
+        elif self.mxfp4_backend in (
+            Mxfp4MoeBackend.MARLIN,
+            Mxfp4MoeBackend.BATCHED_MARLIN,
+        ):
             logger.warning_once(
                 "Your GPU does not have native support for FP4 computation "
                 "but FP4 quantization is being used. Weight-only FP4 "

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
@@ -4,8 +4,6 @@
 
 import torch
 
-import vllm.model_executor.layers.fused_moe.modular_kernel as mk
-from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     FusedMoeWeightScaleSupported,
     RoutedExperts,
@@ -15,61 +13,23 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
-    Mxfp4MoeBackend,
+    convert_packed_weight_to_mxfp4_moe_kernel_format,
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
-    narrow_mxfp4_candidates,
-    pack_deepgemm_mxfp4_scales,
-    select_mxfp4_moe_backend,
-    select_mxfp4_moe_backend_from,
+    select_packed_mxfp4_moe_backend,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
 )
-from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
-    prepare_moe_fp4_layer_for_marlin,
-)
 from vllm.model_executor.utils import set_weight_attrs
-
-logger = init_logger(__name__)
 
 
 class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
-    # Candidate backends in preference order. Must stay in sync with the weight
-    # preparation below: CUTLASS swizzles scales, DeepGEMM packs them, XPU
-    # consumes the checkpoint packing, and Marlin repacks weights and scales.
-    # The oracle drops candidates the deployment cannot use (device, expert
-    # parallelism, activation format), which is how DeepEP V2's PaddedStandard
-    # dispatch reaches DeepGemmFP4Experts instead of a Standard-only kernel.
-    CANDIDATE_BACKENDS = (
-        Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4,
-        Mxfp4MoeBackend.DEEPGEMM_MXFP4,
-        Mxfp4MoeBackend.XPU,
-        Mxfp4MoeBackend.MARLIN,
-    )
-
     def __init__(self, moe):
         super().__init__(moe)
         self.group_size = 32
-        self.experts_cls: type[mk.FusedMoEExperts]
-        if moe.moe_backend == "b12x":
-            # b12x has its own precision policy (VLLM_B12X_MOE_FP4_FORCE_A16).
-            self.mxfp4_backend, experts_cls = select_mxfp4_moe_backend(moe)
-            assert experts_cls is not None
-            self.experts_cls = experts_cls
-            return
-
-        candidates = list(self.CANDIDATE_BACKENDS)
-        if moe.moe_backend != "auto":
-            candidates = narrow_mxfp4_candidates(moe.moe_backend, candidates)
-            if not candidates:
-                raise ValueError(
-                    f"moe_backend={moe.moe_backend!r} is not supported for "
-                    "compressed-tensors MXFP4 MoE; expected one of "
-                    f"{[b.value for b in self.CANDIDATE_BACKENDS]}."
-                )
-        self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend_from(
-            moe, candidates
+        self.mxfp4_backend, self.experts_cls = select_packed_mxfp4_moe_backend(
+            moe, "compressed-tensors"
         )
 
     def create_weights(
@@ -153,78 +113,18 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
-        layer.w13_weight = torch.nn.Parameter(
-            layer.w13_weight_packed.data, requires_grad=False
-        )
-        delattr(layer, "w13_weight_packed")
-
-        layer.w2_weight = torch.nn.Parameter(
-            layer.w2_weight_packed.data, requires_grad=False
-        )
-        delattr(layer, "w2_weight_packed")
-
-        if self.mxfp4_backend == Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4:
-            # Swizzle weight scales from flat checkpoint layout [E, N, K//32]
-            # to CUTLASS tiled layout [E, numMTiles*numKTiles*512].
-            from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
-                swizzle_mxfp4_scales,
-            )
-
-            E = layer.w13_weight_scale.shape[0]
-            w13_N = layer.w13_weight_scale.shape[1]
-            w13_scale_K = layer.w13_weight_scale.shape[2]
-            w13_K = w13_scale_K * 32
-
-            w2_M = layer.w2_weight_scale.shape[1]
-            w2_scale_N = layer.w2_weight_scale.shape[2]
-            w2_N = w2_scale_N * 32
-
-            swizzled_w13 = []
-            swizzled_w2 = []
-            for e_idx in range(E):
-                s13 = layer.w13_weight_scale[e_idx]
-                sw13 = swizzle_mxfp4_scales(s13, w13_N, w13_K)
-                swizzled_w13.append(sw13.reshape(w13_N, w13_scale_K))
-                s2 = layer.w2_weight_scale[e_idx]
-                sw2 = swizzle_mxfp4_scales(s2, w2_M, w2_N)
-                swizzled_w2.append(sw2.reshape(w2_M, w2_scale_N))
-            layer.w13_weight_scale = torch.nn.Parameter(
-                torch.stack(swizzled_w13), requires_grad=False
-            )
-            layer.w2_weight_scale = torch.nn.Parameter(
-                torch.stack(swizzled_w2), requires_grad=False
-            )
-        elif self.mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
-            w13_scale, w2_scale = pack_deepgemm_mxfp4_scales(
-                layer.w13_weight,
-                layer.w2_weight,
-                layer.w13_weight_scale,
-                layer.w2_weight_scale,
-            )
-            layer.w13_weight_scale = torch.nn.Parameter(w13_scale, requires_grad=False)
-            layer.w2_weight_scale = torch.nn.Parameter(w2_scale, requires_grad=False)
-        elif self.mxfp4_backend in (
-            Mxfp4MoeBackend.MARLIN,
-            Mxfp4MoeBackend.BATCHED_MARLIN,
-        ):
-            logger.warning_once(
-                "Your GPU does not have native support for FP4 computation "
-                "but FP4 quantization is being used. Weight-only FP4 "
-                "compression will be used leveraging the Marlin kernel. "
-                "This may degrade performance for compute-heavy workloads."
-            )
-            prepare_moe_fp4_layer_for_marlin(layer)
+        convert_packed_weight_to_mxfp4_moe_kernel_format(self.mxfp4_backend, layer)
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config is not None:
-            self.moe_kernel = make_mxfp4_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                experts_cls=self.experts_cls,
-                mxfp4_backend=self.mxfp4_backend,
-                routing_tables=layer._expert_routing_tables(),
-            )
-            self.moe_kernel.fused_experts.process_weights_after_loading(layer)
+        assert self.moe_quant_config is not None
+        self.moe_kernel = make_mxfp4_moe_kernel(
+            moe_quant_config=self.moe_quant_config,
+            moe_config=self.moe,
+            experts_cls=self.experts_cls,
+            mxfp4_backend=self.mxfp4_backend,
+            routing_tables=layer._expert_routing_tables(),
+        )
+        self.moe_kernel.fused_experts.process_weights_after_loading(layer)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
@@ -13,23 +13,24 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
-    convert_packed_weight_to_mxfp4_moe_kernel_format,
+    PACKED_MXFP4_CANDIDATE_BACKENDS,
+    convert_weight_to_mxfp4_moe_kernel_format,
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
-    select_packed_mxfp4_moe_backend,
+    select_mxfp4_moe_backend,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa E501
     CompressedTensorsMoEMethod,
 )
-from vllm.model_executor.utils import set_weight_attrs
+from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
 
 class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
     def __init__(self, moe):
         super().__init__(moe)
         self.group_size = 32
-        self.mxfp4_backend, self.experts_cls = select_packed_mxfp4_moe_backend(
-            moe, "compressed-tensors"
+        self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(
+            moe, candidates=PACKED_MXFP4_CANDIDATE_BACKENDS
         )
 
     def create_weights(
@@ -113,7 +114,32 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
         )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
-        convert_packed_weight_to_mxfp4_moe_kernel_format(self.mxfp4_backend, layer)
+        # NOTE(rob): wN_weight_packed -> wN_weight is because ModularKernelMethod
+        # requires this naming convention. However, the name change breaks
+        # reloading because the state dict no longer matches disk. Once we
+        # remove MKM, we should revert this change to ensure compatibility.
+        layer.w13_weight = torch.nn.Parameter(
+            layer.w13_weight_packed.data, requires_grad=False
+        )
+        delattr(layer, "w13_weight_packed")
+
+        layer.w2_weight = torch.nn.Parameter(
+            layer.w2_weight_packed.data, requires_grad=False
+        )
+        delattr(layer, "w2_weight_packed")
+
+        w13, w2, w13_scale, w2_scale, _, _ = convert_weight_to_mxfp4_moe_kernel_format(
+            mxfp4_backend=self.mxfp4_backend,
+            layer=layer,
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            w13_weight_scale=layer.w13_weight_scale,
+            w2_weight_scale=layer.w2_weight_scale,
+        )
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         assert self.moe_quant_config is not None

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
@@ -15,12 +15,13 @@ from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
     FusedMoEMethodBase,
 )
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
-    convert_packed_weight_to_mxfp4_moe_kernel_format,
+    PACKED_MXFP4_CANDIDATE_BACKENDS,
+    convert_weight_to_mxfp4_moe_kernel_format,
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
-    select_packed_mxfp4_moe_backend,
+    select_mxfp4_moe_backend,
 )
-from vllm.model_executor.utils import set_weight_attrs
+from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
 
 class INCMxfp4MoEMethod(FusedMoEMethodBase):
@@ -37,8 +38,8 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
     def __init__(self, moe) -> None:
         super().__init__(moe)
         self.group_size = 32
-        self.mxfp4_backend, self.experts_cls = select_packed_mxfp4_moe_backend(
-            moe, "AutoRound"
+        self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(
+            moe, candidates=PACKED_MXFP4_CANDIDATE_BACKENDS
         )
 
     def create_weights(
@@ -118,7 +119,32 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
         )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
-        convert_packed_weight_to_mxfp4_moe_kernel_format(self.mxfp4_backend, layer)
+        # NOTE(rob): wN_weight_packed -> wN_weight is because ModularKernelMethod
+        # requires this naming convention. However, the name change breaks
+        # reloading because the state dict no longer matches disk. Once we
+        # remove MKM, we should revert this change to ensure compatibility.
+        layer.w13_weight = torch.nn.Parameter(
+            layer.w13_weight_packed.data, requires_grad=False
+        )
+        delattr(layer, "w13_weight_packed")
+
+        layer.w2_weight = torch.nn.Parameter(
+            layer.w2_weight_packed.data, requires_grad=False
+        )
+        delattr(layer, "w2_weight_packed")
+
+        w13, w2, w13_scale, w2_scale, _, _ = convert_weight_to_mxfp4_moe_kernel_format(
+            mxfp4_backend=self.mxfp4_backend,
+            layer=layer,
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            w13_weight_scale=layer.w13_weight_scale,
+            w2_weight_scale=layer.w2_weight_scale,
+        )
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         assert self.moe_quant_config is not None

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
@@ -12,29 +12,23 @@ from vllm.model_executor.layers.fused_moe import (
 )
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
-    mxfp4_moe_quant_config,
-)
-from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
-    CutlassExpertsMxfp4,
-)
-from vllm.model_executor.layers.fused_moe.experts.marlin_moe import (
-    MarlinExperts,
 )
 from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
     FusedMoEMethodBase,
 )
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
-    B12X_BACKENDS,
     Mxfp4MoeBackend,
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
+    narrow_mxfp4_candidates,
+    pack_deepgemm_mxfp4_scales,
     select_mxfp4_moe_backend,
+    select_mxfp4_moe_backend_from,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
     prepare_moe_fp4_layer_for_marlin,
 )
 from vllm.model_executor.utils import set_weight_attrs
-from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
@@ -44,37 +38,47 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
 
     Registers the packed MXFP4 layout (uint8 ``weight_packed`` + uint8 E8M0
     ``weight_scale``, ``group_size=32``) and dispatches the fused MoE to b12x
-    when requested; otherwise it uses CUTLASS W4A4, XPU W4A4, or Marlin W4A16.
+    when requested; otherwise it uses CUTLASS W4A4, DeepGEMM W4A8, XPU W4A4, or
+    Marlin W4A16.
     The per-expert ``gate_proj`` / ``up_proj`` / ``down_proj`` tensors are
     folded into the stacked ``w13`` / ``w2`` parameters by
     ``make_expert_params_mapping``.
     """
 
+    # Candidate backends in preference order. Must stay consistent with the
+    # weight preparation in process_weights_after_loading /
+    # get_fused_moe_quant_config: CUTLASS swizzle (true W4A4), DeepGEMM scale
+    # packing (W4A8), XPU packed passthrough, and Marlin weight-only. The
+    # oracle drops candidates the deployment cannot use (device, expert
+    # parallelism, activation format).
+    CANDIDATE_BACKENDS = (
+        Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4,
+        Mxfp4MoeBackend.DEEPGEMM_MXFP4,
+        Mxfp4MoeBackend.XPU,
+        Mxfp4MoeBackend.MARLIN,
+    )
+
     def __init__(self, moe) -> None:
         super().__init__(moe)
         self.group_size = 32
-        # Backend selection must stay consistent with the weight preparation in
-        # process_weights_after_loading / get_fused_moe_quant_config, which use
-        # three layouts: CUTLASS swizzle (true W4A4), b12x and XPU packed
-        # passthrough, and Marlin weight-only. XPU dispatch is deferred to the
-        # shared oracle; b12x dispatch is explicit; every remaining non-CUTLASS
-        # device falls back to Marlin.
-        self.use_cutlass_mxfp4 = CutlassExpertsMxfp4._supports_current_device()
-        self.mxfp4_backend = Mxfp4MoeBackend.MARLIN
         self.experts_cls: type[mk.FusedMoEExperts] | None = None
         if moe.moe_backend == "b12x":
+            # b12x has its own precision policy (VLLM_B12X_MOE_FP4_FORCE_A16).
             self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(moe)
-            self.use_cutlass_mxfp4 = False
-        elif self.use_cutlass_mxfp4:
-            self.experts_cls = CutlassExpertsMxfp4
-            logger.info_once("Using CutlassExpertsMxfp4 for AutoRound MXFP4 MoE")
-        elif current_platform.is_xpu():
-            self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(moe)
-        else:
-            self.experts_cls = MarlinExperts
-            logger.info_once(
-                "Using MarlinExperts (weight-only FP4) for AutoRound MXFP4 MoE"
-            )
+            return
+
+        candidates = list(self.CANDIDATE_BACKENDS)
+        if moe.moe_backend != "auto":
+            candidates = narrow_mxfp4_candidates(moe.moe_backend, candidates)
+            if not candidates:
+                raise ValueError(
+                    f"moe_backend={moe.moe_backend!r} is not supported for "
+                    "AutoRound MXFP4 MoE; expected one of "
+                    f"{[b.value for b in self.CANDIDATE_BACKENDS]}."
+                )
+        self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend_from(
+            moe, candidates
+        )
 
     def create_weights(
         self,
@@ -144,13 +148,8 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:
-        if self.use_cutlass_mxfp4:
-            # W4A4: both weights and activations quantized to MXFP4.
-            return mxfp4_moe_quant_config(
-                w1_scale=layer.w13_weight_scale,
-                w2_scale=layer.w2_weight_scale,
-            )
-        # b12x selects W4A8 or W4A16; XPU uses W4A4; Marlin uses W4A16.
+        # CUTLASS and XPU use W4A4; DeepGEMM W4A8; b12x W4A8 or W4A16;
+        # Marlin W4A16.
         return make_mxfp4_moe_quant_config(
             mxfp4_backend=self.mxfp4_backend,
             w1_scale=layer.w13_weight_scale,
@@ -167,7 +166,7 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
         )
         delattr(layer, "w2_weight_packed")
 
-        if self.use_cutlass_mxfp4:
+        if self.mxfp4_backend == Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4:
             # Swizzle weight scales from flat checkpoint layout [E, N, K//32]
             # to the CUTLASS tiled layout.
             from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
@@ -198,9 +197,19 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_weight_scale = torch.nn.Parameter(
                 torch.stack(swizzled_w2), requires_grad=False
             )
-        elif self.mxfp4_backend in B12X_BACKENDS or current_platform.is_xpu():
-            pass
-        else:
+        elif self.mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
+            w13_scale, w2_scale = pack_deepgemm_mxfp4_scales(
+                layer.w13_weight,
+                layer.w2_weight,
+                layer.w13_weight_scale,
+                layer.w2_weight_scale,
+            )
+            layer.w13_weight_scale = torch.nn.Parameter(w13_scale, requires_grad=False)
+            layer.w2_weight_scale = torch.nn.Parameter(w2_scale, requires_grad=False)
+        elif self.mxfp4_backend in (
+            Mxfp4MoeBackend.MARLIN,
+            Mxfp4MoeBackend.BATCHED_MARLIN,
+        ):
             logger.warning_once(
                 "This device lacks native FP4 compute; using weight-only FP4 "
                 "via the Marlin kernel, which may reduce performance for "

--- a/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
+++ b/vllm/model_executor/layers/quantization/inc/schemes/inc_mxfp4_moe.py
@@ -3,8 +3,6 @@
 
 import torch
 
-import vllm.model_executor.layers.fused_moe.modular_kernel as mk
-from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     FusedMoeWeightScaleSupported,
     RoutedExperts,
@@ -17,67 +15,30 @@ from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
     FusedMoEMethodBase,
 )
 from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import (
-    Mxfp4MoeBackend,
+    convert_packed_weight_to_mxfp4_moe_kernel_format,
     make_mxfp4_moe_kernel,
     make_mxfp4_moe_quant_config,
-    narrow_mxfp4_candidates,
-    pack_deepgemm_mxfp4_scales,
-    select_mxfp4_moe_backend,
-    select_mxfp4_moe_backend_from,
-)
-from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
-    prepare_moe_fp4_layer_for_marlin,
+    select_packed_mxfp4_moe_backend,
 )
 from vllm.model_executor.utils import set_weight_attrs
-
-logger = init_logger(__name__)
 
 
 class INCMxfp4MoEMethod(FusedMoEMethodBase):
     """W4A4 MXFP4 group MoE for AutoRound ``auto_round:llm_compressor`` exports.
 
     Registers the packed MXFP4 layout (uint8 ``weight_packed`` + uint8 E8M0
-    ``weight_scale``, ``group_size=32``) and dispatches the fused MoE to b12x
-    when requested; otherwise it uses CUTLASS W4A4, DeepGEMM W4A8, XPU W4A4, or
-    Marlin W4A16.
+    ``weight_scale``, ``group_size=32``); the oracle picks the backend and
+    converts the weights to its kernel format.
     The per-expert ``gate_proj`` / ``up_proj`` / ``down_proj`` tensors are
     folded into the stacked ``w13`` / ``w2`` parameters by
     ``make_expert_params_mapping``.
     """
 
-    # Candidate backends in preference order. Must stay consistent with the
-    # weight preparation in process_weights_after_loading /
-    # get_fused_moe_quant_config: CUTLASS swizzle (true W4A4), DeepGEMM scale
-    # packing (W4A8), XPU packed passthrough, and Marlin weight-only. The
-    # oracle drops candidates the deployment cannot use (device, expert
-    # parallelism, activation format).
-    CANDIDATE_BACKENDS = (
-        Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4,
-        Mxfp4MoeBackend.DEEPGEMM_MXFP4,
-        Mxfp4MoeBackend.XPU,
-        Mxfp4MoeBackend.MARLIN,
-    )
-
     def __init__(self, moe) -> None:
         super().__init__(moe)
         self.group_size = 32
-        self.experts_cls: type[mk.FusedMoEExperts] | None = None
-        if moe.moe_backend == "b12x":
-            # b12x has its own precision policy (VLLM_B12X_MOE_FP4_FORCE_A16).
-            self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend(moe)
-            return
-
-        candidates = list(self.CANDIDATE_BACKENDS)
-        if moe.moe_backend != "auto":
-            candidates = narrow_mxfp4_candidates(moe.moe_backend, candidates)
-            if not candidates:
-                raise ValueError(
-                    f"moe_backend={moe.moe_backend!r} is not supported for "
-                    "AutoRound MXFP4 MoE; expected one of "
-                    f"{[b.value for b in self.CANDIDATE_BACKENDS]}."
-                )
-        self.mxfp4_backend, self.experts_cls = select_mxfp4_moe_backend_from(
-            moe, candidates
+        self.mxfp4_backend, self.experts_cls = select_packed_mxfp4_moe_backend(
+            moe, "AutoRound"
         )
 
     def create_weights(
@@ -157,77 +118,18 @@ class INCMxfp4MoEMethod(FusedMoEMethodBase):
         )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
-        layer.w13_weight = torch.nn.Parameter(
-            layer.w13_weight_packed.data, requires_grad=False
-        )
-        delattr(layer, "w13_weight_packed")
-        layer.w2_weight = torch.nn.Parameter(
-            layer.w2_weight_packed.data, requires_grad=False
-        )
-        delattr(layer, "w2_weight_packed")
-
-        if self.mxfp4_backend == Mxfp4MoeBackend.CUTLASS_MXFP4_MXFP4:
-            # Swizzle weight scales from flat checkpoint layout [E, N, K//32]
-            # to the CUTLASS tiled layout.
-            from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
-                swizzle_mxfp4_scales,
-            )
-
-            E = layer.w13_weight_scale.shape[0]
-            w13_N = layer.w13_weight_scale.shape[1]
-            w13_scale_K = layer.w13_weight_scale.shape[2]
-            w13_K = w13_scale_K * 32
-
-            w2_M = layer.w2_weight_scale.shape[1]
-            w2_scale_N = layer.w2_weight_scale.shape[2]
-            w2_N = w2_scale_N * 32
-
-            swizzled_w13 = []
-            swizzled_w2 = []
-            for e_idx in range(E):
-                s13 = layer.w13_weight_scale[e_idx]
-                sw13 = swizzle_mxfp4_scales(s13, w13_N, w13_K)
-                swizzled_w13.append(sw13.reshape(w13_N, w13_scale_K))
-                s2 = layer.w2_weight_scale[e_idx]
-                sw2 = swizzle_mxfp4_scales(s2, w2_M, w2_N)
-                swizzled_w2.append(sw2.reshape(w2_M, w2_scale_N))
-            layer.w13_weight_scale = torch.nn.Parameter(
-                torch.stack(swizzled_w13), requires_grad=False
-            )
-            layer.w2_weight_scale = torch.nn.Parameter(
-                torch.stack(swizzled_w2), requires_grad=False
-            )
-        elif self.mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MXFP4:
-            w13_scale, w2_scale = pack_deepgemm_mxfp4_scales(
-                layer.w13_weight,
-                layer.w2_weight,
-                layer.w13_weight_scale,
-                layer.w2_weight_scale,
-            )
-            layer.w13_weight_scale = torch.nn.Parameter(w13_scale, requires_grad=False)
-            layer.w2_weight_scale = torch.nn.Parameter(w2_scale, requires_grad=False)
-        elif self.mxfp4_backend in (
-            Mxfp4MoeBackend.MARLIN,
-            Mxfp4MoeBackend.BATCHED_MARLIN,
-        ):
-            logger.warning_once(
-                "This device lacks native FP4 compute; using weight-only FP4 "
-                "via the Marlin kernel, which may reduce performance for "
-                "compute-heavy workloads."
-            )
-            prepare_moe_fp4_layer_for_marlin(layer)
+        convert_packed_weight_to_mxfp4_moe_kernel_format(self.mxfp4_backend, layer)
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config is not None:
-            assert self.experts_cls is not None
-            self.moe_kernel = make_mxfp4_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                experts_cls=self.experts_cls,
-                mxfp4_backend=self.mxfp4_backend,
-                routing_tables=layer._expert_routing_tables(),
-            )
-            self.moe_kernel.fused_experts.process_weights_after_loading(layer)
+        assert self.moe_quant_config is not None
+        self.moe_kernel = make_mxfp4_moe_kernel(
+            moe_quant_config=self.moe_quant_config,
+            moe_config=self.moe,
+            experts_cls=self.experts_cls,
+            mxfp4_backend=self.mxfp4_backend,
+            routing_tables=layer._expert_routing_tables(),
+        )
+        self.moe_kernel.fused_experts.process_weights_after_loading(layer)
 
     def apply(
         self,


### PR DESCRIPTION
## Purpose

`CompressedTensorsW4A4Mxfp4MoEMethod` and `INCMxfp4MoEMethod` load the same packed MXFP4
layout (uint8 `wN_weight_packed` + uint8 E8M0 `weight_scale`, `group_size=32`) and had the
same drift: `select_mxfp4_moe_backend` was called only for `--moe-backend=b12x`, everything
else went through a hand-rolled CUTLASS/XPU/Marlin device probe, plus ~45 lines of inlined
CUTLASS scale swizzling and a `prepare_moe_fp4_layer_for_marlin(layer)` call in each file.

Both are now reduced to weight creation, loading, and oracle delegation, matching
`CompressedTensorsW4A4Nvfp4MoEMethod`. The packed path folds into the *existing* entrypoints —
there is still exactly one `select_mxfp4_moe_backend` and one
`convert_weight_to_mxfp4_moe_kernel_format` — via a new optional candidate list:

```python                                                                                                                              
select_mxfp4_moe_backend(moe, candidates=PACKED_MXFP4_CANDIDATE_BACKENDS)                                                              
# (CUTLASS_MXFP4_MXFP4, DEEPGEMM_MXFP4, XPU, MARLIN)                                                                                   
```                                                                                                                                    

`--moe-backend=b12x` still routes through `_get_requested_backends`, so b12x keeps picking its
own precision (`VLLM_B12X_MOE_FP4_FORCE_A16`).

5 files, +258/−262, plus 154 lines of new tests.

## Behavior changes to review

1. **`--moe-backend` is now honored** for packed MXFP4; previously anything but `b12x` was
   ignored and the device probe won. Unsupported values now raise instead of silently falling
   through. Same bug as [#55232](https://github.com/vllm-project/vllm/pull/55232).
2. **`DEEPGEMM_MXFP4` is newly reachable**, only when CUTLASS W4A4 doesn't support the
   device/config — cases that previously fell to Marlin. Unchanged on SM100.
3. **Marlin prep**: `prepare_moe_fp4_layer_for_marlin` (in-place) →
   `prepare_moe_mxfp4_layer_for_marlin` (pure). Identical tensors under the default env
   (`get_marlin_input_dtype()` returns `None` unless `VLLM_MARLIN_INPUT_DTYPE` is set); only
   diverges when it is set, where the new path matches `MarlinExperts.input_dtype`.
   `layer.workspace` is no longer allocated — the modular path allocates its own
   (`marlin_moe.py:97-98`).
4. **CUTLASS quant config** `mxfp4_moe_quant_config` → `make_mxfp4_moe_quant_config`; both
   reduce to the same `FusedMoEQuantConfig.make("mxfp4", …)`, so no-op.

Pre-existing constraint carried over verbatim: the CUTLASS swizzle-then-reshape requires
`N % 128 == 0` and `(K // 32) % 4 == 0`.

## Non-duplication — needs a maintainer call

Two open PRs overlap on the compressed-tensors half:

- [#56306](https://github.com/vllm-project/vllm/pull/56306) — CT only, explicitly defers INC.
- [#55232](https://github.com/vllm-project/vllm/pull/55232) — CT only, fixes behavior change 1.

This PR is broader (both methods, unified entrypoints, no parallel packed API), but the CT
changes are not independent. Land one of the narrower PRs and rebase, or close them in favor
of this — to be raised on #54959, not decided here.

Also note #56603 / #53328 reword the Marlin fallback warning that this PR moves into the
oracle; trivial rebase against whichever lands first.

## Tests

New in `tests/kernels/moe/test_ocp_mx_moe.py`, covering the two conversion paths that had no
direct coverage (both mutation-verified — they fail if the oracle's CUTLASS branch is removed
or the in-place Marlin call restored):

- `test_convert_weight_to_mxfp4_cutlass_swizzles_scales_per_expert` (CPU) — per-expert scale
  swizzle; weights returned by identity.
- `test_packed_mxfp4_moe_method_converts_weights_for_marlin` (CUDA) — drives the real
  `process_weights_after_loading` with MARLIN pinned; fails if `prepare_moe_fp4_layer_for_marlin`
  is called; asserts repacked dtypes/shapes and no dead `layer.workspace`.

`test_b12x.py` and `test_auto_round.py` monkeypatches updated for the new signature.

### Results — 8× B200 (SM100)

| Command | Result |                                                                                                                   
|---|---|                                                                                                                              
| `pytest tests/kernels/moe/test_ocp_mx_moe.py -k "cutlass_swizzles or converts_weights_for_marlin"` | 2 passed, 150 deselected |      
| `pytest tests/kernels/moe/test_b12x.py` | 30 passed, 8 skipped |                                                                     
| `pytest tests/quantization/test_gfx950_moe.py tests/kernels/moe/test_ocp_mx_moe.py` | 117 passed, 39 skipped |                       
| `pytest tests/quantization/test_auto_round.py` | 100 passed, 10 skipped, 2 failed |                                                  
| `pytest tests/quantization/test_quark.py -k mxfp4` | collection error: no `lm_eval` (local env gap) |                                
| `ruff check` / `ruff format --diff` / `pre-commit run mypy-3.12 --hook-stage manual` | clean |                                       

The 2 failures are pre-existing — reproduced at `c69d5d72a6` with the branch stashed:
`auto_round:block_wise_fp8_on_cuda` and `auto_round:mxfp8:qwen3-30b-a3b`. Neither touches the
packed MXFP4 path.

### Not yet covered

- **No model eval run.** Behavior changes 2 and 3 can affect output, so GSM8K on a
  `mxfp4-pack-quantized` checkpoint (e.g. `nm-testing/Qwen3-30B-A3B-MXFP4A16`) with
  `--moe-backend` swept over `auto`/`cutlass`/`marlin` is still owed.
- DeepGEMM candidate never selected on B200, so that branch is untested e2e.
- XPU and ROCm/AITER unchanged by inspection, untested here.

## AI assistance

Developed with AI assistance (Claude Code) for the refactor, the two new tests, and this
summary.