### PR TITLE
[Spec Decode] SM120 DFlash/MTP: PP2 aux relay, NVFP4 draft startup, last-block drop

### DIFF
--- a/tests/v1/core/test_mamba_align_chunk_split.py
+++ b/tests/v1/core/test_mamba_align_chunk_split.py
@@ -223,6 +223,26 @@ def test_disabling_eagle_block_drop_keeps_the_trailing_cache_boundary() -> None:
     assert without_drop == 2 * MAMBA_BLOCK_SIZE
 
 
+def test_dflash_does_not_back_off_last_cache_position() -> None:
+    """DFlash/DSpark never write target blocks, so the split must not back
+    off the last prefix-cache position by a mamba block.
+
+    Regression for #53477: the old `use_eagle` back-off made prompts shorter
+    than two mamba blocks skip the final block-aligned chunk, so the mamba
+    recurrent state was never materialized at a block boundary and the next
+    turn's prefix-cache lookup recomputed the whole context.
+    """
+    (request,) = create_requests(1, num_tokens=PROMPT_LEN, block_size=ATTN_BLOCK_SIZE)
+    assert (
+        _split(request, PROMPT_LEN, use_eagle_block_drop=False)
+        == MAMBA_BLOCK_SIZE
+    )
+    assert (
+        _split(request, PROMPT_LEN, use_eagle_block_drop=True)
+        == PROMPT_LEN
+    )
+
+
 def _run_chunked_prefill(
     manager: KVCacheManager, request: Request, budgets: list[int]
 ) -> dict[int, int]:

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4011,6 +4011,7 @@ def test_mamba_align_eagle_schedules_encoder_at_boundary():
     )
     scheduler.need_mamba_block_aligned_split = True
     scheduler.use_eagle = True
+    scheduler.use_eagle_block_drop = True
     scheduler.num_prefill_lookahead = 1
     scheduler.max_num_encoder_input_tokens = 2048
     scheduler.encoder_cache_manager = EncoderCacheManager(cache_size=2048)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1904,8 +1904,23 @@ class SpeculativeConfig:
         return self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
 
     def use_eagle_block_drop(self) -> bool:
-        """Whether volatile trailing cache blocks should be discarded."""
-        return self.use_eagle() and not self.disable_eagle_block_drop
+        """Whether volatile trailing cache blocks should be discarded.
+
+        Only eagle-family drafters share (and pollute via lookahead KV write)
+        the target's full-attention KV cache groups; DFlash/DSpark draft from
+        their own KV cache and never write target blocks (#53477), so the
+        drop applies to eagle/eagle3/mtp only, unless explicitly disabled.
+        """
+        return (
+            self.use_eagle_preserves_target_kv_cache()
+            and not self.disable_eagle_block_drop
+        )
+
+    def use_eagle_preserves_target_kv_cache(self) -> bool:
+        # Only eagle-family drafters share (and pollute via lookahead KV
+        # write) the target's full-attention KV cache groups; DFlash/DSpark
+        # draft from their own KV cache and never write target blocks.
+        return self.method in ("eagle", "eagle3", "mtp")
 
     def use_dflash(self) -> bool:
         return self.method == "dflash"

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -364,7 +364,10 @@ class Qwen3_5ForCausalLMBase(
         return self.model.embed_input_ids(input_ids)
 
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
-        self.model.aux_hidden_state_layers = layers
+        # Use the mixin setter so the per-PP-rank aux-slot layout cache
+        # (_aux_slot_base_cached / _aux_upstream_total_cached) is populated;
+        # a bare attribute write leaves it at 0 and breaks the PP relay.
+        self.model._set_aux_hidden_state_layers(layers)
 
     def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
         num_layers = len(self.model.layers)

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -77,6 +77,20 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
 
         self.config = config
 
+        # The draft runs with its own pipeline_parallel_size == 1 (decoupled
+        # from a target PP>1), i.e. only on the last global PP rank. There
+        # get_pp_group().is_first_rank is False, so without this flag the
+        # forward would take the inter-stage path and demand intermediate
+        # tensors the proposer never supplies.
+        spec_config = vllm_config.speculative_config
+        draft_pp = (
+            spec_config.draft_parallel_config.pipeline_parallel_size
+            if spec_config is not None
+            and spec_config.draft_parallel_config is not None
+            else 1
+        )
+        self.standalone_draft = draft_pp == 1
+
         self.vocab_size = config.vocab_size
 
         self.mtp_start_layer_idx = config.num_hidden_layers
@@ -142,7 +156,11 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.embed_tokens(input_ids)
+        # Draft inputs can carry -1 stubs (rejected/padded draft positions)
+        # under async scheduling; embedding them trips indexSelectSmallIndex.
+        # Clamp to a valid token so the forward stays in bounds; the draft is
+        # rejected by verification anyway.
+        return self.embed_tokens(input_ids.clamp(min=1))
 
     def forward(
         self,
@@ -180,7 +198,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             residual=residual,
         )
 
-        if not get_pp_group().is_last_rank:
+        if not (self.standalone_draft or get_pp_group().is_last_rank):
             return IntermediateTensors(
                 {"hidden_states": hidden_states, "residual": residual}
             )

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -23,9 +23,13 @@ from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+    dequantize_to_dtype,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -461,6 +465,29 @@ class DFlashQwen3Model(nn.Module):
             embeds = torch.where(is_mask, self.mask_embedding.to(embeds.dtype), embeds)
         return embeds
 
+    def _kv_proj_weight(self, attn: DFlashQwen3Attention) -> torch.Tensor:
+        """KV rows of the layer's qkv_proj in compute dtype.
+
+        Non-quantized drafts expose the plain weight. NVFP4 (compressed-
+        tensors) drafts store packed fp4 weights plus per-group and global
+        scales; dequantize the KV rows so the fused context-KV GEMM can run
+        as a plain high-precision GEMM.
+        """
+        qkv_proj = attn.qkv_proj
+        if isinstance(qkv_proj.quant_method, UnquantizedLinearMethod):
+            return qkv_proj.weight[attn.q_size :]
+        # CT stores weight_global_scale as its divisor; the reciprocal is the
+        # scale used by the GEMM kernel after process_weights_after_loading.
+        global_scale = 1.0 / qkv_proj.weight_global_scale.max()
+        return dequantize_to_dtype(
+            qkv_proj.weight_packed[attn.q_size :],
+            qkv_proj.weight_scale[attn.q_size :],
+            global_scale,
+            dtype=qkv_proj.params_dtype,
+            block_size=16,
+            swizzle=False,
+        )
+
     def _build_context_kv_buffers(
         self,
         layers_attn: list[nn.Module],
@@ -469,7 +496,7 @@ class DFlashQwen3Model(nn.Module):
         self._hidden_norm_weight = self.hidden_norm.weight.data
 
         # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
-        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
+        kv_weights = [self._kv_proj_weight(a) for a in layers_attn]
         self._fused_kv_weight = torch.cat(kv_weights, dim=0)
         if has_bias:
             kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -633,6 +633,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             ".shared_expert.up_proj": (".shared_expert.gate_up_proj", 1),
         }
     )
