### PR TITLE
[Spec Decode][Perf] Add opt-in FP8 proposal head for Qwen4Exp MTP

### DIFF
--- a/docs/features/speculative_decoding/mtp.md
+++ b/docs/features/speculative_decoding/mtp.md
@@ -74,3 +74,22 @@ vllm serve XiaomiMiMo/MiMo-7B-Base \
   is a good default to start with.
 - If your model does not support MTP, use another method such as EAGLE or draft
   model speculation.
+
+## Qwen3.8 Flash Next FP8 proposal head
+
+Qwen3.8 Flash Next checkpoints can opt into a private rowwise-FP8 copy of the
+shared BF16 vocabulary head for MTP proposals. Target verification continues
+to use the original BF16 head:
+
+```bash
+VLLM_QWEN4_EXP_FP8_DRAFT_HEAD=1 VLLM_USE_V2_MODEL_RUNNER=1 \
+vllm serve <model> --enforce-eager --tensor-parallel-size 2 \
+    --speculative-config '{"method":"mtp","num_speculative_tokens":4}'
+```
+
+The opt-in currently requires NVIDIA CUDA, BF16 model and head dtypes, Model
+Runner V2, eager execution, TP1 or TP2, and PP/PCP/DCP size 1. It does not
+support LoRA, batch-invariant mode, sleep mode, weight transfer, a custom
+LM-head parallel group, a quantized LM head, or runtime weight reload. The
+private FP8 copy adds approximately one byte per rank-local vocabulary-head
+weight plus one FP32 scale per row. Restart the engine after changing weights.

