### PR TITLE
[Security] Validate NixlPush remote prefill params before registration

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_push_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_push_connector.py
@@ -804,7 +804,75 @@ class TestPushSchedulerNegative:
         )
 
         assert sched._push_pending_registrations == {}
+        assert request.request_id not in sched._reqs_need_recv
+
+    def test_incomplete_do_remote_prefill_params_do_not_register(self):
+        """do_remote_prefill without remote peer fields must not KeyError.
+
+        Client-supplied kv_transfer_params may contain only
+        {"do_remote_prefill": true}. Registration must be skipped and the
+        flag cleared so the scheduler does not claim an unfulfillable
+        remote transfer.
+        """
+        sched = make_nixl_push_scheduler()
+        _stub_sw_clipping(sched)
+
+        request = MagicMock()
+        request.request_id = "req-incomplete-prefill"
+        request.prompt_token_ids = [1, 2, 3, 4]
+        request.kv_transfer_params = {"do_remote_prefill": True}
+
+        assert sched.get_num_new_matched_tokens(request, 0) == (0, False)
+        assert request.kv_transfer_params["do_remote_prefill"] is False
+
+        # Even if external tokens were somehow claimed, registration must
+        # still refuse incomplete params instead of indexing missing keys.
+        request.kv_transfer_params = {"do_remote_prefill": True}
+        sched.update_state_after_alloc(
+            request, _BlocksMock(([10, 11],)), num_external_tokens=32
+        )
+
+        assert sched._push_pending_registrations == {}
         assert sched._push_registration_deadlines == {}
+        assert sched._reqs_need_recv == {}
+        assert request.kv_transfer_params["do_remote_prefill"] is False
+
+    def test_partial_remote_prefill_params_do_not_register(self):
+        """Missing any required remote field skips Push registration."""
+        sched = make_nixl_push_scheduler()
+        _stub_sw_clipping(sched)
+
+        request = MagicMock()
+        request.request_id = "req-partial-prefill"
+        request.prompt_token_ids = [1, 2, 3]
+        request.kv_transfer_params = {
+            "do_remote_prefill": True,
+            "remote_engine_id": "prefill-engine",
+            "remote_host": "10.0.0.1",
+            # missing remote_port and tp_size
+        }
+
+        assert sched.get_num_new_matched_tokens(request, 0) == (0, False)
+        sched.update_state_after_alloc(
+            request, _BlocksMock(([1],)), num_external_tokens=16
+        )
+        assert sched._push_pending_registrations == {}
+        assert request.kv_transfer_params["do_remote_prefill"] is False
+
+    def test_non_dict_kv_transfer_params_do_not_register(self):
+        """Non-dict kv_transfer_params must not crash the Push scheduler."""
+        sched = make_nixl_push_scheduler()
+        _stub_sw_clipping(sched)
+
+        request = MagicMock()
+        request.request_id = "req-bad-type"
+        request.kv_transfer_params = "not-a-dict"
+
+        sched.update_state_after_alloc(
+            request, _BlocksMock(([1, 2],)), num_external_tokens=16
+        )
+        assert sched._push_pending_registrations == {}
+        assert sched._reqs_need_recv == {}
 
     def test_request_finished_unfinished_status_does_not_stage(self):
         """If a request is still RUNNING, request_finished must not stash

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/pull_scheduler.py
@@ -59,6 +59,23 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
 
         if params is not None and params.get("do_remote_prefill"):
             # Remote prefill: get all prompt blocks from remote.
+            # Require peer coordinates before claiming external tokens so
+            # incomplete client params cannot reach the assert below.
+            if not all(
+                p in params
+                for p in (
+                    "remote_engine_id",
+                    "remote_request_id",
+                    "remote_host",
+                    "remote_port",
+                )
+            ):
+                logger.warning(
+                    "Got invalid KVTransferParams: %s. This "
+                    "request will not utilize KVTransfer",
+                    params,
+                )
+                return 0, False
             token_ids = request.prompt_token_ids or []
             actual = self._get_remote_prefill_token_count(len(token_ids))
             count = actual - num_computed_tokens
@@ -181,7 +198,12 @@ class NixlPullConnectorScheduler(NixlBaseConnectorScheduler):
                         params,
                     )
             else:
-                assert num_external_tokens == 0
+                if num_external_tokens > 0:
+                    logger.warning(
+                        "Got invalid KVTransferParams: %s. This "
+                        "request will not utilize KVTransfer",
+                        params,
+                    )
             # Only trigger 1 KV transfer per request.
             params["do_remote_prefill"] = False
             params["_remote_blocks_processed"] = True

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/push_scheduler.py
@@ -50,6 +50,21 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# Prefill peer coordinates required when ``do_remote_prefill`` is set on D.
+_REQUIRED_PUSH_REMOTE_PREFILL_FIELDS = (
+    "remote_engine_id",
+    "remote_host",
+    "remote_port",
+    "tp_size",
+)
+
+
+def _push_remote_prefill_params_ready(params: dict[str, Any]) -> bool:
+    """Return True when Push D-side registration can read remote coordinates."""
+    return all(
+        params.get(key) is not None for key in _REQUIRED_PUSH_REMOTE_PREFILL_FIELDS
+    )
+
 
 class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
     """Push-specific scheduler logic (WRITE-based KV transfer).
