### PR TITLE
[Bugfix] Route every speculation-capable row through the speculative path so recurrent state stays consistent

### DIFF
--- a/tests/v1/attention/test_gdn_zero_draft_spec_rows.py
+++ b/tests/v1/attention/test_gdn_zero_draft_spec_rows.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Which path GDN metadata takes when a decode row carries no draft tokens.
+
+`build_for_cudagraph_capture` derives the draft count from the query length
+(`num_decode_draft_tokens = query_len - 1`), so a capture shape of one token
+per request describes rows with zero drafts. `GDNAttentionMetadataBuilder`
+routes every row with `num_decode_draft_tokens_cpu >= 0` through the
+speculative path, zero drafts included: that path is the only one that
+applies each row's accepted-token offset to the recurrent state, so a
+zero-draft decode row must not fall back to the plain decode path.
+"""
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import (
+    BatchSpec,
+    create_common_attn_metadata,
+    create_vllm_config,
+)
+from vllm.config import SpeculativeConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
+from vllm.v1.kv_cache_interface import MambaSpec
+
+BLOCK_SIZE = 16
+DEVICE = torch.device("cpu")
+NUM_SPEC = 3
+
+
+def _builder(
+    use_spec_decode: bool,
+    mamba_cache_mode: str = "none",
+    shapes: tuple[tuple[int, ...], ...] = ((16, 64),),
+    dtypes: tuple[torch.dtype, ...] = (torch.float16,),
+) -> GDNAttentionMetadataBuilder:
+    vllm_config = create_vllm_config(
+        model_name="Qwen/Qwen3.5-0.8B",
+        block_size=BLOCK_SIZE,
+    )
+    vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_AND_PIECEWISE
+    vllm_config.speculative_config = (
+        SpeculativeConfig(method="ngram", num_speculative_tokens=NUM_SPEC)
+        if use_spec_decode
+        else None
+    )
+    # "none" keeps the block table as-is; the align gather needs columns for
+    # the speculative blocks, which `_decode_metadata` appends on request.
+    vllm_config.cache_config.mamba_cache_mode = mamba_cache_mode
+    mamba_spec = MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=shapes,
+        dtypes=dtypes,
+        num_speculative_blocks=NUM_SPEC,
+    )
+
+    return GDNAttentionMetadataBuilder(
+        kv_cache_spec=mamba_spec,
+        layer_names=["layer.0"],
+        vllm_config=vllm_config,
+        device=DEVICE,
+    )
+
+
+def _capture_metadata(builder, query_len: int, batch_size: int = 2):
+    """Metadata as produced during CUDA-graph capture of a decode shape."""
+    batch = BatchSpec(
+        seq_lens=[64] * batch_size,
+        query_lens=[query_len] * batch_size,
+    )
+    common = create_common_attn_metadata(batch, BLOCK_SIZE, DEVICE)
+    return builder.build_for_cudagraph_capture(common)
+
+
+def _decode_metadata(builder, num_accepted: list[int], seq_len: int = 64):
+    """Metadata for a live decode batch where no row was given drafts.
+
+    Every row schedules a single token, so `num_decode_draft_tokens_cpu` is all
+    zeros -- the shape the runner produces once `zero_draft_decode_mask` has
+    promoted zero-draft decode rows out of the `-1` placeholder.
+    `num_accepted` is what the previous step accepted (bonus token included,
+    so one is the minimum), which is what decides the state slot.
+    """
+    batch = BatchSpec(
+        seq_lens=[seq_len] * len(num_accepted), query_lens=[1] * len(num_accepted)
+    )
+    common = create_common_attn_metadata(
+        batch, BLOCK_SIZE, DEVICE, arange_block_indices=True
+    )
+    if builder.vllm_config.cache_config.mamba_cache_mode == "align":
+        # Align gathers the last 1 + num_speculative_blocks columns starting at
+        # the request's current block, so the table has to reach past the end of
+        # the sequence -- at runtime it is sized by max_model_len, while the
+        # test helper sizes it by seq_len.
+        rows, cols = common.block_table_tensor.shape
+        extra = (
+            torch.arange(
+                rows * NUM_SPEC, dtype=common.block_table_tensor.dtype, device=DEVICE
+            ).view(rows, NUM_SPEC)
+            + rows * cols
+        )
+        common.block_table_tensor = torch.cat([common.block_table_tensor, extra], dim=1)
+    accepted = torch.tensor(num_accepted, dtype=torch.int32, device=DEVICE)
+    num_decode_draft_tokens_cpu = torch.zeros(len(num_accepted), dtype=torch.int32)
+    return builder.build(0, common, accepted, num_decode_draft_tokens_cpu)
+
+
+def test_zero_draft_capture_shape_routes_through_the_speculative_path():
+    """The one-token capture shape is what breaks backends whose decode kernels
+    assume a full num_spec + 1 query window: `num_decode_draft_tokens_cpu =
+    query_len - 1 = 0` for every row, which is `>= 0` and must still take the
+    speculative path (not the plain decode path that drops the state offset),
+    with a state tensor sized for the full window even though every row only
+    supplies a single query token.
+
+    Only `query_len=1` (zero drafts) discriminates this from the plain-decode
+    path before the fix: for any `query_len > 1`, `num_decode_draft_tokens_cpu`
+    is already `> 0` and both the pre-fix and post-fix code agree, so this
+    does not need parametrizing over larger draft counts.
+    """
+    meta = _capture_metadata(_builder(use_spec_decode=True), query_len=1)
+
+    assert meta.num_spec_decodes == 2
+    assert meta.num_decodes == 0
+    slots = meta.spec_state_indices_tensor
+    assert slots is not None
+    # The kernels index columns 0..num_spec of this tensor.
+    assert slots.shape[1] == NUM_SPEC + 1
+    assert int(slots.min()) >= 0
+    query_lens = torch.diff(meta.spec_query_start_loc)
+    assert torch.all(query_lens == 1)
+
+
+def test_plain_decode_without_spec_decode_skips_the_speculative_path():
+    """Without a speculative config the builder never builds spec metadata,
+    so a one-token-per-row decode capture takes the plain decode path.
+
+    Not a regression check for this patch (this branch is untouched by it),
+    but it is what keeps the test above from passing vacuously: it would also
+    pass if the builder routed every row through the speculative path
+    unconditionally, regardless of whether speculative decoding is even
+    configured.
+    """
+    meta = _capture_metadata(_builder(use_spec_decode=False), query_len=1)
+
+    assert meta.num_spec_decodes == 0
+    assert meta.num_decodes == 2
+
+
+@pytest.mark.parametrize(
+    "mamba_cache_mode, shapes, dtypes",
+    [
+        ("none", ((16, 64),), (torch.float16,)),
+        # Kimi-Linear's KDA layers subclass GatedDeltaNetAttention and consume
+        # this same metadata, and prefix caching (which Kimi enables by
+        # default) puts the cache in align mode -- so the guarantee has to hold
+        # for that state shape and mode too.
+        (
+            "align",
+            MambaStateShapeCalculator.kda_state_shape(
+                tp_world_size=1, num_heads=4, head_dim=32, num_spec=NUM_SPEC
+            ),
+            (torch.bfloat16, torch.bfloat16),
+        ),
+    ],
+    ids=["gdn_none", "kimi_kda_align"],
+)
+def test_zero_draft_batch_still_applies_the_accepted_token_offset(
+    mamba_cache_mode, shapes, dtypes
+):
+    """The numeric difference the fix makes, on the batch shape that triggers it.
+
+    The recurrent kernels read their state at column `num_accepted_tokens - 1`
+    of `spec_state_indices_tensor`. Before the fix, a batch in which *every*
+    speculative row drafted nothing was pushed onto the non-speculative path,
+    which passes `non_spec_state_indices_tensor` -- always column 0 -- and
+    drops `num_accepted_tokens` entirely. A row that accepted drafts on the
+    previous step wrote its fresh state further along, so column 0 is stale.
+    """
+    accepted = [NUM_SPEC, 1]
+    meta = _decode_metadata(
+        _builder(
+            use_spec_decode=True,
+            mamba_cache_mode=mamba_cache_mode,
+            shapes=shapes,
+            dtypes=dtypes,
+        ),
+        accepted,
+    )
+
+    assert meta.num_spec_decodes == len(accepted)
+    assert meta.num_decodes == 0
+    # Dropping these is what silently sent the kernels to the wrong slot.
+    assert meta.num_accepted_tokens is not None
+    assert meta.num_accepted_tokens.tolist()[: len(accepted)] == accepted
+    assert meta.non_spec_state_indices_tensor is None
+
+    slots = meta.spec_state_indices_tensor
+    assert slots is not None
+    for row, num_accepted in enumerate(accepted):
+        read = int(slots[row, num_accepted - 1])
+        fallback = int(slots[row, 0])
+        # Only the row that accepted a draft moved off column 0; the row that
+        # accepted nothing but its bonus token legitimately stays there. This
+        # also confirms the columns are genuinely distinct blocks (via
+        # `arange_block_indices=True` in `_decode_metadata`), not just
+        # distinct labels for the same one -- otherwise `read != fallback`
+        # here would mean nothing.
+        assert (read != fallback) == (num_accepted > 1)

--- a/tests/v1/worker/test_gpu_model_runner_prefill_tail_classification.py
+++ b/tests/v1/worker/test_gpu_model_runner_prefill_tail_classification.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""`GPUModelRunner._prepare_inputs` must tell a chunked-prefill continuation
+row apart from a genuine zero-draft decode row.
+
+Both kinds of row are absent from `scheduled_spec_decode_tokens` and both
+schedule exactly one token, so `num_decode_draft_tokens` starts at the
+placeholder `-1` for either. The `zero_draft_decode_mask` in
+`gpu_model_runner.py` is what tells them apart afterwards, using
+`num_computed_tokens >= num_prompt_tokens`: a prefill continuation must keep
+`-1` (it carries no drafts and no accepted-token offset to apply), while a
+zero-draft decode row must become `0` (it still has to run the speculative
+path so the recurrent backends apply that offset). Getting this wrong in
+either direction was the root cause behind issue #40875: Kimi-Linear crashed
+with an illegal memory access when prefill tails were misclassified as
+zero-draft decodes.
+
+Each batch below also includes one row with a real draft token, so
+`scheduled_spec_decode_tokens` is non-empty even under the pre-fix
+`use_spec_decode = len(scheduled_spec_decode_tokens) > 0` predicate. That
+keeps the assertions targeted at the mask fix alone, not the unrelated
+`use_spec_decode` predicate fix (`self.speculative_config is not None`) that
+landed in the same patch.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    SpeculativeConfig,
+    VllmConfig,
+    set_current_vllm_config,
+)
+from vllm.model_executor.layers.attention import Attention
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheTensor,
+)
+from vllm.v1.worker.gpu_input_batch import InputBatch
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+BLOCK_SIZE = 16
+NUM_BLOCKS = 10
+DEVICE_TYPE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def _get_vllm_config() -> VllmConfig:
+    model_config = ModelConfig(model="facebook/opt-125m", dtype="float16", seed=42)
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=10,
+        max_num_batched_tokens=512,
+        max_model_len=512,
+        is_encoder_decoder=model_config.is_encoder_decoder,
+    )
+    cache_config = CacheConfig(
+        block_size=BLOCK_SIZE, gpu_memory_utilization=0.9, cache_dtype="auto"
+    )
+    cache_config.kv_cache_layout = "LBNHC"
+    return VllmConfig(
+        model_config=model_config,
+        cache_config=cache_config,
+        scheduler_config=scheduler_config,
+        parallel_config=ParallelConfig(),
+        # ngram needs no draft model weights, so the fixture stays as cheap as
+        # the speculative-decoding-free one in test_gpu_model_runner.py.
+        speculative_config=SpeculativeConfig(method="ngram", num_speculative_tokens=3),
+    )
+
+
+def _initialize_kv_cache(runner: GPUModelRunner) -> None:
+    attn_spec = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=runner.model_config.get_num_kv_heads(runner.parallel_config),
+        head_size=runner.model_config.get_head_size(),
+        dtype=runner.kv_cache_dtype,
+    )
+    tensor_size = attn_spec.page_size_bytes * NUM_BLOCKS
+    kv_cache_config = KVCacheConfig(
+        num_blocks=NUM_BLOCKS,
+        kv_cache_tensors=[
+            KVCacheTensor(
+                size=tensor_size,
+                layers=["layer.0"],
+                layer_stride=tensor_size,
+                block_stride=attn_spec.page_size_bytes,
+            ),
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=["layer.0"], kv_cache_spec=attn_spec)
+        ],
+    )
+    runner.kv_cache_config = kv_cache_config
+    runner.input_batch = InputBatch(
+        max_num_reqs=runner.max_num_reqs,
+        max_model_len=runner.max_model_len,
+        max_num_batched_tokens=runner.max_num_tokens,
+        device=runner.device,
+        vocab_size=runner.model_config.get_vocab_size(),
+        block_sizes=[kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size],
+        kernel_block_sizes=[
+            kv_cache_config.kv_cache_groups[0].kv_cache_spec.block_size
+        ],
+        max_num_blocks_per_req=[NUM_BLOCKS],
+    )
+    runner.initialize_attn_backend(kv_cache_config)
+
+
+@pytest.fixture
+def spec_decode_model_runner(dist_init):
+    vllm_config = _get_vllm_config()
+    with set_current_vllm_config(vllm_config):
+        model_config = vllm_config.model_config
+        num_heads = model_config.get_num_kv_heads(vllm_config.parallel_config)
+        head_size = model_config.get_head_size()
+        vllm_config.compilation_config.static_forward_context["layer.0"] = Attention(
+            num_heads, head_size, 0.1
+        )
+        runner = GPUModelRunner(vllm_config, DEVICE_TYPE)
+        _initialize_kv_cache(runner)
+        yield runner
+
+
+def _new_request(
+    req_id: str, prompt_len: int, num_computed_tokens: int
+) -> tuple[NewRequestData, int]:
+    """A request with `prompt_len` prompt tokens, `num_computed_tokens` of
+    which are already computed (e.g. a prefix-cache hit), scheduled for the
+    single remaining/next token this step."""
+    return (
+        NewRequestData(
+            req_id=req_id,
+            prompt_token_ids=list(range(prompt_len)),
+            mm_features=[],
+            sampling_params=SamplingParams(),
+            pooling_params=None,
+            block_ids=([0],),
+            num_computed_tokens=num_computed_tokens,
+            lora_request=None,
+        ),
+        1,
+    )
+
+
+def test_prefill_continuation_keeps_placeholder_decode_zero_draft_becomes_zero(
+    spec_decode_model_runner,
+):
+    """One request has one token left to prefill (`num_computed_tokens ==
+    num_prompt_tokens - 1`); another has already finished its prompt and is
+    now decoding with no draft tokens proposed this step; a third is decoding
+    with a real draft. `decode_with_draft` gives the batch a non-empty
+    `scheduled_spec_decode_tokens`, so this also exercises the `-1`-vs-`0`
+    distinction on the pre-fix definition of `use_spec_decode` (`len(sched
+    uled_spec_decode_tokens) > 0`), isolating the mask fix from the unrelated
+    `use_spec_decode` predicate fix that landed in the same patch."""
+    runner = spec_decode_model_runner
+
+    prefill_req, prefill_sched = _new_request(
+        "prefill_tail", prompt_len=11, num_computed_tokens=10
+    )
+    decode_req, decode_sched = _new_request(
+        "decode_zero_draft", prompt_len=3, num_computed_tokens=3
+    )
+    drafted_req, _ = _new_request(
+        "decode_with_draft", prompt_len=3, num_computed_tokens=3
+    )
+    num_scheduled_tokens = {
+        "prefill_tail": prefill_sched,
+        "decode_zero_draft": decode_sched,
+        "decode_with_draft": 2,  # 1 draft token + 1 bonus token
+    }
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[prefill_req, decode_req, drafted_req],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens=num_scheduled_tokens,
+        total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+        scheduled_spec_decode_tokens={"decode_with_draft": [99]},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    runner._update_states(scheduler_output)
+    runner._prepare_inputs(
+        scheduler_output,
+        np.array(
+            [num_scheduled_tokens[r] for r in runner.input_batch.req_ids],
+            dtype=np.int32,
+        ),
+    )
+
+    prefill_idx = runner.input_batch.req_id_to_index["prefill_tail"]
+    decode_idx = runner.input_batch.req_id_to_index["decode_zero_draft"]
+    drafted_idx = runner.input_batch.req_id_to_index["decode_with_draft"]
+    assert runner.num_decode_draft_tokens.np[prefill_idx] == -1
+    assert runner.num_decode_draft_tokens.np[decode_idx] == 0
+    assert runner.num_decode_draft_tokens.np[drafted_idx] == 1
+
+
+def test_prefill_tail_of_two_or_three_tokens_also_keeps_the_placeholder(
+    spec_decode_model_runner,
+):
+    """A chunked-prefill tail can be 1, 2, or 3 tokens (`long_prefill_token_
+    threshold` rounding); the mask only fires for `num_scheduled_tokens == 1`,
+    so wider tails must keep `-1` regardless of how much prompt is left. A
+    third, drafted decode row keeps `scheduled_spec_decode_tokens` non-empty
+    so the assertions hold on the pre-fix `use_spec_decode` predicate too."""
+    runner = spec_decode_model_runner
+
+    tail_2_req, _ = _new_request("tail_2", prompt_len=12, num_computed_tokens=10)
+    tail_3_req, _ = _new_request("tail_3", prompt_len=13, num_computed_tokens=10)
+    drafted_req, _ = _new_request(
+        "decode_with_draft", prompt_len=3, num_computed_tokens=3
+    )
+    num_scheduled_tokens = {"tail_2": 2, "tail_3": 3, "decode_with_draft": 2}
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[tail_2_req, tail_3_req, drafted_req],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens=num_scheduled_tokens,
+        total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+        scheduled_spec_decode_tokens={"decode_with_draft": [99]},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    runner._update_states(scheduler_output)
+    runner._prepare_inputs(
+        scheduler_output,
+        np.array(
+            [num_scheduled_tokens[r] for r in runner.input_batch.req_ids],
+            dtype=np.int32,
+        ),
+    )
+
+    tail_2_idx = runner.input_batch.req_id_to_index["tail_2"]
+    tail_3_idx = runner.input_batch.req_id_to_index["tail_3"]
+    assert runner.num_decode_draft_tokens.np[tail_2_idx] == -1
+    assert runner.num_decode_draft_tokens.np[tail_3_idx] == -1

--- a/tests/v1/worker/test_mamba_hybrid_model_state.py
+++ b/tests/v1/worker/test_mamba_hybrid_model_state.py
@@ -4,6 +4,7 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import numpy as np
 import pytest
 import torch
 
@@ -14,7 +15,10 @@ from vllm.v1.attention.backends.recoverssm_metadata import (
     RecoverSSMPostprocessMetadata,
 )
 from vllm.v1.worker.gpu.model_states import mamba_hybrid
-from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
+from vllm.v1.worker.gpu.model_states.mamba_hybrid import (
+    MambaHybridModelState,
+    compute_num_decode_draft_tokens,
+)
 from vllm.v1.worker.gpu.model_states.recoverssm import RecoverSSMState
 
 
@@ -56,6 +60,162 @@ def test_prepare_attn_forwards_positions(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert metadata is expected_metadata
     assert build_attn_metadata.call_args.kwargs["positions"] is positions
+
+
+def _mamba_hybrid_state(num_speculative_tokens: int) -> MambaHybridModelState:
+    state = object.__new__(MambaHybridModelState)
+    state.vllm_config = SimpleNamespace(num_speculative_tokens=num_speculative_tokens)
+    state._align_mode = False
+    state.recoverssm = None
+    # A request that accepted 3 drafts (plus the bonus token) on the previous
+    # step; the other has never had a draft accepted.
+    state.num_accepted_tokens_gpu = torch.tensor([4, 1], dtype=torch.int32)
+    return state
+
+
+def _input_batch_with_no_scheduled_drafts() -> SimpleNamespace:
+    """A two-request decode batch where nobody proposed a draft this step
+    (`num_draft_tokens_per_req is None`), e.g. because ngram found no match
+    for anyone."""
+    return SimpleNamespace(
+        num_reqs=2,
+        num_reqs_after_padding=2,
+        num_tokens=2,
+        num_tokens_after_padding=2,
+        query_start_loc_np=np.array([0, 1, 2], dtype=np.int32),
+        num_scheduled_tokens=np.array([1, 1], dtype=np.int32),
+        seq_lens_cpu_upper_bound=torch.tensor([10, 10], dtype=torch.int32),
+        is_prefilling_np=np.array([False, False]),
+        num_draft_tokens_per_req=None,
+        idx_mapping=torch.tensor([0, 1], dtype=torch.int64),
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([10, 10], dtype=torch.int32),
+        dcp_local_seq_lens=None,
+        positions=torch.tensor([9, 9], dtype=torch.int64),
+        prompt_lens=None,
+    )
+
+
+def _prepare_attn_metadata(
+    state: MambaHybridModelState, monkeypatch
+) -> SimpleNamespace:
+    captured = {}
+
+    def fake_build_attn_metadata(**kwargs):
+        captured.update(kwargs)
+        return Mock()
+
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu.model_states.mamba_hybrid.build_attn_metadata",
+        fake_build_attn_metadata,
+    )
+
+    state.prepare_attn(
+        input_batch=_input_batch_with_no_scheduled_drafts(),
+        cudagraph_mode=CUDAGraphMode.NONE,
+        block_tables=(),
+        slot_mappings={},
+        attn_groups=[],
+        kv_cache_config=Mock(),
+    )
+    return captured["model_specific_attn_metadata"]
+
+
+def test_prepare_attn_keeps_the_accepted_offset_when_the_batch_drafted_nothing(
+    monkeypatch,
+):
+    """`num_accepted_tokens` must reach the attention builders whenever the
+    speculative config is on, even when *this* batch scheduled no draft
+    tokens at all. Before the fix, `use_spec_decode` was gated on this step's
+    scheduled drafts (`len(scheduled_spec_decode_tokens) > 0` in the V1
+    runner) rather than on the speculative config, so a request that accepted
+    drafts on a previous step would silently lose that offset the moment
+    ngram found no match for anyone in the batch.
+    """
+    state = _mamba_hybrid_state(num_speculative_tokens=3)
+
+    metadata = _prepare_attn_metadata(state, monkeypatch)
+
+    assert metadata.num_accepted_tokens is not None
+    assert metadata.num_accepted_tokens.tolist() == [4, 1]
+    assert metadata.num_decode_draft_tokens_cpu is not None
+
+
+def test_prepare_attn_omits_the_offset_without_a_speculative_config(monkeypatch):
+    """Mirrors the check above: with speculative decoding off entirely, there
+    is no accepted-token offset to carry, and the metadata must say so
+    explicitly (`None`) rather than a stale or default value."""
+    state = _mamba_hybrid_state(num_speculative_tokens=0)
+
+    metadata = _prepare_attn_metadata(state, monkeypatch)
+
+    assert metadata.num_accepted_tokens is None
+    assert metadata.num_decode_draft_tokens_cpu is None
+
+
+def test_zero_draft_decode_row_is_marked_as_a_speculative_row():
+    """A decode row that got no drafts still has to reach the speculative path.
+
+    The recurrent backends only apply a row's accepted-token offset on that
+    path, and a row that accepted drafts on the previous step keeps that offset
+    even when the current step proposes nothing (the scheduler drops drafts
+    whenever the token budget truncates the step). Marking such a row with the
+    -1 sentinel sends it to the plain decode path, which reads the state at
+    column 0 and ignores the offset.
+    """
+    num_decode_draft_tokens = compute_num_decode_draft_tokens(
+        num_padded_reqs=3,
+        num_scheduled_tokens=np.array([3, 1, 1], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([2, 0, 0], dtype=np.int32),
+        is_prefilling=np.array([False, False, True]),
+    )
+
+    assert num_decode_draft_tokens.tolist() == [
+        2,  # decode row with drafts
+        0,  # decode row with no drafts: speculative path, offset applied
+        -1,  # one-token prefill tail: no offset to apply, stays a plain row
+    ]
+
+
+def test_batch_without_any_drafts_still_marks_its_decode_rows():
+    """`num_draft_tokens_per_req` is None whenever no row in the batch drafted
+    anything. Those rows are ordinary decode rows carrying an offset from the
+    previous step, so the absence of drafts in this step must not be read as
+    speculative decoding being off."""
+    num_decode_draft_tokens = compute_num_decode_draft_tokens(
+        num_padded_reqs=2,
+        num_scheduled_tokens=np.array([1, 1], dtype=np.int32),
+        num_draft_tokens_per_req=None,
+        is_prefilling=np.array([False, True]),
+    )
+
+    assert num_decode_draft_tokens.tolist() == [0, -1]
+
+
+def test_padded_rows_keep_the_sentinel():
+    """Full CUDA-graph capture pads the batch; padded rows describe no request
+    and must not be picked up as speculative rows."""
+    num_decode_draft_tokens = compute_num_decode_draft_tokens(
+        num_padded_reqs=4,
+        num_scheduled_tokens=np.array([1, 1], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([0, 0], dtype=np.int32),
+        is_prefilling=np.array([False, False]),
+    )
+
+    assert num_decode_draft_tokens.tolist() == [0, 0, -1, -1]
+
+
+def test_chunked_prefill_tail_of_two_or_three_tokens_keeps_the_sentinel():
+    """A prefill continuation is excluded by `is_prefilling`, not by its token
+    count, so tails wider than one token are covered by the same rule."""
+    num_decode_draft_tokens = compute_num_decode_draft_tokens(
+        num_padded_reqs=2,
+        num_scheduled_tokens=np.array([2, 3], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([0, 0], dtype=np.int32),
+        is_prefilling=np.array([True, True]),
+    )
+
+    assert num_decode_draft_tokens.tolist() == [-1, -1]
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -233,11 +233,10 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         else:
             spec_sequence_masks_cpu = num_decode_draft_tokens_cpu >= 0
             num_spec_decodes = spec_sequence_masks_cpu.sum().item()
-            if (
-                num_spec_decodes == 0
-                or num_decode_draft_tokens_cpu[spec_sequence_masks_cpu].sum().item()
-                == 0
-            ):
+            # A batch whose rows all drafted nothing still has to run the
+            # speculative path: that is the only path that applies each row's
+            # accepted-token offset to the recurrent state.
+            if num_spec_decodes == 0:
                 num_spec_decodes = 0
                 spec_sequence_masks = None
                 spec_sequence_masks_cpu = None

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -74,6 +74,38 @@ class MambaHybridAttnMetadata(ModelSpecificAttnMetadata):
         }
 
 
+def compute_num_decode_draft_tokens(
+    num_padded_reqs: int,
+    num_scheduled_tokens: np.ndarray,
+    num_draft_tokens_per_req: np.ndarray | None,
+    is_prefilling: np.ndarray,
+) -> np.ndarray:
+    """Per-request draft count for the recurrent backends, -1 for other rows.
+
+    The builders select speculative rows with `>= 0`, and that path is the only
+    one that applies a row's accepted-token offset to the recurrent state. So a
+    decode row that happened to get no drafts this step must be marked 0 rather
+    than left at the -1 sentinel: it still carries the offset from the step
+    before, and the plain decode path would read the state at column 0 instead.
+    That also covers the batch where no row was given drafts at all, which is
+    otherwise indistinguishable from speculative decoding being off.
+
+    A one-token chunked-prefill tail schedules exactly one token and has no
+    drafts either, so the token count alone cannot tell it apart from a
+    zero-draft decode row; it carries no accepted-token offset and must keep
+    the sentinel, hence the explicit `is_prefilling` exclusion.
+    """
+    num_reqs = num_scheduled_tokens.shape[0]
+    num_decode_draft_tokens = np.full(num_padded_reqs, -1, dtype=np.int32)
+    if num_draft_tokens_per_req is None:
+        num_draft_tokens_per_req = np.zeros(num_reqs, dtype=np.int32)
+    is_decode = (num_scheduled_tokens == num_draft_tokens_per_req + 1) & ~is_prefilling
+    num_decode_draft_tokens[:num_reqs] = np.where(
+        is_decode, num_draft_tokens_per_req, -1
+    )
+    return num_decode_draft_tokens
+
+
 class MambaHybridModelState(DefaultModelState):
     """Model state for hybrid attention + Mamba / linear-attention models."""
 
@@ -271,21 +303,14 @@ class MambaHybridModelState(DefaultModelState):
                 input_batch.idx_mapping
             ]
 
-            # GDN uses >= 0 to select spec-decode rows, so non-decode rows
-            # need the -1 sentinel rather than a raw zero draft count.
-            num_decode_draft_tokens_np = np.full(num_reqs, -1, dtype=np.int32)
-            num_draft_tokens_per_req = input_batch.num_draft_tokens_per_req
-            if num_draft_tokens_per_req is not None:
-                # A row is a spec-decode row only when its whole prompt is already
-                # computed, i.e. exactly one non-draft (decode) token is scheduled.
-                is_decode = (
-                    input_batch.num_scheduled_tokens == num_draft_tokens_per_req + 1
+            num_decode_draft_tokens_cpu = torch.from_numpy(
+                compute_num_decode_draft_tokens(
+                    num_reqs,
+                    input_batch.num_scheduled_tokens,
+                    input_batch.num_draft_tokens_per_req,
+                    input_batch.is_prefilling_np,
                 )
-                spec_decode_mask = (num_draft_tokens_per_req > 0) & is_decode
-                num_decode_draft_tokens_np[: input_batch.num_reqs] = np.where(
-                    spec_decode_mask, num_draft_tokens_per_req, -1
-                )
-            num_decode_draft_tokens_cpu = torch.from_numpy(num_decode_draft_tokens_np)
+            )
 
         if self._align_mode:
             mamba_group_ids, _ = self._get_mamba_group_info(kv_cache_config)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -862,6 +862,12 @@ class GPUModelRunner(
         self.num_accepted_tokens = self._make_buffer(
             self.max_num_reqs, dtype=torch.int32
         )
+        # The count includes the bonus token, so one is the minimum, and the
+        # recurrent kernels pick their state slot as `accepted - 1`. Dummy runs
+        # skip `_prepare_inputs`, so the zeros from the allocation would reach
+        # those kernels as index -1 and fault on the out-of-bounds read.
+        self.num_accepted_tokens.np.fill(1)
+        self.num_accepted_tokens.copy_to_gpu()
 
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
@@ -2242,7 +2248,7 @@ class GPUModelRunner(
             )
             self.mrope_positions.gpu[:, :total_num_scheduled_tokens] += drift
 
-        use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
+        use_spec_decode = self.speculative_config is not None
         if not use_spec_decode:
             # NOTE(woosuk): Due to chunked prefills, the batch may contain
             # partial requests. While we should not sample any token
@@ -2269,6 +2275,18 @@ class GPUModelRunner(
                 num_draft_tokens[req_idx] = draft_len
                 if num_scheduled_tokens[req_idx] == draft_len + 1:
                     num_decode_draft_tokens[req_idx] = draft_len
+            # Some recurrent backends may read the previous step's state at an
+            # offset that only the speculative path applies. So a decode step
+            # that got no drafts must still count as a speculative row with
+            # zero drafts, not as a plain decode. Prompt chunks are left out:
+            # their tokens are prompt tokens and carry no such offset.
+            zero_draft_decode_mask = (
+                self.input_batch.num_computed_tokens_cpu[:num_reqs]
+                >= self.input_batch.num_prompt_tokens[:num_reqs]
+            ) & (num_scheduled_tokens[:num_reqs] == 1)
+            num_decode_draft_tokens[
+                (num_decode_draft_tokens < 0) & zero_draft_decode_mask
+            ] = 0
             spec_decode_metadata = self._calc_spec_decode_metadata(
                 num_draft_tokens, cu_num_tokens
             )
@@ -4382,7 +4400,7 @@ class GPUModelRunner(
                         self.mamba_state_idx,
                     )
 
-            use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
+            use_spec_decode = self.speculative_config is not None
             ubatch_slices_attn = ubatch_slices_padded if pad_attn else ubatch_slices
 
             slot_mappings_by_group, slot_mappings = self._get_slot_mappings(


### PR DESCRIPTION
Fixes [#40875](https://github.com/vllm-project/vllm/issues/40875): ngram speculative decoding silently corrupts the output of hybrid recurrent models (Qwen3-Next/Qwen3.5 GDN, Nemotron Mamba2, Kimi-Linear KDA).

## Root cause: the two paths store the state differently

SSM/Mamba-style attention keeps a per-request recurrent state, and the speculative and non-speculative paths of the same backend **do not** agree on *where* that state lives.

- **Non-speculative path.** One slot per request: `block_table[:, 0]`. What the step writes is what the next step reads.
- **Speculative path.** A window of `num_spec + 1` slots per request (`spec_state_indices_tensor`). A verification step writes a candidate state per draft position, and the accepted prefix decides which one is authoritative. Kernels pick it as `num_accepted_tokens - 1` — the count includes the bonus token, so `1` is the minimum.

The two layouts coincide only while `num_accepted_tokens == 1`, i.e. slot `0`. The moment a request accepts a draft token its live state sits at slot `k > 0`, and anything reading slot `0` gets a stale state - the one from before the accepted tokens were applied. Nothing detects this: the read is in bounds, the shapes match, and generation continues from a state that silently lost a few tokens of history.

So the bug is not a bad index or a race — it is a **path switch mid-generation**: several independent places in the runner and the GDN builder could flip a row from one convention to the other between two consecutive steps.

They all need the same trigger: a step that accepted drafts, immediately followed by a step that proposed none. Proposers that always draft (EAGLE, MTP) never produce it; ngram does so routinely, whenever the lookup finds no match. That is why the corruption is intermittent, workload-dependent, and shows up as dropped or duplicated tokens rather than a crash.

## Three ways to fix it

1. **Teach the non-speculative kernel about the speculative layout** — make it read `num_accepted_tokens` and pick the right slot.
2. **Copy the authoritative slot into the non-speculative slot** at the boundary, so both conventions agree again. This is what [#52942](https://github.com/vllm-project/vllm/pull/52942) does with a fused normalize kernel for `mamba_cache_mode="none"` only and for V1 only.
3. **Never switch conventions: a row that can be speculative always takes the speculative path.** Zero drafts is simply `num_spec = 0` — the window degenerates to a single slot and the accepted-token offset is applied uniformly, step after step. No kernel changes, no state copies, no new synchronization: it is purely a classification change in the runner and the metadata builder.

Option 1 spreads the fix instead of making it. GDN, KDA, Mamba2 and ShortConv (plus several backends those implement) each carry their own state layout and their own kernels, much of it vendored third-party code (`flash_linear_attention`, the Kimi KDA ops), so the same change has to be written once per backend. It is not even uniform within a single backend: the SSM state needs a different slot, while the conv state needs a window shift inside the block. And it leaves the invariant living in N kernels rather than one, where each can get it wrong independently and every future recurrent backend has to remember to implement it — the bug class outlives the fix. It also makes the plain decode path carry speculative metadata and per-row index arithmetic it has no other use for, on the path whose entire reason for existing is to be the cheap one.

Option 2 pays for the mismatch instead of removing it. The copy is state-sized — `num_heads × head_dim × head_dim` per layer — and runs per affected request on exactly the step we were trying to keep cheap. It also needs the previous step's acceptance count *before* the current forward, which under async scheduling is not yet known on the host, so it cannot be a plain copy: it needs a GPU-resident mirror of the counts and a fused kernel driven off it. Since the `all` and `align` cache modes already run their own post-sampling migration, the copy has to be conditional on cache mode, adding one more branch to state handling that already has several. Most importantly, both conventions survive, so every future place that switches between them — a new backend, a new scheduling path, the V2 runner — brings the same bug back, one patch per switch point.

**This PR implements option 3.**

## What changed

| File                                              | Change                                                                                                                                                                                                             |
| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `vllm/v1/attention/backends/gdn_attn.py`          | Drop the batch-level fallback: a batch whose rows all drafted nothing still takes the speculative path.                                                                                                            |
| `vllm/v1/worker/gpu_model_runner.py`              | `use_spec_decode` now follows the speculative config rather than this step's scheduled drafts; zero-draft decode rows are marked `0` instead of the `-1` placeholder; `num_accepted_tokens` is initialized to `1`. |
| `vllm/v1/worker/gpu/model_states/mamba_hybrid.py` | Same classification fix for the V2 runner, extracted into `compute_num_decode_draft_tokens()`.                                                                                                                     |

Three details worth calling out:

- `use_spec_decode` **is what fixes Mamba2.** Mamba2 never reads the per-row `num_decode_draft_tokens` marker; it only needs `num_accepted_tokens` to reach it. Deriving `use_spec_decode` from this step's scheduled drafts meant that on a step where nobody drafted, the offset was withheld from every backend at once — which is the whole of the bug for Nemotron.
- **The prefill tail.** A one-token chunked-prefill continuation is indistinguishable from a zero-draft decode row by token count alone, and it carries no accepted-token offset. Classifying it as a decode row is what made an earlier revision of this patch crash Kimi-Linear with an illegal memory access. V1 excludes it with `num_computed_tokens >= num_prompt_tokens`, V2 with the `is_prefilling` flag it already computes.
- `num_accepted_tokens` **initialization.** The buffer is now filled with `1` instead of `0`. Dummy and profiling runs skip `_prepare_inputs`, so a zero would reach the kernels as slot index `-1` — an out-of-bounds read on some layouts, a silent wrong-row read on others.

## Relation to open PRs

Three open PRs touch neighbouring ground:

- [#52942](https://github.com/vllm-project/vllm/pull/52942) — **same root cause, different approach.** It identifies the same `num_accepted_tokens - 1` vs column-0 mismatch and fixes it by migrating the accepted state back to column 0 after sampling (option 2 above), scoped to `mamba_cache_mode="none"` and V1 only. This PR instead removes the path switch altogether (option 3), which needs no per-step state migration, is not tied to one cache mode, and covers the V2 runner as well. These two are alternatives; only one should land.
- [#51508](https://github.com/vllm-project/vllm/pull/51508) — adjacent but distinct: `num_accepted_tokens == 0` written by *discarded async-scheduling steps*. Same `-1` index hazard as the initialization part of this patch, different trigger.
- [#55504](https://github.com/vllm-project/vllm/pull/55504) — a partition bug in GDN conv/SSM restoration for mixed batches, also `mamba_cache_mode=none`, V1 only.

## Validation

Three end-to-end reproducers, one per model family and backend, each failing without the patch and passing with it. Runs on 8×B200 183GB, vLLM `0.26.1rc1.dev1424+gdafbef15a`, comparing the working tree against a copy with the patch reverted.

| Model                                        | Backend   | Criterion                | base      | patched   |
| -------------------------------------------- | --------- | ------------------------ | --------- | --------- |
| `Qwen/Qwen3.6-35B-A3B-FP8`                   | GDN       | tool call                | **0/60**  | **60/60** |
| `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` | Mamba2    | self-verifying JSON      | **12/60** | **60/60** |
| `moonshotai/Kimi-Linear-48B-A3B-Instruct`    | GDN + KDA | renumbered verbatim copy | **4/40**  | **40/40** |

No criterion uses `response_format`/xgrammar or `--tool-call-parser`: a grammar makes invalid syntax unreachable and hides exactly the corruption we are looking for, and the tool-call parser both masks artifacts and was itself the source of four backports in the original issue. Each criterion is self-checking and needs no reference server.

Whether a workload reaches the faulty state at all depends on the text the model happens to generate, which is why the criterion differs per model. So every run reads `/metrics` and proves it got there — drafts actually accepted, and decode steps without drafts above the per-request noise floor — reporting `valid: false` instead of "clean" when it did not. That gate is not decorative: the first Kimi attempt was 60/60 clean on both trees only because ngram never had a single draft accepted, which makes the two paths identical by construction.

All three checks read the counters through the same module, which must sit next to the scripts:

<details>
<summary>spec_metrics.py (shared by all three)</summary>

```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

"""Shared /metrics bookkeeping for the check scripts.