+    supports_aux_hidden_states_over_pp = True
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
@@ -703,6 +704,8 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
+        remote_aux = self.collect_remote_aux_hidden_states(intermediate_tensors)
+
         full_num_tokens = positions.shape[-1]
         if self.use_sequence_parallel:
             hidden_states = sequence_parallel_chunk(hidden_states)
@@ -724,7 +727,11 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
-                {"hidden_states": hidden_states, "residual": residual}
+                {
+                    "hidden_states": hidden_states,
+                    "residual": residual,
+                    **self.pack_local_aux_hidden_states(aux_hidden_states),
+                }
             )
         hidden_states, _ = self.norm(hidden_states, residual)
         if self.use_sequence_parallel:
@@ -739,6 +746,7 @@ class Qwen3NextModel(nn.Module, EagleModelMixin):
             else:
                 hidden_states = tensor_model_parallel_all_gather(hidden_states, 0)
                 hidden_states = hidden_states[:full_num_tokens]
+        aux_hidden_states = remote_aux + aux_hidden_states
         if aux_hidden_states:
             return hidden_states, aux_hidden_states
         return hidden_states

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -286,7 +286,10 @@ class Scheduler(SchedulerInterface):
                     else 1
                 )
             self.use_eagle_block_drop = speculative_config.use_eagle_block_drop()
-            if self.use_eagle and not self.use_eagle_block_drop:
+            if (
+                speculative_config.use_eagle_preserves_target_kv_cache()
+                and not self.use_eagle_block_drop
+            ):
                 logger.warning(
                     "EAGLE trailing prefix-cache block dropping is disabled. "
                     "This is experimental and may affect speculative-token "

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1359,6 +1359,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.model_state.num_new_sampled_tokens_per_step,
         )
 