@@ -116,7 +131,15 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
             params,
         )
 
-        if params is not None and params.get("do_remote_prefill"):
+        if isinstance(params, dict) and params.get("do_remote_prefill"):
+            if not _push_remote_prefill_params_ready(params):
+                logger.warning(
+                    "Got invalid KVTransferParams: %s. This "
+                    "request will not utilize KVTransfer",
+                    params,
+                )
+                params["do_remote_prefill"] = False
+                return 0, False
             token_ids = request.prompt_token_ids or []
             actual = self._get_remote_prefill_token_count(len(token_ids))
             count = actual - num_computed_tokens
@@ -141,6 +164,13 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
 
         if not params:
             return
+        if not isinstance(params, dict):
+            logger.warning(
+                "Got invalid KVTransferParams: %s. This "
+                "request will not utilize KVTransfer",
+                params,
+            )
+            return
 
         # P side: track the request as in-batch so the lease accounting
         # matches what the worker expects on the next step.
@@ -160,6 +190,17 @@ class NixlPushConnectorScheduler(NixlBaseConnectorScheduler):
         if num_external_tokens <= 0:
             # Nothing to receive: full prefix-cache hit on D, no
             # registration to stage.
+            return
+
+        if not _push_remote_prefill_params_ready(params):
+            # Present ``do_remote_prefill`` without peer coordinates cannot
+            # register safely; refuse KV transfer rather than KeyError.
+            logger.warning(
+                "Got invalid KVTransferParams: %s. This "
+                "request will not utilize KVTransfer",
+                params,
+            )
+            params["do_remote_prefill"] = False
             return
 
         # First-pass D path: stash registration data the worker will


### PR DESCRIPTION
## Summary

When NixlPush is enabled, a completion request can set `kv_transfer_params.do_remote_prefill=true` without the required remote peer fields. The Push D-side scheduler indexed those fields directly during registration, raising an uncaught `KeyError` that terminated EngineCore. This change requires remote coordinates before claiming external tokens or staging a Push registration, and applies the same incomplete-params guard on the Pull scheduler path so the same payload cannot assert-fail there.

## Changes
- `push_scheduler.py`: validate required remote fields in `get_num_new_matched_tokens` and `update_state_after_alloc`; skip KV transfer and clear the flag on incomplete or non-dict params.
- `pull_scheduler.py`: require remote peer fields before claiming remote-prefill tokens; replace the hard assert on missing `remote_block_ids` with the existing invalid-params warning path.
- `test_nixl_push_connector.py`: regression and completeness tests for incomplete, partial, and non-dict params.

## Codepath coverage
- OpenAI `/v1/completions` and `/v1/chat/completions` (and other routes that pass `kv_transfer_params` into `Request`) → Push `get_num_new_matched_tokens` → `update_state_after_alloc` registration: fixed.
- Same payload on Pull scheduler `get_num_new_matched_tokens` / `update_state_after_alloc`: fixed.
- Rejection-cleanup → `add_new_req_to_recv` incomplete-params path: covered by related open PR https://github.com/vllm-project/vllm/pull/54807 (different sink).

## Duplicate-work check
Searched open/merged PRs for `push_scheduler`, `NixlPush`, `kv_transfer_params do_remote_prefill`, and `[Security] nixl`. Open PR https://github.com/vllm-project/vllm/pull/54807 validates recv registration / abort cleanup and does not guard Push `update_state_after_alloc` indexing; this PR closes that remaining sink.

## Tests
- `test_incomplete_do_remote_prefill_params_do_not_register`
- `test_partial_remote_prefill_params_do_not_register`
- `test_non_dict_kv_transfer_params_do_not_register`
- Commands: `.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_push_connector.py::TestPushSchedulerNegative tests/v1/kv_connector/unit/test_nixl_push_connector.py::TestPushScheduler -v` — all passed
- `pre-commit run --files` on the three changed files — passed

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)