### PR TITLE
[Perf][Qwen] Fuse FP8 Quant into Qwen 3.8 AllReduce

### DIFF
--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -40,6 +40,7 @@ from vllm.distributed.parallel_state import (
     init_distributed_environment,
     initialize_model_parallel,
 )
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
@@ -281,8 +282,60 @@ class TestAllReduceGemmaRMSNormStaticQuantFP8Model(
         self.norm = [GemmaRMSNorm(hidden_size, eps) for _ in range(4)]
         for norm in self.norm:
             norm.weight.requires_grad_(False)
+            norm.weight.data.normal_(mean=0.0, std=0.1)
 
     def ops_in_model_before(self):
+        return super().ops_in_model_before()
+
+
+class TestAllReduceGemmaRMSNormSharedQuantFP8Model(
+    TestAllReduceGemmaRMSNormStaticQuantFP8Model
+):
+    """One quantized norm result feeds two independently scaled GEMMs."""
+
+    share_quant = True
+
+    class Pair(torch.nn.Module):
+        def __init__(self, first, hidden_size, dtype, share_quant):
+            super().__init__()
+            self.first = first
+            self.share_quant = share_quant
+            self.second = TestFP8Layer(
+                weight_shape=(hidden_size, hidden_size),
+                activation_quant_key=kFp8StaticTensorSym,
+                weight_quant_key=kFp8StaticTensorSym,
+                input_dtype=dtype,
+                force_kernel=type(first.kernel),
+            )
+            self.second.input_scale.copy_(
+                first.input_scale if share_quant else first.input_scale * 2
+            )
+
+        def is_quant_fp8_enabled(self):
+            return self.first.is_quant_fp8_enabled()
+
+        def forward(self, x):
+            if not self.share_quant:
+                return self.first(x) + self.second(x)
+            data, scale = self.first.kernel.quant_fp8(x, self.first.input_scale)
+            qa = QuantizedActivation(data, scale, x.dtype, x.shape, kFp8StaticTensorSym)
+            return self.first(qa) + self.second(qa)
+
+    def __init__(self, hidden_size=16, token_num=16, eps=1e-6, dtype=torch.bfloat16):
+        super().__init__(hidden_size, token_num, eps, dtype)
+        self.fp8_linear_layers = [
+            self.Pair(linear, hidden_size, dtype, self.share_quant)
+            for linear in self.fp8_linear_layers
+        ]
+
+
+class TestAllReduceGemmaRMSNormUnequalQuantFP8Model(
+    TestAllReduceGemmaRMSNormSharedQuantFP8Model
+):
+    share_quant = False
+
+    def ops_in_model_before(self):
+        # Both quantizations must survive, while AR/norm can still fuse.
         return [torch.ops.vllm.all_reduce.default]
 
 
@@ -473,6 +526,36 @@ class TestAllReduceFusedAddRMSNormStaticQuantFP4Model(torch.nn.Module):
                 current_platform.is_rocm(),
                 reason="Not supported on ROCm platform",
             ),