+        # Any residual -1 placeholder in the input grid (async spec-decode
+        # stubs that the draft scatter did not cover) would be embedded as a
+        # negative index -> indexSelectSmallIndex device-side assert. Replace
+        # with token 1 so the forward stays in bounds on both PP ranks.
+        input_grid = self.input_buffers.input_ids[:num_tokens]
+        neg = input_grid < 0
+        if neg.any():
+            input_grid[neg] = 1
+
         fast_prefill = None
         if self.fast_prefill is not None:
             fast_prefill = self.fast_prefill.prepare(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
@@ -20,6 +20,20 @@ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     speculative_config = vllm_config.speculative_config
     assert speculative_config is not None
     draft_model_config = speculative_config.draft_model_config
+
+    # The drafter wants a per-drafter KV-cache dtype (e.g. NVFP4) even when the
+    # engine's global cache_config targets a different one. Do NOT replace() a
+    # fresh cache_config object: the draft's attention impl binds it via
+    # get_current_vllm_config(), but the KV cache layout is resolved by the
+    # engine core and adopted into the worker's *single* cache_config (via
+    # set_kv_cache_layout before cudagraph capture). A replaced copy would stay
+    # at layout=None and crash on get_resolved_kv_cache_layout() during capture.
+    # cache_dtype is only read at attention-impl construction, so set it in place
+    # (the draft is the only model here whose impl reads it; the target already
+    # resolved its own KV dtype at build time).
+    if speculative_config.kv_cache_dtype is not None:
+        vllm_config.cache_config.cache_dtype = speculative_config.kv_cache_dtype
+
     # Select an attention backend that supports the drafter's attention: mixing
     # a non-causal layer onto a causal-only backend would fail.
     draft_vllm_config = replace(
@@ -28,14 +42,6 @@ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
             vllm_config.attention_config,
             use_non_causal=dflash_has_any_non_causal(draft_model_config.hf_config),
             backend=speculative_config.attention_backend,
-        ),
-        cache_config=(
-            replace(
-                vllm_config.cache_config,
-                cache_dtype=speculative_config.kv_cache_dtype,
-            )
-            if speculative_config.kv_cache_dtype is not None
-            else vllm_config.cache_config
         ),
     )
     with set_model_tag("dflash_head"):

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -86,13 +86,12 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
             ),
         )
     if speculative_config.kv_cache_dtype is not None:
-        vllm_config = replace(
-            vllm_config,
-            cache_config=replace(
-                vllm_config.cache_config,
-                cache_dtype=speculative_config.kv_cache_dtype,
-            ),
-        )
+        # Set in place rather than replacing cache_config: the draft's attention
+        # impl binds the worker's single cache_config via get_current_vllm_config(),
+        # and the KV cache layout is adopted into that object (via
+        # set_kv_cache_layout) before cudagraph capture. A replaced copy would
+        # stay at layout=None and crash on get_resolved_kv_cache_layout().
+        vllm_config.cache_config.cache_dtype = speculative_config.kv_cache_dtype
     if speculative_config.attention_backend is not None:
         # Before get_model(): the backend is read off the constructed layers.
         # Only when set, so the draft keeps a KV cache layout the target shares.


### PR DESCRIPTION
## Summary

SM120 speculative-decode fixes for the DFlash / DFlash2 and MTP drafters:
- PP2 DFlash/DFlash2 draft via auxiliary hidden-state relay
- NVFP4 draft startup crash fixes (KV-dequant + `kv_cache_layout`)
- PP2 MTP speculative decode (standalone draft forward + `-1` stub sweep to avoid `indexSelectSmallIndex`)
- Scope the prefix-cache last-block drop to eagle-family drafters (DFlash2 offload fix)

The MTP portion is the "complementary" piece @jethac identified that #46329 does not touch; intended to land on top of #46329.

## Why this is not duplicating an existing PR

These are drafter-side fixes (DFlash aux relay, NVFP4 draft startup, MTP standalone-forward, prefix-cache last-block scoping) not present in #46329 or elsewhere. The MTP/spec-decode route is complementary to the NVFP4-KV foundation, per #49891's review thread.

## Changes

- `vllm/model_executor/models/qwen3_dflash.py`, `qwen3_next.py`, `qwen3_5.py`: drafter aux relay + layout
- `vllm/model_executor/models/qwen3_5_mtp.py`: PP2 MTP standalone draft forward
- `vllm/v1/worker/gpu/spec_decode/dflash/utils.py`, `eagle/utils.py`: last-block drop scoping
- `vllm/v1/worker/gpu/model_runner.py`: `-1` stub sweep (kept alongside upstream fast_prefill)
- `vllm/config/speculative.py`, `vllm/v1/core/sched/scheduler.py`: scheduling scoping
- tests: `test_scheduler.py`, `test_mamba_align_chunk_split.py`

## Test

Verified on RTX 5090 (SM120), Qwen3.8-27B NVFP4 with speculative `method=dflash` (DFlash2 draft, 3 tokens): draft engaged, end-to-end generation correct.

> The MTP drafter path is code-verified but not exercised in that config (method=dflash); DFlash path is exercised.

## AI assistance

AI assistance was used in implementing and drafting this change; the changes were reviewed line-by-line.
