### PR TITLE
[Perf][DSv4.1] Capture fused attention output projection

### DIFF
--- a/cmake/external_projects/flashmla.cmake
+++ b/cmake/external_projects/flashmla.cmake
@@ -23,7 +23,7 @@ else()
   FetchContent_Declare(
         flashmla
         GIT_REPOSITORY https://github.com/vllm-project/FlashMLA
-        GIT_TAG c112cc1ed1c61bfdb7dbf25e53753bd272edb767
+        GIT_TAG cbb0f5b9d4278b5725e48c763ef1450dc0116999
         GIT_PROGRESS TRUE
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/vllm/models/deepseek_v4_1/amd/rocm.py
+++ b/vllm/models/deepseek_v4_1/amd/rocm.py
@@ -13,7 +13,7 @@ from vllm.distributed import (
 )
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
-from vllm.models.deepseek_v4_1.attention import DeepseekV4Attention
+from vllm.models.deepseek_v4_1.attention import AttentionOutput, DeepseekV4Attention
 from vllm.models.deepseek_v4_1.common.ops import dequantize_and_gather_k_cache
 from vllm.models.deepseek_v4_1.sparse_mla import (
     DeepseekV4FlashMLAMetadata,
@@ -659,8 +659,9 @@ class DeepseekV41ROCMAiterMLAAttention(DeepseekV4Attention):
         q: torch.Tensor,
         kv: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
+        output: AttentionOutput,
     ) -> None:
+        assert isinstance(output, torch.Tensor)
         assert output.shape == q.shape, (
             f"output buffer shape {output.shape} must match q shape {q.shape}"
         )

--- a/vllm/models/deepseek_v4_1/attention.py
+++ b/vllm/models/deepseek_v4_1/attention.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, cast
 
 import regex as re
 import torch
@@ -71,6 +71,8 @@ from vllm.v1.kv_cache_interface import (
 )
 
 logger = init_logger(__name__)
+
+AttentionOutput: TypeAlias = torch.Tensor | QuantizedActivation
 
 
 def _replace_layer_index(prefix: str, layer_id: int) -> str:
@@ -227,7 +229,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         q: torch.Tensor,
         kv: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
+        output: AttentionOutput,
     ) -> None:
         """Platform-specific sparse MLA forward; writes attention into ``output``."""
         raise NotImplementedError
@@ -627,7 +629,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
     def _alloc_attn_out(
         self, num_tokens: int, hidden_states: torch.Tensor
-    ) -> torch.Tensor:
+    ) -> AttentionOutput:
         """Attention output buffer: ``[N, padded_heads, head_dim]`` bf16."""
         return torch.empty(
             (num_tokens, self.padded_heads, self.head_dim),
@@ -636,9 +638,10 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         )
 
     def _finish_o_proj(
-        self, attn_out: torch.Tensor, positions: torch.Tensor
+        self, attn_out: AttentionOutput, positions: torch.Tensor
     ) -> torch.Tensor:
         """Inverse-RoPE + wo_a + wo_b on the real heads of ``attn_out``."""
+        assert isinstance(attn_out, torch.Tensor)
         return self._o_proj(attn_out[:, : self.n_local_heads, :], positions)
 
     def _prepare_q_and_insert_kv(
@@ -705,7 +708,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         kv_score: torch.Tensor,
         indexer_weights: torch.Tensor,
         positions: torch.Tensor,
-        attn_out: torch.Tensor,
+        attn_out: AttentionOutput,
     ) -> None:
         """Wide eager region: the whole of ``_prepare_and_attn`` runs eagerly.
 
@@ -732,7 +735,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         kv_score: torch.Tensor,
         indexer_weights: torch.Tensor,
         positions: torch.Tensor,
-        attn_out: torch.Tensor,
+        attn_out: AttentionOutput,
     ) -> None:
         """Attention input preparation followed by the sparse indexer and MLA.
 
@@ -886,7 +889,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         q: torch.Tensor,
         kv: torch.Tensor,
         positions: torch.Tensor,
-        out: torch.Tensor,
+        out: AttentionOutput,
     ) -> None:
         if self.indexer is not None and index_q is not None:
             assert index_weights is not None

--- a/vllm/models/deepseek_v4_1/nvidia/flashinfer_sparse.py
+++ b/vllm/models/deepseek_v4_1/nvidia/flashinfer_sparse.py
@@ -13,7 +13,7 @@ from vllm.models.deepseek_v4.nvidia.ops.o_proj import (
     compute_fp8_einsum_recipe,
     deep_gemm_fp8_o_proj,
 )