--- a/tests/models/qwen4_exp/test_fp8_proposal_head.py
+++ b/tests/models/qwen4_exp/test_fp8_proposal_head.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+from torch import nn
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
+)
+from vllm.models.qwen4_exp.nvidia.fp8_proposal_head import Fp8ProposalHead
+from vllm.models.qwen4_exp.nvidia.mtp import (
+    Qwen4ExpMTP,
+    _validate_fp8_proposal_head_config,
+)
+from vllm.platforms import current_platform
+
+
+class _Head(nn.Module):
+    def __init__(self, weight: torch.Tensor) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(weight, requires_grad=False)
+        self.bias = None
+        self.quant_method = UnquantizedEmbeddingMethod()
+        self.parallel_group = None
+        self.tp_size = 1
+        self.shard_indices = SimpleNamespace(num_org_vocab_padding=0)
+        self.num_embeddings_per_partition = weight.shape[0]
+        self.embedding_dim = weight.shape[1]
+
+
+def _empty_qwen_mtp(target_head: nn.Module) -> Qwen4ExpMTP:
+    model = object.__new__(Qwen4ExpMTP)
+    nn.Module.__init__(model)
+    model.lm_head = target_head
+    model._fp8_proposal_head = None
+    return model
+
+
+def _supported_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        use_v2_model_runner=True,
+        lora_config=None,
+        weight_transfer_config=None,
+        model_config=SimpleNamespace(
+            dtype=torch.bfloat16,
+            head_dtype=torch.bfloat16,
+            enforce_eager=True,
+            enable_sleep_mode=False,
+        ),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=2,
+            pipeline_parallel_size=1,
+            prefill_context_parallel_size=1,
+            decode_context_parallel_size=1,
+        ),
+    )
+
+
+def test_fp8_proposal_head_config_accepts_qualified_scope() -> None:
+    with patch("vllm.models.qwen4_exp.nvidia.mtp.envs.VLLM_BATCH_INVARIANT", False):
+        _validate_fp8_proposal_head_config(_supported_config())
+
+
+@pytest.mark.parametrize(
+    ("owner", "field", "value", "message"),
+    [
+        ("config", "use_v2_model_runner", False, "Model Runner V1"),
+        ("model", "dtype", torch.float16, "model dtype"),
+        ("model", "head_dtype", torch.float32, "head dtype"),
+        ("model", "enforce_eager", False, "CUDA graphs"),
+        ("config", "lora_config", object(), "LoRA"),
+        ("model", "enable_sleep_mode", True, "sleep mode"),
+        ("config", "weight_transfer_config", object(), "weight transfer"),
+        ("parallel", "tensor_parallel_size", 4, "tensor parallel size 4"),
+        ("parallel", "pipeline_parallel_size", 2, "pipeline parallelism"),
+        ("parallel", "prefill_context_parallel_size", 2, "prefill context"),
+        ("parallel", "decode_context_parallel_size", 2, "decode context"),
+    ],
+)
+def test_fp8_proposal_head_config_rejects_unqualified_scope(
+    owner: str, field: str, value: object, message: str
+) -> None:
+    config = _supported_config()
+    target = {
+        "config": config,
+        "model": config.model_config,
+        "parallel": config.parallel_config,
+    }[owner]
+    setattr(target, field, value)
+
+    with (
+        patch(
+            "vllm.models.qwen4_exp.nvidia.mtp.envs.VLLM_BATCH_INVARIANT",
+            False,
+        ),
+        pytest.raises(ValueError, match=message),
+    ):
+        _validate_fp8_proposal_head_config(config)
+
+
+def test_fp8_proposal_head_config_rejects_batch_invariance() -> None:
+    with (
+        patch(
+            "vllm.models.qwen4_exp.nvidia.mtp.envs.VLLM_BATCH_INVARIANT",
+            True,
+        ),
+        pytest.raises(ValueError, match="batch-invariant"),
+    ):
+        _validate_fp8_proposal_head_config(_supported_config())
+
+
+def test_compute_logits_selects_private_head() -> None:
+    target_head = _Head(torch.zeros(16, 16))
+    proposal_head = Mock()
+    model = _empty_qwen_mtp(target_head)
+    model.logits_processor = Mock(side_effect=lambda head, hidden: (head, hidden))
+    hidden = torch.zeros(1, 16)
+
+    selected_head, selected_hidden = model.compute_logits(hidden, spec_step_idx=3)
+    assert selected_head is target_head
+    assert selected_hidden is hidden
+
+    model._fp8_proposal_head = proposal_head
+    selected_head, selected_hidden = model.compute_logits(hidden, spec_step_idx=0)
+    assert selected_head is proposal_head
+    assert selected_hidden is hidden
+    assert model.lm_head is target_head
+
+
+def test_initialization_is_disabled_idempotent_and_preserves_target() -> None:
+    target_head = _Head(torch.randn(16, 16, dtype=torch.bfloat16))
+    model = _empty_qwen_mtp(target_head)
+    proposal_head = Mock(storage_bytes=272)
+    target_identity = (
+        id(model.lm_head),
+        id(model.lm_head.weight),
+        model.lm_head.weight.data_ptr(),
+        id(model.lm_head.quant_method),
+    )
+
+    with (
+        patch(
+            "vllm.models.qwen4_exp.nvidia.mtp.envs.VLLM_QWEN4_EXP_FP8_DRAFT_HEAD",
+            False,
+        ),
+        patch(
+            "vllm.models.qwen4_exp.nvidia.mtp.Fp8ProposalHead",
+            return_value=proposal_head,
+        ) as create,
+    ):
+        model.maybe_init_fp8_proposal_head()
+    create.assert_not_called()
+
+    with (
+        patch(
+            "vllm.models.qwen4_exp.nvidia.mtp.envs.VLLM_QWEN4_EXP_FP8_DRAFT_HEAD",
+            True,
+        ),
+        patch(
+            "vllm.models.qwen4_exp.nvidia.mtp.Fp8ProposalHead",
+            return_value=proposal_head,
+        ) as create,
+    ):
+        model.maybe_init_fp8_proposal_head()
+        model.maybe_init_fp8_proposal_head()
+
+    create.assert_called_once_with(target_head)
+    assert model._fp8_proposal_head is proposal_head
+    assert target_identity == (
+        id(model.lm_head),
+        id(model.lm_head.weight),
+        model.lm_head.weight.data_ptr(),
+        id(model.lm_head.quant_method),
+    )
+
+
+def test_direct_reload_rejected_before_consuming_weights() -> None:
+    model = _empty_qwen_mtp(_Head(torch.zeros(16, 16)))
+    model._fp8_proposal_head = Mock()
+    consumed = False
+
+    def weights():
+        nonlocal consumed
+        consumed = True
+        yield "weight", torch.zeros(1)
+
+    with pytest.raises(RuntimeError, match="Cannot reload"):
+        model.load_weights(weights())
+    assert not consumed
+
+
+def test_target_reload_rejected_after_initialization() -> None:
+    model = _empty_qwen_mtp(_Head(torch.zeros(16, 16)))
+    model._fp8_proposal_head = Mock()
+
+    with pytest.raises(RuntimeError, match="Cannot reload target weights"):
+        model.before_target_model_reload()
+
+
+def test_helper_rejects_non_cuda_source() -> None:
+    source = _Head(torch.zeros(16, 16, dtype=torch.bfloat16))
+    with pytest.raises(RuntimeError, match="requires CUDA"):
+        Fp8ProposalHead(source)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda() or not current_platform.supports_fp8(),
+    reason="requires CUDA FP8 support",
+)
+@pytest.mark.parametrize("num_tokens", [1, 7, 32])
+def test_fp8_proposal_head_cuda_math_and_ownership(
+    num_tokens: int,
+    default_vllm_config,
+) -> None:
+    torch.manual_seed(1234)
+    weight = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda")
+    weight.mul_(0.02)
+    weight[0].zero_()
+    weight[1:5].mul_(torch.tensor([0.01, 0.1, 10.0, 100.0], device="cuda")[:, None])
+    source = _Head(weight)
+    source_weight_id = id(source.weight)
+    source_weight_ptr = source.weight.data_ptr()
+    source_before = source.weight.clone()
+    hidden = torch.randn(num_tokens, 256, dtype=torch.bfloat16, device="cuda")
+
+    proposal = Fp8ProposalHead(source)
+    actual = proposal.quant_method.apply(proposal, hidden)
+    hidden_fp8, hidden_scale = ops.scaled_fp8_quant(
+        hidden, use_per_token_if_dynamic=True
+    )
+    reference = (hidden_fp8.float() * hidden_scale.float()) @ (
+        proposal.weight_fp8.float() * proposal.weight_scale.float()
+    ).t()
+
+    assert actual.shape == (num_tokens, 512)
+    assert actual.dtype == torch.bfloat16
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual.float(), reference, rtol=0.03, atol=0.25)
+    assert proposal.weight_fp8.dtype == torch.float8_e4m3fn
+    assert proposal.weight_scale.dtype == torch.float32
+    assert proposal.weight_fp8.untyped_storage().data_ptr() != source_weight_ptr
+    assert list(proposal.named_parameters()) == []
+    assert proposal.state_dict() == {}
+    assert id(source.weight) == source_weight_id
+    assert source.weight.data_ptr() == source_weight_ptr
+    assert torch.equal(source.weight, source_before)
+
+    logits_processor = LogitsProcessor(vocab_size=509)
+    logits_processor.head_dtype = torch.bfloat16
+    with patch.object(logits_processor, "_gather_logits") as gather:
+        processed = logits_processor(proposal, hidden)
+    gather.assert_not_called()
+    torch.testing.assert_close(processed, actual[..., :509])

