### PR TITLE
[Bugfix][FlashInfer] Restrict W4A16 NVFP4 GEMM to SM100/103; fix CuTeDSL autotune op names

### DIFF
--- a/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/flashinfer.py
@@ -46,10 +46,19 @@ class FlashInferCuteDslNvFp4W4A16LinearKernel(NvFp4LinearKernel):
                 return False, "CUDA compute capability is unavailable"
             compute_capability = capability.to_int()
 
-        if compute_capability not in (100, 103) and not (
-            compute_capability >= 120 and compute_capability < 130
-        ):
-            return False, "FlashInfer CuTe-DSL W4A16 requires sm_100 or sm_12x"
+        # Restrict to SM100/103. On SM12x the un-tuned CuTe-DSL W4A16 kernel
+        # uses its heuristic fallback tactic, which is several times slower than
+        # the CUTLASS kernel at prefill shapes (mirrors the b12x GEMM, which vLLM
+        # deliberately keeps behind CUTLASS because its heuristic fallback is up
+        # to 3.6x slower at prefill shapes). Its autotune is also unusable on
+        # 32 GiB consumer GPUs: every tactic JIT-compiles a cubin and captures a
+        # CUDA graph that empty_cache() cannot reclaim, accumulating ~7 GiB and
+        # OOMing KV cache allocation. The W4A16 force-path in
+        # init_nvfp4_linear_kernel already limits CuTe-DSL to SM100/103; keep
+        # is_supported consistent so auto registry selection cannot pick it on
+        # SM12x either.
+        if compute_capability not in (100, 103):
+            return False, "FlashInfer CuTe-DSL W4A16 requires sm_100 or sm_103"
         if not has_flashinfer_bf16_fp4():
             return False, "FlashInfer CuTe-DSL BF16 x FP4 GEMM is unavailable"
         return True, None

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -303,17 +303,26 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
 
     from vllm.model_executor.kernels.linear import (
         FlashInferCuteDslNvFp4LinearKernel,
+        FlashInferCuteDslNvFp4W4A16LinearKernel,
     )
 
+    skip_ops: set[str] = set()
     for module in runner.get_model().modules():
         for holder_name in ("quant_method", "scheme"):
             kernel = getattr(getattr(module, holder_name, None), "kernel", None)
-            # CuTe-DSL mm_fp4 tuning JIT-compiles every tactic and its
-            # fallback is already the heuristic; all mm_fp4 backends share
-            # the "fp4_gemm" op name, so skip only when cute-dsl is selected.
-            if isinstance(kernel, FlashInferCuteDslNvFp4LinearKernel):
-                return {"fp4_gemm"}
-    return None
+            # CuTe-DSL fp4 tuning JIT-compiles every tactic (one CUDA graph and
+            # cubin each) and its fallback is already the heuristic, so skip
+            # only when cute-dsl is selected. Each backend registers a
+            # different autotune op name:
+            #   W4A16 (BF16 x FP4) -> "bf16_fp4_cute_dsl_[sm100_]gemm"
+            #   W4A4  (FP4 x FP4)  -> "fp4_gemm"
+            if isinstance(kernel, FlashInferCuteDslNvFp4W4A16LinearKernel):
+                skip_ops.update(
+                    ("bf16_fp4_cute_dsl_gemm", "bf16_fp4_cute_dsl_sm100_gemm")
+                )
+            elif isinstance(kernel, FlashInferCuteDslNvFp4LinearKernel):
+                skip_ops.add("fp4_gemm")
+    return skip_ops or None
 
 
 _FLASHINFER_BF16_AUTOTUNE_MAX_TOKENS = 32


### PR DESCRIPTION
## Summary

FlashInfer CuTe-DSL W4A16 NVFP4 GEMM correctness/perf fixes:
- Restrict `FlashInferCuteDslNvFp4W4A16LinearKernel` to SM100/103. On SM12x the un-tuned CuTe-DSL W4A16 kernel falls back to its heuristic tactic (several times slower than CUTLASS at prefill), and its autotune JIT-compiles a cubin + CUDA graph per tactic that `empty_cache()` cannot reclaim — accumulating ~7 GiB and OOMing KV-cache allocation on 32 GiB consumer GPUs.
- Fix the CuTe-DSL autotune op-name skip so W4A16 (`bf16_fp4_cute_dsl_[sm100_]gemm`) and W4A4 (`fp4_gemm`) are each skipped under the correct op name.

## Why this is not duplicating an existing PR

No open PR restricts the FlashInfer CuTe-DSL W4A16 GEMM by arch or fixes its autotune op-name skip. Complements the NVFP4-KV work (keeps the CuTe-DSL W4A16 path off SM12x) rather than overlapping it.

## Changes

- `vllm/model_executor/kernels/linear/nvfp4/flashinfer.py`: `is_supported` restricted to SM100/103
- `vllm/model_executor/warmup/kernel_warmup.py`: `_flashinfer_autotune_skip_ops` returns the correct per-backend op names

## Test

On SM120 the CuTe-DSL W4A16 GEMM is no longer selected (consistent with the W4A16 force-path in `init_nvfp4_linear_kernel`); verified the Qwen3.8-27B NVFP4 stack still serves correctly on RTX 5090 after the restriction.

## AI assistance

AI assistance was used in implementing and drafting this change; the changes were reviewed line-by-line.
