### PR TITLE
[Bugfix] Reduce logits memory and profile MRV2 speculative verification

### DIFF
--- a/tests/v1/sample/test_head_dtype.py
+++ b/tests/v1/sample/test_head_dtype.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     UnquantizedEmbeddingMethod,
 )
+from vllm.platforms import current_platform
 
 
 class _FakeLmHead:
@@ -137,19 +138,24 @@ def test_fp32_head_rejects_quantized_lm_head(default_vllm_config):
         lp._get_logits(torch.randn(4, 16, dtype=torch.bfloat16), lm_head, None)
 
 
+@pytest.mark.parametrize("head_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("soft_cap", [2.0, 30.0])
 def test_replicated_lm_head_skips_tp_communication_and_preserves_processing(
     default_vllm_config,
+    monkeypatch,
+    head_dtype,
+    soft_cap,
 ):
     from unittest import mock
 
     vocab_size, hidden_size = 12, 8
-    soft_cap, scale = 2.0, 0.5
+    scale = 0.5
     lp = LogitsProcessor(
         vocab_size,
         soft_cap=soft_cap,
         scale=scale,
     )
-    lp.head_dtype = torch.float32
+    lp.head_dtype = head_dtype
 
     hidden_states = torch.randn(4, hidden_size, dtype=torch.bfloat16)
     weight = torch.randn(vocab_size, hidden_size, dtype=torch.bfloat16)
@@ -165,6 +171,11 @@ def test_replicated_lm_head_skips_tp_communication_and_preserves_processing(
             disable_tp=True,
         )
     lm_head.weight_loader(lm_head.weight, weight)
+    monkeypatch.setattr(
+        lm_head.quant_method,
+        "apply",
+        lambda layer, x, bias=None: torch.nn.functional.linear(x, layer.weight, bias),
+    )
     assert lm_head.tp_size == 1
 
     with mock.patch.object(lp, "_gather_logits") as gather_mock:
@@ -172,9 +183,11 @@ def test_replicated_lm_head_skips_tp_communication_and_preserves_processing(
 
     gather_mock.assert_not_called()
 
-    expected = torch.nn.functional.linear(hidden_states.float(), weight.float())
+    expected = torch.nn.functional.linear(
+        hidden_states.to(head_dtype), weight.to(head_dtype)
+    )
     expected = torch.tanh(expected / soft_cap) * soft_cap * scale
-    torch.testing.assert_close(logits, expected)
+    torch.testing.assert_close(logits, expected, rtol=0, atol=0)
 
     all_gather_path = (
         "vllm.model_executor.layers.logits_processor.tensor_model_parallel_all_gather"
@@ -184,6 +197,84 @@ def test_replicated_lm_head_skips_tp_communication_and_preserves_processing(
 
     all_gather.assert_not_called()
     assert torch.equal(top, expected.argmax(dim=-1))
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_soft_cap_preserves_caller_logits(default_vllm_config, dtype):
+    """Soft capping keeps per-operation rounding and leaves input logits intact."""
+    lp = LogitsProcessor(64, logits_as_input=True, soft_cap=30.0, scale=0.5)
+    logits = torch.linspace(-100, 100, 4 * 72, dtype=dtype).reshape(4, 72)[:, :64]
+    original = logits.clone()
+
+    actual = lp(None, logits)
+
+    expected = torch.tanh(original / 30.0) * 30.0 * 0.5
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(logits, original, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("logits_as_input", [False, True])
+def test_soft_cap_preserves_gradients(
+    default_vllm_config, monkeypatch, logits_as_input
+):
+    """The inference memory optimization must preserve differentiable callers."""
+    lp = LogitsProcessor(8, logits_as_input=logits_as_input, soft_cap=30.0, scale=0.5)
+    inputs = torch.linspace(-100, 100, 24).reshape(3, 8).requires_grad_()
+    original = inputs.detach().clone()
+    weight = torch.eye(8) * 2
+    head = _FakeLmHead(weight)
+    monkeypatch.setattr(
+        head.quant_method,
+        "apply",
+        lambda layer, x, bias=None: torch.nn.functional.linear(x, layer.weight, bias),
+    )
+
+    actual = lp(head, inputs)
+    projected = (
+        inputs if logits_as_input else torch.nn.functional.linear(inputs, weight)
+    )
+    expected = torch.tanh(projected / 30.0) * 30.0 * 0.5
+    actual_grad = torch.autograd.grad(actual.sum(), inputs)[0]
+    expected_grad = torch.autograd.grad(expected.sum(), inputs)[0]
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(actual_grad, expected_grad, rtol=0, atol=0)
+    torch.testing.assert_close(inputs, original, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Allocation regression is tested on CUDA and ROCm",
+)
+@torch.inference_mode()
+def test_soft_cap_uses_projection_storage(default_vllm_config, monkeypatch):
+    """Large-vocabulary processing must not allocate another logits tensor."""
+    if not torch.accelerator.is_available():
+        pytest.skip("Requires an available CUDA or ROCm device")
+
+    vocab_size = 262144
+    lp = LogitsProcessor(vocab_size, soft_cap=30.0)
+    projected_logits = torch.linspace(
+        -100,
+        100,
+        16 * vocab_size,
+        dtype=torch.bfloat16,
+        device=current_platform.device_type,
+    ).view(16, vocab_size)
+    expected = torch.tanh(projected_logits / 30.0) * 30.0
+    logits_bytes = projected_logits.numel() * projected_logits.element_size()
+    monkeypatch.setattr(lp, "_apply_head", lambda *args: projected_logits)
+    lm_head = _FakeLmHead(torch.empty(0))
+    torch.accelerator.synchronize()
+    torch.accelerator.reset_peak_memory_stats()
+    before = torch.accelerator.memory_allocated()
+    assert before >= logits_bytes
+
+    result = lp(lm_head, torch.empty(0))
+    torch.accelerator.synchronize()
+
+    assert torch.accelerator.max_memory_allocated() - before < logits_bytes
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
 
 
 def test_get_top_tokens_honors_head_dtype(default_vllm_config):

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -17,6 +17,7 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.input_batch import InputBuffers
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
 
@@ -295,3 +296,93 @@ def test_capture_model_profile_only_skips_lock(monkeypatch):
     runner.capture_model(profile_only=True)
 
     assert lock_calls == []
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "num_speculative_tokens", "chunk_limit", "expected_logits"),
+    [
+        pytest.param(16, 0, None, 4, id="non-speculative"),
+        pytest.param(16, 2, None, 12, id="full-verification"),
+        pytest.param(10, 2, None, 10, id="token-limited"),
+        pytest.param(3, 2, None, 3, id="fewer-tokens-than-requests"),
+        pytest.param(16, 2, 5, 5, id="adaptive-limited"),
+        pytest.param(16, 2, 3, 4, id="adaptive-no-drafts"),
+    ],
+)
+def test_profile_run_covers_speculative_logits(
+    monkeypatch, num_tokens, num_speculative_tokens, chunk_limit, expected_logits
+):
+    """KV sizing must include every verification row, within the token budget."""
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.supports_mm_inputs = False
+    runner.max_num_reqs = 4
+    runner.max_num_tokens = num_tokens
+    runner.decode_query_len = num_speculative_tokens + 1
+    runner.vocab_size = 8
+    runner.speculative_config = SimpleNamespace(
+        enable_adaptive_verification=chunk_limit is not None
+    )
+    runner.device = torch.device("cpu")
+    runner.is_last_pp_rank = True
+    runner.pooling_runner = None
+    runner.batch_sharder = None
+    runner.input_buffers = InputBuffers(4, num_tokens, runner.device)
+    hidden_states = torch.zeros(num_tokens, 2)
+    runner._dummy_run = lambda *args, **kwargs: (hidden_states, hidden_states[:4])
+    runner.reset_encoder_cache = lambda: None
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
+    # Non-adaptive verification may span multiple sampler chunks.
+    monkeypatch.setattr(
+        model_runner_module,
+        "get_max_chunk_logits",
+        lambda vocab: chunk_limit if chunk_limit is not None else 5,
+    )
+
+    logits_rows = []
+
+    def compute_logits(hidden):
+        logits_rows.append(hidden.shape[0])
+        return torch.zeros(hidden.shape[0], 8)
+
+    runner.model = SimpleNamespace(compute_logits=compute_logits)
+    sampled_batches = []
+    rejected_batches = []
+    sampler_output = SimpleNamespace(num_sampled=None, num_rejected=None)
+
+    def sample(logits, batch):
+        sampled_batches.append(batch)
+        return sampler_output
+
+    runner.sampler = sample
+    draft_logits = torch.zeros(4, num_speculative_tokens, 8)
+    runner.speculator = SimpleNamespace(draft_logits=draft_logits)
+
+    def reject(logits, batch, draft):
+        assert draft is draft_logits
+        assert logits.shape[0] == batch.logits_indices.numel()
+        rejected_batches.append(batch)
+        return sampler_output
+
+    runner.rejection_sampler = reject if num_speculative_tokens else None
+    runner.profile_run()
+
+    assert logits_rows == [expected_logits]
+    num_reqs = min(4, num_tokens)
+    assert len(rejected_batches) == int(expected_logits > num_reqs)
+    assert len(sampled_batches) == int(expected_logits == num_reqs)
+    batch = (sampled_batches + rejected_batches)[0]
+    assert batch.num_reqs == num_reqs
+    assert batch.num_draft_tokens == expected_logits - num_reqs
+    assert batch.cu_num_logits_np[-1] == expected_logits
+    assert batch.cu_num_logits.tolist() == batch.cu_num_logits_np.tolist()
+    if expected_logits > num_reqs:
+        assert batch.num_draft_tokens_per_req is not None
+    else:
+        assert batch.num_draft_tokens_per_req is None
+    for i, (start, end) in enumerate(
+        zip(batch.cu_num_logits_np[:-1], batch.cu_num_logits_np[1:])
+    ):
+        if batch.num_draft_tokens_per_req is not None:
+            assert batch.num_draft_tokens_per_req[i] == end - start - 1
+        assert batch.expanded_idx_mapping[start:end].tolist() == [i] * (end - start)
+        assert batch.expanded_local_pos[start:end].tolist() == list(range(end - start))

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -111,9 +111,13 @@ class LogitsProcessor(PluggableLayer):
             )
         if logits is not None:
             if self.soft_cap is not None:
-                logits = logits / self.soft_cap
-                logits = torch.tanh(logits)
-                logits = logits * self.soft_cap
+                if self.logits_as_input or logits.requires_grad:
+                    logits = logits / self.soft_cap
+                    logits = torch.tanh(logits)
+                    logits = logits * self.soft_cap
+                else:
+                    # Reuse the projection without changing per-operation rounding.
+                    logits.div_(self.soft_cap).tanh_().mul_(self.soft_cap)
 
             if self.scale != 1.0:
                 logits *= self.scale

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -891,17 +891,52 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
     @torch.inference_mode()
     def _dummy_sampler_run(self, hidden_states: torch.Tensor) -> None:
-        num_reqs = hidden_states.shape[0]
-        logits = self.model.compute_logits(hidden_states)
+        num_reqs = min(hidden_states.shape[0], self.max_num_reqs)
+        num_logits = num_reqs
+        if self.rejection_sampler is not None:
+            num_logits = min(hidden_states.shape[0], num_reqs * self.decode_query_len)
+            if (
+                self.speculative_config is not None
+                and self.speculative_config.enable_adaptive_verification
+            ):
+                num_logits = max(
+                    num_reqs, min(num_logits, get_max_chunk_logits(self.vocab_size))
+                )
         dummy_input_batch = InputBatch.make_dummy(
-            num_reqs, num_reqs, self.input_buffers
+            num_reqs, num_logits, self.input_buffers
         )
+        if num_logits > num_reqs:
+            # Verification materializes logits for draft tokens as well as the
+            # bonus token, even though the forward dummy batch samples one row
+            # per request. Profile these rows before sizing the KV cache.
+            dummy_input_batch.num_draft_tokens = num_logits - num_reqs
+            dummy_input_batch.num_draft_tokens_per_req = (
+                dummy_input_batch.num_scheduled_tokens - 1
+            )
+            dummy_input_batch.logits_indices = torch.arange(
+                num_logits, device=self.device
+            )
+            dummy_input_batch.cu_num_logits = dummy_input_batch.query_start_loc
+            dummy_input_batch.cu_num_logits_np = dummy_input_batch.query_start_loc_np
+            num_logits_per_req = torch.from_numpy(
+                dummy_input_batch.num_scheduled_tokens
+            ).to(self.device)
+            dummy_input_batch.expanded_idx_mapping = torch.repeat_interleave(
+                dummy_input_batch.idx_mapping,
+                num_logits_per_req,
+                output_size=num_logits,
+            )
+            dummy_input_batch.expanded_local_pos = (
+                dummy_input_batch.logits_indices
+                - dummy_input_batch.cu_num_logits[
+                    dummy_input_batch.expanded_idx_mapping
+                ]
+            ).to(torch.int32)
 
         # NOTE(woosuk): During the initial memory profiling, the sampler may skip
         # top_k, top_p, and logprobs, using less GPU memory than what is possible
         # during actual execution.
-        assert self.sampler is not None
-        self.sampler(logits, dummy_input_batch)
+        self.sample(hidden_states, dummy_input_batch, None)
 
     @torch.inference_mode()
     def _dummy_pooler_run(self, hidden_states: torch.Tensor) -> None:
@@ -934,7 +969,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.is_last_pp_rank:
             assert sample_hidden_states is not None
             if self.pooling_runner is None:
-                self._dummy_sampler_run(sample_hidden_states)
+                assert hidden_states is not None
+                self._dummy_sampler_run(hidden_states)
             else:
                 self._dummy_pooler_run(hidden_states)
 


### PR DESCRIPTION
- Reuse owned inference logits for soft capping, eliminating a full-vocabulary temporary while preserving per-operation rounding, caller-owned inputs, and gradients.
- Profile speculative target verification rows before sizing the KV cache, respecting request limits, token budgets, and adaptive-verification limits.
- Use the runtime sampling/rejection path during profiling so tensor-parallel projection, sharding, and communication are included.
- Add regression coverage for peak allocation, exact logits and gradients, per-request draft metadata, and verification across sampler chunks; scope the allocation test to CUDA/ROCm.

[AMD CI build 12870](https://buildkite.com/vllm/amd-ci/builds/12870/list?jid=01a08fb2-f8a9-4db6-9757-0fe0a0907e89&tab=output) hit an intermittent Gemma4 MTP OOM while allocating another 1.33 GiB for soft capping. The same commit passed on retry; we investigated [#55864](https://github.com/vllm-project/vllm/pull/55864), but no git bisect was performed or introducing PR established. The investigation also identified an older MRV2 profiling gap: startup sampled up to 1,024 logits rows, while runtime verification reached 2,721. Related [#41779](https://github.com/vllm-project/vllm/pull/41779) retains a full softcap output allocation, and [#46270](https://github.com/vllm-project/vllm/pull/46270) fixes the legacy runner; these changes preserve staged dtype rounding and profile MRV2 verification. 

Implementation and validation were AI-assisted.
