### PR TITLE
docs: Document NIXL KV connector metrics aggregation semantics

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -1,5 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Base metrics infrastructure for KV connectors.
+
+Aggregation pipeline (multi-TP-rank):
+-------------------------------------
+1. Each TP rank's connector worker collects per-transfer telemetry into
+   a connector-specific `KVConnectorStats` subclass (e.g., `NixlKVConnectorStats`).
+   Methods like `record_transfer()` append to internal lists.
+
+2. At the sync interval, each worker serializes its stats via `to_dict()`
+   and sends the payload to the logger process (single per engine).
+
+3. Logger process calls `KVConnectorLogging.observe(payload)` for each
+   worker's payload:
+   a. Deserializes via `connector_cls.build_kv_connector_stats(payload)`
+   b. Calls `accumulator.aggregate(worker_stats)` which CONCATENATES
+      the worker's observation lists onto the accumulator's lists
+      (list.extend semantics, NOT element-wise sum/avg).
+
+4. After all TP ranks have reported, the accumulator holds the
+   concatenated observations from ALL workers for the interval.
+
+5. At the logging interval, `KVConnectorLogging.log()` calls
+   `accumulator.reduce()` which computes summary statistics (mean, p90,
+   throughput, etc.) over the FULL concatenated sample set from all
+   workers. This yields cluster-level aggregates for the interval.
+
+6. For Prometheus metrics, `KVConnectorProm.observe(accumulator.to_dict())`
+   iterates the accumulated lists and calls `observe()`/`inc()` on
+   histograms/counters. Each observation from each worker contributes
+   one sample to the histogram.
+
+Key invariant: `aggregate()` uses list.extend (concatenation). `reduce()`
+computes statistics over the concatenated list. This ensures that
+percentiles, means, and throughputs reflect the true distribution across
+all transfers from all TP ranks, not an average of per-rank averages.
+"""
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias, TypeVar
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -1,6 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Stats and Prometheus metrics for the NIXL connector."""
+"""Stats and Prometheus metrics for the NIXL connector.
+
+This module implements the metrics collection, aggregation, and reporting
+pipeline for NIXL KV cache transfers.
+
+Aggregation semantics (multi-TP-rank):
+--------------------------------------
+Each TP rank runs a NIXL connector worker that collects per-transfer
+telemetry into a local `NixlKVConnectorStats` instance via `record_transfer`
+and related methods. At the sync interval (controlled by the scheduler),
+each worker's stats are serialized via `to_dict()` and sent to the logger
+process.
+
+The logger process (single per engine) calls `KVConnectorLogging.observe()`
+which:
+1. Deserializes each worker's payload into a `NixlKVConnectorStats` object
+2. Calls `aggregate()` on the accumulator, which extends the internal lists
+   with the incoming worker's observations (concat semantics, NOT sum/avg).
+3. Repeats for all TP ranks, so the accumulator holds the concatenated
+   observations from ALL workers for the interval.
+
+At the logging interval, `log()` calls `reduce()` on the accumulated stats.
+`reduce()` computes summary statistics (mean, p90, throughput, etc.) over
+the full concatenated sample set from all workers. This yields cluster-level
+aggregates for the interval.
+
+Prometheus metrics (`NixlPromMetrics.observe()`) are recorded per-engine
+(after aggregation) by iterating the accumulated lists and calling
+`observe()`/`inc()` on histograms/counters. Each observation from each
+worker contributes one sample to the histogram.
+
+Key point: `aggregate()` uses list.extend (concatenation), NOT element-wise
+addition. `reduce()` computes statistics over the concatenated list.
+"""
 
 import copy
 from dataclasses import dataclass


### PR DESCRIPTION
This adds docstrings explaining the multi-TP-rank metrics aggregation pipeline used by the NIXL KV connector, as requested in issue #41230.

Changes:
- stats.py: Added module-level docstring explaining the aggregation pipeline (per-worker collection -> logger aggregation -> reduce -> Prometheus recording), emphasizing that aggregate() uses list.extend (concatenation) semantics.
- metrics.py: Added module-level docstring explaining the same pipeline from the base infrastructure perspective, with the key invariant that aggregate() concatenates observations and reduce() computes statistics over the full concatenated sample set.

Closes #41230