+        ),
+        pytest.param(
+            TestAllReduceGemmaRMSNormStaticQuantFP8Model,
+            False,
+            False,
+            marks=pytest.mark.skipif(current_platform.is_rocm(), reason="CUDA only"),
+        ),
+        pytest.param(
+            TestAllReduceGemmaRMSNormSharedQuantFP8Model,
+            True,
+            False,
+            marks=pytest.mark.skipif(current_platform.is_rocm(), reason="CUDA only"),
+        ),
+        pytest.param(
+            TestAllReduceGemmaRMSNormSharedQuantFP8Model,
+            False,
+            False,
+            marks=pytest.mark.skipif(current_platform.is_rocm(), reason="CUDA only"),
+        ),
+        pytest.param(
+            TestAllReduceGemmaRMSNormUnequalQuantFP8Model,
+            True,
+            False,
+            marks=pytest.mark.skipif(current_platform.is_rocm(), reason="CUDA only"),
+        ),
+        pytest.param(
+            TestAllReduceGemmaRMSNormUnequalQuantFP8Model,
+            False,
+            False,
+            marks=pytest.mark.skipif(current_platform.is_rocm(), reason="CUDA only"),
         ),
         pytest.param(
             TestAllReduceRMSNormStaticQuantFP8Model,
@@ -670,11 +753,21 @@ def all_reduce_fusion_pass_on_test_model(
         if test_model_cls in (
             TestAllReduceGemmaRMSNormModel,
             TestAllReduceGemmaRMSNormStaticQuantFP8Model,
+            TestAllReduceGemmaRMSNormSharedQuantFP8Model,
+            TestAllReduceGemmaRMSNormUnequalQuantFP8Model,
         ):
             fused_op = torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
             fused_nodes = list(find_op_nodes(fused_op, backend.graph_post_pass))
             assert fused_nodes
             assert all(n.kwargs.get("weight_bias") == 1.0 for n in fused_nodes)
+            if isinstance(model, TestAllReduceGemmaRMSNormStaticQuantFP8Model):
+                from flashinfer.comm import AllReduceFusionPattern
+
+                assert sum(
+                    n.kwargs["pattern_code"]
+                    == AllReduceFusionPattern.kARResidualRMSNormFP8Quant
+                    for n in fused_nodes
+                ) == (3 if getattr(model, "share_quant", True) else 0)
         del all_reduce_fusion_pass
 
 

--- a/tests/fusion/test_quant_activation_contract.py
+++ b/tests/fusion/test_quant_activation_contract.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Contract tests for the QuantizedActivation linear-kernel integration."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -125,6 +127,50 @@ def test_bridge_marks_supporting_and_skips_others():
     layer = torch.nn.Module()
     expose_input_quant_key(layer, unsupported)
     assert not hasattr(layer, "input_quant_key")
+
+
+@pytest.mark.parametrize("scale", [0.125, 0.25, 0.0, -1.0, float("nan"), float("inf")])
+@pytest.mark.parametrize("method_kind", ["modelopt", "fp8", "compressed_tensors"])
+def test_gdn_shares_only_equal_valid_static_scales_and_rechecks_reload(
+    scale, method_kind
+):
+    from vllm.model_executor.layers.linear import ColumnParallelLinear
+    from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+        QwenGatedDeltaNetAttention,
+        _shared_input_quant,
+    )
+
+    def projection(value):
+        layer = ColumnParallelLinear.__new__(ColumnParallelLinear)
+        torch.nn.Module.__init__(layer)
+        kernel = _probe(CutlassFP8ScaledMMLinearKernel)
+        kernel.quant_fp8 = torch.nn.Identity()
+        kernel.quant_fp8.num_token_padding = None
+        if method_kind == "compressed_tensors":
+            layer.scheme = SimpleNamespace(fp8_linear=kernel)
+            layer.quant_method = SimpleNamespace()
+        else:
+            attr = "kernel" if method_kind == "modelopt" else "fp8_linear"
+            layer.quant_method = SimpleNamespace(**{attr: kernel})
+        layer.input_scale = torch.tensor([value], dtype=torch.float32, device="cpu")
+        return layer
+
+    qkvz, ba = projection(scale), projection(scale)
+    selected = _shared_input_quant(qkvz, ba)
+    assert (selected is not None) == (scale > 0 and scale != float("inf"))
+    assert qkvz.input_scale.data_ptr() != ba.input_scale.data_ptr()
+
+    layer = SimpleNamespace(
+        in_proj_qkvz=qkvz, in_proj_ba=ba, _allow_shared_input_quant=True
+    )
+    QwenGatedDeltaNetAttention.process_weights_after_loading(layer, torch.bfloat16)
+    assert layer._shared_input_quant is selected
+    ba.input_scale = torch.tensor([0.5], device="cpu")
+    QwenGatedDeltaNetAttention.process_weights_after_loading(layer, torch.bfloat16)
+    assert layer._shared_input_quant is None
+    ba.input_scale = None  # Dynamic quantization cannot share a static input.
+    assert _shared_input_quant(qkvz, ba) is None
+    assert _shared_input_quant(None, ba) is None  # Separate/LoRA projections.
 
 
 def test_as_quantized_activation_validates_key():

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -622,12 +622,14 @@ class AllReduceFusedRMSNormStaticQuantFP8Pattern(BasePattern):
         dtype: torch.dtype,
         device: str | None,
         allreduce_params: FlashInferFusedAllReduceParams,
+        gemma: bool = False,
     ) -> None:
         super().__init__(dtype, device)
         self.epsilon = epsilon
         self.allreduce_params = allreduce_params
         self.quant_dtype = torch.float8_e4m3fn
         self.quant_matcher = MatcherQuantFP8(kFp8StaticTensorSym)
+        self.gemma = gemma
 
     def get_inputs(self) -> list[torch.Tensor]:
         _, scale = self.quant_matcher.inputs()
