### PR TITLE
[DNM] [ROCm] Select Triton explicitly for W4A16 MoE on gfx942/gfx950

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a16_moe.py
@@ -155,7 +155,7 @@ def aiter_triton_kernel_w4a16_moe_forward(
     from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
         should_use_cdna4_mx_scale_swizzle,
     )
-    from vllm.platforms.rocm import on_gfx1250
+    from vllm.platforms.rocm import on_gfx942, on_gfx950, on_gfx1250
 
     try:
         from aiter.ops.triton.moe.moe_op_gemm_a16w4 import moe_gemm_a16w4
@@ -253,6 +253,9 @@ def aiter_triton_kernel_w4a16_moe_forward(
     # kernel indexes a swizzled buffer as if it were linear.
     swz = "CDNA4_SCALE" if should_use_cdna4_mx_scale_swizzle() else None
 
+    # This AITER Gluon GEMM is gfx1250-only. Preserve auto selection there.
+    gemm_backend = "triton" if on_gfx942() or on_gfx950() else None
+
     intermediate = moe_gemm_a16w4(
         hidden_states,
         w1_data,
@@ -271,6 +274,7 @@ def aiter_triton_kernel_w4a16_moe_forward(
         swiglu_add_residual=swiglu_add_residual,
         unpadded_N=unpadded_N_w1,
         unpadded_K=unpadded_K_w1,
+        backend=gemm_backend,
     )
 
     out = moe_gemm_a16w4(
@@ -287,6 +291,7 @@ def aiter_triton_kernel_w4a16_moe_forward(
         swizzle_mx_scale=swz,
         unpadded_N=unpadded_N_w2,
         unpadded_K=unpadded_K_w2,
+        backend=gemm_backend,
     )
 
     return out


### PR DESCRIPTION
## Purpose

Explicitly select `backend="triton"` for both AITER W4A16 MoE GEMMs on gfx942/gfx950. Preserve automatic selection on other architectures, including gfx1250, and leave scale swizzling and the gfx1250 SILU fallback unchanged.

The AITER automatic selector currently logs `GLUON backend not available. Using TRITON backend!!!` on every call where its gfx1250-only Gluon GEMM is unavailable. Both vLLM calls omit `backend`. The [original MI355X job](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34651830283/job/103436309734) contains 56,264 occurrences in its [complete server-log artifact](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34651830283/artifacts/10285837503).

This is a targeted vLLM workaround. [AITER #5471](https://github.com/ROCm/aiter/pull/5471) separately fixes automatic-selection logging. [InferenceX #3031](https://github.com/SemiAnalysisAI/InferenceX/pull/3031) will test both patches together in the existing DeepSeek-V4.1-Flash MI355X image, without suppressing warnings through log levels. The combined run cannot isolate each patch's contribution.

## Validation

The [combined InferenceX sweep](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34661567802) passed: all six MI355X TP4 benchmark points at concurrency 1/2/4/8/16/32 and GSM8K eval succeeded. Both patch hashes matched in all seven jobs. The seven complete server logs contain 44,516 lines and **zero original fallback warnings**, with server readiness and actual inference confirmed. [InferenceX #3031](https://github.com/SemiAnalysisAI/InferenceX/pull/3031) lists every artifact and per-run count.

[GSM8K](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34661567802/artifacts/10287709551): 1,319 questions, strict-match 0.9734647460 and flexible-extract 0.9727065959, both above the configured 0.9 gate. Concurrency 32 recorded one client request-body write error among 2,004 profiling requests (0.05%) and still passed; duration-limit cancellation messages also occur. This result does not isolate either patch or establish baseline-equivalent accuracy/performance.

- `.venv/bin/python -m pytest /home/user/workspace/test_gluon_dispatch.py -q`: 10 passed, 20 subtests passed. These are local source-extracted CPU checks, not committed GPU tests. The vLLM check verifies the architecture-gated backend at both GEMM calls; AITER checks cover automatic and explicit dispatch.
- `.venv/bin/python -m pre_commit run --files vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a16_moe.py`: applicable hooks passed, including Ruff, mypy, SPDX and import checks.
- `git diff --check`: passed.
- The combined GPU benchmark sweep and GSM8K eval passed as reported above. No correctness or speedup claim is made from the CPU checks, and no controlled performance comparison was run.

## Duplicate check and review status

Open-PR searches for the exact warning, Gluon/Triton backend work and references to #56214 found no existing fix for this warning at these two call sites. Related #50817 concerns MI325X MXFP4 enablement, SiTU and tile configurations; this draft does not include those changes.

AI assistance was used for investigation, implementation and verification. This draft is published at the human requester's direction for review and CI. Human line-by-line review remains outstanding; the completed GPU sweep is limited to the combined MI355X configuration. Do not merge or treat this as a reviewed contribution.
