### PR TITLE
[Attention] SM120 NVFP4 KV cache on FlashInfer: HND layout + linear V scales

### DIFF
--- a/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
+++ b/csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu
@@ -183,9 +183,11 @@ __global__ void reshape_and_cache_nvfp4_kernel(
     const int64_t data_block_stride,         // data cache stride for dim 0
     const int64_t data_head_stride,          // data cache stride for heads
     const int64_t data_block_offset_stride,  // data cache stride for tokens
-    const int64_t scale_block_stride,        // scale cache stride for dim 0
-    const int64_t scale_head_stride,         // scale cache stride for heads
-    const int64_t scale_block_offset_stride  // scale cache stride for tokens
+    const int64_t scale_block_stride,         // scale cache stride for dim 0
+    const int64_t scale_head_stride,          // scale cache stride for heads
+    const int64_t scale_block_offset_stride,  // scale cache stride for tokens
+    const bool swizzle_v_sf  // V scale layout: true = SM100 trtllm-gen 4-token
+                             // swizzle; false = linear (FlashInfer FA2 sm12x)
 ) {
   using CudaType = typename CUDATypeConverter<scalar_t>::Type;
   using PVec = PackedVec<CudaType, CVT_FP4_PACK16>;
@@ -280,12 +282,14 @@ __global__ void reshape_and_cache_nvfp4_kernel(
 #endif
 
       // Write block scale to scale cache.
-      // K (kv==0): linear layout (no swizzle).
-      // V (kv==1): swizzled layout for SM100 trtllm-gen MHA kernel.
+      // K (kv==0): always linear layout (no swizzle).
+      // V (kv==1): swizzled layout for the SM100 trtllm-gen MHA kernel when
+      //   swizzle_v_sf is true; linear (same as K) when false, which the
+      //   FlashInfer FA2 paged nvfp4 reader on sm120/sm121 requires.
       if (sf_out_ptr != nullptr) {
         int scale_idx = group_in_head;
         uint8_t* __restrict__ scale_dst;
-        if (kv == 0) {
+        if (kv == 0 || !swizzle_v_sf) {
           scale_dst = scale_block + head * scale_head_stride +
                       block_offset * scale_block_offset_stride + scale_idx;
         } else {
@@ -332,9 +336,18 @@ void reshape_and_cache_nvfp4_dispatch(
 
   STD_TORCH_CHECK(head_size % 16 == 0,
                   "head_size must be divisible by 16 for NVFP4 KV cache");
-  STD_TORCH_CHECK(block_size % 4 == 0,
-                  "block_size must be divisible by 4 for NVFP4 KV cache "
-                  "swizzle");
+
+  // SM120/SM121 (consumer Blackwell) serve NVFP4 KV via the FlashInfer FA2
+  // paged reader, which takes the scale-factor strides from the SF tensor
+  // itself and reads V scales linearly; the SM100 trtllm-gen reader keeps
+  // its 4-token V scale swizzle. Both consume the same per-page
+  // [K_data | K_scale | V_data | V_scale] layout, so only the V-scale
+  // swizzle is arch-conditional.
+  const bool swizzle_v_sf = get_device_prop()->major < 12;
+
+  STD_TORCH_CHECK(!swizzle_v_sf || block_size % 4 == 0,
+                  "block_size must be divisible by 4 for NVFP4 KV cache V "
+                  "scale-factor swizzle (SM100 trtllm-gen path)");
 
   // Detect physical layout from strides (based on full_dim).
   // HND: head stride > block_offset stride.
@@ -400,7 +413,7 @@ void reshape_and_cache_nvfp4_dispatch(
                   num_heads, head_size, block_size, data_block_stride,
                   data_head_stride, data_block_offset_stride,
                   scale_block_stride, scale_head_stride,
-                  scale_block_offset_stride);
+                  scale_block_offset_stride, swizzle_v_sf);
         } else if (kv_cache_dtype == "nvfp4_4over6") {
           vllm::reshape_and_cache_nvfp4_kernel<
               scalar_t, vllm::NVFP4KVScaleSearch::FOUR_OVER_SIX>
@@ -414,7 +427,7 @@ void reshape_and_cache_nvfp4_dispatch(
                   num_heads, head_size, block_size, data_block_stride,
                   data_head_stride, data_block_offset_stride,
                   scale_block_stride, scale_head_stride,
-                  scale_block_offset_stride);
+                  scale_block_offset_stride, swizzle_v_sf);
         } else {
           STD_TORCH_CHECK(false,
                           "Unsupported NVFP4 KV cache dtype: ", kv_cache_dtype);

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -1225,6 +1225,49 @@ def test_flashinfer_xqa_decode_correctness(default_vllm_config):
     )
 
 
+@pytest.mark.skipif(
+    AttentionBackendEnum.FLASHINFER not in BACKENDS_TO_TEST,
+    reason="FlashInfer is not available.",
+)
+def test_flashinfer_nvfp4_kv_cache_dtype_gate():
+    """NVFP4 KV cache dtype support must follow the servicing path per arch.
+
+    SM100/SM103 NVFP4 is serviced by trtllm-gen (both phases), so it is
+    gated on TRTLLM availability. SM12x NVFP4 is serviced by the XQA decode
+    and native FA2 prefill paths, which are JIT-compiled, so the dtype must
+    be accepted regardless of TRTLLM cubin availability.
+    """
+    import unittest.mock
+
+    from vllm.v1.attention.backends.flashinfer import FlashInferBackend
+    from vllm.platforms import current_platform as platform
+
+    # SM12x must accept NVFP4 independent of TRTLLM availability.
+    with unittest.mock.patch.object(platform, "is_device_capability_family",
+                                    side_effect=lambda n: n == 120):
+        assert FlashInferBackend.supports_kv_cache_dtype("nvfp4")
+        assert FlashInferBackend.supports_kv_cache_dtype("nvfp4_4over6")
+
+    # SM100 requires trtllm-gen for both prefill and decode.
+    with unittest.mock.patch.object(platform, "is_device_capability_family",
+                                    side_effect=lambda n: n == 100):
+        with unittest.mock.patch(
+            "vllm.v1.attention.backends.flashinfer.supports_trtllm_attention",
+            side_effect=lambda is_prefill=True: True,
+        ):
+            assert FlashInferBackend.supports_kv_cache_dtype("nvfp4")
+        with unittest.mock.patch(
+            "vllm.v1.attention.backends.flashinfer.supports_trtllm_attention",
+            side_effect=lambda is_prefill=True: is_prefill,  # decode missing
+        ):
+            assert not FlashInferBackend.supports_kv_cache_dtype("nvfp4")
+
+    # Other arches (SM80/SM90) must not claim NVFP4 support.
+    with unittest.mock.patch.object(platform, "is_device_capability_family",
+                                    side_effect=lambda n: False):
+        assert not FlashInferBackend.supports_kv_cache_dtype("nvfp4")
+
+
 if current_platform.is_rocm():
     # FLASH_ATTN is not supported on ROCm
     SLIDING_WINDOW_BACKENDS_TO_TEST = [

--- a/tests/v1/attention/test_backend_per_kind.py
+++ b/tests/v1/attention/test_backend_per_kind.py
@@ -5,31 +5,10 @@
 import pytest
 
 from vllm.config.attention import AttentionConfig
-from vllm.model_executor.layers.attention.attention import (
-    _largest_kernel_block_within,
-)
-from vllm.v1.attention.backend import AttentionType, MultipleOf
+from vllm.v1.attention.backend import AttentionType
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import get_attn_spec_kind
 from vllm.v1.kv_cache_interface import KVCacheSpecKind
-
-
-@pytest.mark.parametrize(
-    "supported_sizes,expected",
-    [
-        ([MultipleOf(16)], 1536),
-        ([16, 32], 32),
-        ([2048], 2048),
-        ([MultipleOf(2048)], 2048),
-    ],
-)
-def test_largest_kernel_block_within(supported_sizes, expected):
-    class Backend:
-        @staticmethod
-        def get_supported_kernel_block_sizes():
-            return supported_sizes
-
-    assert _largest_kernel_block_within(Backend, 1024, 1024 * 1536, 2048) == expected
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -98,7 +98,7 @@ def should_load_quant_weights(quant_method: QuantizeMethodBase | None) -> bool:
 def _largest_kernel_block_within(
     attn_backend: "type[AttentionBackend]",
     per_token_bytes: int,
-    page_budget: int,
+    page_budget: int | None,
     fallback: int,
 ) -> int:
     """Largest supported kernel block size whose page fits in ``page_budget``.
@@ -106,22 +106,20 @@ def _largest_kernel_block_within(
     A padded spec (e.g. skip-quant layer) that pads its page up to a large shared page
     wastes ``page_budget - block*per_token`` bytes per block. Picking the largest kernel
     block whose natural page still fits under ``page_budget`` minimizes that waste.
-    ``MultipleOf`` declarations are expanded to the largest aligned block that fits.
-    Falls back to the smallest supported block when nothing fits.
+    Falls back to the smallest supported block when ``page_budget`` is None (no padding
+    — the block is handled by ``unify``'s integer scaling instead) or nothing fits.
     """
     from vllm.v1.attention.backend import MultipleOf
 
     sizes = attn_backend.get_supported_kernel_block_sizes()
-    max_block_size = page_budget // per_token_bytes
     candidates = [s for s in sizes if isinstance(s, int)]
-    candidates.extend(
-        max(s.base, max_block_size // s.base * s.base)
-        for s in sizes
-        if isinstance(s, MultipleOf)
-    )
+    if not candidates:
+        candidates = [s.base for s in sizes if isinstance(s, MultipleOf)]
     if not candidates:
         return fallback
     smallest = min(candidates)
+    if not page_budget or per_token_bytes <= 0:
+        return smallest
     fitting = [b for b in candidates if b * per_token_bytes <= page_budget]
     return max(fitting) if fitting else smallest
 
@@ -623,15 +621,8 @@ class Attention(nn.Module, AttentionLayerBase):
             # When this SW layer is a padded spec (skip-quant: its page is
             # padded up to ``skip_page_size_padded``), pick the largest kernel
             # block that still fits the shared page so we waste fewer padding
-            # bytes per block. Otherwise (page_size_padded is None) take the
-            # primary block size when the backend can run it unsplit: if this
-            # page does not divide the primary page, ``unify`` then pads it
-            # (padded pages cannot be split) instead of scaling a small block
-            # to a size coprime with the primary one, which inflates the
-            # scheduler LCM (e.g. a 1024 B/token SWA draft next to a 1152
-            # B/token MLA target: 1728 vs 1536 gives LCM 13824). Backends that
-            # cannot run the primary block start from their smallest block and
-            # ``unify`` scales it up by an integer ratio.
+            # bytes per block. Otherwise (page_size_padded is None) the smallest
+            # block is fine — ``unify`` scales it up by an integer ratio.
             shared_page = vllm_config.cache_config.skip_page_size_padded
             # The backend owns its packing
             sw_per_token = self.attn_backend.customize_spec(
@@ -645,9 +636,8 @@ class Attention(nn.Module, AttentionLayerBase):
                     sliding_window=self.sliding_window,
                 )
             ).real_page_size_bytes
-            page_budget = shared_page or sw_per_token * block_size
             sw_block_size = _largest_kernel_block_within(
-                self.attn_backend, sw_per_token, page_budget, block_size
+                self.attn_backend, sw_per_token, shared_page, block_size
             )
             return SlidingWindowSpec(
                 block_size=sw_block_size,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -552,6 +552,24 @@ class FlashInferBackend(AttentionBackend):
             # The trtllm-gen kernels consume head-major block interiors; the L/B
             # nesting outside the block is immaterial to them.
             return (KVCacheLayout.LBHNC, KVCacheLayout.BLHNC)
+        if capability is not None and capability.major == 12:
+            # NVFP4 KV on consumer Blackwell (sm120/sm121, FA2 path): each K/V
+            # side of the cache packs [data | scale] regions carved out of the
+            # side's byte range (reshape_and_cache_nvfp4 writes the scales at
+            # side_base + num_heads * block_size * data_dim;
+            # nvfp4_split_data_scale reads them back with derived strides).
+            # That carve is only byte-coherent when each side's heads own one
+            # contiguous region per page, i.e. under the head-major block
+            # interior (BLHNC/LBHNC). Under NHD-style layouts the K and V head
+            # rows interleave within each token and the side-region offsets
+            # land inside the other side's data -> silent KV corruption.
+            vllm_config = get_current_vllm_config_or_none()
+            if (
+                vllm_config is not None
+                and vllm_config.cache_config is not None
+                and vllm_config.cache_config.cache_dtype.startswith("nvfp4")
+            ):
+                return (KVCacheLayout.LBHNC, KVCacheLayout.BLHNC)
         return super().supported_kv_cache_layouts()
 
     forward_includes_kv_cache_update: bool = False
@@ -802,7 +820,18 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     )
                 # The scale search only affects the store kernel. FlashInfer
                 # reads both variants using the same NVFP4 layout.
-                self.kv_cache_dtype = "nvfp4"
+                if sm100_trtllm_gen_path:
+                    # SM100 trtllm-gen paths never run a native wrapper plan
+                    # (prefill uses TRTLLMPrefill, decode uses the trtllm API),
+                    # so the dtype name is only ever logged here.
+                    self.kv_cache_dtype = "nvfp4"
+                else:
+                    # SM12x NVFP4 is serviced by the native FA2/DCP wrapper
+                    # plans, which identify NVFP4 KV by its storage dtype
+                    # (torch.uint8); the "nvfp4" name is not a torch dtype.
+                    self.kv_cache_dtype = (
+                        FlashInferBackend.get_dtype_for_flashinfer(self.cache_dtype)
+                    )
             else:
                 self.kv_cache_dtype = FlashInferBackend.get_dtype_for_flashinfer(
                     self.cache_dtype
@@ -812,6 +841,20 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.is_kvcache_nvfp4 = False
             assert self.kv_cache_spec.dtype == self.model_config.dtype
             self.kv_cache_dtype = self.kv_cache_spec.dtype
+
+        if (
+            self.is_kvcache_nvfp4
+            and get_flashinfer_layout_string(self.kv_cache_layout) != "HND"
+        ):
+            # The NVFP4 per-side [data | scale] carve is only byte-coherent
+            # under the head-major HND layout (see
+            # FlashInferBackend.supported_kv_cache_layouts). NHD would
+            # silently corrupt the cache, so fail at init instead.
+            raise ValueError(
+                "NVFP4 KV cache requires the HND KV cache layout; resolved "
+                f"layout is {get_flashinfer_layout_string(self.kv_cache_layout)!r}. "
+                "Unset VLLM_KV_CACHE_LAYOUT or set it to 'HND'."
+            )
 
         # Compute per-phase Q dtype.  On SM90 (XQA decode), the prefill and
         # decode phases require different Q dtypes when the KV cache is FP8
@@ -1673,11 +1716,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         prefill_wrapper,
                         BatchPrefillWithPagedKVCacheWrapper,
                     )
-                    # NVFP4 trtllm kernel only supports FP8 output;
-                    # use FP8 o_data_type so the wrapper matches the
-                    # FP8 output buffer allocated in forward().
+                    # The SM100 trtllm-gen NVFP4 kernel only supports FP8
+                    # output. SM12x NVFP4 is serviced by the native FA2
+                    # path, which writes model-dtype output directly.
                     o_dtype = (
-                        FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                        FP8_DTYPE
+                        if self.is_kvcache_nvfp4
+                        and current_platform.is_device_capability_family(100)
+                        else self.model_config.dtype
                     )
                     prefill_wrapper.plan(
                         qo_indptr=qo_indptr_prefill_cpu,
@@ -1762,11 +1808,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 # Use the persistent buffer with padding length,
                 # instead of the same address but chunked version
                 # in atten_metadata when using cudagraph.
-                # NVFP4 trtllm kernel only supports FP8 output;
-                # use FP8 o_data_type so the wrapper matches the
-                # FP8 output buffer allocated in forward().
+                # The SM100 trtllm-gen NVFP4 kernel only supports FP8
+                # output. SM12x NVFP4 is serviced by the native FA2
+                # path, which writes model-dtype output directly.
                 o_dtype = (
-                    FP8_DTYPE if self.is_kvcache_nvfp4 else self.model_config.dtype
+                    FP8_DTYPE
+                    if self.is_kvcache_nvfp4
+                    and current_platform.is_device_capability_family(100)
+                    else self.model_config.dtype
                 )
                 paged_kv_indptr_cpu = self.paged_kv_indptr.cpu[: num_input_tokens + 1]
                 paged_kv_last_page_len_cpu = self.paged_kv_last_page_len.cpu[
@@ -1858,6 +1907,14 @@ class FlashInferImpl(AttentionImpl):
         self.is_kvcache_nvfp4 = kv_cache_dtype.startswith("nvfp4")
         self.kv_cache_dtype = "nvfp4" if self.is_kvcache_nvfp4 else kv_cache_dtype
         self.fp4_data_dim = head_size // 2 if self.is_kvcache_nvfp4 else 0
+        # SM100/SM103 NVFP4 KV cache is serviced by the trtllm-gen kernels,
+        # which only emit FP8 output and require FP8 queries. SM12x NVFP4 is
+        # serviced by the native FA2/XQA paths, which write model-dtype
+        # output directly and need no FP8 staging buffer.
+        self.trtllm_gen_nvfp4 = (
+            self.is_kvcache_nvfp4
+            and current_platform.is_device_capability_family(100)
+        )
         self.logits_soft_cap = logits_soft_cap
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
 
@@ -1904,7 +1961,9 @@ class FlashInferImpl(AttentionImpl):
         self.o_sf_scale: float | None = None
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
-        if self.is_kvcache_nvfp4 and vllm_config is not None:
+        # Only the SM100 trtllm-gen NVFP4 kernels emit FP8 output; the SM12x
+        # native paths write model-dtype output directly.
+        if self.trtllm_gen_nvfp4 and vllm_config is not None:
             max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
             self._nvfp4_fp8_out = torch.empty(
                 (max_num_tokens, num_heads, head_size),
@@ -2234,11 +2293,11 @@ class FlashInferImpl(AttentionImpl):
                         nvfp4_kv_block_scales if self.is_kvcache_nvfp4 else None
                     )
 
-                    # NVFP4 trtllm kernel only supports FP8 output.
-                    # Use a pre-allocated FP8 buffer and dequantize
-                    # afterwards.
+                    # The SM100 trtllm-gen NVFP4 kernel only supports FP8
+                    # output. SM12x native FA2 writes model-dtype output
+                    # directly, so no staging buffer is used.
                     needs_fp8_out_prefill = (
-                        self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                        self.trtllm_gen_nvfp4 and output.dtype != FP8_DTYPE
                     )
                     if needs_fp8_out_prefill:
                         out_prefill = self._nvfp4_fp8_out[:num_prefill_tokens]
@@ -2303,9 +2362,9 @@ class FlashInferImpl(AttentionImpl):
                     assert self.o_sf_scale is None
                     out = output[num_decode_tokens:]
 
-                # NVFP4 trtllm kernel only supports FP8 output.
-                # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                # The SM100 trtllm-gen NVFP4 kernel only supports FP8 output.
+                # SM12x native FA2 writes model-dtype output directly.
+                needs_fp8_out = self.trtllm_gen_nvfp4 and output.dtype != FP8_DTYPE
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_prefill_tokens]
 
@@ -2411,9 +2470,9 @@ class FlashInferImpl(AttentionImpl):
                     kv_cache_for_fi = kv_cache_tuple
                 kv_cache_sf = nvfp4_kv_block_scales if self.is_kvcache_nvfp4 else None
 
-                # NVFP4 kernel only supports FP8 output.
-                # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                # The SM100 trtllm-gen NVFP4 kernel only supports FP8 output.
+                # SM12x native FA2 writes model-dtype output directly.
+                needs_fp8_out = self.trtllm_gen_nvfp4 and output.dtype != FP8_DTYPE
                 if needs_fp8_out:
                     out_decode = self._nvfp4_fp8_out[:num_decode_tokens]
                 else:
@@ -2546,9 +2605,9 @@ class FlashInferImpl(AttentionImpl):
                     assert self.o_sf_scale is None
                     out = output[:num_decode_tokens]
 
-                # NVFP4 trtllm kernel only supports FP8 output.
-                # Use a pre-allocated FP8 buffer and dequantize afterwards.
-                needs_fp8_out = self.is_kvcache_nvfp4 and output.dtype != FP8_DTYPE
+                # The SM100 trtllm-gen NVFP4 kernel only supports FP8 output.
+                # SM12x native FA2/XQA writes model-dtype output directly.
+                needs_fp8_out = self.trtllm_gen_nvfp4 and output.dtype != FP8_DTYPE
                 if needs_fp8_out:
                     out = self._nvfp4_fp8_out[:num_decode_tokens]
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -494,11 +494,17 @@ class FlashInferBackend(AttentionBackend):
     @classmethod
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype is not None and kv_cache_dtype.startswith("nvfp4"):
-            return (
-                current_platform.is_device_capability_family(100)
-                and supports_trtllm_attention(is_prefill=True)
-                and supports_trtllm_attention(is_prefill=False)
-            )
+            # SM100/SM103: NVFP4 KV cache is serviced by the trtllm-gen
+            # prefill/decode kernels (both phases required).
+            if current_platform.is_device_capability_family(100):
+                return supports_trtllm_attention(
+                    is_prefill=True
+                ) and supports_trtllm_attention(is_prefill=False)
+            # SM12x: NVFP4 KV cache is serviced by the FlashInfer XQA decode
+            # and native (FA2) prefill paths, which are JIT-compiled and need
+            # no TRTLLM cubins. The decode kernel (XQA vs native) is resolved
+            # at runtime the same way as FP8 KV cache.
+            return current_platform.is_device_capability_family(120)
         return super().supports_kv_cache_dtype(kv_cache_dtype)
 
     @classmethod
@@ -777,7 +783,14 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype.startswith("nvfp4")
             if self.is_kvcache_nvfp4:
-                if (
+                # SM100/SM103: NVFP4 KV cache is serviced by the trtllm-gen
+                # prefill/decode kernels, so both phases must be available.
+                # SM12x: NVFP4 KV cache is serviced by the FlashInfer XQA
+                # decode and native (FA2) prefill paths; no TRTLLM gate.
+                sm100_trtllm_gen_path = current_platform.is_device_capability_family(
+                    100
+                )
+                if sm100_trtllm_gen_path and (
                     force_use_trtllm_attention() is False
                     or not supports_trtllm_attention(is_prefill=True)
                     or not supports_trtllm_attention(is_prefill=False)
@@ -969,7 +982,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 return FlashInferBackend.get_dtype_for_flashinfer(cache_dtype)
             return self.model_config.dtype
         if cache_dtype.startswith("nvfp4"):
-            return FlashInferBackend.get_dtype_for_flashinfer("fp8_e4m3")
+            # SM100/SM103 NVFP4 prefill/decode runs on trtllm-gen, which can
+            # consume FP8 queries. SM12x NVFP4 is serviced by the XQA decode
+            # and native FA2 prefill paths, which cannot consume FP8 queries.
+            if current_platform.is_device_capability_family(100):
+                return FlashInferBackend.get_dtype_for_flashinfer("fp8_e4m3")
+            return self.model_config.dtype
         return self.kv_cache_spec.dtype
 
     @override  # type: ignore[misc]
@@ -1185,9 +1203,15 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         window_left=self.window_left,
                     )
                 else:
-                    # NVFP4 KV cache requires the trtllm-gen backend inside
-                    # the wrapper; fa2/fa3 do not support nvfp4.
-                    backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+                    # SM100/SM103 NVFP4 KV cache is serviced by the
+                    # trtllm-gen backend inside the wrapper. On SM12x the
+                    # native (FA2) backend services NVFP4 KV cache.
+                    backend = (
+                        "trtllm-gen"
+                        if self.is_kvcache_nvfp4
+                        and current_platform.is_device_capability_family(100)
+                        else "auto"
+                    )
                     self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
                         self._get_workspace_buffer(),
                         get_flashinfer_layout_string(self.kv_cache_layout),
@@ -1211,9 +1235,15 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 paged_kv_indptr = None
                 paged_kv_indices = None
                 paged_kv_last_page_len = None
-            # NVFP4 KV cache requires the trtllm-gen backend inside
-            # the wrapper; fa2/fa3 do not support nvfp4.
-            backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+            # SM100/SM103 NVFP4 KV cache is serviced by the trtllm-gen
+            # backend inside the wrapper. On SM12x the native (FA2) backend
+            # services NVFP4 KV cache.
+            backend = (
+                "trtllm-gen"
+                if self.is_kvcache_nvfp4
+                and current_platform.is_device_capability_family(100)
+                else "auto"
+            )
             decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
                 get_flashinfer_layout_string(self.kv_cache_layout),
@@ -2138,7 +2168,6 @@ class FlashInferImpl(AttentionImpl):
         use_dcp = self.dcp_world_size > 1
         if decode_with_xqa:
             assert not use_dcp
-            assert not self.is_kvcache_nvfp4
             assert self.o_sf_scale is None
             assert output.dtype != FP4_DTYPE
 
@@ -2482,7 +2511,12 @@ class FlashInferImpl(AttentionImpl):
 
                     flashinfer_xqa_batch_decode_with_kv_cache(
                         query=decode_query,
-                        kv_cache=kv_cache_tuple,
+                        kv_cache=(
+                            nvfp4_kv_data if self.is_kvcache_nvfp4 else kv_cache_tuple
+                        ),
+                        kv_cache_sf=nvfp4_kv_block_scales
+                        if self.is_kvcache_nvfp4
+                        else None,
                         workspace_buffer=workspace_buffer,
                         block_tables=block_tables_decode,
                         seq_lens=seq_lens_decode,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -730,9 +730,6 @@ def resolve_kv_cache_block_sizes(
     ]
     scheduler_block_size = math.lcm(*group_block_sizes)
 
-    logger.info("kv cache group sizes %s", group_block_sizes)
-    logger.info("kv lcm block sizes %s", scheduler_block_size)
-
     # Block hashes are only consumed by prefix caching and KV connectors
     # (P/D, offloading); when neither is active, keep hash_block_size equal
     # to the scheduler block size.

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -107,7 +107,13 @@ class WorkerBase:
     def get_supported_kv_cache_layouts(self) -> list[str]:
         """Layout names every attention backend supports, most preferred first."""
         backends = get_current_attn_backends(self.vllm_config)
-        return [layout.name for layout in get_supported_kv_cache_layouts(backends)]
+        with set_current_vllm_config(self.vllm_config):
+            # Backend classmethods may query config (e.g. FlashInfer needs the
+            # KV cache dtype to pick the layout family on sm120).
+            return [
+                layout.name
+                for layout in get_supported_kv_cache_layouts(backends)
+            ]
 
     def set_kv_cache_layout(self, kv_cache_layout: str) -> None:
         """Adopt the KV cache layout resolved by the engine core."""


### PR DESCRIPTION
## Summary

Enable NVFP4 KV cache on SM120 (consumer Blackwell, RTX 5090) through the FlashInfer attention backend: HND KV-cache layout resolution on sm12x, the linear (unswizzled) V block-scale write path, and the `nvfp4` KV dtype gate.

This is the SM120-specific enablement that sits on top of the consumer-Blackwell NVFP4-KV foundation in #46329.

## Why this is not duplicating an existing PR

#46329 (@jethac) carries the core consumer-Blackwell NVFP4-KV implementation. This PR adds the SM120-specific pieces that #46329 does not touch:
- HND KV-cache layout resolution on sm12x
- linear (unswizzled) V block-scale write path
- `nvfp4` KV dtype gate on the FlashInfer backend
- revert of #53007 (SWA primary block size), which breaks the NVFP4 + SWA block-size consistency constraint on SM120 (see `nvfp4_kv_cache_kernels.cu` `block_size % 4 == 0`)

Intended to land on top of #46329 rather than in parallel.

## Changes

- `vllm/v1/attention/backends/flashinfer.py`: SM120 NVFP4 KV enablement + HND layout + dtype gate
- `csrc/libtorch_stable/nvfp4_kv_cache_kernels.cu`: linear V block-scale write
- `vllm/model_executor/layers/attention/attention.py`: block-size / layout plumbing
- `vllm/v1/core/kv_cache_utils.py` + revert of #53007
- `tests/v1/attention/test_attention_backends.py`, `test_backend_per_kind.py`: dtype-gate + per-kind coverage

## Test

Verified on RTX 5090 (SM120), Qwen3.8-27B-QUASAR-NVFP4, `--kv-cache-dtype nvfp4`, TP=2, speculative method=dflash:
- engine starts, KV allocated in nvfp4, cudagraphs captured
- end-to-end chat completion returns correct output

Command: `vllm serve --config Qwen3.8-27B-nvfp4-dflash.yaml` (systemd `chat2.service`); this PR exercises the KV-cache layout / V-scale path.

> Test evidence is from the combined SM120 NVFP4 stack; the KV-cache path is exercised in that run.

## AI assistance

AI assistance was used in implementing and drafting this change; the changes were reviewed line-by-line.
