### PR TITLE
[Perf][DSV4.1] Pad shared experts for native MegaMoE fusion

### DIFF
--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -370,17 +370,21 @@ def test_deepseek_v4_mega_moe_padding_preserves_weights(monkeypatch, intermediat
     [
         pytest.param(128, 512, 128, True, False, id="aligned-block128"),
         pytest.param(128, 512, 128, True, True, id="aligned-block128-mxfp8"),
-        pytest.param(5120, 2304, 32, False, False, id="deepseek-v41-flash"),
+        pytest.param(5120, 2304, 32, True, False, id="deepseek-v41-flash"),
+        pytest.param(128, 2304, 128, True, False, id="padded-block128"),
+        pytest.param(5120, 2304, 32, True, True, id="deepseek-v41-flash-mxfp8"),
+        pytest.param(128, 2304, 128, False, False, id="padded-packed-scale-fallback"),
     ],
 )
 def test_deepseek_v4_mega_moe_finalizes_native_shared_expert_weights(
     monkeypatch, hidden_size, intermediate_size, block_size, fused, mxfp8
 ):
-    """V4.1-Flash's routed padding must preserve the serial shared-expert fallback."""
+    """Shared fusion preserves checkpoint channels and zeros padded channels."""
 
     class FakeDeepGemm:
         transformed_dims: list[tuple[int, int]] = []
         scale_inputs: list[tuple[int, ...]] = []
+        scale_values: list[torch.Tensor] = []
 
         @staticmethod
         def get_symm_buffer_for_mega_moe(*args, num_shared_experts=0, **kwargs):
