### PR TITLE
[Security] Validate MoRI-IO remote_dp_size before EngineCore use

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_kv_params.py
+++ b/tests/v1/kv_connector/unit/test_moriio_kv_params.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for MoRI-IO kv_transfer_params integer coercion.
+
+Kept outside test_moriio_connector.py so they run without ROCm/mori.
+"""
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
+    MoRIIOConnectorMetadata,
+    MoRIIOMode,
+    coerce_kv_int_param,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_connector import (
+    MoRIIOConnectorScheduler,
+)
+
+
+def test_coerce_kv_int_param_absent_and_valid():
+    assert coerce_kv_int_param({}, "remote_dp_size", 1) == 1
+    assert coerce_kv_int_param({"remote_dp_size": 4}, "remote_dp_size", 1) == 4
+    assert coerce_kv_int_param({"remote_dp_size": "8"}, "remote_dp_size", 1) == 8
+    assert coerce_kv_int_param({"remote_dp_size": None}, "remote_dp_size", 1) == 1
+
+
+def test_coerce_kv_int_param_rejects_non_integer():
+    with pytest.raises(ValueError, match="remote_dp_size"):
+        coerce_kv_int_param({"remote_dp_size": "x"}, "remote_dp_size", 1)
+    with pytest.raises(ValueError, match="remote_dp_size"):
+        coerce_kv_int_param({"remote_dp_size": ["bad"]}, "remote_dp_size", 1)
+
+
+def test_write_decode_update_state_rejects_non_numeric_remote_dp_size():
+    """Malformed remote_dp_size must not raise into EngineCore.
+
+    A client can set do_remote_prefill with remote_dp_size=\"x\". The WRITE
+    decode notify path must refuse KV transfer and clear the flag instead of
+    letting bare int() terminate the process.
+    """
+    scheduler = MoRIIOConnectorScheduler.__new__(MoRIIOConnectorScheduler)
+    scheduler.mode = MoRIIOMode.WRITE
+    scheduler.map_request_id = MagicMock()
+    scheduler._reqs_need_save = {}
+    scheduler._req_kv_params = {}
+
+    request = MagicMock()
+    request.request_id = "req-bad-dp-size"
+    request.kv_transfer_params = {
+        "do_remote_prefill": True,
+        "remote_dp_size": "x",
+        "transfer_id": "xfer-1",
+    }
+    blocks = MagicMock()
+
+    scheduler.update_state_after_alloc(request, blocks, num_external_tokens=16)
+
+    assert request.kv_transfer_params["do_remote_prefill"] is False
+    scheduler.map_request_id.assert_called_once()
+
+
+def test_add_new_req_skips_non_numeric_remote_dp_size():
+    """Metadata registration must skip malformed remote_dp_size without raising."""
+    meta = MoRIIOConnectorMetadata()
+    zmq_addr = "host:10.0.0.1,handshake:5600,notify:5601"
+    request_id = (
+        f"___prefill_addr_{zmq_addr}___decode_addr_{zmq_addr}_{uuid.uuid4().hex}"
+    )
+
+    meta.add_new_req(
+        request_id=request_id,
+        local_block_ids=[1, 2, 3],
+        kv_transfer_params={
+            "transfer_id": "xfer-bad-dp",
+            "remote_engine_id": "engine-a",
+            "remote_block_ids": [1, 2, 3],
+            "remote_dp_size": "x",
+        },
+        write_mode=False,
+    )
+
+    assert meta.reqs_to_recv == {}
+    assert meta.reqs_to_save == {}

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -37,6 +37,29 @@ from enum import Enum
 logger = init_logger(__name__)
 
 
+def coerce_kv_int_param(
+    params: dict[str, Any],
+    key: str,
+    default: int,
+) -> int:
+    """Return ``int(params[key])``, or ``default`` when the key is absent.
+
+    A present-but-non-integer value raises ``ValueError`` so callers can fail
+    closed without letting bare ``int(...)`` kill EngineCore.
+    """
+    if key not in params:
+        return default
+    raw = params[key]
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            f"kv_transfer_params[{key!r}] must be an integer, got {raw!r}"
+        ) from e
+
+
 Transfer = tuple[int, float]
 EngineId = str
 ReqId = str
@@ -549,12 +572,27 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
         if not isinstance(_pod_hosts, list):
             _pod_hosts = [_pod_hosts]
         _pod_hosts = [str(h) for h in _pod_hosts]
-        _remote_dp_size_local = int(
-            kv_transfer_params.get(
-                "remote_dp_size_local",
-                kv_transfer_params.get("remote_dp_size", 1),
+        try:
+            _remote_dp_size = coerce_kv_int_param(
+                kv_transfer_params, "remote_dp_size", 1
             )
-        )
+            if not _remote_dp_size:
+                _remote_dp_size = 1
+            _remote_dp_size_local = coerce_kv_int_param(
+                kv_transfer_params, "remote_dp_size_local", _remote_dp_size
+            )
+            _remote_dp_rank = coerce_kv_int_param(
+                kv_transfer_params, "remote_dp_rank", 0
+            )
+        except ValueError as e:
+            logger.warning(
+                "Got invalid KVTransferParams for %s: %s (%s). "
+                "This request will not utilize KVTransfer",
+                request_id,
+                kv_transfer_params,
+                e,
+            )
+            return
 
         _req = ReqMeta(
             transfer_id=transfer_id,
@@ -574,8 +612,8 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
                 or kv_transfer_params.get("tp_size")
                 or 0
             ),
-            remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
-            remote_dp_rank=kv_transfer_params.get("remote_dp_rank", 0),
+            remote_dp_size=_remote_dp_size,
+            remote_dp_rank=_remote_dp_rank,
             multi_pod_hosts=_pod_hosts,
             remote_dp_size_local=_remote_dp_size_local,
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -37,6 +37,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     ReqMeta,
     TransferId,
     WriteTask,
+    coerce_kv_int_param,
     fold_local_rank,
     get_moriio_mode,
     get_peer_zmq_from_request_id,
@@ -688,22 +689,42 @@ class MoRIIOConnectorScheduler:
                 assert request.kv_transfer_params is not None, (
                     "kv_transfer_params should not be None"
                 )
-
-                remote_dp_rank = request.kv_transfer_params.get("remote_dp_rank", 0)
+                if not isinstance(request.kv_transfer_params, dict):
+                    logger.warning(
+                        "Got invalid KVTransferParams: %s. This "
+                        "request will not utilize KVTransfer",
+                        request.kv_transfer_params,
+                    )
+                    return
 
                 # Effective DP fan-out for the per-pod port/host math below
                 # (see _remote_dp_rank_for_port / _pod_idx). Capped to the
                 # per-pod local size when the router advertises it (Wide-EP).
-                _dp_size = int(request.kv_transfer_params.get("remote_dp_size", 1) or 1)
+                # Present-but-malformed sizes must not reach bare int() and
+                # kill EngineCore; refuse KV transfer instead.
                 try:
-                    _dp_local = int(
-                        request.kv_transfer_params.get("remote_dp_size_local", 0) or 0
+                    remote_dp_rank = coerce_kv_int_param(
+                        request.kv_transfer_params, "remote_dp_rank", 0
                     )
-                    if _dp_local > 0:
-                        _dp_size = min(_dp_size, _dp_local)
-                except (TypeError, ValueError):
-                    _dp_local = 0
-
+                    _dp_size = (
+                        coerce_kv_int_param(
+                            request.kv_transfer_params, "remote_dp_size", 1
+                        )
+                        or 1
+                    )
+                    _dp_local = coerce_kv_int_param(
+                        request.kv_transfer_params, "remote_dp_size_local", 0
+                    )
+                except ValueError:
+                    logger.warning(
+                        "Got invalid KVTransferParams: %s. This "
+                        "request will not utilize KVTransfer",
+                        request.kv_transfer_params,
+                    )
+                    request.kv_transfer_params["do_remote_prefill"] = False
+                    return
+                if _dp_local > 0:
+                    _dp_size = min(_dp_size, _dp_local)
                 # Rank routing is ROUTER-AUTHORITATIVE: honor the router-pinned
                 # remote_dp_rank (matched to the X-data-parallel-rank dispatch
                 # pin). Self-deriving a rank could disagree and notify a rank


### PR DESCRIPTION
## Summary
MoRI-IO WRITE decode notify and metadata ingestion used bare `int()` on `kv_transfer_params["remote_dp_size"]` (and related DP fields). A present but non-integer value (for example `"x"`) raised into EngineCore and killed the process. This change coerces those fields safely: absent/None keep documented defaults; present-but-malformed values refuse KV transfer instead of crashing.

## Changes
- `moriio_common.py`: add `coerce_kv_int_param`; use it in `MoRIIOConnectorMetadata.add_new_req` and skip registration on malformed DP ints.
- `moriio_connector.py`: use the same helper on the WRITE `update_state_after_alloc` decode-notify path; clear `do_remote_prefill` and return on failure.
- `test_moriio_kv_params.py`: unit tests for coercion, WRITE notify refusal, and `add_new_req` skip (runs without ROCm/mori).

## Codepath coverage
- Completions/`kv_transfer_params` → WRITE `update_state_after_alloc` notify: covered.
- Scheduler/`build_connector_meta` → `add_new_req`: covered.
- Worker uses already-coerced `ReqMeta.remote_dp_size` ints: covered by construction.

## Duplicate-work check
Searched open/merged PRs for MoRI-IO `remote_dp_size` validation / EngineCore kill on malformed DP size. Open MoRI-IO PRs (including deferred-send ACK work) do not close this sink. No matching merged fix found.

## Tests
- `test_coerce_kv_int_param_absent_and_valid`
- `test_coerce_kv_int_param_rejects_non_integer`
- `test_write_decode_update_state_rejects_non_numeric_remote_dp_size`
- `test_add_new_req_skips_non_numeric_remote_dp_size`

Commands:
```
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_moriio_kv_params.py -v
pre-commit run --files <touched files>
```
Results: 4 passed; pre-commit passed.

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)