### PR TITLE
[Security] Disable cookie persistence on shared media HTTP clients

### DIFF
--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
 import threading
 from collections.abc import Generator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -43,6 +44,36 @@ def local_media_server() -> Generator[str, None, None]:
     thread.start()
     try:
         yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+@pytest.fixture
+def local_cookie_server() -> Generator[tuple[str, list[str | None]], None, None]:
+    received_cookies: list[str | None] = []
+
+    class _CookieHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            received_cookies.append(self.headers.get("Cookie"))
+            body = b"ok"
+            self.send_response(200)
+            if self.path.startswith("/set-cookie"):
+                self.send_header("Set-Cookie", "sid=shared-session")
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, fmt: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _CookieHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", received_cookies
     finally:
         server.shutdown()
         thread.join()
@@ -187,6 +218,55 @@ async def test_get_bytes_allows_body_within_limit(
     try:
         actual = await connection.async_get_bytes(f"{local_media_server}/small")
         assert actual == _SMALL_BODY
+    finally:
+        if connection._async_client is not None:
+            await connection._async_client.close()
+
+
+def test_sync_http_connection_does_not_replay_response_cookies(
+    local_cookie_server: tuple[str, list[str | None]],
+) -> None:
+    base_url, received_cookies = local_cookie_server
+    connection = HTTPConnection()
+
+    assert connection.get_bytes(f"{base_url}/set-cookie") == b"ok"
+    assert connection.get_bytes(f"{base_url}/next") == b"ok"
+    assert received_cookies == [None, None]
+
+
+@pytest.mark.asyncio
+async def test_async_http_connection_does_not_replay_response_cookies(
+    local_cookie_server: tuple[str, list[str | None]],
+) -> None:
+    base_url, received_cookies = local_cookie_server
+    connection = HTTPConnection()
+
+    try:
+        assert await connection.async_get_bytes(f"{base_url}/set-cookie") == b"ok"
+        assert await connection.async_get_bytes(f"{base_url}/next") == b"ok"
+        assert received_cookies == [None, None]
+    finally:
+        if connection._async_client is not None:
+            await connection._async_client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_http_connection_does_not_replay_cookies_concurrently(
+    local_cookie_server: tuple[str, list[str | None]],
+) -> None:
+    base_url, received_cookies = local_cookie_server
+    connection = HTTPConnection()
+
+    try:
+        await asyncio.gather(
+            connection.async_get_bytes(f"{base_url}/set-cookie-a"),
+            connection.async_get_bytes(f"{base_url}/set-cookie-b"),
+        )
+        await asyncio.gather(
+            connection.async_get_bytes(f"{base_url}/next-a"),
+            connection.async_get_bytes(f"{base_url}/next-b"),
+        )
+        assert received_cookies == [None, None, None, None]
     finally:
         if connection._async_client is not None:
             await connection._async_client.close()

--- a/vllm/connections.py
+++ b/vllm/connections.py
@@ -5,6 +5,7 @@ import asyncio
 import functools
 import time
 from collections.abc import Callable, Coroutine, Mapping, MutableMapping
+from http.cookiejar import DefaultCookiePolicy
 from pathlib import Path
 from typing import Any, ParamSpec, TypeVar
 
@@ -321,8 +322,18 @@ def _async_retry(
     return wrapper  # type: ignore[return-value]
 
 
+def _session_without_cookies() -> requests.Session:
+    session = requests.Session()
+    session.cookies.set_policy(DefaultCookiePolicy(allowed_domains=()))
+    return session
+
+
 class HTTPConnection:
-    """Helper class to send HTTP requests."""
+    """Helper class to send HTTP requests.
+
+    Reused clients do not persist cookies, so caller-supplied media fetches
+    cannot replay another request's ``Set-Cookie`` state.
+    """
 
     def __init__(self, *, reuse_client: bool = True) -> None:
         super().__init__()
@@ -334,7 +345,7 @@ class HTTPConnection:
 
     def get_sync_client(self) -> requests.Session:
         if self._sync_client is None or not self.reuse_client:
-            self._sync_client = requests.Session()
+            self._sync_client = _session_without_cookies()
 
         return self._sync_client
 
@@ -342,7 +353,10 @@ class HTTPConnection:
     # required, so that the client is only accessible inside async event loop
     async def get_async_client(self) -> aiohttp.ClientSession:
         if self._async_client is None or not self.reuse_client:
-            self._async_client = aiohttp.ClientSession(trust_env=True)
+            self._async_client = aiohttp.ClientSession(
+                trust_env=True,
+                cookie_jar=aiohttp.DummyCookieJar(),
+            )
 
         return self._async_client
 


### PR DESCRIPTION
## Summary

The process-wide HTTP clients used for media fetches reuse a `requests.Session` and an `aiohttp.ClientSession` with default cookie jars. A `Set-Cookie` from one caller-supplied media URL was stored and replayed on later fetches to the same origin, so cookie-authenticated origins could leak across API principals. This change keeps connection pooling but disables automatic cookie store and replay on both clients.

## Changes

- `vllm/connections.py`: construct the sync session with a reject-all cookie policy, and the async session with `aiohttp.DummyCookieJar`.
- `tests/test_connections.py`: assert that a `Set-Cookie` from one fetch is not sent on later sequential or concurrent fetches.

## Codepath coverage

- `/v1/chat/completions` (including batch and render), `/v1/messages`, `/v1/responses`, `/invocations`, and gRPC generate all fetch media through `MediaConnector` → `global_http_connection`.
- `vllm run-batch` `file_url` downloads go through `global_http_connection.async_get_bytes`.
- Asset downloads use the same shared clients.
- All of those paths are covered by changing client construction in `HTTPConnection`. Per-request jar clearing is not used because it is not concurrency-safe.

## Duplicate-work check

Searched open, draft, and recently merged PRs for `HTTPConnection`, cookie jar / `DummyCookieJar`, and media HTTP client changes. https://github.com/vllm-project/vllm/pull/54729 disables NETRC/`trust_env` only and does not disable cookie persistence. https://github.com/vllm-project/vllm/pull/55539 is redirect allowlisting. No open or merged PR closes this sink.

## Tests

- `test_sync_http_connection_does_not_replay_response_cookies`
- `test_async_http_connection_does_not_replay_response_cookies`
- `test_async_http_connection_does_not_replay_cookies_concurrently`

Command: `.venv/bin/python -m pytest tests/test_connections.py -v` — 8 passed.

## AI assistance

This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)