### PR TITLE
[Profiler] Add per-session profiling controls to Python and Rust frontends

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -22,6 +22,9 @@ To use the `torch.profiler` module, set the `profiler` entry to `'torch'` and `t
 - `torch_profiler_with_flops` to enable recording FLOPs, off by default
 - `torch_profiler_use_gzip` to control gzip-compressing profiling files, on by default
 - `torch_profiler_dump_cuda_time_total` to control dumping and printing the aggregated CUDA self time table, on by default
+- `torch_profiler_activities` to select worker activities (`["CPU", "CUDA"]` by
+  default). Use `["CUDA"]` for lower-overhead GPU-only traces; omitting `CPU`
+  also disables the frontend CPU profiler.
 
 When using `vllm bench serve`, you can enable profiling by passing the `--profile` flag.
 
@@ -83,6 +86,24 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 # After need call /stop_profile api to stop profile.
 $ curl -X POST http://localhost:8000/stop_profile
 ```
+
+`/start_profile` also accepts an optional JSON body with per-session settings.
+`profile_prefix` identifies the generated trace files, `delay_iterations`
+skips worker iterations before collection starts, and `max_iterations` limits
+the number of collected iterations (`0` means no limit):
+
+```shell
+curl -X POST http://localhost:8000/start_profile \
+    -H "Content-Type: application/json" \
+    -d '{
+        "profile_prefix": "sharegpt_run_1",
+        "delay_iterations": 5000,
+        "max_iterations": 20
+    }'
+```
+
+The Python and Rust API frontends accept the same request body. Per-session
+iteration bounds are currently supported by GPU workers.
 
 ## Profile with Triton Proton
 

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -22,9 +22,10 @@ To use the `torch.profiler` module, set the `profiler` entry to `'torch'` and `t
 - `torch_profiler_with_flops` to enable recording FLOPs, off by default
 - `torch_profiler_use_gzip` to control gzip-compressing profiling files, on by default
 - `torch_profiler_dump_cuda_time_total` to control dumping and printing the aggregated CUDA self time table, on by default
-- `torch_profiler_activities` to select worker activities (`["CPU", "CUDA"]` by
-  default). Use `["CUDA"]` for lower-overhead GPU-only traces; omitting `CPU`
-  also disables the frontend CPU profiler.
+- `torch_profiler_activities` to override the platform default activities:
+  `["CPU"]` on CPU, `["CPU", "CUDA"]` on CUDA/ROCm, and `["CPU", "XPU"]` on
+  XPU. Use `["CUDA"]` for lower-overhead GPU-only traces; omitting `CPU` also
+  disables the frontend CPU profiler.
 
 When using `vllm bench serve`, you can enable profiling by passing the `--profile` flag.
 
@@ -102,8 +103,7 @@ curl -X POST http://localhost:8000/start_profile \
     }'
 ```
 
-The Python and Rust API frontends accept the same request body. Per-session
-iteration bounds are currently supported by GPU workers.
+The Python and Rust API frontends accept the same request body.
 
 ## Profile with Triton Proton
 

--- a/rust/src/engine-core-client/src/client.rs
+++ b/rust/src/engine-core-client/src/client.rs
@@ -927,8 +927,22 @@ impl EngineCoreClient {
     }
 
     /// Start profiling the engine.
-    pub async fn start_profile(&self, profile_prefix: Option<&str>) -> Result<()> {
-        self.call_utility::<(), _>("profile", (true, profile_prefix)).await?;
+    pub async fn start_profile(
+        &self,
+        profile_prefix: Option<&str>,
+        delay_iterations: Option<u64>,
+        max_iterations: Option<u64>,
+    ) -> Result<()> {
+        self.call_utility::<(), _>(
+            "profile",
+            (
+                true,
+                profile_prefix,
+                delay_iterations,
+                max_iterations,
+            ),
+        )
+        .await?;
         Ok(())
     }
 

--- a/rust/src/server/src/routes/profile.rs
+++ b/rust/src/server/src/routes/profile.rs
@@ -3,20 +3,60 @@
 
 use std::sync::Arc;
 
+use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
+use serde::Deserialize;
 use tracing::info;
 
 use crate::error::ApiError;
 use crate::state::AppState;
 use crate::utils::utility_call_error;
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct StartProfileRequest {
+    profile_prefix: Option<String>,
+    delay_iterations: Option<u64>,
+    max_iterations: Option<u64>,
+}
+
+fn valid_profile_prefix(prefix: &str) -> bool {
+    let bytes = prefix.as_bytes();
+    (1..=128).contains(&bytes.len())
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes[1..]
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
 /// Start profiling the engine.
-pub async fn start_profile(State(state): State<Arc<AppState>>) -> Result<StatusCode, ApiError> {
+pub async fn start_profile(
+    State(state): State<Arc<AppState>>,
+    body: Option<Json<StartProfileRequest>>,
+) -> Result<StatusCode, ApiError> {
+    let body = body.map(|Json(body)| body).unwrap_or_default();
+    if body
+        .profile_prefix
+        .as_deref()
+        .is_some_and(|prefix| !valid_profile_prefix(prefix))
+    {
+        return Err(ApiError::invalid_request(
+            "profile_prefix must be 1-128 characters, start with a letter or number, and \
+             contain only letters, numbers, '.', '_', or '-'"
+                .to_string(),
+            Some("profile_prefix"),
+        ));
+    }
+
     info!("starting profiler");
     state
         .engine_core_client()
-        .start_profile(None)
+        .start_profile(
+            body.profile_prefix.as_deref(),
+            body.delay_iterations,
+            body.max_iterations,
+        )
         .await
         .map_err(|error| utility_call_error("start_profile", error))?;
     info!("profiler started");
@@ -33,4 +73,20 @@ pub async fn stop_profile(State(state): State<Arc<AppState>>) -> Result<StatusCo
         .map_err(|error| utility_call_error("stop_profile", error))?;
     info!("profiler stopped");
     Ok(StatusCode::OK)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::valid_profile_prefix;
+
+    #[test]
+    fn validates_profile_prefixes() {
+        for prefix in ["benchmark", "sharegpt_run-1", "profile.2"] {
+            assert!(valid_profile_prefix(prefix), "{prefix}");
+        }
+        for prefix in ["", "../trace", "/tmp/trace", "trace name", "_trace"] {
+            assert!(!valid_profile_prefix(prefix), "{prefix}");
+        }
+        assert!(!valid_profile_prefix(&"a".repeat(129)));
+    }
 }

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -6989,7 +6989,15 @@ async fn start_profile_route_sends_expected_utility_call() {
             let call_id = array[1].as_u64().expect("call id");
 
             assert_eq!(array[2], Value::from("profile"));
-            assert_eq!(array[3], Value::Array(vec![Value::from(true), Value::Nil]));
+            assert_eq!(
+                array[3],
+                Value::Array(vec![
+                    Value::from(true),
+                    Value::Nil,
+                    Value::Nil,
+                    Value::Nil,
+                ])
+            );
 
             send_outputs(push, utility_outputs(call_id, utility_none_result())).await;
         })
@@ -7003,6 +7011,61 @@ async fn start_profile_route_sends_expected_utility_call() {
                 .method("POST")
                 .uri("/start_profile")
                 .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("call app");
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("read body");
+    assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+    assert!(body.is_empty());
+    engine_task.await.expect("mock engine task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn start_profile_route_forwards_session_overrides() {
+    let (app, engine_task) = test_profiling_app_with_engine_script(|dealer, push| {
+        boxed_test_future(async move {
+            let utility = recv_engine_message(dealer).await;
+            assert_eq!(utility[0].as_ref(), &[0x03]);
+
+            let payload = decode_value(&utility[1]).expect("decode utility payload");
+            let array = payload.as_array().expect("utility payload array");
+            let call_id = array[1].as_u64().expect("call id");
+
+            assert_eq!(array[2], Value::from("profile"));
+            assert_eq!(
+                array[3],
+                Value::Array(vec![
+                    Value::from(true),
+                    Value::from("sharegpt_run-1"),
+                    Value::from(5000),
+                    Value::from(20),
+                ])
+            );
+
+            send_outputs(push, utility_outputs(call_id, utility_none_result())).await;
+        })
+    })
+    .await;
+
+    let response = app
+        .clone()
+        .call(
+            Request::builder()
+                .method("POST")
+                .uri("/start_profile")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "profile_prefix": "sharegpt_run-1",
+                        "delay_iterations": 5000,
+                        "max_iterations": 20,
+                    })
+                    .to_string(),
+                ))
                 .expect("build request"),
         )
         .await