@@ -405,6 +409,7 @@ def test_deepseek_v4_mega_moe_finalizes_native_shared_expert_weights(
         @classmethod
         def transform_sf_into_required_layout(cls, sf, mn, k, *args, **kwargs):
             cls.scale_inputs.append(tuple(sf.shape))
+            cls.scale_values.append(sf)
             return torch.empty((sf.shape[0], mn, k // 128), dtype=torch.int32)
 
         @classmethod
@@ -432,7 +437,10 @@ def test_deepseek_v4_mega_moe_finalizes_native_shared_expert_weights(
 
     def fp8_parameter(*shape):
         return torch.nn.Parameter(
-            torch.empty(*shape, dtype=torch.float8_e4m3fn), requires_grad=False
+            torch.empty(*shape, dtype=torch.uint8)
+            .random_(1, 119)
+            .view(torch.float8_e4m3fn),
+            requires_grad=False,
         )
 
     def scale_parameter(*shape, dtype=torch.int32):
@@ -463,21 +471,34 @@ def test_deepseek_v4_mega_moe_finalizes_native_shared_expert_weights(
             linear.weight_block_size = (1, 32)
             linear.weight_scale = torch.nn.Parameter(
                 linear.weight_scale_inv.view(torch.uint8)
-                .repeat_interleave(128, dim=0)
-                .repeat_interleave(4, dim=1),
+                .repeat_interleave(block_size, dim=0)
+                .repeat_interleave(block_size // 32, dim=1),
                 requires_grad=False,
             )
             del linear.weight_scale_inv
+    originals = []
+    for linear in (shared_experts.gate_up_proj, shared_experts.down_proj):
+        scale = linear.weight_scale if mxfp8 else linear.weight_scale_inv
+        if not fused:
+            # Already packed scales cannot be padded as checkpoint UE8M0 bytes.
+            linear.weight_scale_inv = scale_parameter(
+                linear.weight.shape[0], linear.weight.shape[1] // 128
+            )
+            continue
+        scale.data.view(torch.uint8).random_(124, 130)
+        block_m, block_k = linear.weight_block_size
+        scale_1x32 = (
+            experts._ue8m0_uint8_to_float(scale.view(torch.uint8))
+            .repeat_interleave(block_m, dim=0)
+            .repeat_interleave(block_k // 32, dim=1)
+        )
+        originals.append((linear.weight.view(torch.uint8).clone(), scale_1x32))
     monkeypatch.setattr("vllm.utils.deep_gemm._import_deep_gemm", lambda: FakeDeepGemm)
 
     original_gate_up_ptr = shared_experts.gate_up_proj.weight.data_ptr()
     original_down_ptr = shared_experts.down_proj.weight.data_ptr()
     experts.finalize_weights(shared_experts)
 
-    assert FakeDeepGemm.scale_inputs[-2:] == [
-        (1, 2 * intermediate_size, hidden_size // 32),
-        (1, hidden_size, intermediate_size // 32),
-    ]
     assert experts.has_fused_shared_experts is fused
     if not fused:
         assert experts.intermediate_size == 2560
@@ -493,15 +514,56 @@ def test_deepseek_v4_mega_moe_finalizes_native_shared_expert_weights(
         return
 
     assert FakeDeepGemm.transformed_dims == [(3, 3), (2, 2)]
-    assert shared_experts.gate_up_proj.weight.data_ptr() != original_gate_up_ptr
-    assert (
-        experts._transformed_shared_l1_weights[0].data_ptr()
-        == shared_experts.gate_up_proj.weight.data_ptr()
-    )
-    assert (
-        experts._transformed_shared_l2_weights[0].data_ptr()
-        == shared_experts.down_proj.weight.data_ptr()
-    )
+    padded_size = experts.intermediate_size
+    assert FakeDeepGemm.scale_inputs[-2:] == [
+        (1, 2 * padded_size, hidden_size // 32),
+        (1, hidden_size, padded_size // 32),
+    ]
+    for actual, original, fill in (
+        (
+            experts._transformed_shared_l1_weights[0].view(torch.uint8),
+            originals[0][0],
+            0,
+        ),
+        (FakeDeepGemm.scale_values[-2][0], originals[0][1], 1),
+    ):
+        actual = actual.unflatten(0, (2, padded_size))
+        assert torch.equal(
+            actual[:, :intermediate_size], original.unflatten(0, (2, intermediate_size))
+        )
+        assert torch.all(actual[:, intermediate_size:] == fill)
+    for actual, original, fill in (
+        (
+            experts._transformed_shared_l2_weights[0].view(torch.uint8),
+            originals[1][0],
+            0,
+        ),
+        (FakeDeepGemm.scale_values[-1][0], originals[1][1], 1),
+    ):
+        assert torch.equal(actual[:, : original.shape[1]], original)
+        assert torch.all(actual[:, original.shape[1] :] == fill)
+    if padded_size != intermediate_size:
+        # Generic linear post-load hooks still receive checkpoint-shaped weights.
+        for linear, (weight, _) in zip(
+            (shared_experts.gate_up_proj, shared_experts.down_proj), originals
+        ):
+            assert torch.equal(linear.weight.view(torch.uint8), weight)
+        assert shared_experts.gate_up_proj.weight.data_ptr() == original_gate_up_ptr
+        assert shared_experts.down_proj.weight.data_ptr() == original_down_ptr
+    else:
+        assert shared_experts.gate_up_proj.weight.data_ptr() != original_gate_up_ptr
+        assert (
+            experts._transformed_shared_l1_weights[0].data_ptr()
+            == shared_experts.gate_up_proj.weight.data_ptr()
+        )
+        assert (
+            experts._transformed_shared_l2_weights[0].data_ptr()
+            == shared_experts.down_proj.weight.data_ptr()
+        )
+
+    transformed_l1 = experts._transformed_shared_l1_weights
+    experts.finalize_weights(shared_experts)
+    assert experts._transformed_shared_l1_weights is transformed_l1
 
 
 @pytest.mark.parametrize("fused", [False, True])

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -204,6 +204,7 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         self.top_k = top_k
         self.hidden_size = hidden_size
         self.intermediate_size = intermediate_size
+        self.unpadded_intermediate_size = intermediate_size
         self.num_shared_experts = num_shared_experts
         self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
 
@@ -386,6 +387,17 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         # the generic linear post-load hook replaces the raw checkpoint scales
         # with its 128x128 DeepGEMM layout.
         checkpoint_scale_dtypes = (torch.float8_e8m0fnu, torch.uint8)
+        unpadded_size = self.unpadded_intermediate_size * self.num_shared_experts
+        padding = self.intermediate_size * self.num_shared_experts - unpadded_size
+        pad_weights = (
+            padding > 0
+            and gate_up_weight.dtype == torch.float8_e4m3fn
+            and down_weight.dtype == torch.float8_e4m3fn
+            and gate_up_weight.shape == (2 * unpadded_size, self.hidden_size)
+            and down_weight.shape == (self.hidden_size, unpadded_size)
+            and gate_up_scale.dtype in checkpoint_scale_dtypes
+            and down_scale.dtype in checkpoint_scale_dtypes
+        )
         if (
             gate_up_scale.dtype in checkpoint_scale_dtypes
             and down_scale.dtype in checkpoint_scale_dtypes
@@ -396,6 +408,7 @@ class DeepseekV4MegaMoEExperts(nn.Module):
                 gate_up_scale,
                 gate_up_weight.shape[0],
                 gate_up_weight.shape[1],
+                padding=(padding, 0) if pad_weights else (0, 0),
             )
             down_scale = self._prepare_shared_expert_scale(
                 deep_gemm,
@@ -403,11 +416,26 @@ class DeepseekV4MegaMoEExperts(nn.Module):
                 down_scale,
                 down_weight.shape[0],
                 down_weight.shape[1],
+                padding=(0, padding) if pad_weights else (0, 0),
             )
 
         if gate_up_scale is None or down_scale is None:
             self.num_shared_experts = 0
             return
+
+        if pad_weights:
+            # Pad gate/up separately so the SwiGLU split stays at the midpoint.
+            gate_up_weight = (
+                torch.nn.functional.pad(
+                    gate_up_weight.view(torch.uint8).unflatten(0, (2, unpadded_size)),
+                    (0, 0, 0, padding),
+                )
+                .flatten(0, 1)
+                .view(gate_up_weight.dtype)
+            )
+            down_weight = torch.nn.functional.pad(
+                down_weight.view(torch.uint8), (0, padding)
+            ).view(down_weight.dtype)
 
         shared_intermediate_size = self.intermediate_size * self.num_shared_experts
         expected_gate_up_shape = (
@@ -449,11 +477,11 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         # released instead of adding roughly 0.7 GiB per rank on DSV4-Flash.
         # The generic linear post-load hook may still repack the serial scales,
         # but this shared MLP is never called after native fusion is enabled.
-        gate_up.weight.data = transformed_l1[0]
-        self._transformed_shared_l1_weights = (
-            gate_up.weight.data,
-            transformed_l1[1],
-        )
+        # Padded weights need separate storage: the generic linear post-load
+        # hooks still expect the original checkpoint weight/scale shapes.
+        if not pad_weights:
+            gate_up.weight.data = transformed_l1[0]
+        self._transformed_shared_l1_weights = transformed_l1
         self._transformed_shared_l2_weights = transformed_l2
 
     def _prepare_shared_expert_scale(
@@ -463,6 +491,8 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         scale: torch.Tensor,
         mn: int,
         k: int,
+        *,
+        padding: tuple[int, int] = (0, 0),
     ) -> torch.Tensor | None:
         block_size = getattr(linear, "weight_block_size", None)
         if block_size is None or len(block_size) != 2:
@@ -497,6 +527,19 @@ class DeepseekV4MegaMoEExperts(nn.Module):
             .repeat_interleave(block_k // 32, dim=1)[:mn, : k // 32]
             .contiguous()
         )
+        pad_m, pad_k = padding
+        if pad_m:
+            scale_1x32 = torch.nn.functional.pad(
+                scale_1x32.unflatten(0, (2, mn // 2)),
+                (0, 0, 0, pad_m),
+                value=1.0,
+            ).flatten(0, 1)
+            mn += 2 * pad_m
+        if pad_k:
+            scale_1x32 = torch.nn.functional.pad(
+                scale_1x32, (0, pad_k // 32), value=1.0
+            )
+            k += pad_k
         # The grouped API is used with a singleton dimension to request the
         # MN-major, TMA-aligned packed-UE8M0 strides, then squeezed back to the
         # 2D layout required for a shared expert.


### PR DESCRIPTION
## Purpose

https://github.com/vllm-project/vllm/issues/56217

DeepSeek-V4.1-Flash's 2304-wide shared expert cannot fuse with MegaMoE's routed experts padded to 2560. Pad shared weights with zeros and unit scales to enable fusion in all 40 layers, preserving checkpoint-shaped parameters and the unsupported-layout fallback.

Extends #53040. Checks of #45861 and related open PRs found no fix for this padding gap; #53567 and #54049 cover different paths.

AI assistance was used for implementation, testing, and documentation.

## Test Plan

### Deploy

Use a fresh server per arm: `VLLM_DISABLE_DSV4_MEGAMOE_SHARED_EXPERT_FUSION=1` for serial shared experts, `0` for fused. The omitted load-time hook verifies fusion state on all 8 ranks.

```bash
export MODEL=/path/to/DeepSeek-V4.1-Flash
export VLLM_USE_V2_MODEL_RUNNER=1
export GLOO_SOCKET_IFNAME=bond0 NCCL_SOCKET_IFNAME=bond0 NCCL_DEBUG=WARN
export VLLM_DISABLE_DSV4_MEGAMOE_SHARED_EXPERT_FUSION=0
uv run --active --no-project python -m vllm.entrypoints.cli.main serve "$MODEL" \
  --served-model-name dsv41-bench --host 127.0.0.1 --port 8032 \
  --tensor-parallel-size 8 --enable-expert-parallel --distributed-executor-backend mp \
  --moe-backend deep_gemm_mega_moe \
  --tokenizer-mode deepseek_v41 --reasoning-parser deepseek_v41 \
  --attention-backend FLASHINFER_MLA_SPARSE_DSV41 --kv-cache-dtype fp8 --block-size 128 \
  --max-model-len 16384 --max-num-batched-tokens 8192 --max-num-seqs 256 \
  --gpu-memory-utilization 0.9 --seed 2026 --generation-config vllm \
  --no-enable-prefix-caching --no-enable-flashinfer-autotune --enable-prompt-tokens-details \
  --compilation-config '{"cudagraph_capture_sizes":[1,2,4,8,16,32,64,128,256],"max_cudagraph_capture_size":256}'
```

### Benchmark

Workloads follow #53040, plus 8192/1024 at C16. V4.1 uses block size 128 and FP8 indexer cache.

```bash
# Use a separate result directory for each arm.
export RESULT_DIR=results/dsv41-fused
mkdir -p "$RESULT_DIR"
bench() {
  uv run --active --no-project python -m vllm.entrypoints.cli.main bench serve \
    --backend vllm --base-url http://127.0.0.1:8032 --endpoint /v1/completions \
    --model dsv41-bench --tokenizer "$MODEL" --tokenizer-mode deepseek_v41 \
    --trust-remote-code --dataset-name random \
    --random-input-len "$1" --random-output-len "$2" \
    --max-concurrency "$3" --num-prompts "$4" \
    --random-range-ratio 0 --random-prefix-len 0 --request-rate inf \
    --ignore-eos --temperature 0 --seed 42 --num-warmups 2 \
    --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 50,95,99 \
    --save-result --save-detailed --disable-tqdm \
    --result-dir "$RESULT_DIR" --result-filename "$5.json"
}
for repeat in 1 2 3; do bench 128 256 1 8 "decode-128-256-c1-r$repeat"; done
for repeat in 1 2 3; do bench 1024 128 1 8 "decode-1024-128-c1-r$repeat"; done
for repeat in 1 2 3; do bench 1024 128 64 128 "balanced-1024-128-c64-r$repeat"; done
for repeat in 1 2 3; do bench 8192 32 16 32 "prefill-8192-32-c16-r$repeat"; done
bench 8192 1024 16 100 kimi-8192-1024-c16-r1
```

<details>
<summary>GSM8K evaluation reproduction</summary>

Use lm-eval 0.4.12, the same fusion flag, and a fresh server per arm.

```bash
export MODEL=/path/to/DeepSeek-V4.1-Flash
export VLLM_USE_V2_MODEL_RUNNER=1
export GLOO_SOCKET_IFNAME=bond0 NCCL_SOCKET_IFNAME=bond0
export NCCL_DEBUG=WARN
export VLLM_DISABLE_DSV4_MEGAMOE_SHARED_EXPERT_FUSION=0
uv run --active --no-project python -m vllm.entrypoints.cli.main serve "$MODEL" \
  --served-model-name dsv41-gsm8k --host 127.0.0.1 --port 8031 \
  --tensor-parallel-size 8 --enable-expert-parallel --distributed-executor-backend mp \
  --moe-backend deep_gemm_mega_moe \
  --tokenizer-mode deepseek_v41 --reasoning-parser deepseek_v41 \
  --attention-backend FLASHINFER_MLA_SPARSE_DSV41 --kv-cache-dtype fp8 \
  --max-model-len 16384 --max-num-batched-tokens 8192 --max-num-seqs 96 \
  --gpu-memory-utilization 0.9 --no-enable-prefix-caching \
  --no-enable-flashinfer-autotune --generation-config vllm --seed 123 \
  --default-chat-template-kwargs '{"thinking": false}'
```

Run the full test split in the lm-eval environment, with separate output directories:

```bash
OPENAI_API_KEY=EMPTY uv run --active --no-project python -m lm_eval run \
  --model local-chat-completions \
  --model_args model=dsv41-gsm8k,base_url=http://127.0.0.1:8031/v1/chat/completions,num_concurrent=64,timeout=600,max_retries=2,max_gen_toks=1024,max_length=16384,seed=123 \
  --tasks gsm8k --num_fewshot 5 --batch_size 1 \
  --apply_chat_template --fewshot_as_multiturn \
  --gen_kwargs max_gen_toks=1024 temperature=0.0 do_sample=False "chat_template_kwargs={'thinking': False}" \
  --seed 123,123,123,123 --log_samples --output_path results/gsm8k-fused
```

</details>

## Test Result

31 tests passed on B200. Ruff, typos, mypy 3.10/3.12, and applicable pre-commit checks passed; nonmatching Actionlint and requirements-compilation hooks were skipped.

All 8 ranks confirmed 0 → 40 fused layers. Model-load memory increased from 41.47 to 43.34 GiB/rank (+1.87 GiB) because the original shared parameters remain allocated.

8×B200, TP8/EP/SP, FP8 KV, 16K context. `vllm bench serve`: 2 warmups/run, median of 3 runs except 8192/1024 (1 run), no profiler. All 1,256 requests succeeded with the requested token counts. Both arms used source `30aa0ade39ab6625674865f578fae19a49cf3e43` + this patch, native build `e7edf17cea217e52701f913cd8491fcacf2d9490`, and PyTorch 2.13.0+cu130.

| Input / output | Concurrency | Requests × runs | Output tok/s: serial → fused | Change | Mean TPOT ms: serial → fused | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 128 / 256 | 1 | 8 × 3 | 122.6 → 134.3 | +9.6% | 8.115 → 7.402 | -8.8% |
| 1024 / 128 | 1 | 8 × 3 | 109.2 → 121.0 | +10.9% | 8.178 → 7.455 | -8.8% |
| 1024 / 128 | 64 | 128 × 3 | 2853.9 → 3359.2 | +17.7% | 16.851 → 14.567 | -13.6% |
| 8192 / 32 | 16 | 32 × 3 | 192.7 → 226.1 | +17.3% | 48.804 → 41.806 | -14.3% |
| 8192 / 1024 | 16 | 100 × 1 | 1292.1 → 1428.8 | +10.6% | 10.449 → 9.449 | -9.6% |

| Input / output, concurrency | Mean TTFT ms: serial → fused | Change | Median ITL ms: serial → fused | Change |
| --- | ---: | ---: | ---: | ---: |
| 128 / 256, C1 | 18.57 → 17.80 | -4.1% | 8.107 → 7.392 | -8.8% |
| 1024 / 128, C1 | 133.85 → 110.82 | -17.2% | 8.162 → 7.439 | -8.9% |
| 1024 / 128, C64 | 706.90 → 558.69 | -21.0% | 11.038 → 10.285 | -6.8% |
| 8192 / 32, C16 | 1109.92 → 937.88 | -15.5% | 9.170 → 8.387 | -8.5% |
| 8192 / 1024, C16 | 912.06 → 815.41 | -10.6% | 9.082 → 8.357 | -8.0% |

Negative latency changes mean lower latency. C1 has only 8 requests/run, so tail-latency estimates are limited.

C64's first run hit quantization JIT in both arms. Excluding it from both changes the throughput gain from +17.7% to +16.6%.

| GSM8K metric | Serial shared | Fused shared | Change (percentage points) |
| --- | ---: | ---: | ---: |
| flexible-extract | 96.21% (1269/1319) | 96.13% (1268/1319) | -0.076 |
| strict-match | 78.17% (1031/1319) | 79.23% (1045/1319) | +1.061 |
