### PR TITLE
[Misc] Show resolved KV cache dtype in startup logs

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -265,6 +265,24 @@ def test_compile_config_repr_succeeds():
 
 
 @pytest.mark.parametrize(
+    ("cache_dtype", "expected"),
+    [
+        ("auto", "auto (torch.bfloat16)"),
+        ("fp8", "fp8"),
+    ],
+)
+def test_kv_cache_dtype_str_resolves_auto(cache_dtype: str, expected: str):
+    import torch
+
+    config = SimpleNamespace(
+        cache_config=SimpleNamespace(cache_dtype=cache_dtype),
+        model_config=SimpleNamespace(dtype=torch.bfloat16),
+    )
+
+    assert VllmConfig.kv_cache_dtype_str(cast(VllmConfig, config)) == expected
+
+
+@pytest.mark.parametrize(
     ("env_value", "expected"),
     [
         (None, None),

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2530,6 +2530,14 @@ class VllmConfig:
         path = self.compilation_config.debug_dump_path / append_path
         return path
 
+    def kv_cache_dtype_str(self) -> str:
+        """Resolves `auto` to the actual dtype used.
+        """
+        cache_dtype = self.cache_config.cache_dtype
+        if cache_dtype != "auto":
+            return cache_dtype
+        return f"auto ({self.model_config.dtype})"
+
     def __str__(self):
         return (
             f"model={self.model_config.model!r}, "
@@ -2554,7 +2562,7 @@ class VllmConfig:
             f"quantization_config={self.model_config.quantization_config}, "  # noqa
             f"enforce_eager={self.model_config.enforce_eager}, "
             f"enable_return_routed_experts={self.model_config.enable_return_routed_experts}, "  # noqa
-            f"kv_cache_dtype={self.cache_config.cache_dtype}, "
+            f"kv_cache_dtype={self.kv_cache_dtype_str()}, "
             f"device_config={self.device_config.device}, "
             f"structured_outputs_config={self.structured_outputs_config!r}, "
             f"observability_config={self.observability_config!r}, "


### PR DESCRIPTION
 When `--kv-cache-dtype` is not specified it defaults to `"auto"`,  the startup logs as is:

```
kv_cache_dtype=auto,
```

so users cannot tell what dtype their KV cache actually uses easily.