### PR TITLE
[Bugfix][Mamba] Zero mamba state blocks on (re)allocation to stop stale-state poisoning on hybrid models

### DIFF
--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -105,8 +105,13 @@ class SingleTypeKVCacheManager(ABC):
         # consume them and this manager holds a spec type that gets zeroed.
         self._record_new_block_ids = (
             needs_kv_cache_zeroing
-            and isinstance(kv_cache_spec, AttentionSpec)
-            and not isinstance(kv_cache_spec, CircularBufferSpec)
+            and (
+                (
+                    isinstance(kv_cache_spec, AttentionSpec)
+                    and not isinstance(kv_cache_spec, CircularBufferSpec)
+                )
+                or isinstance(kv_cache_spec, MambaSpec)
+            )
         )
         self.new_block_ids: list[int] = []
 
@@ -1876,6 +1881,8 @@ class MambaManager(SingleTypeKVCacheManager):
                     max_new_blocks += self.num_speculative_blocks
                 assert num_new_blocks <= max_new_blocks
                 new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+                if self._record_new_block_ids:
+                    self.new_block_ids.extend(b.block_id for b in new_blocks)
                 returned_blocks = req_blocks[prev_block_len:]
                 if partial_hit is not None:
                     block_idx, source_block = partial_hit

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -135,7 +135,7 @@ class KVBlockZeroer:
         Each virtual block is represented as an independent segment so its
         physical block stride and zeroed page span remain independent.
 
