### PR TITLE
[CI/Build] Keep a plain CUDA arch requested alongside its a/f variant in cuda_archs_loose_intersection

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -464,8 +464,16 @@ function(cuda_archs_loose_intersection OUT_CUDA_ARCHS SRC_CUDA_ARCHS TGT_CUDA_AR
       string(REGEX REPLACE "[af]$" "" _base "${_arch}")
       if ("${_base}" IN_LIST _SRC_CUDA_ARCHS)
         list(REMOVE_ITEM _TGT_CUDA_ARCHS "${_arch}")
-        list(REMOVE_ITEM _SRC_CUDA_ARCHS "${_base}")
         list(APPEND _CUDA_ARCHS "${_arch}")
+        # Only consume the plain SRC entry when TGT did not also ask for the
+        # plain arch. If TGT lists both x.y and x.ya (as TORCH_CUDA_ARCH_LIST
+        # commonly does for "10.0 10.0a"), the plain x.y must stay available
+        # for the loose-intersection pass below, otherwise it is silently
+        # dropped and the build ships x.ya-only cubins that do not load on
+        # other GPUs of the same major (e.g. sm_100a on a CC 10.3 B300).
+        if(NOT "${_base}" IN_LIST _TGT_CUDA_ARCHS)
+          list(REMOVE_ITEM _SRC_CUDA_ARCHS "${_base}")
+        endif()
       endif()
     endif()
   endforeach()

--- a/tests/test_cmake_utils.py
+++ b/tests/test_cmake_utils.py
@@ -35,6 +35,40 @@ endif()
     subprocess.run([_get_cmake_bin(), "-P", script], check=True)
 
 
+def test_plain_arch_kept_when_suffixed_variant_also_requested(tmp_path: Path):
+    """TORCH_CUDA_ARCH_LIST commonly lists both a plain arch and its ``a``
+    variant, e.g. ``10.0 10.0a``. Matching ``10.0a`` must not consume the
+    plain ``10.0`` source entry, or the generic kernels end up with sm_100a
+    cubins only and fail to load on CC 10.3 (B300). A target that requests
+    only the suffixed variant must still get exactly that variant."""
+    repo_root = Path(__file__).parents[1]
+    script = tmp_path / "test_plain_and_suffixed.cmake"
+    script.write_text(
+        f"""
+cmake_minimum_required(VERSION 3.26)
+include("{repo_root / "cmake" / "utils.cmake"}")
+cuda_archs_loose_intersection(
+  actual "7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0"
+         "7.5;8.0;8.6;8.7;8.9;9.0a;10.0;10.0a;12.0;12.1")
+foreach(expected 7.5 8.0 8.6 8.7 8.9 9.0a 10.0 10.0a 12.0)
+  if(NOT "${{expected}}" IN_LIST actual)
+    message(FATAL_ERROR "Expected '${{expected}}' in '${{actual}}'")
+  endif()
+endforeach()
+# 9.0a was requested without a plain 9.0, so the plain arch must not appear.
+if("9.0" IN_LIST actual)
+  message(FATAL_ERROR "Did not expect plain '9.0' in '${{actual}}'")
+endif()
+list(LENGTH actual actual_len)
+if(NOT actual_len EQUAL 9)
+  message(FATAL_ERROR "Expected 9 entries, got '${{actual}}'")
+endif()
+"""
+    )
+
+    subprocess.run([_get_cmake_bin(), "-P", script], check=True)
+
+
 def test_extract_archs_prefers_sass_target_over_corrupted_virtual_arch(
     tmp_path: Path,
 ):


### PR DESCRIPTION
## Purpose

Fixes #56548.

Since #38126, `cuda_archs_loose_intersection` drops a plain arch from `TORCH_CUDA_ARCH_LIST` when the list also contains its `a`/`f` variant. With

```
TORCH_CUDA_ARCH_LIST="7.5 8.0 8.6 8.7 8.9 9.0a 10.0 10.0a 12.0 12.1+PTX"
```

the "Symmetric handling" block matches TGT `10.0a` against SRC `10.0`, emits `10.0a`, and removes `10.0` from SRC. When the plain TGT `10.0` is processed afterwards there is no SRC entry with major 10 left, so it is discarded silently. The generic kernels (`_C`, `_moe_C`, cumem) are then built with `sm_100a` only; `sm_100a` loads on CC 10.0 (B200) but not on CC 10.3 (B300), where the first custom-op launch fails with `cudaErrorNoKernelImageForDevice`. torch built from the same list emits both `sm_100` and `sm_100a`.

## Change

In the symmetric block, only consume the plain SRC entry when TGT did **not** also request the plain arch. If TGT lists both `x.y` and `x.ya`, the plain `x.y` stays available for the loose-intersection pass and is emitted alongside `x.ya`, matching torch. A TGT that requests only the suffixed variant still gets exactly that variant (`#38126` behaviour unchanged).

Before / after for the issue's input, run with `cmake -P` (no GPU needed):

```
SRC 7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0   TGT 7.5;8.0;8.6;8.7;8.9;9.0a;10.0;10.0a;12.0;12.1
before: 9.0a;10.0a;7.5;8.0;8.6;8.7;8.9;12.0
after : 9.0a;10.0a;7.5;8.0;8.6;8.7;8.9;10.0;12.0
```

Unchanged on the other documented cases: `"8.0+PTX"/"9.0"` → `8.0+PTX`; `"10.0f;10.7f"/"10.7"` → `10.7f`; `"12.0;12.1"/"12.1a"` → `12.1a`; the `cuda_archs_sm90plus` SRC list against the same TGT → `9.0a;10.0a;12.0a;12.1a` (no plain arch is emitted there because that SRC list has no plain entries, which is the intended behaviour for the arch-specific kernels).

## Test Plan

- New `tests/test_cmake_utils.py::test_plain_arch_kept_when_suffixed_variant_also_requested`: the issue's input must yield the nine entries `7.5 8.0 8.6 8.7 8.9 9.0a 10.0 10.0a 12.0`, must not contain plain `9.0` (only `9.0a` was requested), and nothing else.
- Mutation-checked: with the `cmake/utils.cmake` change reverted the new test fails on the missing `10.0`; with it applied all four tests in the file pass.
- `ruff check` / `ruff format --check` clean on the test file.

I do not have the affected wheel to rebuild here; the reporter's `cuobjdump --list-elf` showing `60 sm_100a … (0 sm_100)` is the runtime symptom this is meant to remove. Happy to add a B300 (CC 10.3) run of a rebuilt wheel as a follow-up comment — I have access to one.

## Test Result

```
tests/test_cmake_utils.py ....                                    [100%]
4 passed
```

## AI assistance

Parts of this change were written with AI assistance (Claude Code); the diff, the reproduction and the tests were reviewed and run by the submitter. The commit carries a `Co-authored-by:` trailer per the contributing guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
