### PR TITLE
Use skip-redaction option for crcr-report

### DIFF
--- a/.buildkite/scripts/crcr-report.sh
+++ b/.buildkite/scripts/crcr-report.sh
@@ -57,7 +57,7 @@ if [[ -z "${BK_TOKEN}" ]]; then
         # the container -- it fails before the flag is read. That ordering was
         # only fixed in v3.107.0. Skipping redaction would also stop the token
         # being registered with the log redactor, for no gain here.
-        if BK_TOKEN="$(buildkite-agent secret get "${TOKEN_SECRET_KEY}" 2>"${secret_err}")"; then
+        if BK_TOKEN="$(buildkite-agent secret get --skip-redaction "${TOKEN_SECRET_KEY}" 2>"${secret_err}")"; then
             if [[ -z "${BK_TOKEN}" ]]; then
                 echo "secret '${TOKEN_SECRET_KEY}' resolved but is empty"
             fi


### PR DESCRIPTION
## Depends on

https://github.com/vllm-project/ci-infra/pull/554

## Purpose

Make the nightly CRCR report actually post, now that
`small_cpu_queue_premerge` runs buildkite-agent 3.107.0 (ci-infra pin to
elastic-ci-stack v6.41.5).

Both `buildkite-agent` calls in the script need `--skip-redaction` to work
inside the container. The docker plugin mounts the agent binary and passes
`BUILDKITE_AGENT_ACCESS_TOKEN` and `BUILDKITE_JOB_ID`, but not
`BUILDKITE_AGENT_JOB_API_SOCKET` nor the socket, so anything that builds a Job
API client fails with `BUILDKITE_AGENT_JOB_API_SOCKET empty or undefined`.

- `secret get`: on 3.73.1 the secret was fetched and then discarded, because
  `jobapi.NewDefaultClient` was called unconditionally and `SkipRedaction` only
  checked afterwards — which is why the flag could not help before and why the
  step has skipped on every nightly since #54605. From v3.107.0 the client is
  built inside the guard, so the flag skips it.
- `oidc request-token`: OIDC tokens are auto-redacted via the Job API from
  agent v3.104.0. This call works today only because 3.73.1 predates that; the
  upgrade would start breaking it. Its `2>/dev/null` means the failure would
  surface only as `could not mint a Buildkite OIDC token -- skipping report`.

## Changes

`--skip-redaction` on both calls, plus a comment correcting the block at lines
53–59 which currently says the flag cannot help.

The flag must precede the key — urfave/cli v1 stops parsing flags at the first
positional argument.

Safe on both paths: the secret becomes a curl `Authorization` header, the OIDC
token is passed to `crcr_report.py` as an argument, neither is echoed, and the
script does not run under `set -x`.

Behaviour is otherwise unchanged: still gated on `TORCH_NIGHTLY=1` and
`main`, still best-effort, still `exit 0` on every failure path, still prefers
`BUILDKITE_API_TOKEN` from the environment.