--- a/tests/v1/worker/test_gpu_mtp_speculator.py
+++ b/tests/v1/worker/test_gpu_mtp_speculator.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from torch import nn
+
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
+
+
+def test_model_hook_runs_after_target_head_aliasing() -> None:
+    target_model = nn.Module()
+    target_model.model = nn.Module()
+    target_model.model.embed_tokens = nn.Embedding(8, 4)
+    target_model.lm_head = nn.Linear(4, 8, bias=False)
+    draft_model = nn.Module()
+    draft_model.model = nn.Module()
+    draft_model.model.embed_tokens = nn.Embedding(8, 4)
+    old_draft_head = nn.Linear(4, 8, bias=False)
+    draft_model.lm_head = old_draft_head
+
+    def initialize() -> None:
+        assert draft_model.lm_head is target_model.lm_head
+
+    draft_model.maybe_init_fp8_proposal_head = Mock(side_effect=initialize)
+    speculator = object.__new__(MTPSpeculator)
+    speculator.vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(index_share_for_mtp_iteration=False)
+            ),
+            moe_backend=None,
+            kv_cache_dtype=None,
+            attention_backend=None,
+        ),
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=1),
+    )
+
+    with (
+        patch(
+            "vllm.v1.worker.gpu.spec_decode.eagle.utils.get_model",
+            return_value=draft_model,
+        ),
+        patch(
+            "vllm.v1.worker.gpu.spec_decode.eagle.utils.get_pp_group",
+            return_value=SimpleNamespace(world_size=1),
+        ),
+    ):
+        result = speculator.load_draft_model(target_model, set())
+
+    assert result is draft_model
+    assert old_draft_head is not target_model.lm_head
+    assert draft_model.lm_head is target_model.lm_head
+    draft_model.maybe_init_fp8_proposal_head.assert_called_once_with()
+
+
+def test_model_runner_rejects_target_reload_before_mutation(monkeypatch) -> None:
+    draft_model = Mock()
+    draft_model.before_target_model_reload.side_effect = RuntimeError("blocked reload")
+    runner = object.__new__(GPUModelRunner)
+    monkeypatch.setattr(runner, "get_draft_model", Mock(return_value=draft_model))
+    reload_impl = Mock()
+    monkeypatch.setattr(
+        "vllm.v1.worker.gpu_model_runner.GPUModelRunner.reload_weights", reload_impl
+    )
+
+    with pytest.raises(RuntimeError, match="blocked reload"):
+        runner.reload_weights()
+
+    draft_model.before_target_model_reload.assert_called_once_with()
+    reload_impl.assert_not_called()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -299,6 +299,7 @@ if TYPE_CHECKING:
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool | None = None
+    VLLM_QWEN4_EXP_FP8_DRAFT_HEAD: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
@@ -2053,6 +2054,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Flag to control the v2 model runner. If unset, use config defaults.
     "VLLM_USE_V2_MODEL_RUNNER": lambda: maybe_convert_bool(
         os.getenv("VLLM_USE_V2_MODEL_RUNNER", None)
+    ),
+    # Use a private rowwise-FP8 copy of Qwen4Exp's shared BF16 LM head for MTP
+    # proposals. Target verification retains the original head.
+    "VLLM_QWEN4_EXP_FP8_DRAFT_HEAD": lambda: bool(
+        int(os.getenv("VLLM_QWEN4_EXP_FP8_DRAFT_HEAD", "0"))
     ),
     # Log model inspection after loading.
     # If enabled, logs a transformers-style hierarchical view of the model