@@ -642,7 +644,8 @@ class AllReduceFusedRMSNormStaticQuantFP8Pattern(BasePattern):
             scale: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor]:
             all_reduce = tensor_model_parallel_all_reduce(input)
-            rms = vllm.ir.ops.rms_norm(all_reduce, weight, self.epsilon)
+            gamma = weight.float() + 1.0 if self.gemma else weight
+            rms = vllm.ir.ops.rms_norm(all_reduce, gamma, self.epsilon)
             quant, _ = self.quant_matcher(rms, scale)
             return quant, all_reduce
 
@@ -667,6 +670,7 @@ class AllReduceFusedRMSNormStaticQuantFP8Pattern(BasePattern):
                     flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNormFP8Quant
                 ),
                 scale_factor=scale,
+                weight_bias=1.0 if self.gemma else 0.0,
                 **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),
             )
 
@@ -679,7 +683,9 @@ class AllReduceFusedRMSNormStaticQuantFP8Pattern(BasePattern):
             self.get_inputs(),
             pm.fwd_only,
             pm_pass,
-            extra_check=_rms_input_weight_dtype_match,
+            extra_check=(lambda match: True)
+            if self.gemma
+            else _rms_input_weight_dtype_match,
         )
 
 
@@ -697,6 +703,7 @@ class AllReduceFusedAddRMSNormStaticQuantFP8Pattern(BasePattern):
         dtype: torch.dtype,
         device: str | None,
         allreduce_params: FlashInferFusedAllReduceParams,
+        gemma: bool = False,
     ) -> None:
         super().__init__(dtype, device)
         self.epsilon = epsilon
@@ -704,6 +711,7 @@ class AllReduceFusedAddRMSNormStaticQuantFP8Pattern(BasePattern):
         self.quant_dtype = torch.float8_e4m3fn
 
         self.quant_matcher = MatcherQuantFP8(kFp8StaticTensorSym)
+        self.gemma = gemma
 
     def get_inputs(self) -> list[torch.Tensor]:
         input = self.empty(5, 16)
@@ -722,8 +730,9 @@ class AllReduceFusedAddRMSNormStaticQuantFP8Pattern(BasePattern):
             scale: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor]:
             allreduce_output = tensor_model_parallel_all_reduce(input)
+            gamma = weight.float() + 1.0 if self.gemma else weight
             rms, res = vllm.ir.ops.fused_add_rms_norm(
-                allreduce_output, residual, weight, self.epsilon
+                allreduce_output, residual, gamma, self.epsilon
             )
             quant, _ = self.quant_matcher(rms, scale)
 
@@ -751,6 +760,7 @@ class AllReduceFusedAddRMSNormStaticQuantFP8Pattern(BasePattern):
                     flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNormFP8Quant
                 ),
                 scale_factor=scale,
+                weight_bias=1.0 if self.gemma else 0.0,
                 **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),
             )
             # quant_out, rms_norm_residual
@@ -762,7 +772,9 @@ class AllReduceFusedAddRMSNormStaticQuantFP8Pattern(BasePattern):
             self.get_inputs(),
             pm.fwd_only,
             pm_pass,
-            extra_check=_norm_input_weight_dtype_match,
+            extra_check=(lambda match: True)
+            if self.gemma
+            else _norm_input_weight_dtype_match,
         )
 
 
@@ -1075,18 +1087,21 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
     def register_patterns(self) -> None:
         for epsilon in [1e-5, 1e-6]:
             if self.supports_quant_fusion:
-                AllReduceFusedRMSNormStaticQuantFP8Pattern(
-                    epsilon,
-                    self.model_dtype,
-                    self.device,
-                    self.allreduce_params,
-                ).register(self.patterns)
-                AllReduceFusedAddRMSNormStaticQuantFP8Pattern(
-                    epsilon,
-                    self.model_dtype,
-                    self.device,
-                    self.allreduce_params,
-                ).register(self.patterns)
+                for gemma in (False, True):
+                    AllReduceFusedRMSNormStaticQuantFP8Pattern(
+                        epsilon,
+                        self.model_dtype,
+                        self.device,
+                        self.allreduce_params,
+                        gemma=gemma,
+                    ).register(self.patterns)
+                    AllReduceFusedAddRMSNormStaticQuantFP8Pattern(
+                        epsilon,
+                        self.model_dtype,
+                        self.device,
+                        self.allreduce_params,
+                        gemma=gemma,
+                    ).register(self.patterns)
                 if current_platform.has_device_capability(100):
                     AllReduceFusedRMSNormStaticQuantNVFP4Pattern(
                         epsilon,

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -23,6 +23,10 @@ from vllm.distributed import (
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp, PluggableLayer
+from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
+    FP8ScaledMMLinearKernel,
+)
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
 from vllm.model_executor.layers.layernorm import RMSNormGated
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -43,6 +47,10 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.auto_awq import AutoAWQConfig
 from vllm.model_executor.layers.quantization.auto_gptq import AutoGPTQConfig
 from vllm.model_executor.layers.quantization.inc import INCConfig
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    kFp8StaticTensorSym,
+)
 from vllm.model_executor.model_loader.weight_utils import (
     sharded_weight_loader,
 )
