### PR TITLE
[Perf][DSv4.1] Skip candidate sorting when all blocks fit

### DIFF
--- a/tests/model_executor/layers/test_mla_short_prefill_indexer.py
+++ b/tests/model_executor/layers/test_mla_short_prefill_indexer.py
@@ -320,6 +320,9 @@ def test_select_candidate_blocks_tolerates_empty_rows():
     "width,block_size,k,decode",
     [
         (73, 8, 16, False),
+        (73, 8, 16, True),
+        (80, 8, 10, False),
+        (81, 8, 10, False),
         (97, 3, 7, False),
         (32768, 8, 2048, False),
         (32768, 8, 2048, True),
@@ -339,6 +342,7 @@ def test_candidate_kernels_preserve_packed_bounds_and_padding(
     logits = torch.randn(rows, width * 2, device="cuda")[:, ::2]
     logits[0, :16] = 0
     logits[2, 5] = float("nan")
+    logits[3, :] = -torch.inf
     starts = torch.tensor([0, 5, 3, 0, 7, 1], device="cuda", dtype=torch.int32)
     ends = torch.tensor([0, width, width - 1, 1, 11, width], device="cuda")
     repeat = 1
@@ -365,9 +369,17 @@ def test_candidate_kernels_preserve_packed_bounds_and_padding(
     expected[:, : top.indices.shape[1]] = torch.where(
         top.values > -torch.inf, top.indices, -1
     ).int()
-    actual = torch.empty(rows, k * 2, device="cuda", dtype=torch.int32)[:, ::2]
+    storage = torch.full((rows, k * 2), -99, device="cuda", dtype=torch.int32)
+    actual = storage[:, ::2]
     select_candidate_blocks(logits, starts, ends, k, block_size, actual, repeat)
-    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    if k >= nblocks:
+        # All blocks fit: their membership matters, not their score order.
+        torch.testing.assert_close(
+            actual.sort().values, expected.sort().values, rtol=0, atol=0
+        )
+    else:
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert torch.all(storage[:, 1::2] == -99)
 
     candidates = actual.clone()
     candidates[:, 0] = nblocks + 10
@@ -400,3 +412,34 @@ def test_candidate_kernels_preserve_packed_bounds_and_padding(
         keep = valid & (block >= 0) & ((cols - ks[:, None]) // block_size == block)
         reference = torch.where(keep, 3.0, -torch.inf)
         torch.testing.assert_close(logits, reference, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_candidate_selection_all_blocks_graph_replay():
+    """Replay must refresh block validity and newest-block inclusion."""
+    from vllm.model_executor.kernels.attention.dsa.candidate_blocks import (
+        select_candidate_blocks,
+    )
+
+    logits = torch.ones(2, 32, device="cuda")
+    ends = torch.tensor([32, 32], device="cuda", dtype=torch.int32)
+    out = torch.empty(2, 6, device="cuda", dtype=torch.int32)
+    select_candidate_blocks(logits, None, ends, 6, 8, out)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        select_candidate_blocks(logits, None, ends, 6, 8, out)
+    for length in (17, 0, 32):
+        ends.fill_(length)
+        logits.fill_(-torch.inf)
+        logits[:, :8] = torch.nan
+        logits[:, 8:16] = 1
+        graph.replay()
+        # NaN and all-minus-inf blocks are excluded, except the newest block.
+        blocks = {1} if length > 8 else set()
+        if length:
+            blocks.add((length - 1) // 8)
+        expected = sorted(list(blocks) + [-1] * (6 - len(blocks)))
+        torch.testing.assert_close(
+            out.sort().values,
+            torch.tensor([expected] * 2, device="cuda", dtype=torch.int32),
+        )

--- a/vllm/model_executor/kernels/attention/dsa/candidate_blocks.py
+++ b/vllm/model_executor/kernels/attention/dsa/candidate_blocks.py
@@ -11,7 +11,7 @@ def _max_with_nan(a, b):
     return tl.maximum(a, b, propagate_nan=tl.PropagateNan.ALL)
 
 
-@triton.jit(do_not_specialize=["width", "nblocks"])
+@triton.jit(do_not_specialize=["width", "nblocks", "out_width"])
 def _block_scores_kernel(
     logits,
     starts,
@@ -21,11 +21,15 @@ def _block_scores_kernel(
     stride_col,
     stride_start,
     stride_end,
+    stride_out_row,
+    stride_out_col,
     width,
     nblocks,
+    out_width,
     BLOCK_SIZE: tl.constexpr,
     HAS_STARTS: tl.constexpr,
     ROW_REPEAT: tl.constexpr,
+    ALL_BLOCKS: tl.constexpr,
     TILE: tl.constexpr,
 ):
     row = tl.program_id(0).to(tl.int64)
@@ -48,7 +52,13 @@ def _block_scores_kernel(
         float("inf"),
         reduced,
     )
-    tl.store(scores + row * nblocks + blocks, reduced, blocks < nblocks)
+    if ALL_BLOCKS:
+        reduced = tl.where((blocks < nblocks) & (reduced > -float("inf")), blocks, -1)
+    tl.store(
+        scores + row * stride_out_row + blocks * stride_out_col,
+        reduced,
+        blocks < out_width,
+    )
 
 
 @triton.jit(do_not_specialize=["k"])
@@ -150,6 +160,7 @@ def select_candidate_blocks(
 
     Row bounds are in packed column space; absent starts mean zero.
     Decode rows share bounds in groups of ``row_repeat``. Output is -1 padded.
+    Candidate order is unspecified when every block fits in the budget.
     """
     assert logits.is_cuda
     rows, width = logits.shape
@@ -159,8 +170,10 @@ def select_candidate_blocks(
         out.fill_(-1)
         return
     nblocks = triton.cdiv(width, block_size)
-    scores = logits.new_empty((rows, nblocks))
-    _block_scores_kernel[(rows, triton.cdiv(nblocks, 128))](
+    all_blocks = topk_blocks >= nblocks
+    scores = out if all_blocks else logits.new_empty((rows, nblocks))
+    out_width = topk_blocks if all_blocks else nblocks
+    _block_scores_kernel[(rows, triton.cdiv(out_width, 128))](
         logits,
         row_ks,
         row_ke,
@@ -168,13 +181,18 @@ def select_candidate_blocks(
         *logits.stride(),
         row_ks.stride(0) if row_ks is not None else 0,
         row_ke.stride(0),
+        *scores.stride(),
         width,
         nblocks,
+        out_width,
         block_size,
         row_ks is not None,
         row_repeat,
+        all_blocks,
         128,
     )
+    if all_blocks:
+        return
     # Keep the existing top-k tie behavior.
     top = scores.topk(min(topk_blocks, nblocks), dim=-1)
     _store_candidates_kernel[(rows, triton.cdiv(topk_blocks, 256))](


### PR DESCRIPTION
## Summary

When every logits block fits in the V4.1 candidate budget, sorting the block scores cannot change candidate membership. Write block IDs directly from the existing max reduction in this case, avoiding the score allocation, `torch.topk`, and separate candidate-store launch.

```text
ASIS
block maxima -> temporary scores -> sort all blocks -> candidate IDs
```

```text
PR (all blocks fit)
block maxima -> candidate IDs
```

The fast path uses the logits tensor width, without reading GPU row bounds on the host. It preserves NaN/minus-infinity exclusion, forced inclusion of the newest block, packed request offsets, repeated decode bounds, arbitrary output strides, and -1 padding. Candidate order is unspecified when all blocks fit; current consumers use membership. When selection is needed, the existing top-k ordering is preserved.

This is separate from #56254, which scores only candidate blocks in candidate-consuming layers. This change optimizes the candidate-source layer's block selection and requires no new DeepGEMM API. Current main and open candidate-block PRs were checked for equivalent work.

## Validation

- Nine candidate tests passed, covering the budget boundary, packed bounds, partial blocks, NaN/minus-infinity scores, newest-block inclusion, repeated decode bounds, strided-output guards, and CUDA graph replay with changing scores and lengths.
- CUDA-graph A/B/B/A operator measurements on GB200: **3.35-17.22x faster** for eligible shapes. A shape that still requires sorting measured 0.9997x, consistent with unchanged performance. These are operator results, not serving speedup claims.
- MRV2 TP4 full-model A/B/B/A: all 72 outputs match token-for-token at 17/8192/32768 input tokens with 64 outputs, plus mixed prefill/decode requests. Every worker matches 1/1/4 prefill steps and 63 decode steps. TTFT results are order-sensitive; no end-to-end speedup claimed. TPOT changes are below 0.3%. Actual 8K prefill exercises the fast path; 40K-wide full-graph decode retains the original selector.
- Model runs use the previously qualified ad72e29 integration with non-fused attention, changing only the candidate-selector helper; they are not a whole-model build of current main. Feature/unit-test base is current main 46d2b23. Full-model ROCm, DCP, DBO and speculative decoding are not qualified.

```bash
.venv/bin/python -m pytest tests/model_executor/layers/test_mla_short_prefill_indexer.py -k candidate -q
```

AI assistance was used for implementation, testing, and investigation. The submitting human reviewed and approved this change.

[Report, raw results, reproducible drivers and checksums](https://github.com/foraxe/vllm/tree/c421dd36f62bafbfab64678af79891fefef3c634/evidence/candidate-full). Feature: e43951fda1fafe7e29eb3788092834a6e0124180. Scoped pre-commit/mypy and commit hooks passed.