--- a/tests/entrypoints/serve/profile/test_api_router.py
+++ b/tests/entrypoints/serve/profile/test_api_router.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm.entrypoints.serve.profile.api_router import router
+
+
+@pytest.fixture
+def engine_client() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def client(engine_client: AsyncMock) -> TestClient:
+    app = FastAPI()
+    app.state.engine_client = engine_client
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_start_profile_without_body_is_backwards_compatible(
+    client: TestClient, engine_client: AsyncMock
+) -> None:
+    response = client.post("/start_profile")
+
+    assert response.status_code == 200
+    engine_client.start_profile.assert_awaited_once_with()
+
+
+def test_start_profile_forwards_session_overrides(
+    client: TestClient, engine_client: AsyncMock
+) -> None:
+    response = client.post(
+        "/start_profile",
+        json={
+            "profile_prefix": "sharegpt_run-1",
+            "delay_iterations": 5000,
+            "max_iterations": 20,
+        },
+    )
+
+    assert response.status_code == 200
+    engine_client.start_profile.assert_awaited_once_with("sharegpt_run-1", 5000, 20)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"profile_prefix": "../trace"},
+        {"profile_prefix": ""},
+        {"delay_iterations": -1},
+        {"max_iterations": "20"},
+        {"unknown": 1},
+    ],
+)
+def test_start_profile_rejects_invalid_overrides(
+    client: TestClient, engine_client: AsyncMock, body: dict
+) -> None:
+    response = client.post("/start_profile", json=body)
+
+    assert response.status_code == 422
+    engine_client.start_profile.assert_not_awaited()