@@ -89,6 +97,37 @@ logger = init_logger(__name__)
 
 MAX_FUSED_GDN_MTP_TOKENS = 8
 FUSED_GDN_STATE_DTYPES = (torch.float32, torch.bfloat16)
+
+
+def _input_fp8_kernel(linear):
+    method = getattr(linear, "scheme", getattr(linear, "quant_method", None))
+    return getattr(method, "fp8_linear", getattr(method, "kernel", None))
+
+
+def _shared_input_quant(qkvz, ba) -> QuantFP8 | None:
+    """Select one quantizer after both projections' weights have been finalized."""
+    kernels = []
+    scales = []
+    for linear in (qkvz, ba):
+        if not isinstance(linear, ColumnParallelLinear):
+            return None
+        kernel = _input_fp8_kernel(linear)
+        if (
+            not isinstance(kernel, FP8ScaledMMLinearKernel)
+            or kernel.input_quant_key() != kFp8StaticTensorSym
+            or kernel.quant_fp8.num_token_padding is not None
+        ):
+            return None
+        scale = getattr(linear, "input_scale", None)
+        if scale is None or scale.numel() != 1 or scale.dtype != torch.float32:
+            return None
+        kernels.append(kernel)
+        scales.append(scale.reshape(()))
+    if not torch.equal(scales[0], scales[1]):
+        return None
+    if not (torch.isfinite(scales[0]) & (scales[0] > 0)).item():
+        return None
+    return kernels[0].quant_fp8
 
 
 def _resolve_gdn_prefill_backend(
@@ -446,6 +485,12 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             prefix=f"{prefix}.in_proj_ba",
         )
         self.disable_tp_for_ba_proj = self.maybe_disable_tp(self.quant_config)
+        self._allow_shared_input_quant = (
+            current_platform.is_cuda()
+            and vllm_config.lora_config is None
+            and not envs.VLLM_BATCH_INVARIANT
+        )
+        self._shared_input_quant: QuantFP8 | None = None
 
         query_key_settings = (self.key_dim, 0, False)
         value_settings = (self.value_dim, 0, False)
@@ -895,6 +940,34 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         else:
             return self.forward_cuda(hidden_states)
 
+    def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:
+        # The loader invokes attention post-load hooks after quant finalization,
+        # including reloads. Keep both scale parameters independent for refits.
+        self._shared_input_quant = (
+            _shared_input_quant(self.in_proj_qkvz, self.in_proj_ba)
+            if self._allow_shared_input_quant
+            else None
+        )
+
+    def _input_projections(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        proj_input: torch.Tensor | QuantizedActivation = hidden_states
+        if self._shared_input_quant is not None:
+            data, scale = self._shared_input_quant(
+                hidden_states, self.in_proj_qkvz.input_scale
+            )
+            proj_input = QuantizedActivation(
+                data,
+                scale,
+                hidden_states.dtype,
+                hidden_states.shape,
+                kFp8StaticTensorSym,
+            )
+        qkvz, _ = self.in_proj_qkvz(proj_input)
+        ba, _ = self.in_proj_ba(proj_input)
+        return qkvz, ba
+
     def forward_cuda(
         self,
         hidden_states: torch.Tensor,
@@ -909,8 +982,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        mixed_qkvz, ba = self._input_projections(hidden_states)
 
         use_fused_gdn_decode = (
             self.enable_fused_gdn_decode


### PR DESCRIPTION
## Purpose

Currently for Qwen3.x we do not utilize the AllReduce+Norm+Quant fusion because the QKVZ and BA projections have separate quant scales -- so we can't use the quant fusion which would only use one set of scales.

However, the scales for Qwen3.8 2.4T all have exactly the same value (across both QKVZ, BA, and all layers AFAICT). This makes the fusion feasible.

## Test Plan

Unit tests included

## Test Result

Have not run E2E yet