-from vllm.models.deepseek_v4_1.attention import DeepseekV4Attention
+from vllm.models.deepseek_v4_1.attention import AttentionOutput, DeepseekV4Attention
 from vllm.models.deepseek_v4_1.common.ops import (
     build_flashinfer_mixed_sparse_indices,
     compute_global_topk_indices_and_lens,
@@ -253,8 +253,9 @@ class DeepseekV4FlashInferMLAAttention(DeepseekV4Attention):
         q: torch.Tensor,
         kv: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
+        output: AttentionOutput,
     ) -> None:
+        assert isinstance(output, torch.Tensor)
         # The TRTLLM-gen kernel requires h_q in {64, 128}, so the output buffer
         # is allocated at the padded head count while q arrives at the local
         # head count; _forward pads q to match before the launcher.
@@ -658,8 +659,9 @@ class DeepseekV4FlashInferSM120Attention(DeepseekV4Attention):
         q: torch.Tensor,
         kv: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
+        output: AttentionOutput,
     ) -> None:
+        assert isinstance(output, torch.Tensor)
         # Output may be padded to backend-supported head counts.
         assert output.shape[0] == q.shape[0] and output.shape[-1] == q.shape[-1], (
             f"output buffer shape {output.shape} incompatible with q shape {q.shape}"

--- a/vllm/models/deepseek_v4_1/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4_1/nvidia/flashmla.py
@@ -10,7 +10,7 @@ from vllm.models.deepseek_v4.nvidia.ops.o_proj import (
     compute_fp8_einsum_recipe,
     deep_gemm_fp8_o_proj,
 )
-from vllm.models.deepseek_v4_1.attention import DeepseekV4Attention
+from vllm.models.deepseek_v4_1.attention import AttentionOutput, DeepseekV4Attention
 from vllm.models.deepseek_v4_1.common.ops import (
     combine_topk_swa_indices,
     compute_global_topk_indices_and_lens,
@@ -89,8 +89,9 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
         q: torch.Tensor,
         kv: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
+        output: AttentionOutput,
     ) -> None:
+        assert isinstance(output, torch.Tensor)
         assert output.shape == q.shape, (
             f"output buffer shape {output.shape} must match q shape {q.shape}"
         )

--- a/vllm/models/deepseek_v4_1/nvidia/flashmla_fused.py
+++ b/vllm/models/deepseek_v4_1/nvidia/flashmla_fused.py
@@ -13,12 +13,15 @@ from typing import TYPE_CHECKING, ClassVar, cast
 
 import torch
 
-from vllm.config import VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fusion.quant_activation import QuantizedActivation
+from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
 from vllm.models.deepseek_v4.common.ops.fused_inv_rope_fp8_quant import (
     fused_inv_rope_fp8_quant,
 )
+from vllm.models.deepseek_v4_1.attention import AttentionOutput
 from vllm.models.deepseek_v4_1.common.ops import (
     combine_topk_swa_indices,
     compute_global_topk_indices_and_lens,
@@ -126,18 +129,50 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
 
     def _alloc_attn_out(
         self, num_tokens: int, hidden_states: torch.Tensor
-    ) -> torch.Tensor:
-        """Post-``wo_a`` activation ``z``; ``wo_b`` consumes it in the graph."""
-        return torch.empty(
-            (num_tokens, self.n_local_groups, self.o_lora_rank),
-            dtype=torch.bfloat16,
+    ) -> AttentionOutput:
+        if num_tokens < self.fused_decode_min_tokens:
+            context = get_forward_context()
+            metadata = context.attn_metadata
+            if context.cudagraph_runtime_mode != CUDAGraphMode.PIECEWISE and isinstance(
+                metadata, dict
+            ):
+                swa = cast(
+                    "DeepseekSparseSWAMetadata", metadata[self.swa_cache_layer.prefix]
+                )
+                if swa.num_prefills == 0 and swa.num_decode_tokens > 0:
+                    # FULL captures wo_a already; preserve its direct BF16
+                    # destination rather than copying split-KV quantized outputs.
+                    return torch.empty(
+                        (num_tokens, self.n_local_groups, self.o_lora_rank),
+                        dtype=torch.bfloat16,
+                        device=hidden_states.device,
+                    )
+        shape = (num_tokens, self.n_wv_group, WV_GROUP_SIZE * self.head_dim)
+        data = torch.empty(
+            shape, dtype=torch.float8_e4m3fn, device=hidden_states.device
+        )
+        scale = torch.empty(
+            (self.n_wv_group, shape[-1] // 128, round_up(num_tokens, 4)),
+            dtype=torch.int32,
             device=hidden_states.device,
+        ).permute(2, 0, 1)[:num_tokens]
+        return QuantizedActivation(
+            data, scale, hidden_states.dtype, torch.Size(shape), kMxfp8Dynamic
         )
 
     def _finish_o_proj(
-        self, attn_out: torch.Tensor, positions: torch.Tensor
+        self, attn_out: AttentionOutput, positions: torch.Tensor
     ) -> torch.Tensor:
-        return self.wo_b(attn_out.flatten(1))
+        if isinstance(attn_out, torch.Tensor):
+            return self.wo_b(attn_out.flatten(1))
+        assert isinstance(attn_out, QuantizedActivation)
+        z = torch.empty(
+            (attn_out.data.shape[0], self.n_local_groups, self.o_lora_rank),
+            dtype=torch.bfloat16,
+            device=attn_out.data.device,
+        )
+        self._wo_a_einsum(attn_out.data, attn_out.scale, z)
+        return self.wo_b(z.flatten(1))
 
     def _prepare_q_and_insert_kv(
         self,
@@ -182,7 +217,7 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
         q: torch.Tensor,
         kv: torch.Tensor,
         positions: torch.Tensor,
-        output: torch.Tensor,
+        output: AttentionOutput,
     ) -> None:
         if not (self._permuted_wq_b and self._permuted_wo_a):
             raise RuntimeError(
@@ -196,7 +231,9 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
             # padding kernel, produce zeros.
             self._reserve_dummy_run_workspace(q)
             dsv41_q_layout(q, self.padded_heads, "fused")
-            output.zero_()
+            assert isinstance(output, QuantizedActivation)
+            output.data.zero_()
+            output.scale.zero_()
             return
         assert isinstance(attn_metadata, dict)
         flashmla_metadata = cast(
@@ -211,13 +248,26 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
         )
         assert swa_metadata.positions_int32 is not None
         num_decode_tokens = swa_metadata.num_decode_tokens
+        if isinstance(output, torch.Tensor):
+            assert swa_metadata.num_prefills == 0
+            assert num_decode_tokens < self.fused_decode_min_tokens
+            self._forward_decode_split_kv(
+                q[:num_decode_tokens],
+                positions[:num_decode_tokens],
+                flashmla_metadata,
+                swa_metadata,
+                output[:num_decode_tokens],
+                None,
+            )
+            return
         if swa_metadata.num_prefills > 0:
             self._forward_prefill_fused(
                 q[num_decode_tokens:],
                 swa_metadata.positions_int32[num_decode_tokens:],
                 flashmla_metadata,
                 swa_metadata,
-                output[num_decode_tokens:],
+                output.data[num_decode_tokens:],
+                output.scale[num_decode_tokens:],
             )
         if swa_metadata.num_decodes > 0:
             if num_decode_tokens >= self.fused_decode_min_tokens:
@@ -226,7 +276,8 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
                     swa_metadata.positions_int32[:num_decode_tokens],
                     flashmla_metadata,
                     swa_metadata,
-                    output[:num_decode_tokens],
+                    output.data[:num_decode_tokens],
+                    output.scale[:num_decode_tokens],
                 )
             else:
                 self._forward_decode_split_kv(
@@ -234,7 +285,8 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
                     positions[:num_decode_tokens],
                     flashmla_metadata,
                     swa_metadata,
-                    output[:num_decode_tokens],
+                    output.data[:num_decode_tokens],
+                    output.scale[:num_decode_tokens],
                 )
 
     def _reserve_dummy_run_workspace(self, q: torch.Tensor) -> None:
@@ -280,13 +332,14 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
         positions_int32: torch.Tensor,
         flashmla_metadata: DeepseekV4FlashMLAMetadata | None,
         swa_metadata: "DeepseekSparseSWAMetadata",
-        z: torch.Tensor,
+        out_fp8: torch.Tensor,
+        out_sf: torch.Tensor,
     ) -> None:
         extra_cache, extra_idx, extra_len = self._decode_extra(
             flashmla_metadata, swa_metadata
         )
         assert swa_metadata.decode_swa_indices is not None
-        out_fp8, out_sf, _ = flash_mla_fused_sparse_decode(
+        flash_mla_fused_sparse_decode(
             dsv41_q_layout(q, self.padded_heads, "fused"),
             self.swa_cache_layer.kv_cache.unsqueeze(-2),
             swa_metadata.decode_swa_indices.view(q.shape[0], -1),
@@ -299,8 +352,9 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
             extra_k_cache=extra_cache,
             extra_indices=extra_idx,
             extra_topk_length=extra_len,
+            out_fp8=out_fp8,
+            out_sf=out_sf,
         )
-        self._wo_a_einsum(out_fp8, out_sf, z)
 
     def _forward_decode_split_kv(
         self,
@@ -308,7 +362,8 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
         positions: torch.Tensor,
         flashmla_metadata: DeepseekV4FlashMLAMetadata | None,
         swa_metadata: "DeepseekSparseSWAMetadata",
-        z: torch.Tensor,
+        output: torch.Tensor,
+        out_sf: torch.Tensor | None,
     ) -> None:
         extra_cache, extra_idx, extra_len = self._decode_extra(
             flashmla_metadata, swa_metadata
@@ -357,7 +412,11 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
             tma_aligned_scales=True,
             permuted_output=True,
         )
-        self._wo_a_einsum(o_fp8, o_sf, z)
+        if out_sf is None:
+            self._wo_a_einsum(o_fp8, o_sf, output)
+        else:
+            output[:, : self.n_local_groups].copy_(o_fp8)
+            out_sf[:, : self.n_local_groups].copy_(o_sf)
 
     def _forward_prefill_fused(
         self,
@@ -365,7 +424,8 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
         positions_int32: torch.Tensor,
         flashmla_metadata: DeepseekV4FlashMLAMetadata | None,
         swa_metadata: "DeepseekSparseSWAMetadata",
-        z: torch.Tensor,
+        out_fp8: torch.Tensor,
+        out_sf: torch.Tensor,
     ) -> None:
         swa_only = self.compress_ratio == 0
         num_decodes = swa_metadata.num_decodes
@@ -453,7 +513,7 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
                 ),
                 max_image_tokens=self.max_image_tokens,
             )
-            out_fp8, out_sf, _, _ = flash_mla_fused_sparse_prefill(
+            flash_mla_fused_sparse_prefill(
                 q_pad[qs:qe],
                 kv_ws.view(-1, 1, q.shape[-1]),
                 combined_indices.unsqueeze(1),
@@ -463,5 +523,6 @@ class DeepseekV4FlashMLAFusedAttention(DeepseekV4FlashMLAAttention):
                 self.n_wv_group,
                 attn_sink=self.attn_sink,
                 topk_length=combined_lens,
+                out_fp8=out_fp8[qs:qe],
+                out_sf=out_sf[qs:qe],
             )
-            self._wo_a_einsum(out_fp8, out_sf, z[qs:qe])

--- a/vllm/v1/attention/ops/flashmla.py
+++ b/vllm/v1/attention/ops/flashmla.py
@@ -183,6 +183,9 @@ def flash_mla_fused_sparse_prefill(
     n_wv_group: int,
     attn_sink: torch.Tensor | None = None,
     topk_length: torch.Tensor | None = None,
+    *,
+    out_fp8: torch.Tensor | None = None,
+    out_sf: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Fused sparse prefill over a non-paged bf16 ``kv`` (DeepSeek V4.1).
 
@@ -224,6 +227,8 @@ def flash_mla_fused_sparse_prefill(
             True,
             True,
             True,
+            out_fp8,
+            out_sf,
         )
     )
     return out_fp8, out_sf, max_logits, lse
@@ -242,6 +247,9 @@ def flash_mla_fused_sparse_decode(
     extra_k_cache: torch.Tensor | None = None,
     extra_indices: torch.Tensor | None = None,
     extra_topk_length: torch.Tensor | None = None,
+    *,
+    out_fp8: torch.Tensor | None = None,
+    out_sf: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Fused sparse decode over paged quantized caches (batch flattened).
 
@@ -276,5 +284,7 @@ def flash_mla_fused_sparse_decode(
         True,
         True,
         True,
+        out_fp8,
+        out_sf,
     )
     return out_fp8, out_sf, lse


### PR DESCRIPTION
## Summary

This draft is now historical: #56344 closed after its base branch was deleted,
and #56935 is the replacement integration against main. #56935 already includes
the shared FP8 output buffers and downstream projection handoff described here.
The native caller-output capability landed in vllm-project/FlashMLA#23.

The implementation and measurements below apply to the original #56344 stack;
they are not new performance claims for #56935. Current work is validating
#56935 on MRV2 and a separate, small input-padding follow-up. There is no need
to port this seven-file output-side change a second time.

Fused V4.1 attention in #56344 allocates FP8 values/scales and runs wo_a inside the eager attention region. For piecewise prefill, that adds output allocation and projection dispatch to every replay. Allocate a graph-owned QuantizedActivation, fill it through FlashMLA's output-buffer API, and capture wo_a together with wo_b.

```text
ASIS (piecewise)
graph projections -> eager [attention + new FP8/SF + wo_a] -> graph wo_b
```

```text
PR (piecewise)
graph-owned FP8/SF -> eager [attention writes outputs] -> graph [wo_a + wo_b]
```

Full-graph decode already captures the projection. Preserve the original direct BF16 destination for pure split-KV fallback decode outside PIECEWISE mode, avoiding two added copies on that route. Floating-output backends retain Tensor output and explicit type guards.

## Dependencies and duplicate check

Historical stack on #56344, targeting `vllm-project/vllm:v41-megakernel`. Its original FlashMLA #22 dependency was superseded by merged #23. The replacement #56935 comes from `zyongye/vllm:v41-megakernel`, a different repository branch, and already implements this output-side capability. The original duplicate-work search predates #56935.

## Validation

- MRV2 on the current-main integration: short-input A/B/B/A with 32 exact token-matched outputs plus mixed requests, matching scheduler steps, PIECEWISE prefill and FULL decode. Eager prefill wo_a calls drop from 40 to zero per worker. Median TTFT 28.87 -> 25.13 ms (-13.0%), with both order comparisons favoring the candidate. TPOT 6.329 -> 6.324 ms; no decode speedup claimed. MRV2 long-context timing and split-KV fallback remain unqualified.
- FlashMLA caller-output API: 27 tests passed on GB200, including exact output/scale equality, independent optional destinations, sliced/padded buffers, invalid arguments, changing-input CUDA graph replay and FP4 secondary cache.
- MRV1 model correctness/performance on a current-main integration of #56344: TP4 GB200, 17/8192/32768 input tokens, 64 output tokens, no prefix cache, FULL_AND_PIECEWISE with capture sizes [1,2,4,32,64]. A/B/B/A order, two warmups and six measured requests per context/run. All 96 outputs and mixed prefill/decode outputs match token-for-token. Every worker executes 1/1/4 prefill steps and 63 nonempty decode steps.
- MRV1 short-prefill replay: baseline makes 40 eager wo_a calls; candidate makes zero. Decode uses a full graph in both cases. Diagnostic hooks are removed before timings.
- MRV1 pooled median 17-token TTFT: 41.85 -> 36.92 ms (-11.8%), with both order comparisons favoring the candidate. Long-input results were order-sensitive; no long-context speedup claimed. TPOT differences were at most 0.21%; no decode speedup claimed.
- MRV1 split-KV fallback copying caused a spot regression. The direct-output fallback correction preserves exact outputs and returns TPOT to about 6.13 ms versus 6.11 ms baseline. Final default-route short-context recheck remained correct at about 37.3 ms TTFT.
- Scoped pre-commit/mypy and commit hooks passed on both the current-main integration and this stacked branch. The fused consumer file is byte-identical between them. Model runs used the current-main integration, not the older parent branch; full-model ROCm and DBO are not qualified here.

[Report, raw results, tests, reproducible drivers and checksums](https://github.com/foraxe/FlashMLA/tree/e29669d88a0aabc1a6e36827c0572b5c1d9eccad/evidence/fused-outputs). Main integration base: 22258a2 + #56344 at 6ff1e20. Measured prototype: 74d2d52. Fallback-preserving integration: ce57852. Native output API: cbb0f5b.

Test commands, with the report's environment/model paths (native tests from the FlashMLA checkout; model runs from the vLLM integration):

```bash
.venv/bin/python -m pytest tests/test_output_buffer_api.py -q
VLLM_USE_V2_MODEL_RUNNER=1 .venv/bin/python fused_output_bench_mrv2.py --variant baseline --contexts 17 --trials 6 --output a.json
VLLM_USE_V2_MODEL_RUNNER=1 .venv/bin/python fused_output_bench_mrv2.py --variant candidate --contexts 17 --trials 6 --output b.json
```