--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -100,7 +100,9 @@ def test_cuda_profiler_requests_reach_engine_core(monkeypatch: pytest.MonkeyPatc
     asyncio.run(profile())
 
     assert engine.profiler is None
-    engine_core.profile_async.assert_has_awaits([call(True, None), call(False)])
+    engine_core.profile_async.assert_has_awaits(
+        [call(True, None, None, None), call(False)]
+    )
 
 
 async def generate(

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -23,8 +23,10 @@ from vllm.profiler.wrapper import (
     WorkerProfiler,
 )
 from vllm.v1.core.sched.output import CachedRequestData
+from vllm.v1.worker.cpu_worker import CPUWorker
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_worker import Worker
+from vllm.v1.worker.xpu_worker import XPUWorker
 
 
 class ConcreteWorkerProfiler(WorkerProfiler):
@@ -253,10 +255,38 @@ def test_mixed_delay_and_stop(default_profiler_config):
     assert profiler.start_call_count == 0
 
 
-def test_torch_profiler_activities_default_to_cpu_and_cuda():
+def test_torch_profiler_activities_default_to_platform_default():
     config = ProfilerConfig(profiler="torch", torch_profiler_dir="/tmp/mock")
 
-    assert config.torch_profiler_activities == ["CPU", "CUDA"]
+    assert config.torch_profiler_activities is None
+
+
+@pytest.mark.parametrize(
+    ("worker_cls", "expected"),
+    [
+        (Worker, ("CPU", "CUDA")),
+        (CPUWorker, ("CPU",)),
+        (XPUWorker, ("CPU", "XPU")),
+    ],
+)
+def test_worker_resolves_platform_default_torch_activities(worker_cls, expected):
+    config = ProfilerConfig(profiler="torch", torch_profiler_dir="/tmp/mock")
+    worker = object.__new__(worker_cls)
+
+    assert worker._resolve_torch_profiler_activities(config) == expected
+
+
+@pytest.mark.parametrize("worker_cls", [CPUWorker, XPUWorker])
+def test_worker_rejects_unsupported_torch_activities(worker_cls):
+    config = ProfilerConfig(
+        profiler="torch",
+        torch_profiler_dir="/tmp/mock",
+        torch_profiler_activities=["CUDA"],
+    )
+    worker = object.__new__(worker_cls)
+
+    with pytest.raises(ValueError, match="Unsupported torch profiler activities"):
+        worker._resolve_torch_profiler_activities(config)
 
 
 def test_cuda_only_torch_profiler_skips_cpu_annotations(
@@ -637,9 +667,11 @@ class TestProtonProfilerWrapper:
 
 @_requires_cuda_for_proton
 def test_gpu_worker_creates_proton_profiler():
-    worker = MagicMock()
+    worker = object.__new__(Worker)
     worker.rank = 1
+    worker.local_rank = 0
     worker.profiler = None
+    worker.profiler_config = MagicMock()
     worker.profiler_config.profiler = "proton"
 
     with (
@@ -657,9 +689,11 @@ def test_gpu_worker_creates_proton_profiler():
 
 @_requires_cuda_for_proton
 def test_gpu_worker_recreates_proton_profiler_for_each_run():
-    worker = MagicMock()
+    worker = object.__new__(Worker)
     worker.rank = 1
+    worker.local_rank = 0
     worker.profiler = None
+    worker.profiler_config = MagicMock()
     worker.profiler_config.profiler = "proton"
 
     with (
@@ -681,7 +715,7 @@ def test_gpu_worker_recreates_proton_profiler_for_each_run():
 
 
 def test_gpu_worker_applies_per_session_torch_overrides():
-    worker = MagicMock()
+    worker = object.__new__(Worker)
     worker.rank = 1
     worker.local_rank = 0
     worker.profiler = None
@@ -716,6 +750,52 @@ def test_gpu_worker_applies_per_session_torch_overrides():
         session_config,
         worker_name="benchmark_rank1",
         local_rank=0,
-        activities=["CUDA"],
+        activities=("CUDA",),
     )
+    wrapper.return_value.start.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("worker_cls", "expected_activities"),
+    [
+        (CPUWorker, ("CPU",)),
+        (XPUWorker, ("CPU", "XPU")),
+    ],
+)
+def test_non_gpu_worker_creates_one_platform_profiler_per_session(
+    worker_cls, expected_activities
+):
+    worker = object.__new__(worker_cls)
+    worker.rank = 1
+    worker.local_rank = 0
+    worker.profiler = None
+    worker.profiler_config = ProfilerConfig(
+        profiler="torch",
+        torch_profiler_dir="/tmp/mock",
+        delay_iterations=1,
+        max_iterations=2,
+    )
+
+    with (
+        patch(
+            "vllm.distributed.utils.get_worker_rank_suffix",
+            return_value="rank1",
+        ),
+        patch("vllm.v1.worker.gpu_worker.TorchProfilerWrapper") as wrapper,
+    ):
+        worker.profile(
+            profile_prefix="first",
+            delay_iterations=10,
+            max_iterations=20,
+        )
+
+    session_config = wrapper.call_args.args[0]
+    wrapper.assert_called_once_with(
+        session_config,
+        worker_name="first_rank1",
+        local_rank=0,
+        activities=expected_activities,
+    )
+    assert session_config.delay_iterations == 10
+    assert session_config.max_iterations == 20
     wrapper.return_value.start.assert_called_once_with()

--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -17,7 +17,11 @@ from vllm.config import (
 )
 from vllm.config.profiler import _is_uri_path
 from vllm.platforms import current_platform
-from vllm.profiler.wrapper import ProtonProfilerWrapper, WorkerProfiler
+from vllm.profiler.wrapper import (
+    ProtonProfilerWrapper,
+    TorchProfilerWrapper,
+    WorkerProfiler,
+)
 from vllm.v1.core.sched.output import CachedRequestData
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_worker import Worker
@@ -247,6 +251,33 @@ def test_mixed_delay_and_stop(default_profiler_config):
     profiler.step()
 
     assert profiler.start_call_count == 0
+
+
+def test_torch_profiler_activities_default_to_cpu_and_cuda():
+    config = ProfilerConfig(profiler="torch", torch_profiler_dir="/tmp/mock")
+
+    assert config.torch_profiler_activities == ["CPU", "CUDA"]
+
+
+def test_cuda_only_torch_profiler_skips_cpu_annotations(
+    default_profiler_config, monkeypatch
+):
+    profiler = MagicMock()
+    monkeypatch.setattr(
+        "vllm.profiler.wrapper.torch.profiler.profile", Mock(return_value=profiler)
+    )
+    monkeypatch.setattr(
+        "vllm.profiler.wrapper.torch.profiler.tensorboard_trace_handler", Mock()
+    )
+
+    wrapper = TorchProfilerWrapper(
+        default_profiler_config,
+        worker_name="rank0",
+        local_rank=0,
+        activities=["CUDA"],
+    )
+
+    assert isinstance(wrapper.annotate_context_manager("iteration"), nullcontext)
 
 
 class TestIsUriPath:
@@ -647,3 +678,44 @@ def test_gpu_worker_recreates_proton_profiler_for_each_run():
         call(worker.profiler_config, worker_name="second_rank1"),
     ]
     assert wrapper.return_value.start.call_count == 2
+
+
+def test_gpu_worker_applies_per_session_torch_overrides():
+    worker = MagicMock()
+    worker.rank = 1
+    worker.local_rank = 0
+    worker.profiler = None
+    worker.profiler_config = ProfilerConfig(
+        profiler="torch",
+        torch_profiler_dir="/tmp/mock",
+        torch_profiler_activities=["CUDA"],
+        delay_iterations=1,
+        max_iterations=2,
+    )
+
+    with (
+        patch(
+            "vllm.distributed.utils.get_worker_rank_suffix",
+            return_value="rank1",
+        ),
+        patch("vllm.v1.worker.gpu_worker.TorchProfilerWrapper") as wrapper,
+    ):
+        Worker.profile(
+            worker,
+            profile_prefix="benchmark",
+            delay_iterations=10,
+            max_iterations=20,
+        )
+
+    session_config = wrapper.call_args.args[0]
+    assert session_config.delay_iterations == 10
+    assert session_config.max_iterations == 20
+    assert worker.profiler_config.delay_iterations == 1
+    assert worker.profiler_config.max_iterations == 2
+    wrapper.assert_called_once_with(
+        session_config,
+        worker_name="benchmark_rank1",
+        local_rank=0,
+        activities=["CUDA"],
+    )
+    wrapper.return_value.start.assert_called_once_with()

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -4,6 +4,7 @@
 import os
 from typing import Any, Literal
 
+import regex as re
 from pydantic import Field, model_validator
 from typing_extensions import Self
 
@@ -14,11 +15,28 @@ from vllm.utils.hashing import safe_hash
 logger = init_logger(__name__)
 
 ProfilerKind = Literal["torch", "cuda", "proton"]
+TorchProfilerActivity = Literal["CPU", "CUDA"]
 ProtonBackend = Literal["cupti"]
 ProtonContext = Literal["shadow", "python"]
 ProtonData = Literal["tree", "trace"]
 ProtonHook = Literal["triton"]
 ProtonOutputFormat = Literal["hatchet", "hatchet_msgpack", "chrome_trace"]
+
+_PROFILE_PREFIX_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+
+
+def _default_torch_profiler_activities() -> list[TorchProfilerActivity]:
+    return ["CPU", "CUDA"]
+
+
+def validate_profile_prefix(profile_prefix: str) -> str:
+    """Validate a profile prefix used in local trace file names."""
+    if _PROFILE_PREFIX_PATTERN.fullmatch(profile_prefix) is None:
+        raise ValueError(
+            "profile_prefix must be 1-128 characters, start with a letter or "
+            "number, and contain only letters, numbers, '.', '_', or '-'"
+        )
+    return profile_prefix
 
 
 def _is_uri_path(path: str) -> bool:
@@ -50,6 +68,13 @@ class ProfilerConfig:
     """Directory to save torch profiler traces. Both AsyncLLM's CPU traces and
     worker's traces (CPU & GPU) will be saved under this directory. Note that
     it must be an absolute path."""
+
+    torch_profiler_activities: list[TorchProfilerActivity] = Field(
+        default_factory=_default_torch_profiler_activities,
+        min_length=1,
+    )
+    """Activities recorded by GPU workers using the torch profiler. Defaults
+    to CPU and CUDA for backwards compatibility."""
 
     proton_profiler_dir: str = ""
     """Directory to save Triton Proton profiles. Each worker writes a
@@ -167,7 +192,12 @@ class ProfilerConfig:
     @model_validator(mode="after")
     def _validate_profiler_config(self) -> Self:
         has_delay_or_limit = self.delay_iterations > 0 or self.max_iterations > 0
-        if self.profiler == "torch" and has_delay_or_limit and not self.ignore_frontend:
+        if (
+            self.profiler == "torch"
+            and has_delay_or_limit
+            and not self.ignore_frontend
+            and "CPU" in self.torch_profiler_activities
+        ):
             logger.warning_once(
                 "Using 'torch' profiler with delay_iterations or max_iterations "
                 "while ignore_frontend is False may result in high overhead."

--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -15,7 +15,7 @@ from vllm.utils.hashing import safe_hash
 logger = init_logger(__name__)
 
 ProfilerKind = Literal["torch", "cuda", "proton"]
-TorchProfilerActivity = Literal["CPU", "CUDA"]
+TorchProfilerActivity = Literal["CPU", "CUDA", "PrivateUse1", "XPU"]
 ProtonBackend = Literal["cupti"]
 ProtonContext = Literal["shadow", "python"]
 ProtonData = Literal["tree", "trace"]
@@ -23,10 +23,6 @@ ProtonHook = Literal["triton"]
 ProtonOutputFormat = Literal["hatchet", "hatchet_msgpack", "chrome_trace"]
 
 _PROFILE_PREFIX_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
-
-
-def _default_torch_profiler_activities() -> list[TorchProfilerActivity]:
-    return ["CPU", "CUDA"]
 
 
 def validate_profile_prefix(profile_prefix: str) -> str:
@@ -69,12 +65,11 @@ class ProfilerConfig:
     worker's traces (CPU & GPU) will be saved under this directory. Note that
     it must be an absolute path."""
 
-    torch_profiler_activities: list[TorchProfilerActivity] = Field(
-        default_factory=_default_torch_profiler_activities,
-        min_length=1,
+    torch_profiler_activities: list[TorchProfilerActivity] | None = Field(
+        default=None, min_length=1
     )
-    """Activities recorded by GPU workers using the torch profiler. Defaults
-    to CPU and CUDA for backwards compatibility."""
+    """Activities recorded by workers using the torch profiler. When unset,
+    each worker uses its platform default: CPU; CPU and CUDA; or CPU and XPU."""
 
     proton_profiler_dir: str = ""
     """Directory to save Triton Proton profiles. Each worker writes a
@@ -192,11 +187,15 @@ class ProfilerConfig:
     @model_validator(mode="after")
     def _validate_profiler_config(self) -> Self:
         has_delay_or_limit = self.delay_iterations > 0 or self.max_iterations > 0
+        records_cpu_activity = (
+            self.torch_profiler_activities is None
+            or "CPU" in self.torch_profiler_activities
+        )
         if (
             self.profiler == "torch"
             and has_delay_or_limit
             and not self.ignore_frontend
-            and "CPU" in self.torch_profiler_activities
+            and records_cpu_activity
         ):
             logger.warning_once(
                 "Using 'torch' profiler with delay_iterations or max_iterations "

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -153,8 +153,13 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
-    async def start_profile(self) -> None:
-        """Start profiling the engine"""
+    async def start_profile(
+        self,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ) -> None:
+        """Start profiling the engine with optional per-session overrides."""
         ...
 
     @abstractmethod

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -780,15 +780,24 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
             mm_processor_kwargs=mm_processor_kwargs,
         )
 
-    def start_profile(self, profile_prefix: str | None = None) -> None:
-        """Start profiling with optional custom trace prefix.
+    def start_profile(
+        self,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ) -> None:
+        """Start profiling with optional per-session overrides.
 
         Args:
             profile_prefix: Optional prefix for the trace file names. If provided,
                            trace files will be named as "<prefix>_dp<X>_pp<Y>_tp<Z>".
                            If not provided, default naming will be used.
+            delay_iterations: Optional number of engine iterations to skip before
+                profiling starts.
+            max_iterations: Optional maximum number of engine iterations to profile.
+                Zero means no limit.
         """
-        self.llm_engine.start_profile(profile_prefix)
+        self.llm_engine.start_profile(profile_prefix, delay_iterations, max_iterations)
 
     def stop_profile(self) -> None:
         self.llm_engine.stop_profile()

--- a/vllm/entrypoints/serve/profile/api_router.py
+++ b/vllm/entrypoints/serve/profile/api_router.py
@@ -4,8 +4,10 @@
 
 from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import Response
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from vllm.config import ProfilerConfig
+from vllm.config.profiler import validate_profile_prefix
 from vllm.engine.protocol import EngineClient
 from vllm.logger import init_logger
 
@@ -14,14 +16,40 @@ logger = init_logger(__name__)
 router = APIRouter()
 
 
+class StartProfileRequest(BaseModel):
+    """Per-session profiling overrides."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    profile_prefix: str | None = None
+    delay_iterations: int | None = Field(default=None, ge=0)
+    max_iterations: int | None = Field(default=None, ge=0)
+
+    @field_validator("profile_prefix")
+    @classmethod
+    def validate_prefix(cls, value: str | None) -> str | None:
+        if value is not None:
+            validate_profile_prefix(value)
+        return value
+
+
 def engine_client(request: Request) -> EngineClient:
     return request.app.state.engine_client
 
 
 @router.post("/start_profile")
-async def start_profile(raw_request: Request):
+async def start_profile(
+    raw_request: Request, profile_request: StartProfileRequest | None = None
+):
     logger.info("Starting profiler...")
-    await engine_client(raw_request).start_profile()
+    if profile_request is None:
+        await engine_client(raw_request).start_profile()
+    else:
+        await engine_client(raw_request).start_profile(
+            profile_request.profile_prefix,
+            profile_request.delay_iterations,
+            profile_request.max_iterations,
+        )
     logger.info("Profiler started.")
     return Response(status_code=200)
 

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -6,7 +6,7 @@ import inspect
 import json
 import os
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from contextlib import nullcontext
 from typing import Literal
 from uuid import uuid4
@@ -54,6 +54,11 @@ class WorkerProfiler(ABC):
     def is_running(self) -> bool:
         """Whether the underlying profiler is currently collecting data."""
         return self._running
+
+    @property
+    def is_active(self) -> bool:
+        """Whether a profiling session is active, including its delay."""
+        return self._active
 
     @abstractmethod
     def _start(self) -> None:
@@ -179,7 +184,7 @@ class TorchProfilerWrapper(WorkerProfiler):
         profiler_config: ProfilerConfig,
         worker_name: str,
         local_rank: int,
-        activities: list[TorchProfilerActivity],
+        activities: Sequence[TorchProfilerActivity],
         on_trace_ready: Callable[[torch.profiler.profile], None] | None = None,
     ) -> None:
         super().__init__(profiler_config)
@@ -212,7 +217,11 @@ class TorchProfilerWrapper(WorkerProfiler):
                 use_gzip=profiler_config.torch_profiler_use_gzip,
             )
 
-        self.dump_cpu_time_total = "CPU" in activities and len(activities) == 1
+        self._records_cpu_activity = "CPU" in activities
+        self.dump_cuda_time_total = (
+            "CUDA" in activities and profiler_config.torch_profiler_dump_cuda_time_total
+        )
+        self.dump_cpu_time_total = self._records_cpu_activity and len(activities) == 1
 
         # Create profiler schedule if warmup or wait iterations are configured
         profiler_schedule = None
@@ -311,9 +320,8 @@ class TorchProfilerWrapper(WorkerProfiler):
     def _stop(self) -> None:
         self.profiler.stop()
 
-        profiler_config = self.profiler_config
         rank = self.local_rank
-        if profiler_config.torch_profiler_dump_cuda_time_total:
+        if self.dump_cuda_time_total:
             table = self._build_profiler_table(sort_key="self_cuda_time_total")
             self._write_profiler_table(rank, table)
 
@@ -351,6 +359,8 @@ class TorchProfilerWrapper(WorkerProfiler):
 
     @override
     def annotate_context_manager(self, name: str):
+        if not self._records_cpu_activity:
+            return nullcontext()
         return torch.profiler.record_function(name)
 
 

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -8,7 +8,6 @@ import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from contextlib import nullcontext
-from typing import Literal
 from uuid import uuid4
 
 import torch
@@ -17,7 +16,7 @@ from typing_extensions import override
 
 import vllm.version
 from vllm.config import ProfilerConfig
-from vllm.config.profiler import _is_uri_path
+from vllm.config.profiler import TorchProfilerActivity, _is_uri_path
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -169,7 +168,6 @@ class WorkerProfiler(ABC):
         return nullcontext()
 
 
-TorchProfilerActivity = Literal["CPU", "CUDA", "PrivateUse1", "XPU"]
 TorchProfilerActivityMap = {
     "CPU": torch.profiler.ProfilerActivity.CPU,
     "CUDA": torch.profiler.ProfilerActivity.CUDA,

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -192,10 +192,14 @@ class AsyncLLM(EngineClient):
 
         self.profiler = profiler
         self._frontend_profiler_injected = profiler is not None
+        configured_activities = vllm_config.profiler_config.torch_profiler_activities
+        records_cpu_activity = (
+            configured_activities is None or "CPU" in configured_activities
+        )
         self._frontend_profiler_enabled = self._frontend_profiler_injected or (
             vllm_config.profiler_config.profiler == "torch"
             and not vllm_config.profiler_config.ignore_frontend
-            and "CPU" in vllm_config.profiler_config.torch_profiler_activities
+            and records_cpu_activity
         )
         self._frontend_profiler_running = False
         if self._frontend_profiler_enabled and not self._frontend_profiler_injected:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -191,21 +191,21 @@ class AsyncLLM(EngineClient):
             pass
 
         self.profiler = profiler
-        if (
+        self._frontend_profiler_injected = profiler is not None
+        self._frontend_profiler_enabled = self._frontend_profiler_injected or (
             vllm_config.profiler_config.profiler == "torch"
             and not vllm_config.profiler_config.ignore_frontend
-        ):
+            and "CPU" in vllm_config.profiler_config.torch_profiler_activities
+        )
+        self._frontend_profiler_running = False
+        if self._frontend_profiler_enabled and not self._frontend_profiler_injected:
             profiler_dir = vllm_config.profiler_config.torch_profiler_dir
             logger.info(
                 "Torch profiler enabled. AsyncLLM CPU traces will be collected under %s",  # noqa: E501
                 profiler_dir,
             )
-            worker_name = f"{socket.gethostname()}_{os.getpid()}.async_llm"
-            self.profiler = TorchProfilerWrapper(
-                vllm_config.profiler_config,
-                worker_name=worker_name,
-                local_rank=0,
-                activities=["CPU"],
+            self._frontend_profiler_worker_name = (
+                f"{socket.gethostname()}_{os.getpid()}.async_llm"
             )
 
     @classmethod
@@ -1027,17 +1027,61 @@ class AsyncLLM(EngineClient):
         if self.errored:
             raise self.dead_error
 
-    async def start_profile(self, profile_prefix: str | None = None) -> None:
-        coros = [self.engine_core.profile_async(True, profile_prefix)]
-        if self.profiler is not None:
+    def _create_frontend_profiler(
+        self, profile_prefix: str | None
+    ) -> TorchProfilerWrapper:
+        from vllm.config.utils import replace
+
+        worker_name = self._frontend_profiler_worker_name
+        if profile_prefix is not None:
+            worker_name = f"{profile_prefix}_{worker_name}"
+        # The frontend has no engine-step callback, so worker-only delay and
+        # schedule settings must not be applied to its CPU profiler.
+        profiler_config = replace(
+            self.vllm_config.profiler_config,
+            delay_iterations=0,
+            max_iterations=0,
+            wait_iterations=0,
+            warmup_iterations=0,
+        )
+        return TorchProfilerWrapper(
+            profiler_config,
+            worker_name=worker_name,
+            local_rank=0,
+            activities=["CPU"],
+        )
+
+    async def start_profile(
+        self,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ) -> None:
+        coros = [
+            self.engine_core.profile_async(
+                True, profile_prefix, delay_iterations, max_iterations
+            )
+        ]
+        if self._frontend_profiler_enabled and not self._frontend_profiler_running:
+            from vllm.config.profiler import validate_profile_prefix
+
+            if profile_prefix is not None:
+                validate_profile_prefix(profile_prefix)
+            if not self._frontend_profiler_injected:
+                self.profiler = self._create_frontend_profiler(profile_prefix)
+            assert self.profiler is not None
+            self._frontend_profiler_running = True
             coros.append(asyncio.to_thread(self.profiler.start))
         await asyncio.gather(*coros)
 
     async def stop_profile(self) -> None:
         coros = [self.engine_core.profile_async(False)]
-        if self.profiler is not None:
+        if self.profiler is not None and self._frontend_profiler_running:
             coros.append(asyncio.to_thread(self.profiler.stop))
+            self._frontend_profiler_running = False
         await asyncio.gather(*coros)
+        if not self._frontend_profiler_injected:
+            self.profiler = None
 
     async def reset_mm_cache(self) -> None:
         # Join the background MM warmup first: the mm_processor_cache is not

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -771,8 +771,16 @@ class EngineCore:
         cleanup_dist_env_and_memory()
         logger.debug_once("[shutdown] EngineCore: local resource teardown complete")
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
-        self.model_executor.profile(is_start, profile_prefix)
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ):
+        self.model_executor.profile(
+            is_start, profile_prefix, delay_iterations, max_iterations
+        )
 
     def reset_mm_cache(self):
         # NOTE: Since this is mainly for debugging, we don't attempt to

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -177,7 +177,13 @@ class EngineCoreClient(ABC):
     def add_request(self, request: EngineCoreRequest) -> None:
         raise NotImplementedError
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ) -> None:
         raise NotImplementedError
 
     def reset_mm_cache(self) -> None:
@@ -268,7 +274,11 @@ class EngineCoreClient(ABC):
         raise NotImplementedError
 
     async def profile_async(
-        self, is_start: bool = True, profile_prefix: str | None = None
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
     ) -> None:
         raise NotImplementedError
 
@@ -377,8 +387,16 @@ class InprocClient(EngineCoreClient):
     def shutdown(self, timeout: float | None = None) -> None:
         self.engine_core.shutdown()
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
-        self.engine_core.profile(is_start, profile_prefix)
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ) -> None:
+        self.engine_core.profile(
+            is_start, profile_prefix, delay_iterations, max_iterations
+        )
 
     def reset_mm_cache(self) -> None:
         self.engine_core.reset_mm_cache()
@@ -982,8 +1000,20 @@ class SyncMPClient(MPClient):
         if request_ids and not self.resources.engine_dead:
             self._send_input(EngineCoreRequestType.ABORT, request_ids)
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
-        self.call_utility("profile", is_start, profile_prefix)
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ) -> None:
+        self.call_utility(
+            "profile",
+            is_start,
+            profile_prefix,
+            delay_iterations,
+            max_iterations,
+        )
 
     def reset_mm_cache(self) -> None:
         self.call_utility("reset_mm_cache")
@@ -1237,9 +1267,19 @@ class AsyncMPClient(MPClient):
         return await self.call_utility_async("is_scheduler_paused")
 
     async def profile_async(
-        self, is_start: bool = True, profile_prefix: str | None = None
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
     ) -> None:
-        await self.call_utility_async("profile", is_start, profile_prefix)
+        await self.call_utility_async(
+            "profile",
+            is_start,
+            profile_prefix,
+            delay_iterations,
+            max_iterations,
+        )
 
     async def reset_mm_cache_async(self) -> None:
         await self.call_utility_async("reset_mm_cache")

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -341,8 +341,13 @@ class LLMEngine:
 
         return processed_outputs.request_outputs
 
-    def start_profile(self, profile_prefix: str | None = None):
-        self.engine_core.profile(True, profile_prefix)
+    def start_profile(
+        self,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ):
+        self.engine_core.profile(True, profile_prefix, delay_iterations, max_iterations)
 
     def stop_profile(self):
         self.engine_core.profile(False)

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -263,8 +263,17 @@ class Executor(ABC):
         output: list[DraftTokenIds] = self.collective_rpc("take_draft_token_ids")
         return output[0]
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
-        self.collective_rpc("profile", args=(is_start, profile_prefix))
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ):
+        self.collective_rpc(
+            "profile",
+            args=(is_start, profile_prefix, delay_iterations, max_iterations),
+        )
 
     def save_sharded_state(
         self,

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -7,16 +7,16 @@ import vllm.v1.worker.cpu.shm  # noqa # isort: skip
 import math
 import os
 import sys
-from typing import Any
+from typing import ClassVar
 
 import psutil
 import torch
 
 from vllm import envs
 from vllm.config import CompilationMode, VllmConfig
+from vllm.config.profiler import ProfilerKind, TorchProfilerActivity
 from vllm.logger import init_logger
 from vllm.platforms import CpuArchEnum, current_platform
-from vllm.profiler.wrapper import TorchProfilerWrapper
 from vllm.utils.cpu_resource_utils import (
     get_allowed_cpu_list,
     get_memory_node_info,
@@ -32,6 +32,14 @@ logger = init_logger(__name__)
 
 
 class CPUWorker(Worker):
+    DEFAULT_TORCH_PROFILER_ACTIVITIES: ClassVar[tuple[TorchProfilerActivity, ...]] = (
+        "CPU",
+    )
+    SUPPORTED_TORCH_PROFILER_ACTIVITIES: ClassVar[frozenset[TorchProfilerActivity]] = (
+        frozenset(DEFAULT_TORCH_PROFILER_ACTIVITIES)
+    )
+    SUPPORTED_PROFILER_KINDS: ClassVar[frozenset[ProfilerKind]] = frozenset(("torch",))
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -105,18 +113,6 @@ class CPUWorker(Worker):
         )
 
         self.parallel_config.disable_custom_all_reduce = True
-
-        # Torch profiler. Enabled and configured through profiler_config.
-        self.profiler: Any | None = None
-        profiler_config = vllm_config.profiler_config
-        if profiler_config.profiler == "torch":
-            worker_name = f"{vllm_config.instance_id}-rank-{self.rank}"
-            self.profiler = TorchProfilerWrapper(
-                profiler_config,
-                worker_name=worker_name,
-                local_rank=self.local_rank,
-                activities=["CPU"],
-            )
 
     def init_device(self):
         self.device = torch.device("cpu")
@@ -284,22 +280,3 @@ class CPUWorker(Worker):
             language_model=self.compilation_config.compilation_time,
             encoder=self.compilation_config.encoder_compilation_time,
         )
-
-    def profile(
-        self,
-        is_start: bool = True,
-        profile_prefix: str | None = None,
-        delay_iterations: int | None = None,
-        max_iterations: int | None = None,
-    ):
-        if self.profiler is None:
-            raise RuntimeError("Profiler is not enabled.")
-        if delay_iterations is not None or max_iterations is not None:
-            raise ValueError(
-                "Per-session delay_iterations and max_iterations are only "
-                "supported by GPU workers."
-            )
-        if is_start:
-            self.profiler.start()
-        else:
-            self.profiler.stop()

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -285,9 +285,20 @@ class CPUWorker(Worker):
             encoder=self.compilation_config.encoder_compilation_time,
         )
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ):
         if self.profiler is None:
             raise RuntimeError("Profiler is not enabled.")
+        if delay_iterations is not None or max_iterations is not None:
+            raise ValueError(
+                "Per-session delay_iterations and max_iterations are only "
+                "supported by GPU workers."
+            )
         if is_start:
             self.profiler.start()
         else:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1216,7 +1216,13 @@ class Worker(WorkerBase):
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         return self.model_runner.take_draft_token_ids()
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ):
         # Check if profiling is enabled
         if self.profiler_config is None or self.profiler_config.profiler is None:
             raise RuntimeError(
@@ -1227,6 +1233,27 @@ class Worker(WorkerBase):
             )
 
         if is_start:
+            from vllm.config.profiler import validate_profile_prefix
+            from vllm.config.utils import replace
+
+            if profile_prefix is not None:
+                validate_profile_prefix(profile_prefix)
+
+            if self.profiler is not None and self.profiler.is_active:
+                self.profiler.start()
+                return
+
+            overrides = {}
+            if delay_iterations is not None:
+                overrides["delay_iterations"] = delay_iterations
+            if max_iterations is not None:
+                overrides["max_iterations"] = max_iterations
+            session_config = (
+                replace(self.profiler_config, **overrides)
+                if overrides
+                else self.profiler_config
+            )
+
             profiler_type = self.profiler_config.profiler
             # Generate the trace name by combining prefix with comprehensive rank suffix
             from vllm.distributed.utils import get_worker_rank_suffix
@@ -1239,33 +1266,25 @@ class Worker(WorkerBase):
             else:
                 trace_name = rank_suffix
 
-            # Create the profiler wrapper only on the first start call
-            if self.profiler is None:
-                if profiler_type == "torch":
-                    self.profiler = TorchProfilerWrapper(
-                        self.profiler_config,
-                        worker_name=trace_name,
-                        local_rank=self.local_rank,
-                        activities=["CPU", "CUDA"],
-                    )
-                    logger.debug(
-                        "Starting torch profiler with trace name: %s", trace_name
-                    )
-                elif profiler_type == "cuda":
-                    self.profiler = CudaProfilerWrapper(self.profiler_config)
-                    logger.debug("Starting CUDA profiler")
-                elif profiler_type == "proton":
-                    self.profiler = ProtonProfilerWrapper(
-                        self.profiler_config, worker_name=trace_name
-                    )
-                    logger.debug(
-                        "Starting Proton profiler with trace name: %s", trace_name
-                    )
-                else:
-                    # Config validation should prevent this code being reached
-                    raise ValueError(
-                        f"Invalid profiler value of {self.profiler_config.profiler}"
-                    )
+            if profiler_type == "torch":
+                self.profiler = TorchProfilerWrapper(
+                    session_config,
+                    worker_name=trace_name,
+                    local_rank=self.local_rank,
+                    activities=session_config.torch_profiler_activities,
+                )
+                logger.debug("Starting torch profiler with trace name: %s", trace_name)
+            elif profiler_type == "cuda":
+                self.profiler = CudaProfilerWrapper(session_config)
+                logger.debug("Starting CUDA profiler")
+            elif profiler_type == "proton":
+                self.profiler = ProtonProfilerWrapper(
+                    session_config, worker_name=trace_name
+                )
+                logger.debug("Starting Proton profiler with trace name: %s", trace_name)
+            else:
+                # Config validation should prevent this code being reached
+                raise ValueError(f"Invalid profiler value of {session_config.profiler}")
 
             self.profiler.start()
         else:
@@ -1275,10 +1294,9 @@ class Worker(WorkerBase):
             try:
                 self.profiler.stop()
             finally:
-                if self.profiler_config.profiler == "proton":
-                    # Proton output names are fixed when the wrapper is constructed.
-                    # Recreate it so the next profile_prefix is honored.
-                    self.profiler = None
+                # Torch profilers are one-shot, and every profiler type needs
+                # a fresh wrapper to honor the next session's bounds and prefix.
+                self.profiler = None
 
     def execute_dummy_batch(self) -> None:
         num_tokens = getattr(self.model_runner, "uniform_decode_query_len", 1)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from datetime import timedelta
 from types import NoneType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 import regex as re
@@ -19,6 +19,13 @@ import torch.nn as nn
 import vllm.envs as envs
 from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.config.compilation import CompilationMode
+from vllm.config.profiler import (
+    ProfilerConfig,
+    ProfilerKind,
+    TorchProfilerActivity,
+    validate_profile_prefix,
+)
+from vllm.config.utils import replace
 from vllm.device_allocator import get_mem_allocator_instance
 from vllm.distributed import (
     ensure_model_parallel_initialized,
@@ -63,6 +70,7 @@ from vllm.profiler.wrapper import (
     CudaProfilerWrapper,
     ProtonProfilerWrapper,
     TorchProfilerWrapper,
+    WorkerProfiler,
 )
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
@@ -177,6 +185,17 @@ class AsyncIntermediateTensors(IntermediateTensors):
 
 
 class Worker(WorkerBase):
+    DEFAULT_TORCH_PROFILER_ACTIVITIES: ClassVar[tuple[TorchProfilerActivity, ...]] = (
+        "CPU",
+        "CUDA",
+    )
+    SUPPORTED_TORCH_PROFILER_ACTIVITIES: ClassVar[frozenset[TorchProfilerActivity]] = (
+        frozenset(DEFAULT_TORCH_PROFILER_ACTIVITIES)
+    )
+    SUPPORTED_PROFILER_KINDS: ClassVar[frozenset[ProfilerKind]] = frozenset(
+        ("torch", "cuda", "proton")
+    )
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -1216,6 +1235,56 @@ class Worker(WorkerBase):
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         return self.model_runner.take_draft_token_ids()
 
+    def _resolve_torch_profiler_activities(
+        self, profiler_config: ProfilerConfig
+    ) -> tuple[TorchProfilerActivity, ...]:
+        configured = profiler_config.torch_profiler_activities
+        activities = (
+            self.DEFAULT_TORCH_PROFILER_ACTIVITIES
+            if configured is None
+            else tuple(configured)
+        )
+        unsupported = set(activities) - self.SUPPORTED_TORCH_PROFILER_ACTIVITIES
+        if unsupported:
+            unsupported_names = ", ".join(sorted(unsupported))
+            supported_names = ", ".join(
+                sorted(self.SUPPORTED_TORCH_PROFILER_ACTIVITIES)
+            )
+            raise ValueError(
+                f"Unsupported torch profiler activities for "
+                f"{type(self).__name__}: {unsupported_names}. "
+                f"Supported activities: {supported_names}."
+            )
+        return activities
+
+    def _create_profiler(
+        self, profiler_config: ProfilerConfig, trace_name: str
+    ) -> WorkerProfiler:
+        profiler_type = profiler_config.profiler
+        if profiler_type not in self.SUPPORTED_PROFILER_KINDS:
+            supported_names = ", ".join(sorted(self.SUPPORTED_PROFILER_KINDS))
+            raise ValueError(
+                f"Unsupported profiler type for {type(self).__name__}: "
+                f"{profiler_type}. Supported profiler types: {supported_names}."
+            )
+
+        if profiler_type == "torch":
+            profiler = TorchProfilerWrapper(
+                profiler_config,
+                worker_name=trace_name,
+                local_rank=self.local_rank,
+                activities=self._resolve_torch_profiler_activities(profiler_config),
+            )
+            logger.debug("Starting torch profiler with trace name: %s", trace_name)
+            return profiler
+        if profiler_type == "cuda":
+            logger.debug("Starting CUDA profiler")
+            return CudaProfilerWrapper(profiler_config)
+
+        assert profiler_type == "proton"
+        logger.debug("Starting Proton profiler with trace name: %s", trace_name)
+        return ProtonProfilerWrapper(profiler_config, worker_name=trace_name)
+
     def profile(
         self,
         is_start: bool = True,
@@ -1233,9 +1302,6 @@ class Worker(WorkerBase):
             )
 
         if is_start:
-            from vllm.config.profiler import validate_profile_prefix
-            from vllm.config.utils import replace
-
             if profile_prefix is not None:
                 validate_profile_prefix(profile_prefix)
 
@@ -1254,7 +1320,6 @@ class Worker(WorkerBase):
                 else self.profiler_config
             )
 
-            profiler_type = self.profiler_config.profiler
             # Generate the trace name by combining prefix with comprehensive rank suffix
             from vllm.distributed.utils import get_worker_rank_suffix
 
@@ -1266,26 +1331,7 @@ class Worker(WorkerBase):
             else:
                 trace_name = rank_suffix
 
-            if profiler_type == "torch":
-                self.profiler = TorchProfilerWrapper(
-                    session_config,
-                    worker_name=trace_name,
-                    local_rank=self.local_rank,
-                    activities=session_config.torch_profiler_activities,
-                )
-                logger.debug("Starting torch profiler with trace name: %s", trace_name)
-            elif profiler_type == "cuda":
-                self.profiler = CudaProfilerWrapper(session_config)
-                logger.debug("Starting CUDA profiler")
-            elif profiler_type == "proton":
-                self.profiler = ProtonProfilerWrapper(
-                    session_config, worker_name=trace_name
-                )
-                logger.debug("Starting Proton profiler with trace name: %s", trace_name)
-            else:
-                # Config validation should prevent this code being reached
-                raise ValueError(f"Invalid profiler value of {session_config.profiler}")
-
+            self.profiler = self._create_profiler(session_config, trace_name)
             self.profiler.start()
         else:
             if self.profiler is None:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1281,7 +1281,7 @@ class Worker(WorkerBase):
             logger.debug("Starting CUDA profiler")
             return CudaProfilerWrapper(profiler_config)
 
-        assert profiler_type == "proton"
+        assert profiler_type == "proton", f"Unknown profiler type: {profiler_type}"
         logger.debug("Starting Proton profiler with trace name: %s", trace_name)
         return ProtonProfilerWrapper(profiler_config, worker_name=trace_name)
 

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -197,7 +197,13 @@ class XPUWorker(Worker):
             # If usage stat is enabled, collect relevant info.
             report_usage_stats(self.vllm_config)
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        delay_iterations: int | None = None,
+        max_iterations: int | None = None,
+    ):
         if self.profiler_config is None or self.profiler_config.profiler is None:
             raise RuntimeError(
                 "Profiling is not enabled. Please set --profiler-config to enable "
@@ -222,7 +228,12 @@ class XPUWorker(Worker):
             )
             logger.debug("Starting torch profiler with trace name: %s", trace_name)
 
-        super().profile(is_start=is_start, profile_prefix=profile_prefix)
+        super().profile(
+            is_start=is_start,
+            profile_prefix=profile_prefix,
+            delay_iterations=delay_iterations,
+            max_iterations=max_iterations,
+        )
 
     def shutdown(self) -> None:
         logger.info(

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -2,13 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import gc
 import os
+from typing import ClassVar
 
 import torch
 
 from vllm.config import VllmConfig
+from vllm.config.profiler import ProfilerKind, TorchProfilerActivity
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
-from vllm.profiler.wrapper import TorchProfilerWrapper
 from vllm.utils.mem_utils import MemorySnapshot, format_gib
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.utils import report_usage_stats
@@ -23,6 +24,15 @@ logger = init_logger(__name__)
 
 class XPUWorker(Worker):
     """A XPU worker class."""
+
+    DEFAULT_TORCH_PROFILER_ACTIVITIES: ClassVar[tuple[TorchProfilerActivity, ...]] = (
+        "CPU",
+        "XPU",
+    )
+    SUPPORTED_TORCH_PROFILER_ACTIVITIES: ClassVar[frozenset[TorchProfilerActivity]] = (
+        frozenset(DEFAULT_TORCH_PROFILER_ACTIVITIES)
+    )
+    SUPPORTED_PROFILER_KINDS: ClassVar[frozenset[ProfilerKind]] = frozenset(("torch",))
 
     def __init__(
         self,
@@ -196,44 +206,6 @@ class XPUWorker(Worker):
         if self.rank == 0:
             # If usage stat is enabled, collect relevant info.
             report_usage_stats(self.vllm_config)
-
-    def profile(
-        self,
-        is_start: bool = True,
-        profile_prefix: str | None = None,
-        delay_iterations: int | None = None,
-        max_iterations: int | None = None,
-    ):
-        if self.profiler_config is None or self.profiler_config.profiler is None:
-            raise RuntimeError(
-                "Profiling is not enabled. Please set --profiler-config to enable "
-                "profiling. Example: "
-                "'--profiler-config.profiler=torch --profiler-config.torch_profiler_dir"
-                "=YOUR_DIR_PATH_TO_DUMP_TRACE'"
-            )
-
-        if is_start and self.profiler is None:
-            from vllm.distributed.utils import get_worker_rank_suffix
-
-            rank_suffix = get_worker_rank_suffix(global_rank=self.rank)
-            trace_name = (
-                f"{profile_prefix}_{rank_suffix}" if profile_prefix else rank_suffix
-            )
-
-            self.profiler = TorchProfilerWrapper(
-                self.profiler_config,
-                worker_name=trace_name,
-                local_rank=self.local_rank,
-                activities=["CPU", "XPU"],
-            )
-            logger.debug("Starting torch profiler with trace name: %s", trace_name)
-
-        super().profile(
-            is_start=is_start,
-            profile_prefix=profile_prefix,
-            delay_iterations=delay_iterations,
-            max_iterations=max_iterations,
-        )
 
     def shutdown(self) -> None:
         logger.info(


### PR DESCRIPTION
## Purpose

Support per-session profile prefixes and iteration bounds in both Python and Rust frontends, with configurable CUDA-only torch profiler activities (set by `torch_profiler_activities=["CUDA"]`). Addresses https://github.com/vllm-project/vllm/issues/55207 (excluding the cloud storage upload part)

Specifically the `/start_profile` accepts 3 optional inputs `profile_prefix`, `delay_iterations`, `max_iterations` which allows user to flexibly profile different workloads/iterations against the same deployment without restarting the server.

## Test Plan
unit tests
```
# rust
cd rust
cargo nextest run -p vllm-server -E 'test(profile)'

# python
pytest \
  tests/entrypoints/serve/profile/test_api_router.py \
  tests/v1/worker/test_gpu_profiler.py \
  tests/v1/engine/test_async_llm.py::test_cuda_profiler_requests_reach_engine_core \
  -v
```

## Test Result
rust and python unit tests pass

validate on model using (python, rust) frontend

start server
```
export MODEL=Qwen/Qwen3-0.6B
export TRACE_DIR=/tmp/profile-python
rm -rf "$TRACE_DIR"
mkdir -p "$TRACE_DIR"

# for rust
VLLM_USE_RUST_FRONTEND=1 \
VLLM_RUST_FRONTEND_PATH=/root/repos/vllm/vllm/vllm-rs \
vllm serve "$MODEL" \
  --profiler-config "{
    \"profiler\": \"torch\",
    \"torch_profiler_dir\": \"$TRACE_DIR\",
    \"torch_profiler_activities\": [\"CUDA\"],
    \"torch_profiler_with_stack\": false,
    \"torch_profiler_use_gzip\": false
  }"

```
start profiler
```
curl --fail-with-body -X POST http://127.0.0.1:8000/start_profile \
  -H "Content-Type: application/json" \
  -d '{
    "profile_prefix": "manual_test",
    "delay_iterations": 50,
    "max_iterations": 10
  }'
```
send req
```
curl --fail-with-body http://127.0.0.1:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen3-0.6B",
    "prompt": "Explain how a GPU executes a matrix multiplication:",
    "max_tokens": 100,
    "temperature": 0,
    "ignore_eos": true
  }'
```
the trace is saved to 
`/tmp/profile-python/manual_test_rank0.1789179030971210523.pt.trace.json`


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