-        Only AttentionSpec layers are processed; Mamba layers are skipped.
+        Only AttentionSpec and MambaSpec layers are processed.
         """
         self.device = device
         self._meta: (
@@ -154,7 +154,7 @@ class KVBlockZeroer:
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
-            if not isinstance(spec, AttentionSpec):
+            if not isinstance(spec, (AttentionSpec, MambaSpec)):
                 continue
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue
@@ -163,51 +163,60 @@ class KVBlockZeroer:
             for layer_name in group.layer_names:
                 if layer_name in runner_only_attn_layers:
                     continue
-                kv = static_forward_context[layer_name].kv_cache
-                if not isinstance(kv, torch.Tensor):
-                    continue
-                dp = kv.data_ptr()
-
-                assert kv.shape[0] % num_blocks == 0, (
-                    f"{layer_name}: {kv.shape[0]} kernel blocks is not a "
-                    f"multiple of {num_blocks} logical blocks"
+                layer_cache = static_forward_context[layer_name].kv_cache
+                # Mamba layers bind a tuple of state tensors (conv, recurrent,
+                # RecoverSSM records), each carved block-strided from the same
+                # backing pages; every tensor gets its own segment.
+                kvs = (
+                    list(layer_cache)
+                    if isinstance(layer_cache, (list, tuple))
+                    else [layer_cache]
                 )
-                ratio = kv.shape[0] // num_blocks
+                for kv in kvs:
+                    if not isinstance(kv, torch.Tensor):
+                        continue
+                    dp = kv.data_ptr()
 
-                el = kv.element_size()
-                block_stride_bytes = kv.stride(0) * el
-                assert block_stride_bytes % 4 == 0
-                assert kv.shape[0] % ratio == 0
-                outer_dims = [
-                    d
-                    for d in range(1, kv.ndim)
-                    if kv.stride(d) * el > block_stride_bytes
-                ]
-                outer_strides = [kv.stride(d) * el for d in outer_dims]
-                inner_dims = [d for d in range(1, kv.ndim) if d not in outer_dims]
-                kernel_page_bytes = el + sum(
-                    (kv.shape[d] - 1) * kv.stride(d) * el for d in inner_dims
-                )
-                assert kernel_page_bytes % 4 == 0
-                logical_block_stride_bytes = block_stride_bytes * ratio
-                for outer in iprod(*(range(kv.shape[d]) for d in outer_dims)):
-                    off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
-                    assert (dp + off_bytes) % 4 == 0
-                    for virtual_index in range(ratio):
-                        addr = dp + off_bytes + virtual_index * block_stride_bytes
-                        if (idx := seen_ptrs.get(addr)) is not None:
-                            assert (
-                                seg_block_strides[idx]
-                                == logical_block_stride_bytes // 4
-                            )
-                            seg_page_sizes[idx] = max(
-                                seg_page_sizes[idx], kernel_page_bytes // 4
-                            )
-                            continue
-                        seen_ptrs[addr] = len(seg_addrs)
-                        seg_addrs.append(addr)
-                        seg_block_strides.append(logical_block_stride_bytes // 4)
-                        seg_page_sizes.append(kernel_page_bytes // 4)
+                    assert kv.shape[0] % num_blocks == 0, (
+                        f"{layer_name}: {kv.shape[0]} kernel blocks is not a "
+                        f"multiple of {num_blocks} logical blocks"
+                    )
+                    ratio = kv.shape[0] // num_blocks
+
+                    el = kv.element_size()
+                    block_stride_bytes = kv.stride(0) * el
+                    assert block_stride_bytes % 4 == 0
+                    assert kv.shape[0] % ratio == 0
+                    outer_dims = [
+                        d
+                        for d in range(1, kv.ndim)
+                        if kv.stride(d) * el > block_stride_bytes
+                    ]
+                    outer_strides = [kv.stride(d) * el for d in outer_dims]
+                    inner_dims = [d for d in range(1, kv.ndim) if d not in outer_dims]
+                    kernel_page_bytes = el + sum(
+                        (kv.shape[d] - 1) * kv.stride(d) * el for d in inner_dims
+                    )
+                    assert kernel_page_bytes % 4 == 0
+                    logical_block_stride_bytes = block_stride_bytes * ratio
+                    for outer in iprod(*(range(kv.shape[d]) for d in outer_dims)):
+                        off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
+                        assert (dp + off_bytes) % 4 == 0
+                        for virtual_index in range(ratio):
+                            addr = dp + off_bytes + virtual_index * block_stride_bytes
+                            if (idx := seen_ptrs.get(addr)) is not None:
+                                assert (
+                                    seg_block_strides[idx]
+                                    == logical_block_stride_bytes // 4
+                                )
+                                seg_page_sizes[idx] = max(
+                                    seg_page_sizes[idx], kernel_page_bytes // 4
+                                )
+                                continue
+                            seen_ptrs[addr] = len(seg_addrs)
+                            seg_addrs.append(addr)
+                            seg_block_strides.append(logical_block_stride_bytes // 4)
+                            seg_page_sizes.append(kernel_page_bytes // 4)
 
         if not seg_addrs:
             self._meta = None


### PR DESCRIPTION
# [Bugfix] Zero mamba state blocks on (re)allocation to stop stale-state poisoning on hybrid models

**Status: draft pending CI + unit tests. Validated in production on an 8×B300 node serving `moonshotai/Kimi-K3` (hybrid MLA + KDA/mamba, `--kv-cache-dtype fp8`, prefix caching, dspark spec-decode).**

## Problem

Mamba/KDA state blocks are handed out by `BlockPool.get_new_blocks` **without zeroing**, and the attention-only zeroing queue never covers them:

- `KVCacheConfig.needs_kv_cache_zeroing` is set to `True` for mamba models (`kv_cache_interface.py`, "Required for Mamba layers, whose state is read before it is fully written (#35219)"),
- but `SingleTypeKVCacheManager.__init__` only sets `_record_new_block_ids` for `AttentionSpec` (`vllm/v1/core/single_type_kv_cache_manager.py`), so mamba block IDs are never recorded for the zeroing queue,
- and `KVBlockZeroer` (`vllm/v1/worker/utils.py`) skips non-`AttentionSpec` layers and non-`Tensor` `kv_cache` values — KDA layers bind a **tuple** of state tensors (`conv_state, recurrent_state, *recoverssm_records = self.kv_cache`, `vllm/models/kimi_k3/nvidia/kda.py`), so both guards exclude them.

Any read of a mamba state slot that was not written by the current tenant therefore inherits **arbitrary bytes from a previous tenant**. We observed this in production as cross-request poisoning: after an aborted prefill, a retry resumed from a state block previously freed mid-write and emitted unbounded multilingual garbage until engine restart.

## Fix

1. `_record_new_block_ids`: record allocations for `MambaSpec` managers (in addition to attention).
2. `MambaManager.allocate_new_blocks` (align cache mode): record the IDs returned by its direct `block_pool.get_new_blocks()` call, which bypasses the base-class recording path.
3. `KVBlockZeroer.__init__`: accept `MambaSpec` groups and unpack tuple/list `kv_cache` bindings, emitting one segment per state tensor. The existing per-block segment math applies unchanged (state tensors are `[num_blocks, ...]` block-strided carves of the shared page).

Per-step ordering is already `zero → block copies → forward`, so a slot read before its legitimate write returns zeros (i.e. a *fresh* recurrent state) instead of a previous tenant's bytes — degrading quality gracefully instead of corrupting the session.

## Cost

~0.6–1.0 MiB zeroed per mamba state block per layer group (K3: 69 KDA layers / 14 groups ⇒ a few MiB per block ID in practice), only at allocation time; mamba blocks are allocated at prefill-chunk boundaries. Measured overhead in production: none observable (throughput and TTFT unchanged within noise).

## Validation

- Reproducer (`storm4.py`, attached below): N workers sharing a 40k-token prefix; each cycle aborts mid-prefill (~1.2 s in) and immediately retries. Unpatched nightly: 1–2 in 36 retries poisoned with garbage (verified by full-text inspection). Patched: 0/72.
- `idlegap.py`: cache-hit-after-idle regression test, passes.
- `verify.py` functional suite (text/reasoning/vision/prefix-cache) passes; `stress_multiturn.py` (3×6-round growing sessions) passes; throughput unchanged (243–246 tok/s single-conn decode).

## Related

- #51039 (KDA one-token misclassification — different path, separate PR #51483)
- #53912, #43650, #48375 — surrounding hybrid/mamba prefix-cache issues

*AI-assisted (Claude Code / Kimi Code agent) root-cause and patch authoring, with human operator running all production experiments.*

(POC repro script and full production logs available; happy to attach.)