--- a/vllm/models/qwen4_exp/nvidia/fp8_proposal_head.py
+++ b/vllm/models/qwen4_exp/nvidia/fp8_proposal_head.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Private rowwise-FP8 proposal head for Qwen4Exp MTP."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from torch import nn
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
+)
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        VocabParallelEmbedding,
+    )
+
+
+class Fp8ProposalHeadMethod(QuantizeMethodBase):
+    """Dynamic-per-token W8A8 projection over a private FP8 weight copy."""
+
+    def create_weights(self, layer: nn.Module, *args, **kwargs) -> None:
+        raise RuntimeError("FP8 proposal-head weights are derived after loading")
+
+    def apply(
+        self,
+        layer: nn.Module,
+        hidden_states: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if hidden_states.dtype != torch.bfloat16:
+            raise ValueError(
+                "The Qwen4Exp FP8 proposal head requires BF16 hidden states, "
+                f"got {hidden_states.dtype}."
+            )
+        if hidden_states.shape[-1] != layer.weight_fp8.shape[1]:
+            raise ValueError(
+                "The Qwen4Exp FP8 proposal-head hidden width does not match "
+                f"its weight: {hidden_states.shape[-1]} != "
+                f"{layer.weight_fp8.shape[1]}."
+            )
+
+        output_shape = (*hidden_states.shape[:-1], layer.weight_fp8.shape[0])
+        hidden_2d = hidden_states.reshape(-1, hidden_states.shape[-1]).contiguous()
+        hidden_fp8, hidden_scale = ops.scaled_fp8_quant(
+            hidden_2d, use_per_token_if_dynamic=True
+        )
+        logits = ops.cutlass_scaled_mm(
+            hidden_fp8,
+            layer.weight_fp8.t(),
+            scale_a=hidden_scale,
+            scale_b=layer.weight_scale.t(),
+            out_dtype=hidden_states.dtype,
+            bias=bias,
+        )
+        return logits.view(output_shape)
+
+
+class Fp8ProposalHead(nn.Module):
+    """LM-head adapter owning an immutable rowwise-E4M3 weight copy."""
+
+    def __init__(self, source: VocabParallelEmbedding) -> None:
+        super().__init__()
+        self._validate_source(source)
+        weight = source.weight.detach()
+
+        # This fused quantizer avoids full-size FP32/absolute-value temporaries.
+        weight_fp8, weight_scale = ops.scaled_fp8_quant(
+            weight, use_per_token_if_dynamic=True
+        )
+        expected_scale_shape = (weight.shape[0], 1)
+        if (
+            weight_fp8.shape != weight.shape
+            or weight_scale.shape != expected_scale_shape
+        ):
+            raise RuntimeError(
+                "Unexpected Qwen4Exp proposal-head FP8 shapes: "
+                f"weight={tuple(weight_fp8.shape)}, "
+                f"scale={tuple(weight_scale.shape)}."
+            )
+        if weight_fp8.dtype != torch.float8_e4m3fn:
+            raise RuntimeError(f"Unexpected proposal-head dtype: {weight_fp8.dtype}.")
+        if weight_scale.dtype != torch.float32:
+            raise RuntimeError(
+                f"Unexpected proposal-head scale dtype: {weight_scale.dtype}."
+            )
+
+        self.register_buffer("weight_fp8", weight_fp8, persistent=False)
+        self.register_buffer("weight_scale", weight_scale, persistent=False)
+        self.quant_method = Fp8ProposalHeadMethod()
+        self.tp_size = source.tp_size
+        self.shard_indices = source.shard_indices
+        self.num_embeddings_per_partition = source.num_embeddings_per_partition
+        self.embedding_dim = source.embedding_dim
+
+    @staticmethod
+    def _validate_source(source: VocabParallelEmbedding) -> None:
+        weight = source.weight
+        if not isinstance(
+            source.quant_method,
+            (UnquantizedEmbeddingMethod, UnquantizedLinearMethod),
+        ):
+            raise RuntimeError(
+                "The Qwen4Exp FP8 proposal head requires an ordinary "
+                "unquantized source LM head."
+            )
+        if getattr(source, "parallel_group", None) is not None:
+            raise RuntimeError(
+                "The Qwen4Exp FP8 proposal head does not support a custom "
+                "LM-head parallel group."
+            )
+        if getattr(source, "bias", None) is not None:
+            raise RuntimeError("The Qwen4Exp FP8 proposal head does not support bias.")
+        if not weight.is_cuda:
+            raise RuntimeError("The Qwen4Exp FP8 proposal head requires CUDA.")
+        if weight.ndim != 2:
+            raise RuntimeError(
+                "The Qwen4Exp FP8 proposal head requires a 2-D weight, "
+                f"got {tuple(weight.shape)}."
+            )
+        if weight.dtype != torch.bfloat16:
+            raise RuntimeError(
+                "The Qwen4Exp FP8 proposal head requires a BF16 weight, "
+                f"got {weight.dtype}."
+            )
+        if not weight.is_contiguous():
+            raise RuntimeError(
+                "The Qwen4Exp FP8 proposal head requires a contiguous weight; "
+                "it will not make a full-size contiguous copy."
+            )
+        if weight.shape[0] % 16 or weight.shape[1] % 16:
+            raise RuntimeError(
+                "The Qwen4Exp FP8 proposal-head dimensions must be divisible "
+                f"by 16, got {tuple(weight.shape)}."
+            )
+        major, minor = torch.cuda.get_device_capability(weight.device)
+        capability = major * 10 + minor
+        if not ops.cutlass_scaled_mm_supports_fp8(capability):
+            raise RuntimeError(
+                "The Qwen4Exp FP8 proposal head requires CUTLASS FP8 scaled "
+                f"MM support; SM{capability} is unsupported."
+            )
+
+    @property
+    def storage_bytes(self) -> int:
+        return self.weight_fp8.nbytes + self.weight_scale.nbytes
+
+
+__all__ = ["Fp8ProposalHead", "Fp8ProposalHeadMethod"]

--- a/vllm/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp.py
@@ -19,8 +19,10 @@ import regex as re
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm.config import VllmConfig, replace, set_current_vllm_config
 from vllm.distributed import get_pp_group
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.utils import (
     is_model_fused_shared_expert_compatible,
 )
@@ -48,6 +50,7 @@ from vllm.transformers_utils.configs.qwen4_exp import (
     Qwen4ExpTextConfig,
 )
 
+from .fp8_proposal_head import Fp8ProposalHead
 from .hyperconnection import GatedResidual, HyperConnectionConfig
 from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
 from .model import (
@@ -57,6 +60,48 @@ from .model import (
     Qwen4ExpMixtureOfExperts,
     Qwen4ExpSparseMoeBlock,
 )
+
+logger = init_logger(__name__)
+
+
+def _validate_fp8_proposal_head_config(vllm_config: VllmConfig) -> None:
+    model_config = vllm_config.model_config
+    parallel_config = vllm_config.parallel_config
+    unsupported: list[str] = []
+
+    if not vllm_config.use_v2_model_runner:
+        unsupported.append("Model Runner V1")
+    if model_config.dtype != torch.bfloat16:
+        unsupported.append(f"model dtype {model_config.dtype}")
+    if model_config.head_dtype != torch.bfloat16:
+        unsupported.append(f"head dtype {model_config.head_dtype}")
+    if not model_config.enforce_eager:
+        unsupported.append("CUDA graphs/torch compilation")
+    if vllm_config.lora_config is not None:
+        unsupported.append("LoRA")
+    if model_config.enable_sleep_mode:
+        unsupported.append("sleep mode")
+    if vllm_config.weight_transfer_config is not None:
+        unsupported.append("weight transfer")
+    if envs.VLLM_BATCH_INVARIANT:
+        unsupported.append("batch-invariant mode")
+    if parallel_config.pipeline_parallel_size != 1:
+        unsupported.append("pipeline parallelism")
+    if parallel_config.prefill_context_parallel_size != 1:
+        unsupported.append("prefill context parallelism")
+    if parallel_config.decode_context_parallel_size != 1:
+        unsupported.append("decode context parallelism")
+    if parallel_config.tensor_parallel_size not in (1, 2):
+        unsupported.append(
+            f"tensor parallel size {parallel_config.tensor_parallel_size}"
+        )
+
+    if unsupported:
+        raise ValueError(
+            "VLLM_QWEN4_EXP_FP8_DRAFT_HEAD=1 does not support: "
+            + ", ".join(unsupported)
+            + "."
+        )
 
 
 def _remap_ignored_layers(
@@ -379,6 +424,8 @@ class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
         self.vllm_config = vllm_config
+        if envs.VLLM_QWEN4_EXP_FP8_DRAFT_HEAD:
+            _validate_fp8_proposal_head_config(vllm_config)
         cache_config = vllm_config.cache_config
         if cache_config.mamba_cache_mode == "all":
             raise NotImplementedError(
@@ -408,6 +455,7 @@ class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
             self.lm_head = PPMissingLayer()
 
         self.logits_processor = LogitsProcessor(config.vocab_size)
+        self._fp8_proposal_head: Fp8ProposalHead | None = None
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors
         )
@@ -438,9 +486,46 @@ class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
     def compute_logits(
         self, hidden_states: torch.Tensor, spec_step_idx: int = 0
     ) -> torch.Tensor | None:
-        return self.logits_processor(self.lm_head, hidden_states)
+        proposal_head = self._fp8_proposal_head
+        return self.logits_processor(
+            self.lm_head if proposal_head is None else proposal_head,
+            hidden_states,
+        )
+
+    def maybe_init_fp8_proposal_head(self) -> None:
+        """Create the opt-in proposal copy after target-head aliasing."""
+        if not envs.VLLM_QWEN4_EXP_FP8_DRAFT_HEAD:
+            return
+        if isinstance(self.lm_head, PPMissingLayer):
+            raise RuntimeError(
+                "The Qwen4Exp FP8 proposal head requires the LM head on this rank."
+            )
+        if self._fp8_proposal_head is not None:
+            return
+
+        proposal_head = Fp8ProposalHead(self.lm_head)
+        self._fp8_proposal_head = proposal_head
+        logger.info_once(
+            "Qwen4Exp MTP proposals use a private rowwise-FP8 LM head "
+            "(%d bytes/rank); target verification retains the BF16 head.",
+            proposal_head.storage_bytes,
+        )
+
+    def before_target_model_reload(self) -> None:
+        """Reject target reloads that would stale the private proposal copy."""
+        if self._fp8_proposal_head is not None:
+            raise RuntimeError(
+                "Cannot reload target weights while the Qwen4Exp FP8 proposal "
+                "head is active. Restart the engine with the new weights."
+            )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        if self._fp8_proposal_head is not None:
+            raise RuntimeError(
+                "Cannot reload Qwen4Exp weights after creating the private FP8 "
+                "proposal head. Restart the engine to rebuild it."
+            )
+
         def remap_weight_names():
             for name, weight in weights:
                 remapped_name = _remap_mtp_weight_name(name)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -530,6 +530,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return speculator.model
 
     def reload_weights(self, *args, **kwargs) -> None:
+        draft_model = self.get_draft_model()
+        before_target_model_reload = (
+            getattr(draft_model, "before_target_model_reload", None)
+            if draft_model is not None
+            else None
+        )
+        if before_target_model_reload is not None:
+            before_target_model_reload()
+
         # TODO(Wentao): Use full version instead of import when fully migrated to v2
         from vllm.v1.worker.gpu_model_runner import GPUModelRunner as GPUModelRunnerV1
 

--- a/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/mtp/speculator.py
@@ -18,6 +18,11 @@ class MTPSpeculator(AutoRegressiveSpeculator):
         target_attn_layer_names: set[str],
     ) -> nn.Module:
         draft_model = load_eagle_model(target_model, self.vllm_config)
+        maybe_init_fp8_proposal_head = getattr(
+            draft_model, "maybe_init_fp8_proposal_head", None
+        )
+        if maybe_init_fp8_proposal_head is not None:
+            maybe_init_fp8_proposal_head()
         spec_config = self.vllm_config.speculative_config
         draft_hf_config = (
             spec_config.draft_model_config.hf_config


### PR DESCRIPTION
## Purpose

Qwen4Exp MTP repeatedly projects proposals through the large BF16 vocabulary
head shared with the target model. This adds a default-off, Qwen4Exp-specific
option that creates a private rowwise-E4M3 copy for proposal projection while
target verification retains the original BF16 head:

```bash
VLLM_QWEN4_EXP_FP8_DRAFT_HEAD=1 VLLM_USE_V2_MODEL_RUNNER=1 \
vllm serve <model> --enforce-eager --tensor-parallel-size 2 \
    --speculative-config '{"method":"mtp","num_speculative_tokens":4}'
```

The adapter uses vLLM's existing `scaled_fp8_quant` and
`cutlass_scaled_mm` operations with dynamic per-token activation scales. It
implements the ordinary head/quantization-method contract, so the existing
`LogitsProcessor` continues to own vocabulary trimming and TP behavior. The
derived FP8 weight and FP32 row scales are nonpersistent buffers and do not
mutate or retain the source weight.

Initialization runs after the MTP head is aliased to the target head. The
supported configuration is CUDA, BF16 model/head, Model Runner V2, eager
execution, TP1/TP2, and PP/PCP/DCP size 1. Full-model qualification below is
TP2; TP1 is covered at the helper/unit level, not a separate full-model run.
Unsupported configurations fail explicitly,
including LoRA, batch-invariant mode, sleep, weight transfer, quantized source
heads, and runtime reload.

This is distinct from #47584: that PR provides a DSpark helper/API and fallback
contract, while this change is a Qwen4Exp-local model adapter using the standard
`LogitsProcessor` path. It does not replace or modify #47584's API. #51947
(packed FP8 logits inputs), #55494 (lossless BF16 ordinary head), and #55557
(QSA KV-cache FP8) are adjacent rather than duplicates. #54166 concerned MTP
sampling-mask replay and rejection sampling; it is now closed unmerged and
does not supply proposal projection. Our unanswered coordination notice on
#47584 explicitly described this separate route after September 11.

#54897 is a broader hybrid NVFP4 LM-head sampling proposal: it prunes candidates
with NVFP4, refines with BF16, and changes compact target/rejection sampling for
Qwen3.5. This patch instead retains full-vocabulary projection and changes only
the Qwen4Exp draft head; the target head and sampler are not replaced. No
coexistence qualification with that unmerged PR is claimed. #56273's packed
NVFP4 PLE embedding support is also distinct from proposal projection.

Related #52487 restores draft weights during disk-backed reload. This opt-in
currently rejects sleep and runtime reload; its V2 model hook rejects reload
before delegating to the shared loader, preserving the private proposal copy's
lifecycle restriction.

No custom CUDA operation or kernel is added.

## Test Plan

Review/test source base: `dc07f1638f73814b95776832b85df1cc92850416`.
Full-model performance and quality used the pinned runtime source
`7ef4d9bfed6311e3b78a40abb4a8bb6a2fc741b0`, not a rebuilt latest-main image.
The intervening update to the review base left the Qwen4Exp proposal/MTP/GDN
path unchanged. Final clean-apply check also passed against upstream
`eed1f3d0c6043bd494424a22443ee198dd56f657`; that later base was not GPU-qualified.

```bash
env CUDA_VISIBLE_DEVICES=0 .venv/bin/python -m pytest -q \
    tests/models/qwen4_exp/test_fp8_proposal_head.py \
    tests/v1/worker/test_gpu_mtp_speculator.py

.venv/bin/pre-commit run --files \
    docs/features/speculative_decoding/mtp.md \
    vllm/envs.py \
    vllm/models/qwen4_exp/nvidia/mtp.py \
    vllm/models/qwen4_exp/nvidia/fp8_proposal_head.py \
    vllm/v1/worker/gpu/model_runner.py \
    vllm/v1/worker/gpu/spec_decode/mtp/speculator.py \
    tests/models/qwen4_exp/test_fp8_proposal_head.py \
    tests/v1/worker/test_gpu_mtp_speculator.py

.venv/bin/pre-commit run mypy-3.12 --hook-stage manual --files \
    vllm/envs.py \
    vllm/models/qwen4_exp/nvidia/mtp.py \
    vllm/models/qwen4_exp/nvidia/fp8_proposal_head.py \
    vllm/v1/worker/gpu/model_runner.py \
    vllm/v1/worker/gpu/spec_decode/mtp/speculator.py \
    tests/models/qwen4_exp/test_fp8_proposal_head.py \
    tests/v1/worker/test_gpu_mtp_speculator.py

git diff --check
```

Model-level validation used two NVIDIA DGX Spark nodes (GB10), TP2, Model Runner
V2, eager MTP4, BF16 KV, maximum sequence length 262,144, maximum four
sequences, 4,096 batched tokens, and
`nvidia/Qwen3.8-Flash-Next-NVFP4` revision
`fab0aecb760cec45227f6656abcaafa11abca87a`. Candidate and control used the
same immutable runtime and fresh caches; the option above was the sole A/B
service variable. Each arm ran one discarded C1 warmup, three retained
1,024-token C1 requests with full token-ID capture, and one unequal-prefill
passkey/repetition smoke.

Task evaluation used EvalScope 1.11.1 in a separate client environment and the
generation configuration from
`tests/evals/qwen4_exp/configs/Qwen3.8-Flash-Next-FP8.yaml`: seed 1236,
temperature 0.7, top-p 0.8, top-k 20, repetition penalty 1.0, presence penalty
1.5, thinking enabled, streaming, and 32,768 maximum output tokens. Both full
datasets were evaluated once per arm (GSM8K four-shot, AIME25 zero-shot), with
concurrency four, no request retries and local rule scoring. The recipe's FP8
checkpoint thresholds are not treated as NVFP4 baseline scores.

Equivalent client invocation from the contribution checkout, with an
EvalScope-1.11.1 environment at `.eval-venv` and the service's model alias below
(use a fresh output directory for each arm; enable/disable only the FP8-head
option between otherwise identical service launches):

```bash
.eval-venv/bin/python - <<'PY'
from pathlib import Path
import yaml
from evalscope.run import run_task

recipe = yaml.safe_load(Path(
    "tests/evals/qwen4_exp/configs/Qwen3.8-Flash-Next-FP8.yaml"
).read_text())
run_task({
    "model": "qwen3.8-flash-next-nvfp4",
    "api_url": "http://127.0.0.1:8000/v1",
    "api_key": "EMPTY_TOKEN",
    "datasets": list(recipe["datasets"]),
    "eval_batch_size": 4,
    "generation_config": dict(recipe["generation_config"], timeout=1800, retries=0),
    "work_dir": "quality-bf16-fresh",  # use quality-fp8-fresh for the other arm
    "no_timestamp": True,
    "ignore_errors": False,
    "enable_progress_tracker": True,
    "judge": {"strategy": "rule"},
})
PY
```

The executed local wrapper additionally checked per-question errors, grading
errors, finish reasons, and identical paired prompts/targets, and saved runtime
provenance. No external model judge or discretionary answer rescoring was used.

## Test Result

- Focused tests on review base `dc07f1638f`: **23 passed**, 14 deprecation
  warnings, 5.40 s in the final CUDA-enabled rerun.
- All changed-file pre-commit hooks passed.
- Manual Python 3.12 mypy hook passed.
- `git diff --check` passed.
- Independent model-unmounted FP8/CUTLASS probes passed on both GB10 GPUs.

Headline serving measurements (six retained 1,024-token C1 requests per arm,
full token-ID capture disabled):

| GDN prefill backend, held fixed within A/B | BF16 head median tok/s | FP8 head median tok/s | Head uplift |
|---|---:|---:|---:|
| Default (FlashInfer) | 63.075 | 71.2475 | **12.96%** |
| Explicit Triton | 62.148 | 72.359 | **16.43%** |

These are alternative recipes, not additive gains. The explicit-Triton result
reproduces the historical output/acceptance trajectory; it does not prove an
isolated FlashInfer kernel regression. Both comparisons keep the target
checkpoint and verifier unchanged. Gains are specific to this workload,
hardware and eager TP2 MTP4 configuration.

Earlier full-token-ID-capture correctness run (three retained requests/arm):

| Proposal head | C1 samples (tok/s) | Median | Acceptance |
|---|---|---:|---:|
| BF16 control | 63.113, 63.130, 63.160 | 63.130 | 0.7823 |
| Rowwise-FP8 candidate | 69.258, 72.378, 69.317 | 69.317 | 0.7781 |

In that capture-enabled run, median C1 throughput improved **9.8004%**. All six retained
requests completed exactly 1,024 tokens without errors and matched across arms
at both the full-text and token-ID SHA-256 level. Both unequal-prefill smokes
retained the passkey, avoided repeated fragments, terminated validly, and
produced identical responses. Formal result validation reported zero failures.

Both candidate ranks activated a 318,346,240-byte private FP8 proposal head and
retained the BF16 target head. Observed model-load memory was 63.03 GiB/rank
versus 62.74 GiB/rank for control. Effective GPU KV capacity was 1,314,994
tokens (5.02x at 262,144 context) versus 1,369,132 control tokens (5.22x).
Every candidate/control rank exited with `OOMKilled=false`, exit code 0, and
zero restarts; the service and client memory guards did not fire.

These results use startup-separated candidate/control runs. Historical
experiments measured approximately +17.1%; the current recipe-specific
measurements above supersede that as the contribution's performance claim.
Keeping target weights BF16 does not promise bitwise-identical output for all
prompts: different accepted proposal segmentation can move near-tie
floating-point decisions. A historical concurrent smoke observed such a
divergence. Matching smoke outputs are not broad task-quality qualification.

Full task-quality results with default GDN, NVFP4 checkpoint, TP2/MTP4 and
concurrency four:

| Dataset | BF16 proposal head | FP8 proposal head | Accuracy delta |
|---|---:|---:|---:|
| GSM8K | 1294/1319 (98.1046%) | 1290/1319 (97.8014%) | -0.3033 percentage points |
| AIME25 | 26/30 (86.6667%) | 27/30 (90.0000%) | +3.3333 percentage points |

GSM8K had six control-only correct and two candidate-only correct responses;
AIME25 had one control-only and two candidate-only correct responses. There
were no request or grading errors. All GSM8K responses finished normally.
Four control and three candidate AIME responses reached the output-token cap;
all remain included in the scores. Both services shut down cleanly, without
OOM or restart; sampled available memory remained above 20 GiB on both nodes.

This is a mixed result from one sampled run per arm, not an equivalence or
no-regression proof: four fewer GSM8K answers were correct, and one more AIME25
answer was correct. It does not establish whether the difference is systematic
or sampling/numerical variation. The explicit-Triton 16.43% performance recipe
was not separately task-quality evaluated. The opt-in remains default-off.

AI assistance (OpenAI Codex, including an Astra review agent) was used for
investigation, implementation, review, testing, benchmarking, and drafting.
