### PR TITLE
[Bugfix] Defer xgrammar annotations to fix startup crash when xgrammar is unavailable

### DIFF
--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Summary

On platforms where `xgrammar` is not installed, vLLM crashes at import time before serving any requests. The import of `xgrammar` in `vllm/v1/structured_output/backend_xgrammar.py` is already wrapped in `LazyLoader`, but the `XgrammarGrammar` dataclass still references `xgr.GrammarMatcher` and `xgr.CompiledGrammar` in field annotations. Without `from __future__ import annotations`, Python evaluates those annotations when the class body runs, which triggers the `LazyLoader` and pulls in `xgrammar` during module import.

This affects s390x in particular, where `xgrammar` has no pre-built wheel and cannot be built from source (its `apache-tvm-ffi` build dependency also lacks s390x support). The result is an `ImportError` on `from vllm import LLM`, even for workloads that never use structured output.

This change adds `from __future__ import annotations` so the annotations are deferred and no longer evaluated at import time. The module (and vLLM) can then be imported without `xgrammar` installed, and `xgrammar` is only loaded when a request actually selects the xgrammar backend. This matches `backend_outlines.py`, which already defers its optional-dependency annotations the same way.

Fixes #56559.

## Why this is not a duplicate

Searched open PRs for #56559 and for "xgrammar s390x" / "defer xgrammar annotations" and found none. The issue is open with no linked pull request and no comments.

## Testing

- `ruff check vllm/v1/structured_output/backend_xgrammar.py` passes.
- `ruff format --check vllm/v1/structured_output/backend_xgrammar.py` passes.
- Confirmed the root cause with a minimal repro: a `LazyLoader`-backed module attribute used in a dataclass field annotation is evaluated (and imports the module) at class-definition time without `from __future__ import annotations`, and is left as a string with it.
- No new test added. The change defers an import that CI (where `xgrammar` is always installed) cannot reproduce as a failure, and the existing xgrammar structured-output tests still cover the runtime path.