Every leg needs two independent proofs before its clean/broken count means
anything:

* decode steps with zero drafts actually happened -- `make_spec_decoding_stats`
  returns early on those steps, so they never reach `num_drafts` and have to be
  derived: `(generated - accepted) - drafts`, minus one step per request for
  the prompt-to-decode transition that is never spec-scheduled.

* drafts were actually accepted. This is the one the first Kimi round was
  missing. The recurrent kernels pick their state slot as
  `num_accepted_tokens - 1`, and the pre-fix fallback path reads slot 0
  unconditionally. With nothing ever accepted the slot is 0 either way, so base
  and patched are identical by construction and a clean leg proves nothing.
"""

import contextlib
from urllib.parse import urljoin

import requests

COUNTERS = (
    "vllm:spec_decode_num_drafts_total",
    "vllm:spec_decode_num_draft_tokens_total",
    "vllm:spec_decode_num_accepted_tokens_total",
    "vllm:generation_tokens_total",
)


def snapshot_counters(server_url):
    """Read the speculative-decoding counters off any endpoint of the server."""
    text = requests.get(urljoin(server_url, "/metrics"), timeout=30).text
    totals = dict.fromkeys(COUNTERS, 0.0)
    for line in text.splitlines():
        if line.startswith("#"):
            continue
        for name in COUNTERS:
            if line.startswith(name + "{") or line.startswith(name + " "):
                with contextlib.suppress(ValueError):
                    totals[name] += float(line.rsplit(" ", 1)[1])
    return totals


def summarize(before, after, num_requests):
    deltas = {k: after[k] - before[k] for k in before}
    generated = deltas["vllm:generation_tokens_total"]
    accepted = deltas["vllm:spec_decode_num_accepted_tokens_total"]
    drafts = deltas["vllm:spec_decode_num_drafts_total"]
    draft_tokens = deltas["vllm:spec_decode_num_draft_tokens_total"]

    steps_total = generated - accepted
    steps_without_drafts = steps_total - drafts
    return {
        "metric_deltas": deltas,
        "steps_total": steps_total,
        "steps_without_drafts": steps_without_drafts,
        "num_requests": num_requests,
        "excess_zero_draft_steps": steps_without_drafts - num_requests,
        "num_drafts": drafts,
        "num_draft_tokens": draft_tokens,
        "num_accepted_tokens": accepted,
        "acceptance_rate": (accepted / draft_tokens) if draft_tokens else 0.0,
    }


def print_summary(leg, summary):
    print(f"[{leg}] metric deltas: {summary['metric_deltas']}", flush=True)
    print(
        f"[{leg}] steps without drafts: {summary['steps_without_drafts']} "
        f"(requests={summary['num_requests']}, "
        f"excess over noise floor={summary['excess_zero_draft_steps']})",
        flush=True,
    )
    print(
        f"[{leg}] accepted {summary['num_accepted_tokens']:.0f} of "
        f"{summary['num_draft_tokens']:.0f} draft tokens "
        f"({summary['acceptance_rate'] * 100:.1f}%)",
        flush=True,
    )


def validity(leg, summary, require_acceptance):
    """Whether this leg exercised the code path the patch changes.

    `require_acceptance` is set by the caller for legs that run with
    speculative decoding on; legs deliberately run without it are valid with
    zero accepted tokens.
    """
    reasons = []
    if summary["excess_zero_draft_steps"] <= 0:
        reasons.append("no decode steps without drafts beyond the noise floor")
    if require_acceptance and summary["num_accepted_tokens"] <= 0:
        reasons.append(
            "no draft tokens accepted, so every state slot index is 0 and the "
            "pre-fix and post-fix paths read the same slot"
        )
    if reasons:
        for reason in reasons:
            print(f"[{leg}] INVALID LEG: {reason}", flush=True)
    return not reasons, reasons
```

</details>

<details>
<summary>Qwen reproducer</summary>

```bash
vllm serve Qwen/Qwen3.6-35B-A3B-FP8 --port 8000 \
  --max-model-len 8192 --gpu-memory-utilization 0.8 --trust-remote-code \
  --enable-prefix-caching --max-num-batched-tokens 256 \
  --speculative-config '{"method":"ngram","num_speculative_tokens":3,"prompt_lookup_min":2,"prompt_lookup_max":4}'
```

The server runs **without** `--tool-call-parser`. The prompt is rendered client-side (`apply_chat_template` with `tools=TOOLS`) and posted to `/v1/completions` as plain text, so neither the server-side `tool_choice` validation nor the tool-call parser takes part in the check. The expected answer is not hardcoded either: it comes from a second render of the same template with the call filled in.

```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

"""Group 1: does a zero-draft speculative step corrupt tool-call output?

