### PR TITLE
[Kernel] Avoid runtime alignment specialization in Triton MoE

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -69,6 +69,13 @@ from vllm.utils.torch_utils import set_random_seed
 DEVICE_TYPE = current_platform.device_type
 
 
+def test_triton_moe_runtime_token_counts_do_not_specialize_alignment() -> None:
+    assert set(fused_moe_module.fused_moe_kernel.do_not_specialize_on_alignment) == {
+        "EM",
+        "num_valid_tokens",
+    }
+
+
 def test_triton_moe_launcher_passes_scalar_scale_as_pointer(monkeypatch) -> None:
     captured: dict[str, torch.Tensor] = {}
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -295,7 +295,9 @@ def fused_moe_kernel_gptq_awq(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
-@triton.jit
+# These values vary with runtime token routing. Alignment specialization would
+# compile new kernel variants when an unseen routing shape reaches inference.
+@triton.jit(do_not_specialize_on_alignment=["EM", "num_valid_tokens"])
 def fused_moe_kernel(
     # Pointers to matrices
     a_ptr,


### PR DESCRIPTION
## Summary

Avoid Triton alignment specialization for `EM` and `num_valid_tokens` in `fused_moe_kernel`. Both values are determined by runtime token routing, so a route alignment not seen during engine profiling can otherwise compile a new kernel variant on the first production request.

The kernel math and launch configuration are unchanged. This only makes those two scalar arguments alignment-generic.

## Prior work / duplicate check

This revives and credits the core idea from #11057 / #11056, which was automatically closed as stale in 2025 without review and no longer applies cleanly to current `main`. I found no active PR implementing the same change. Compared with that closed PR, this submission ports the change to the current kernel shape, adds a focused regression test, and supplies RTX 5090 production-shape correctness, compilation-cardinality, and first-request measurements. A read-only pre-submission check also found no changes to either touched path on current `main` and a clean merge-tree.

## Why

On Qwen3.6-35B-A3B-FP8 with TP2+EP on RTX 5090, an unseen route shape compiled `fused_moe_kernel` during inference even though its block configuration and algorithm matched the profiled variant. Marking the runtime route sizes as non-specialized-on-alignment removed that compile event.

## Validation

- Qwen3.6 local fused-MoE production shape (`E128`, `topk=8`, `N=512`, `K=2048`): 11/11 route-size cases produced identical output hashes.
- Production-shape kernel p50 geomean: 1.0016x control/candidate; minimum individual ratio 0.9939x.
- Compiled fused-MoE variants across the shape portfolio: 18 control, 10 candidate.
- Fresh TP2+EP first request at an unseen runtime route shape: 1.70x and 1.76x faster in two randomized-order repeats, with 0 candidate versus 1 control inference-time MoE JIT warning per repeat.
- A separate unaligned one-token screen improved first-request latency by 2.73x; an already-covered aligned shape was unchanged at 0.999x.

## Claim boundary

This change targets cold/unseen runtime route-shape JIT latency and compilation cardinality. It does not claim a steady-state serving throughput improvement. A 64-token cross-process generation screen had nondeterministic token/expert-routing paths and one noisy candidate repeat, so that result is retained as inconclusive rather than used as no-regression evidence.

## Tests

- Focused production-shape Triton MoE output/performance portfolio on RTX 5090.
- Direct decorator property assertion.
- Ruff check on the modified files.

This contribution was prepared with AI assistance. Before this Draft is marked
ready, the submitting human will review every changed line, rerun the relevant
tests, and be prepared to defend the implementation and claim boundary.

