### PR TITLE
[Perf][Qwen] Inline zero padding kernel during MTP decodes (1% decode speedup)

### DIFF
--- a/csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu
+++ b/csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu
@@ -158,7 +158,7 @@ __global__ __launch_bounds__(kThreads, 2) void gdn_decode_post_conv_mtp_kernel(
     const void* __restrict__ norm_weight, __nv_bfloat16* __restrict__ out,
     int H, int HV, int state_indices_width, int dt_bias_type,
     bool norm_weight_is_bf16, float scale, float norm_eps,
-    GdnDecodeStrides strides) {
+    GdnDecodeStrides strides, int num_output_tokens) {
   const int request = blockIdx.x;
   const int value_head = blockIdx.y;
   const int tid = threadIdx.x;
@@ -167,6 +167,16 @@ __global__ __launch_bounds__(kThreads, 2) void gdn_decode_post_conv_mtp_kernel(
   const int bos = cu_seqlens[request];
   const int eos = cu_seqlens[request + 1];
   const int num_tokens = eos - bos;
+  // The last request owns the padded tail, including an empty final request.
+  if (request == gridDim.x - 1) {
+    for (int linear = tid; linear < (num_output_tokens - eos) * kDimV;
+         linear += kThreads) {
+      const int token = eos + linear / kDimV;
+      const int value = linear % kDimV;
+      out[(static_cast<int64_t>(token) * HV + value_head) * kDimV + value] =
+          __float2bfloat16(0.0f);
+    }
+  }
   if (num_tokens <= 0) {
     return;
   }
@@ -410,7 +420,8 @@ void launch_gdn_decode_post_conv_mtp(
           num_key_heads, num_value_heads,
           static_cast<int>(state_indices.size(1)), dt_bias_type,
           norm_weight.scalar_type() == ScalarType::BFloat16,
-          static_cast<float>(scale), static_cast<float>(norm_eps), strides);
+          static_cast<float>(scale), static_cast<float>(norm_eps), strides,
+          static_cast<int>(out.size(0)));
   const cudaError_t error = cudaGetLastError();
   STD_TORCH_CHECK(error == cudaSuccess,
                   "GDN decode MTP post-conv kernel launch failed: ",
@@ -526,9 +537,9 @@ void fused_gdn_decode_post_conv_mtp(
                   "output_gate must have shape [L, HV, 128]");
   STD_TORCH_CHECK(norm_weight.is_contiguous() && norm_weight.numel() == kDimV,
                   "norm_weight must be contiguous with 128 elements");
-  STD_TORCH_CHECK(out.dim() == 3 && out.size(0) == num_tokens &&
+  STD_TORCH_CHECK(out.dim() == 3 && out.size(0) >= num_tokens &&
                       out.size(1) == num_value_heads && out.size(2) == kDimV,
-                  "out must have shape [L, HV, 128]");
+                  "out must have shape [L_padded, HV, 128] with L_padded >= L");
   STD_TORCH_CHECK(mixed_qkv.stride(1) == 1,
                   "mixed_qkv channels must be contiguous");
   STD_TORCH_CHECK(a.stride(1) == 1 && b.stride(1) == 1,

--- a/tests/kernels/mamba/test_gdn_fused_mtp.py
+++ b/tests/kernels/mamba/test_gdn_fused_mtp.py
@@ -252,6 +252,7 @@ def test_fused_forward_uses_packed_entrypoint() -> None:
     ],
 )
 @pytest.mark.parametrize("output_gate_activation", ["silu", "sigmoid"])
+@pytest.mark.parametrize("padding_tokens", [0, 3])
 @torch.inference_mode()
 def test_fused_model_path_matches_reference(
     seq_lens: list[int],
@@ -259,6 +260,7 @@ def test_fused_model_path_matches_reference(
     draft_tokens: list[int],
     expected_fused_calls: int,
     output_gate_activation: str,
+    padding_tokens: int,
 ) -> None:
     """Fused MTP and its mixed/prefill/decode fallbacks match the reference."""
     torch.manual_seed(1)
@@ -316,7 +318,8 @@ def test_fused_model_path_matches_reference(
         CONV_DIM, 1, CONV_KERNEL, dtype=torch.bfloat16, device=device
     )
     norm_weight = torch.randn(V, dtype=torch.float32, device=device)
-    num_tokens = batch.compute_num_tokens()
+    num_actual_tokens = batch.compute_num_tokens()
+    num_tokens = num_actual_tokens + padding_tokens
     mixed_qkv = 0.1 * torch.randn(
         num_tokens, CONV_DIM, dtype=torch.bfloat16, device=device
     )
@@ -362,7 +365,7 @@ def test_fused_model_path_matches_reference(
         output_gate_activation,
     )
     context.no_compile_layers = {PREFIX: fused_layer}
-    fused_out = torch.zeros_like(output_gate)
+    fused_out = torch.full_like(output_gate, float("nan"))
     fused_op = qwen_gdn_linear_attn.ops.fused_gdn_decode_post_conv_mtp
     with (
         patch.object(qwen_gdn_linear_attn, "get_forward_context", return_value=context),
@@ -380,6 +383,12 @@ def test_fused_model_path_matches_reference(
         )
 
     assert fused_mock.call_count == expected_fused_calls
+    torch.testing.assert_close(
+        fused_out[num_actual_tokens:],
+        torch.zeros_like(fused_out[num_actual_tokens:]),
+        atol=0,
+        rtol=0,
+    )
     torch.testing.assert_close(
         fused_layer.kv_cache[0], reference_layer.kv_cache[0], atol=0, rtol=0
     )

--- a/tests/kernels/test_fused_gdn_post_conv.py
+++ b/tests/kernels/test_fused_gdn_post_conv.py
@@ -268,6 +268,7 @@ def test_fused_post_conv_l0():
     ],
 )
 @pytest.mark.parametrize("output_gate_activation", ["silu", "sigmoid"])
+@pytest.mark.parametrize("padding_tokens", [0, 3])
 @torch.inference_mode()
 def test_fused_gdn_decode_post_conv_mtp_head_ratios(
     head_ratio: int,
@@ -276,7 +277,9 @@ def test_fused_gdn_decode_post_conv_mtp_head_ratios(
     state_dtype: torch.dtype,
     norm_dtype: torch.dtype,
     output_gate_activation: str,
+    padding_tokens: int,
 ) -> None:
+    """Live outputs match the reference and padding is zero, even after empty requests."""
     if torch.cuda.get_device_capability() < (8, 0):
         pytest.skip("fused GDN decode MTP requires compute capability 8.0+")
     if not hasattr(torch.ops._C, "fused_gdn_decode_post_conv_mtp"):
@@ -361,6 +364,14 @@ def test_fused_gdn_decode_post_conv_mtp_head_ratios(
             norm_before_gate=True,
             activation=output_gate_activation,
         )
+        output_storage = torch.full(
+            (num_tokens + padding_tokens + 2, HV, V),
+            17.0,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        out = output_storage[1:-1]
+        out.fill_(float("nan"))
         actual = ops.fused_gdn_decode_post_conv_mtp(
             mixed_qkv=mixed_qkv,
             a=a,
@@ -373,13 +384,18 @@ def test_fused_gdn_decode_post_conv_mtp_head_ratios(
             state=state_actual,
             output_gate=output_gate,
             norm_weight=norm_weight,
-            out=torch.empty_like(output_gate),
+            out=out,
             scale=scale,
             norm_eps=eps,
             output_gate_activation=output_gate_activation,
         )
 
-        output_error = (actual.float() - expected.float()).norm()
+        torch.testing.assert_close(
+            actual[num_tokens:], torch.zeros_like(actual[num_tokens:]), atol=0, rtol=0
+        )
+        assert torch.all(output_storage[0] == 17)
+        assert torch.all(output_storage[-1] == 17)
+        output_error = (actual[:num_tokens].float() - expected.float()).norm()
         output_relative_l2 = output_error / expected.float().norm().clamp_min(1e-20)
         assert output_relative_l2 < 5e-4, (
             f"MTP output relative L2 mismatch at step {step}: "

--- a/tests/kernels/test_fused_gdn_post_conv.py
+++ b/tests/kernels/test_fused_gdn_post_conv.py
@@ -279,7 +279,7 @@ def test_fused_gdn_decode_post_conv_mtp_head_ratios(
     output_gate_activation: str,
     padding_tokens: int,
 ) -> None:
-    """Live outputs match the reference and padding is zero, even after empty requests."""
+    """Live outputs match the reference and padding is zero."""
     if torch.cuda.get_device_capability() < (8, 0):
         pytest.skip("fused GDN decode MTP requires compute capability 8.0+")
     if not hasattr(torch.ops._C, "fused_gdn_decode_post_conv_mtp"):

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -918,7 +918,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             and self.norm.weight.dtype in (torch.bfloat16, torch.float32)
         )
         if use_fused_gdn_decode:
-            # The core op clears this unless it selects the padding-aware kernel.
+            # Padding slots are guaranteed to be cleared to avoid NaN
+            # Either with .zero_() or inlined within the GDN kernel 
             core_attn_out = torch.empty(
                 (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
                 dtype=hidden_states.dtype,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -918,7 +918,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             and self.norm.weight.dtype in (torch.bfloat16, torch.float32)
         )
         if use_fused_gdn_decode:
-            core_attn_out = torch.zeros(
+            # The core op clears this unless it selects the padding-aware kernel.
+            core_attn_out = torch.empty(
                 (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
                 dtype=hidden_states.dtype,
                 device=hidden_states.device,
@@ -1751,7 +1752,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             b=b[:num_actual_tokens],
             a=a[:num_actual_tokens],
             output_gate=output_gate[:num_actual_tokens],
-            core_attn_out=core_attn_out[:num_actual_tokens],
+            core_attn_out=core_attn_out,
             attn_metadata=attn_metadata,
         )
 
@@ -1803,6 +1804,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if isinstance(attn_metadata_raw, dict):
             attn_metadata = attn_metadata_raw.get(self.prefix)
         if attn_metadata is None:
+            core_attn_out.zero_()
             self._warmup_prefill_kernels(mixed_qkvz[:, :qkv_size], 0)
             return
 
@@ -1887,6 +1889,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         if isinstance(attn_metadata_raw, dict):
             attn_metadata = attn_metadata_raw.get(self.prefix)
         if attn_metadata is None:
+            core_attn_out.zero_()
             self._warmup_prefill_kernels(mixed_qkv, 0)
             return
 
@@ -1904,6 +1907,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
                 attn_metadata=attn_metadata,
             )
             return
+        # Prefill, mixed batches and decode fallbacks retain zeroed padding.
+        core_attn_out.zero_()
         self._forward_core(
             mixed_qkv=mixed_qkv,
             b=b.contiguous(),

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -1909,6 +1909,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
             return
         # Prefill, mixed batches and decode fallbacks retain zeroed padding.
+        # Specialized MTP decode kernel will zero the padding directly.
         core_attn_out.zero_()
         self._forward_core(
             mixed_qkv=mixed_qkv,


### PR DESCRIPTION
## Purpose

Eliminate this little zero-er kernel from the Qwen3.x GDN decode layer execution.
<img width="2329" height="160" alt="image" src="https://github.com/user-attachments/assets/12da880a-7077-4185-92e3-9be3f2d64093" />

It's small, only nets a 0.5-1% speedup E2E at BS1, but enables more comprehensive PDL overlapping between the QKVZ projection and the causal convolution (since there is no longer a kernel between them) -- which I may optimize further in a follow up PR.

To eliminate the zero I evaluated several strategies, but inlining into the GDN kernel itself seems the cleanest: a net speedup for all batch sizes (up to 1024) as long as padding is <25% of total token count. 

We still apply the zeroing when the specialized kernel is not invoked. So, the contract has not changed -- GDN still zeros the padding slots to avoid NaNs

## Test Plan

Unit tests are included.

## Test Result

Seems to be passing locally. Will ensure they run and pass in CI to be sure