No ``--tool-call-parser`` is registered on the server under test: the parser
itself was the source of four of the five upstream backports in issue #40875,
so it can both mask and manufacture artifacts. This script reads the raw
``message.content`` and validates it directly against the format the model's
own chat template renders for a tool call -- nothing about the expected
syntax is hardcoded per model family.

Canonical rendering: ``apply_chat_template`` is called twice, once with only
the user turn (plus a generation prompt) and once with a fabricated assistant
turn containing the expected tool call. The prefix is identical by
construction, so the suffix of the second render is exactly the raw text the
model should produce. That suffix is classified into one of the two known
tool-call syntaxes (XML-ish ``<tool_call>/<function=NAME>/<parameter=KEY>``
used by Qwen and Nemotron, or Kimi's ``<|tool_call_begin|>`` token family) by
looking for their marker substrings, and validated structurally: right
function name, no duplicate/unknown parameter keys, no ``<<``/`` function=
function=``-style artifacts, and (for Kimi) parseable non-duplicate-key JSON
arguments.

One invocation measures one server: whichever is listening on --url. The
server configuration (patched or not, speculative settings) is what varies
between runs. Results, raw failing completions, and a before/after snapshot
of the vllm:spec_decode_* counters (proof that some steps in the run
actually had zero draft tokens, and that drafts were accepted at all) are
written to --out as JSON.

Note on transport: vLLM's chat-completions endpoint rejects any non-empty
``tool_choice`` unless the server was started with ``--enable-auto-tool-choice``
and ``--tool-call-parser`` -- there is no way to ask for tool_choice="auto"
without one. Registering a parser is exactly what this test avoids (the
parser both masks and can itself inject artifacts -- see the module
docstring). So instead of ``/v1/chat/completions``, this script renders the
prompt itself with ``apply_chat_template`` (the same rendering used to build
the canonical answer) and posts the raw text straight to
``/v1/completions``. That also sidesteps any server-side structural-tag
grammar tool-choice machinery might otherwise apply, keeping the run fully
unconstrained as intended.
"""

import argparse
import json
import sys
import time
from collections import Counter
from concurrent.futures import ThreadPoolExecutor

import regex as re
import requests
from spec_metrics import print_summary, snapshot_counters, summarize, validity
from transformers import AutoTokenizer

QUERY = "Get weather for Tokyo"
TOOL_NAME = "get_weather"
TOOL_ARGS = {"city": "Tokyo"}
ALLOWED_PARAMS = {"city", "unit"}
REQUIRED_PARAMS = {"city"}

TOOLS = [
    {
        "type": "function",
        "function": {
            "name": TOOL_NAME,
            "description": "Get the current weather for a city.",
            "parameters": {
                "type": "object",
                "properties": {
                    "city": {"type": "string"},
                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
                },
                "required": ["city"],
            },
        },
    }
]

CLOSE_MARKERS = ["</tool_call>", "<|tool_calls_section_end|>"]

XML_CALL_RE = re.compile(r"<tool_call>(.*?)</tool_call>", re.S)
XML_FUNC_RE = re.compile(r"<function=([^>]*)>(.*?)</function>", re.S)
XML_PARAM_RE = re.compile(r"<parameter=([^>]*)>\s*(.*?)\s*</parameter>", re.S)
XML_ARTIFACT_RE = re.compile(
    r"<<|>>|function=function=|parameter=parameter=|argname|argvalue|<tool_code>"
)

KIMI_SECTION_RE = re.compile(
    r"<\|tool_calls_section_begin\|>(.*?)<\|tool_calls_section_end\|>", re.S
)
KIMI_CALL_RE = re.compile(
    r"<\|tool_call_begin\|>\s*functions\.([^:\s]+):\d+\s*"
    r"<\|tool_call_argument_begin\|>\s*(\{.*?\})\s*<\|tool_call_end\|>",
    re.S,
)


def build_prefix(tok, extra_template_kwargs):
    """Render the prompt text up to and including the generation marker.

    This is what actually gets sent to /v1/completions: the tool list and
    instructions are already baked in by the chat template, so the server
    sees a plain text-completion request and none of the tool_choice
    validation or parser machinery is involved.
    """
    user_msgs = [{"role": "user", "content": QUERY}]
    return tok.apply_chat_template(
        user_msgs,
        tools=TOOLS,
        tokenize=False,
        add_generation_prompt=True,
        **extra_template_kwargs,
    )


def build_canonical(tok, prefix, extra_template_kwargs):
    """Render the exact raw text the model should produce for TOOL_NAME/TOOL_ARGS."""
    user_msgs = [{"role": "user", "content": QUERY}]
    full_msgs = user_msgs + [
        {
            "role": "assistant",
            "content": None,
            "tool_calls": [
                {
                    "id": f"functions.{TOOL_NAME}:0",
                    "type": "function",
                    "function": {
                        # A dict, not a JSON string: the XML-family templates
                        # (Qwen, Nemotron) iterate arguments.items() directly
                        # to render <parameter=KEY> blocks. Kimi's template
                        # accepts either shape (falls back to `| tojson`).
                        "name": TOOL_NAME,
                        "arguments": TOOL_ARGS,
                    },
                }
            ],
        }
    ]
    full = tok.apply_chat_template(
        full_msgs,
        tools=TOOLS,
        tokenize=False,
        add_generation_prompt=False,
        **extra_template_kwargs,
    )
    if not full.startswith(prefix):
        raise RuntimeError(
            "chat template prefix mismatch: cannot isolate the assistant "
            "turn's raw rendering (common prefix diverges before the "
            "generation-prompt boundary)"
        )
    canonical = full[len(prefix) :]
    for marker in CLOSE_MARKERS:
        idx = canonical.rfind(marker)
        if idx != -1:
            return canonical[: idx + len(marker)]
    return canonical.rstrip()


def classify_family(canonical):
    if "<function=" in canonical and "<tool_call>" in canonical:
        return "xml"
    if "<|tool_call_begin|>" in canonical:
        return "kimi"
    raise RuntimeError(
        f"unrecognized tool-call rendering, cannot pick a validator: {canonical!r}"
    )


def _dup_key_hook(pairs):
    keys = [k for k, _ in pairs]
    dupes = [k for k, c in Counter(keys).items() if c > 1]
    if dupes:
        raise ValueError(f"duplicate JSON keys: {dupes}")
    return dict(pairs)


def check_xml(content):
    if XML_ARTIFACT_RE.search(content):
        return False, "artifact marker in content"
    calls = XML_CALL_RE.findall(content)
    if len(calls) != 1:
        return False, f"expected 1 <tool_call> block, found {len(calls)}"
    funcs = XML_FUNC_RE.findall(calls[0])
    if len(funcs) != 1:
        return False, f"expected 1 <function=...> block, found {len(funcs)}"
    name, body = funcs[0]
    if name != TOOL_NAME:
        return False, f"wrong function name {name!r}"
    params = XML_PARAM_RE.findall(body)
    keys = [k for k, _ in params]
    if len(keys) != len(set(keys)):
        return False, f"duplicate parameter keys {keys}"
    if not set(keys) <= ALLOWED_PARAMS:
        return False, f"unknown parameter keys {sorted(set(keys) - ALLOWED_PARAMS)}"
    if not set(keys) >= REQUIRED_PARAMS:
        return False, f"missing required parameters {REQUIRED_PARAMS - set(keys)}"
    return True, "ok"


def check_kimi(content):
    sections = KIMI_SECTION_RE.findall(content)
    if len(sections) != 1:
        return False, f"expected 1 tool_calls section, found {len(sections)}"
    calls = KIMI_CALL_RE.findall(sections[0])
    if len(calls) != 1:
        return False, f"expected 1 tool call, found {len(calls)}"
    name, args_json = calls[0]
    if name != TOOL_NAME:
        return False, f"wrong function name {name!r}"
    try:
        obj = json.loads(args_json, object_pairs_hook=_dup_key_hook)
    except (json.JSONDecodeError, ValueError) as e:
        return False, f"bad json args: {e}"
    if not isinstance(obj, dict):
        return False, "args not a JSON object"
    if not set(obj) <= ALLOWED_PARAMS:
        return False, f"unknown parameter keys {sorted(set(obj) - ALLOWED_PARAMS)}"
    if not set(obj) >= REQUIRED_PARAMS:
        return False, f"missing required parameters {REQUIRED_PARAMS - set(obj)}"
    return True, "ok"


VALIDATORS = {"xml": check_xml, "kimi": check_kimi}


def generate(url, model, prompt, extra_body, max_tokens, timeout=600):
    payload = {
        "model": model,
        "prompt": prompt,
        "max_tokens": max_tokens,
        "temperature": 0,
    }
    payload.update(extra_body)
    r = requests.post(url, json=payload, timeout=timeout)
    r.raise_for_status()
    choice = r.json()["choices"][0]
    return choice.get("text") or ""


def run_batch(url, model, prompt, extra_body, max_tokens, n, workers):
    def one(_):
        try:
            return generate(url, model, prompt, extra_body, max_tokens)
        except Exception as e:  # noqa: BLE001 - report as a failed sample
            return f"__REQUEST_ERROR__ {e}"

    with ThreadPoolExecutor(max_workers=workers) as pool:
        return list(pool.map(one, range(n)))


def main():
    ap = argparse.ArgumentParser()
    ap.add_argument("--url", required=True, help="/v1/completions endpoint")
    ap.add_argument("--model", required=True)
    ap.add_argument(
        "--leg", required=True, help="label for this run, e.g. patched_spec"
    )
    ap.add_argument("--serial", type=int, default=40)
    ap.add_argument("--concurrent", type=int, default=20)
    ap.add_argument("--concurrency", type=int, default=8)
    ap.add_argument("--max-tokens", type=int, default=200)
    ap.add_argument("--no-thinking", action="store_true")
    ap.add_argument(
        "--skip-special-tokens", dest="skip_special_tokens", action="store_true"
    )
    ap.add_argument(
        "--no-skip-special-tokens", dest="skip_special_tokens", action="store_false"
    )
    ap.set_defaults(skip_special_tokens=True)
    ap.add_argument(
        "--require-acceptance",
        action="store_true",
        help="mark the leg invalid unless the server accepted draft tokens; "
        "set this for every leg that runs with speculative decoding on",
    )
    ap.add_argument("--out", required=True)
    args = ap.parse_args()

    template_kwargs = {"enable_thinking": False} if args.no_thinking else {}
    tok = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
    prefix = build_prefix(tok, template_kwargs)
    canonical = build_canonical(tok, prefix, template_kwargs)
    family = classify_family(canonical)
    validate = VALIDATORS[family]
    print(f"[{args.leg}] family={family}", flush=True)
    print(f"[{args.leg}] canonical:\n{canonical}", flush=True)

    extra_body = {"skip_special_tokens": args.skip_special_tokens}

    num_requests = args.serial + args.concurrent
    before = snapshot_counters(args.url)

    results = []
    outputs = run_batch(
        args.url, args.model, prefix, extra_body, args.max_tokens, args.serial, 1
    )
    for content in outputs:
        ok, reason = (
            (False, "request error")
            if content.startswith("__REQUEST_ERROR__")
            else validate(content)
        )
        results.append(
            {"mode": "serial", "ok": ok, "reason": reason, "content": content}
        )

    outputs = run_batch(
        args.url,
        args.model,
        prefix,
        extra_body,
        args.max_tokens,
        args.concurrent,
        args.concurrency,
    )
    for content in outputs:
        ok, reason = (
            (False, "request error")
            if content.startswith("__REQUEST_ERROR__")
            else validate(content)
        )
        results.append(
            {"mode": "concurrent", "ok": ok, "reason": reason, "content": content}
        )

    # Every request has exactly one prompt-to-decode transition step that is
    # never spec-scheduled either, so steps_without_drafts == num_requests is
    # the noise floor. Anything above that is genuine mid-generation decode
    # steps where ngram proposed zero drafts -- the scenario the patch fixes.
    summary = summarize(before, snapshot_counters(args.url), num_requests)

    n_ok = sum(r["ok"] for r in results)
    n_total = len(results)
    print(f"[{args.leg}] clean {n_ok}/{n_total}", flush=True)
    print_summary(args.leg, summary)
    valid, invalid_reasons = validity(args.leg, summary, args.require_acceptance)

    for r in results:
        if not r["ok"]:
            print(
                f"  FAIL [{r['mode']}] {r['reason']}: {r['content'][:200]!r}",
                flush=True,
            )

    out = {
        "leg": args.leg,
        "model": args.model,
        "family": family,
        "canonical": canonical,
        "clean": n_ok,
        "total": n_total,
        "valid": valid,
        "invalid_reasons": invalid_reasons,
        **summary,
        "results": results,
        "timestamp": time.time(),
    }
    with open(args.out, "w") as f:
        json.dump(out, f, indent=2)

    sys.exit(0 if valid else 2)


if __name__ == "__main__":
    main()
```

```bash
python toolcall_check.py --url http://localhost:8000/v1/completions \
  --model Qwen/Qwen3.6-35B-A3B-FP8 --leg qwen --no-thinking \
  --require-acceptance --out qwen.json
```

</details>

<details>
<summary>Nemotron reproducer</summary>

```bash
vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 --port 8000 \
  --max-model-len 8192 --gpu-memory-utilization 0.8 --trust-remote-code \
  --enable-prefix-caching --max-num-batched-tokens 256 \
  --speculative-config '{"method":"ngram","num_speculative_tokens":3,"prompt_lookup_min":2,"prompt_lookup_max":4}'
```

The schema lives in the prompt only; nothing constrains the tokens. The validator tolerates text around the object (Nemotron writes its reasoning as plain prose) but not duplicate keys, and not any deviation in `numbers`.

```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

"""Group 1 fallback criterion: self-verifying JSON task, no chat template.

A tool-call criterion only fires on models whose corruption surfaces as
broken syntax; on Nemotron it stays clean while the same state corruption
lands as content that is syntactically valid JSON but semantically wrong --
a duplicated or dropped key -- which a syntax-only check cannot see.

The task here is self-verifying: the answer must be the JSON object
``{"topic": <string>, "numbers": [1, 2, ..., 20]}``. Nothing constrains the
tokens (no ``response_format``), so a healthy model reproduces the exact
counting sequence essentially every time, and any deviation -- duplicate
keys, a repeated or skipped number, wrong length -- is a corruption signal
independent of syntax validity. No structured-output parser is involved.
"""

import argparse
import json
import sys
import time
from collections import Counter
from concurrent.futures import ThreadPoolExecutor

import regex as re
import requests
from spec_metrics import print_summary, snapshot_counters, summarize, validity

INSTRUCTION = (
    "Answer with a single JSON object and nothing else. No markdown, no code "
    'fence. The object must have exactly these keys: "topic": a short string, '
    '"numbers": a JSON array containing the integers 1 through 20 in order, '
    "each exactly once."
)

FENCE_RE = re.compile(r"```(?:json)?|```")


def _dup_key_hook(pairs):
    keys = [k for k, _ in pairs]
    dupes = [k for k, c in Counter(keys).items() if c > 1]
    if dupes:
        raise ValueError(f"duplicate JSON keys: {dupes}")
    return dict(pairs)


def _candidate_objects(text):
    cleaned = FENCE_RE.sub("", text)
    starts = [i for i, c in enumerate(cleaned) if c == "{"]
    for start in starts:
        depth = 0
        for i in range(start, len(cleaned)):
            if cleaned[i] == "{":
                depth += 1
            elif cleaned[i] == "}":
                depth -= 1
                if depth == 0:
                    yield cleaned[start : i + 1]
                    break


def check(text):
    if not text.strip():
        return False, "empty"
    saw_object = False
    last_reason = "no json object"
    for candidate in _candidate_objects(text):
        saw_object = True
        try:
            obj = json.loads(candidate, object_pairs_hook=_dup_key_hook)
        except (json.JSONDecodeError, ValueError) as e:
            last_reason = f"malformed object: {e}"
            continue
        if "topic" not in obj or "numbers" not in obj:
            last_reason = "missing required key"
            continue
        numbers = obj["numbers"]
        if not isinstance(numbers, list):
            last_reason = "numbers is not a list"
            continue
        if numbers != list(range(1, 21)):
            last_reason = f"numbers wrong: {numbers}"
            continue
        return True, "ok"
    return False, "malformed object" if saw_object else last_reason


def generate(url, model, max_tokens, chat_template_kwargs=None, timeout=600):
    payload = {
        "model": model,
        "messages": [{"role": "user", "content": INSTRUCTION}],
        "max_tokens": max_tokens,
        "temperature": 0,
    }
    if chat_template_kwargs:
        payload["chat_template_kwargs"] = chat_template_kwargs
    r = requests.post(url, json=payload, timeout=timeout)
    r.raise_for_status()
    return r.json()["choices"][0]["message"].get("content") or ""


def run_batch(url, model, max_tokens, no_thinking, n, workers):
    kwargs = {"enable_thinking": False} if no_thinking else None

    def one(_):
        try:
            return generate(url, model, max_tokens, kwargs)
        except Exception as e:  # noqa: BLE001
            return f"__REQUEST_ERROR__ {e}"

    with ThreadPoolExecutor(max_workers=workers) as pool:
        return list(pool.map(one, range(n)))


def main():
    ap = argparse.ArgumentParser()
    ap.add_argument("--url", required=True)
    ap.add_argument("--model", required=True)
    ap.add_argument("--leg", required=True)
    ap.add_argument("--serial", type=int, default=40)
    ap.add_argument("--concurrent", type=int, default=20)
    ap.add_argument("--concurrency", type=int, default=8)
    ap.add_argument("--max-tokens", type=int, default=300)
    ap.add_argument("--no-thinking", action="store_true")
    ap.add_argument(
        "--require-acceptance",
        action="store_true",
        help="mark the leg invalid unless the server accepted draft tokens; "
        "set this for every leg that runs with speculative decoding on",
    )
    ap.add_argument("--out", required=True)
    args = ap.parse_args()

    num_requests = args.serial + args.concurrent
    before = snapshot_counters(args.url)

    results = []
    for content in run_batch(
        args.url, args.model, args.max_tokens, args.no_thinking, args.serial, 1
    ):
        ok, reason = (
            (False, "request error")
            if content.startswith("__REQUEST_ERROR__")
            else check(content)
        )
        results.append(
            {"mode": "serial", "ok": ok, "reason": reason, "content": content}
        )

    for content in run_batch(
        args.url,
        args.model,
        args.max_tokens,
        args.no_thinking,
        args.concurrent,
        args.concurrency,
    ):
        ok, reason = (
            (False, "request error")
            if content.startswith("__REQUEST_ERROR__")
            else check(content)
        )
        results.append(
            {"mode": "concurrent", "ok": ok, "reason": reason, "content": content}
        )

    summary = summarize(before, snapshot_counters(args.url), num_requests)

    n_ok = sum(r["ok"] for r in results)
    n_total = len(results)
    print(f"[{args.leg}] clean {n_ok}/{n_total}", flush=True)
    print_summary(args.leg, summary)
    valid, invalid_reasons = validity(args.leg, summary, args.require_acceptance)
    for r in results:
        if not r["ok"]:
            print(
                f"  FAIL [{r['mode']}] {r['reason']}: {r['content'][:200]!r}",
                flush=True,
            )

    out = {
        "leg": args.leg,
        "model": args.model,
        "clean": n_ok,
        "total": n_total,
        "valid": valid,
        "invalid_reasons": invalid_reasons,
        **summary,
        "results": results,
        "timestamp": time.time(),
    }
    with open(args.out, "w") as f:
        json.dump(out, f, indent=2)
    sys.exit(0 if valid else 2)


if __name__ == "__main__":
    main()
```

```bash
python selfverify_check.py --url http://localhost:8000/v1/chat/completions \
  --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 --leg nemotron --no-thinking \
  --require-acceptance --out nemotron.json
```

</details>

<details>
<summary>Kimi reproducer</summary>

```bash
vllm serve moonshotai/Kimi-Linear-48B-A3B-Instruct --port 8000 \
  --max-model-len 8192 --gpu-memory-utilization 0.8 --trust-remote-code \
  --enable-prefix-caching --max-num-seqs 1 --max-num-batched-tokens 2048 \
  --speculative-config '{"method":"ngram","num_speculative_tokens":7,"prompt_lookup_min":6,"prompt_lookup_max":8}'
```

`--max-num-seqs 1` is mandatory, and `prompt_lookup_min=6` triggers the condition more often (`min=2` gives 20/40 instead of 4/40). Only the copied part of each line is graded: the model may well get the numbering wrong, which has nothing to do with state corruption.

```python
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
"""Group 1, third criterion: verbatim copy, built to make ngram actually hit.

The first Kimi round produced a vacuous result. `toolcall_check.py` and
`selfverify_check.py` both came back 60/60 clean on base and patched alike,
but the counters show why: ngram proposed 60 drafts across 60 requests in one
run and none at all in the other, and *nothing was ever accepted*. Kimi's
answers there were short and non-repetitive (`{"topic":"sample","numbers":
[1,2,...,20]}`), so the lookup never found a matching n-gram.

That makes the leg say nothing about the patch. The recurrent kernels select
their state slot as `num_accepted_tokens - 1`, and the pre-fix fallback path
reads slot 0 unconditionally; with nothing accepted the slot is 0 on both
sides, so base and patched are identical by construction.

This task fixes the workload rather than the criterion. The prompt carries a
block of unique lines and asks for it back verbatim, so while the model
copies, every n-gram it has just emitted already occurs earlier in the
context and ngram's proposal is the true continuation -- acceptance runs near
100%, and the zero-draft steps that do occur (start of the copy, and wherever
the lookup misses) follow steps that accepted several drafts. That is exactly
the sequence the fix is about.

The criterion is self-verifying and needs no reference server: the answer
either reproduces the block or it does not, and the first differing character
localizes the corruption.
"""

import argparse
import json
import random
import sys
import time

import requests
from spec_metrics import print_summary, snapshot_counters, summarize, validity

WORDS = [
    "amber",
    "bronze",
    "cedar",
    "delta",
    "ember",
    "fjord",
    "garnet",
    "harbor",
    "indigo",
    "jasper",
    "kelvin",
    "lumen",
    "marble",
    "nickel",
    "onyx",
    "pewter",
    "quartz",
    "russet",
    "sable",
    "topaz",
]


def build_block(num_lines, seed, numbered=True):
    """Lines unique enough that a wrong copy is obvious, repetitive enough in
    shape that the tokenizer produces long recurring n-grams."""
    rng = random.Random(seed)
    lines = []
    for i in range(num_lines):
        words = " ".join(rng.choice(WORDS) for _ in range(4))
        prefix = f"{i:02d}. " if numbered else ""
        lines.append(f"{prefix}{words} {rng.randrange(1000, 10000)}")
    return "\n".join(lines)


def build_prompt(block):
    return (
        "Reproduce the following block exactly, character for character. "
        "Output only the block itself: no preamble, no commentary, no code "
        "fence.\n\n"
        f"{block}\n\n"
        "Now output the block again, exactly:\n"
    )


def build_renumber_prompt(block, base):
    """Copy interleaved with content that is not in the prompt.

    A pure copy keeps ngram permanently in range: every n-gram the model is
    about to emit already sits in the prompt, so a proposal always exists and
    zero-draft steps only happen once the copy ends. The corrupting sequence
    needs the opposite to happen mid-generation -- a step that accepts drafts
    followed by a step with no proposal at all. Prefixing every line with a
    counter the prompt never mentions supplies that: the payload is copied
    (long matches, drafts accepted) and each prefix is novel (no match, zero
    drafts), alternating once per line.
    """
    return (
        "Below is a block of lines. Output every line again, in the same "
        f"order, each prefixed with '#N| ' where N starts at {base} and "
        "increases by one per line. Copy the rest of each line exactly. "
        "Output only those lines: no preamble, no commentary, no code "
        "fence.\n\n"
        f"{block}\n\n"
        f"Output, starting with '#{base}| ':\n"
    )


def _first_diff(want, got):
    return next(
        (i for i, (a, b) in enumerate(zip(want, got)) if a != b),
        min(len(want), len(got)),
    )


def check(block, text):
    """Exact reproduction of the block, ignoring surrounding whitespace only."""
    got = text.strip()
    want = block.strip()
    if not got:
        return False, "empty", None
    if got == want:
        return True, "ok", None
    # Models occasionally wrap the answer; accept it if the block is present
    # intact, since the point is state corruption, not instruction following.
    if want in got:
        return True, "ok (wrapped)", None
    first_diff = _first_diff(want, got)
    return (
        False,
        f"mismatch at char {first_diff} (want {len(want)} chars, got {len(got)})",
        first_diff,
    )


def check_renumber(block, text):
    """Only the copied payload is graded.

    Whether the model got the counter right is instruction following, not
    state corruption, so the prefix is stripped before comparing. A line the
    model failed to prefix at all is still graded on its payload.
    """
    want_lines = block.strip().splitlines()
    got_lines = [ln for ln in (x.strip() for x in text.splitlines()) if ln]
    payloads = [ln.split("| ", 1)[1] if "| " in ln else ln for ln in got_lines]
    # Extra leading/trailing chatter is tolerated as long as the block's own
    # lines appear in order somewhere in the output.
    for start in range(max(1, len(payloads) - len(want_lines) + 1)):
        window = payloads[start : start + len(want_lines)]
        if window == want_lines:
            return True, "ok", None
    if not payloads:
        return False, "empty", None
    for i, want in enumerate(want_lines):
        if i >= len(payloads):
            return False, f"missing line {i} of {len(want_lines)}", i
        if payloads[i] != want:
            return (
                False,
                f"line {i} differs at char {_first_diff(want, payloads[i])}: "
                f"{payloads[i]!r} != {want!r}",
                i,
            )
    return False, f"extra lines: {len(payloads)} vs {len(want_lines)}", len(want_lines)


def generate(url, model, prompt, max_tokens, timeout=900):
    payload = {
        "model": model,
        "prompt": prompt,
        "max_tokens": max_tokens,
        "temperature": 0,
    }
    r = requests.post(url, json=payload, timeout=timeout)
    r.raise_for_status()
    return r.json()["choices"][0].get("text") or ""


def main():
    ap = argparse.ArgumentParser()
    ap.add_argument("--url", required=True, help="/v1/completions endpoint")
    ap.add_argument("--model", required=True)
    ap.add_argument("--leg", required=True)
    ap.add_argument("--requests", type=int, default=30)
    ap.add_argument("--lines", type=int, default=24)
    ap.add_argument(
        "--mode",
        choices=("copy", "renumber"),
        default="copy",
        help="'copy' maximizes draft acceptance; 'renumber' interleaves it "
        "with content the prompt never mentions, which is what produces "
        "zero-draft steps right after drafts were accepted",
    )
    ap.add_argument(
        "--max-tokens",
        type=int,
        default=700,
        help="must comfortably exceed the block length in tokens",
    )
    ap.add_argument(
        "--require-acceptance",
        action="store_true",
        help="mark the leg invalid unless the server accepted draft tokens; "
        "set this for every leg that runs with speculative decoding on",
    )
    ap.add_argument("--out", required=True)
    args = ap.parse_args()

    before = snapshot_counters(args.url)

    results = []
    for i in range(args.requests):
        # A fresh block per request keeps prefix caching from serving the
        # whole answer back and keeps every request's copy a real decode.
        renumber = args.mode == "renumber"
        block = build_block(args.lines, seed=1000 + i, numbered=not renumber)
        if renumber:
            prompt = build_renumber_prompt(block, base=3000 + i * 37)
        else:
            prompt = build_prompt(block)
        try:
            text = generate(args.url, args.model, prompt, args.max_tokens)
            ok, reason, first_diff = (check_renumber if renumber else check)(
                block, text
            )
        except Exception as e:  # noqa: BLE001
            ok, reason, first_diff, text = False, f"request error: {e}", None, ""
        results.append(
            {
                "seed": 1000 + i,
                "ok": ok,
                "reason": reason,
                "first_diff": first_diff,
                "block": block if not ok else None,
                "content": text if not ok else None,
            }
        )

    summary = summarize(before, snapshot_counters(args.url), args.requests)

    n_ok = sum(r["ok"] for r in results)
    print(f"[{args.leg}] clean {n_ok}/{len(results)}", flush=True)
    print_summary(args.leg, summary)
    valid, invalid_reasons = validity(args.leg, summary, args.require_acceptance)
    for r in results:
        if not r["ok"]:
            print(f"  FAIL seed={r['seed']} {r['reason']}", flush=True)

    out = {
        "leg": args.leg,
        "model": args.model,
        "clean": n_ok,
        "total": len(results),
        "valid": valid,
        "invalid_reasons": invalid_reasons,
        **summary,
        "results": results,
        "timestamp": time.time(),
    }
    with open(args.out, "w") as f:
        json.dump(out, f, indent=2)
    sys.exit(0 if valid else 2)


if __name__ == "__main__":
    main()
```

```bash
python copy_check.py --url http://localhost:8000/v1/completions \
  --model moonshotai/Kimi-Linear-48B-A3B-Instruct --leg kimi --mode renumber \
  --requests 40 --require-acceptance --out kimi.json
```

</details>

## AI assistance

AI assistance was used for this change: investigating the root cause, building the reproducers and the instrumented counter used to prove the workloads reach the faulty state, writing the tests, and drafting this description. Every changed line and every reported number was reviewed and re-run by me.
