### PR TITLE
[Bugfix] Detect multi-branch allOf for xgrammar structured-output fallback

### DIFF
--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -56,6 +56,35 @@ def unsupported_object_schemas():
 
 
 @pytest.fixture
+def unsupported_allof_schemas():
+    return [
+        {
+            "$defs": {
+                "Base": {
+                    "type": "object",
+                    "properties": {"x": {"type": "integer", "minimum": 10}},
+                    "required": ["x"],
+                }
+            },
+            "allOf": [
+                {"$ref": "#/$defs/Base"},
+                {
+                    "type": "object",
+                    "properties": {"y": {"type": "string"}},
+                    "required": ["y"],
+                },
+            ],
+        },
+        {
+            "allOf": [
+                {"type": "string", "minLength": 1},
+                {"type": "string", "maxLength": 5},
+            ],
+        },
+    ]
+
+
+@pytest.fixture
 def supported_schema():
     return {
         "type": "object",
@@ -96,6 +125,7 @@ def supported_schema():
         "unsupported_number_schemas",
         "unsupported_array_schemas",
         "unsupported_object_schemas",
+        "unsupported_allof_schemas",
     ],
 )
 def test_unsupported_json_features_by_type(schema_type, request):
@@ -110,3 +140,18 @@ def test_supported_json_features(supported_schema):
     assert not has_xgrammar_unsupported_json_features(supported_schema), (
         "Schema should be supported"
     )
+
+
+def test_supported_single_branch_allof():
+    # A single-branch `allOf` is enforced correctly by xgrammar and must not
+    # be flagged as unsupported.
+    schema = {
+        "allOf": [
+            {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}},
+                "required": ["x"],
+            },
+        ],
+    }
+    assert not has_xgrammar_unsupported_json_features(schema)

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -282,6 +282,13 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
         ):
             return True
 
+        # xgrammar enforces `allOf` only when it has a single branch. For
+        # multiple branches it silently compiles to an "accept anything" rule,
+        # dropping every constraint without surfacing an error.
+        allof = obj.get("allOf")
+        if isinstance(allof, list) and len(allof) > 1:
+            return True
+
         # Recursively check all nested objects and arrays
         for value in obj.values():
             if isinstance(value, dict):


### PR DESCRIPTION
## Summary

xgrammar only enforces `allOf` when it has exactly one branch. For a schema
with multiple `allOf` branches it compiles to an accept-anything rule and
silently drops every constraint. The model can then emit JSON that violates
the schema, and vLLM reports no error because the `auto` backend keeps
selecting xgrammar: `has_xgrammar_unsupported_json_features` does not list
`allOf`, so the fallback to `guidance` never triggers.

This is a common pattern. Pydantic and OpenAPI emit multi-branch `allOf` for
model inheritance, for example
`allOf: [{"$ref": "#/$defs/Base"}, {...}]`.

## Fix

Flag any `allOf` with more than one branch as unsupported in
`has_xgrammar_unsupported_json_features`, so the `auto` backend falls back to
a backend that enforces the schema correctly. Single-branch `allOf` remains
supported, since xgrammar handles it by delegating to the single sub-schema.

## Tests

Added `unsupported_allof_schemas` cases (the `$ref` inheritance schema from
the issue, and a plain two-branch `allOf`) to the existing
`test_unsupported_json_features_by_type` parametrization, plus a
`test_supported_single_branch_allof` case to guard against over-rejection.

Verified the detection logic directly against the issue reproduction and the
edge cases (multi-branch, single-branch, nested `allOf`, empty and non-list
`allOf`), all behaving as expected.

Fixes #56556
