### PR TITLE
[Bugfix][ROCm][MoE] Fall back instead of crashing when AITER MoE is requested for a non-gated (is_act_and_mul=False) model

### DIFF
--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from tests.kernels.moe.utils import make_dummy_moe_config
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     UnquantizedMoeBackend,
@@ -225,6 +226,51 @@ def test_select_rocm_aiter_backend(mock_aiter_enabled, mock_has_flashinfer):
         )
 
         assert selected_backend == UnquantizedMoeBackend.AITER
+        assert expert_cls is not None
+
+
+@patch(
+    "vllm.utils.flashinfer.has_flashinfer",
+    return_value=False,
+)
+@patch(
+    "vllm.model_executor.layers.fused_moe.oracle.unquantized.rocm_aiter_ops."
+    "is_fused_moe_enabled",
+    return_value=True,
+)
+@patch(
+    "vllm.model_executor.layers.fused_moe.oracle.unquantized.rocm_aiter_ops."
+    "is_rdna_aiter_enabled",
+    return_value=False,
+)
+@pytest.mark.skipif(
+    not current_platform.is_rocm(), reason="ROCm-specific backend selection test"
+)
+def test_select_rocm_aiter_backend_non_gated_activation_falls_back(
+    mock_rdna_disabled, mock_aiter_enabled, mock_has_flashinfer, monkeypatch
+):
+    """Test ROCm backend selection falls back (not raises) for non-gated MoE."""
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
+    monkeypatch.setenv("VLLM_ROCM_USE_AITER_MOE", "1")
+
+    with patch(
+        "vllm.model_executor.layers.fused_moe.oracle.unquantized.current_platform"
+    ) as mock_platform:
+        mock_platform.is_cuda.return_value = False
+        mock_platform.is_rocm.return_value = True
+        mock_platform.is_cpu.return_value = False
+        mock_platform.is_xpu.return_value = False
+        mock_platform.is_tpu.return_value = False
+        mock_platform.is_out_of_tree.return_value = False
+
+        moe_config = make_dummy_moe_config(activation=MoEActivation.SILU_NO_MUL)
+        assert moe_config.is_act_and_mul is False
+
+        selected_backend, expert_cls = select_unquantized_moe_backend(
+            moe_config=moe_config,
+        )
+
+        assert selected_backend != UnquantizedMoeBackend.AITER
         assert expert_cls is not None
 
 

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -308,7 +308,26 @@ def select_unquantized_moe_backend(
                 AVAILABLE_BACKENDS.remove(UnquantizedMoeBackend.AITER)
         else:
             backend = UnquantizedMoeBackend.AITER
-            return _return_or_raise(backend, moe_config, activation_format)
+            reason = None
+            for k_cls in backend_to_kernel_cls(backend):
+                supported, reason = k_cls.is_supported_config(
+                    k_cls, moe_config, None, None, activation_format
+                )
+                if supported:
+                    logger.info_once(_make_log_backend(backend))
+                    return backend, k_cls
+            # AITER was explicitly requested but does not support this
+            # deployment configuration (e.g. a non-gated MoE activation,
+            # which AiterExperts._supports_no_act_and_mul() rejects
+            # unconditionally). Rather than hard-crashing at engine init,
+            # warn and fall back to the remaining backends in priority
+            # order below.
+            logger.warning_once(
+                "VLLM_ROCM_USE_AITER_MOE=1 was requested, but %s",
+                _make_log_unsupported(backend, reason),
+            )
+            if UnquantizedMoeBackend.AITER in AVAILABLE_BACKENDS:
+                AVAILABLE_BACKENDS.remove(UnquantizedMoeBackend.AITER)
 
     for backend in AVAILABLE_BACKENDS:
         for k_cls in backend_to_kernel_cls(backend):


### PR DESCRIPTION

## Purpose

Found during uplift investigation for
`nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16`: setting `VLLM_ROCM_USE_AITER_MOE=1` crashes engine init for any MoE model with a non-gated activation (`is_act_and_mul=False`). `AiterExperts` has no kernel for this case, and `select_unquantized_moe_backend()` raised a `ValueError` instead of falling back to another backend.

This PR prevents the crash by falling back to an alternative backend instead of raising.

## Test Plan

Also reproduced the crash directly and verified the fix by launching `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16` with
`VLLM_ROCM_USE_AITER_MOE=1` on real MI350X hardware (TP=8), before and after this change.

**Note**: This PR's scope is limited to fixing the crash; the benchmark results above are for reference only (confirming no regression), not a performance improvement claim.

## Test Result

Unit tests: `24 passed, 3 skipped` (3 skips are CUDA-only, unrelated)

**Accuracy (GSM8K, `lm_eval`, 5-shot)**, baseline (`AITER_MOE=0`) vs.
this fix (`AITER_MOE=1`, falls back to Triton):

| Config | n=100 exact_match | n=1319 strict-match | n=1319 flexible-extract |
|---|---|---|---|
| Baseline | 0.96 ± 0.0197 | 0.9386 ± 0.0066 | 0.9393 ± 0.0066 |
| This fix | 0.96 ± 0.0197 | 0.9409 ± 0.0065 | 0.9431 ± 0.0064 |

Both scores are within one stderr of each other and no measurable accuracy regression.

**Concurrency / performance reference** (`vllm bench serve`, random dataset, max_concurrency=128, num_prompts=256, 0 failures in every run). Not a claim about this PR's performance impact — see note below.

| Profile | Metric | Baseline (`AITER_MOE=0`) | With this PR applied (`AITER_MOE=1`, falls back to Triton) |
|---|---|---|---|
| 1024 in / 1024 out | Throughput | 2.72 req/s | 2.95 req/s |
| 1024 in / 1024 out | Mean TTFT | 2855 ms | 2446 ms |
| 8192 in / 1024 out | Throughput | 1.35 req/s | 1.47 req/s |
| 8192 in / 1024 out | Mean TTFT | 13408 ms | 13017 ms |

**Note:** This table compares two different, already-existing backends (AITER for everything except MoE in the baseline row, vs. Triton handling MoE after this PR's fallback). Before this PR, the `AITER_MOE=1` configuration never produced a working run to compare against at all. This PR does not change or improve any kernel's performance; it only prevents a crash. These numbers are included solely to confirm the now-working fallback path is not slower than the existing default.

---
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

