### PR TITLE
[Bugfix] tolerate malformed EXIF metadata during hashing (#56527)

### DIFF
--- a/tests/multimodal/test_hasher.py
+++ b/tests/multimodal/test_hasher.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
 import hashlib
+import struct
 import uuid
 from io import BytesIO
 from pathlib import Path
@@ -197,6 +199,35 @@ def test_hash_image_exif_id():
     assert hasher.hash_kwargs("blake3", image=image2) == hasher.hash_kwargs(
         "blake3", image=image2a
     )
+
+
+def test_hash_image_malformed_exif():
+    # Test that images with malformed EXIF headers (e.g. invalid TIFF header)
+    # do not raise an unhandled exception during hashing and fall back to image data.
+    from PIL import ImageOps
+
+    buf = BytesIO()
+    Image.new("RGB", (64, 48)).save(buf, "JPEG")
+    jpg = buf.getvalue()
+    rest = jpg[2:]
+    rest = rest[2 + struct.unpack(">H", rest[2:4])[0] :]
+    payload = b"Exif\x00\x00XXXX\x00\x00\x00\x08" + bytes(32)
+    data = b"\xff\xd8\xff\xe1" + struct.pack(">H", len(payload) + 2) + payload + rest
+
+    image = Image.open(BytesIO(data))
+    with contextlib.suppress(Exception):
+        image = ImageOps.exif_transpose(image)
+    image.load()
+
+    hasher = MultiModalHasher
+    # Should hash without raising SyntaxError or any other exception
+    hash_val = hasher.hash_kwargs("blake3", image=image)
+    assert isinstance(hash_val, str) and len(hash_val) > 0
+
+    # Also verify MediaWithBytes wrapping the image with malformed EXIF
+    media_item = MediaWithBytes(image, data)
+    hash_media = hasher.hash_kwargs("blake3", image=media_item)
+    assert isinstance(hash_media, str) and len(hash_media) > 0
 
 
 def _rgba_png_bytes() -> bytes:

--- a/tests/multimodal/test_hasher.py
+++ b/tests/multimodal/test_hasher.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import torch
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageOps
 
 from vllm.config.multimodal import MMHasherAlgorithm
 from vllm.multimodal.hasher import MultiModalHasher
@@ -204,8 +204,6 @@ def test_hash_image_exif_id():
 def test_hash_image_malformed_exif():
     # Test that images with malformed EXIF headers (e.g. invalid TIFF header)
     # do not raise an unhandled exception during hashing and fall back to image data.
-    from PIL import ImageOps
-
     buf = BytesIO()
     Image.new("RGB", (64, 48)).save(buf, "JPEG")
     jpg = buf.getvalue()

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -48,6 +48,19 @@ def _get_hasher_factory(
         raise ValueError(f"Unsupported hash algorithm: {algorithm}")
 
 
+def _get_image_id_bytes(image: Image.Image) -> bytes | None:
+    try:
+        exif = image.getexif()
+        image_id = exif.get(Image.ExifTags.Base.ImageID)
+        if isinstance(image_id, uuid.UUID):
+            return image_id.bytes
+    except Exception:
+        # Tolerate malformed EXIF metadata (e.g. invalid TIFF header)
+        # and fall back to serializing raw image data or bytes.
+        pass
+    return None
+
+
 class MultiModalHasher:
     @classmethod
     def serialize_item(cls, obj: object) -> Iterable[bytes | memoryview]:
@@ -60,11 +73,9 @@ class MultiModalHasher:
             return (np.array(obj).tobytes(),)
 
         if isinstance(obj, Image.Image):
-            exif = obj.getexif()
-            if Image.ExifTags.Base.ImageID in exif and isinstance(
-                exif[Image.ExifTags.Base.ImageID], uuid.UUID
-            ):
-                return (exif[Image.ExifTags.Base.ImageID].bytes,)
+            image_id = _get_image_id_bytes(obj)
+            if image_id is not None:
+                return (image_id,)
 
             data = {"mode": obj.mode, "data": np.asarray(obj)}
             palette = obj.palette
@@ -76,11 +87,9 @@ class MultiModalHasher:
             return cls.iter_item_to_bytes("image", data)
 
         if isinstance(obj, MediaWithBytes) and isinstance(obj.media, Image.Image):
-            exif = obj.media.getexif()
-            if Image.ExifTags.Base.ImageID in exif and isinstance(
-                exif[Image.ExifTags.Base.ImageID], uuid.UUID
-            ):
-                return (exif[Image.ExifTags.Base.ImageID].bytes,)
+            image_id = _get_image_id_bytes(obj.media)
+            if image_id is not None:
+                return (image_id,)
 
             if obj.io_config:
                 return cls.iter_item_to_bytes(


### PR DESCRIPTION
## Purpose

Fixes #56527

When handling images with malformed or corrupt EXIF segments (for example, an APP1 segment containing an invalid TIFF header), calls to `Image.getexif()` raise exceptions such as `SyntaxError: not a TIFF file (header b'...' not valid)` or Pillow internal parser errors.

While `normalize_image` in `vllm/multimodal/image.py` wraps `ImageOps.exif_transpose` in `contextlib.suppress(Exception)` to gracefully tolerate malformed metadata, `MultiModalHasher.serialize_item` previously called `obj.getexif()` directly without error handling in both the `Image.Image` and `MediaWithBytes` branches (`vllm/multimodal/hasher.py`). Because `SyntaxError` does not inherit from `ValueError`, this uncaught exception causes the API server request to abort with HTTP 500.

This PR introduces a dedicated helper `_get_image_id_bytes()` with safe exception handling:
- Reads the optional `Image.ExifTags.Base.ImageID` UUID tag inside a `try ... except Exception:` block.
- If EXIF parsing or header extraction fails for any reason, gracefully falls back to standard pixel hashing (for `Image.Image`) or `original_bytes` (for `MediaWithBytes`), matching the error tolerance of `normalize_image`.

## Test Plan

Added unit test `test_hash_image_malformed_exif` in `tests/multimodal/test_hasher.py`:
- Constructs a JPEG containing a malformed APP1 EXIF segment with an invalid TIFF header.
- Verifies that `MultiModalHasher.hash_kwargs("blake3", image=image)` produces a valid hash without raising `SyntaxError`.
- Verifies that `MediaWithBytes(image, data)` wrapping the malformed image also serializes and hashes successfully.
- Verified existing `test_hash_image_exif_id` continues to pass and correctly extract valid UUID ImageIDs.

Run tests:
```bash
pytest tests/multimodal/test_hasher.py -k "test_hash_image_malformed_exif or test_hash_image_exif_id"
```

## Test Result

```text
tests/multimodal/test_hasher.py::test_hash_image_malformed_exif PASSED
tests/multimodal/test_hasher.py::test_hash_image_exif_id PASSED
```

Linting & formatting:
```bash
ruff check vllm/multimodal/hasher.py tests/multimodal/test_hasher.py
ruff format --check vllm/multimodal/hasher.py tests/multimodal/test_hasher.py
```
Output:
```text
All checks passed!
2 files already formatted
```
