### PR TITLE
[Attention] Fix FA3 TMA descriptor initialization on zero-token segments

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -3095,6 +3095,46 @@ def test_flashattn_hisparse_decode_uses_index_group():
     impl._run_mqa_kernel.assert_called_once()
 
 
+def test_flashattn_mla_sparse_zero_tokens():
+    num_heads = 16
+    head_size = 128
+    q_nope = torch.empty(0, num_heads, head_size, device=DEVICE_TYPE)
+    q_rope = torch.empty(0, num_heads, 64, device=DEVICE_TYPE)
+    topk = torch.zeros((0, 4), dtype=torch.int32, device=DEVICE_TYPE)
+
+    impl = object.__new__(FlashAttnMLASparseImpl)
+    impl.num_heads = num_heads
+    impl.head_size = head_size
+    impl.topk_indices_buffer = topk
+    impl._run_mqa_kernel = MagicMock()
+
+    metadata = SimpleNamespace(num_decode_tokens=0, block_size=64)
+
+    output, lse = FlashAttnMLASparseImpl.forward_mqa(
+        impl,
+        (q_nope, q_rope),
+        torch.empty(1, device=DEVICE_TYPE),
+        metadata,
+        SimpleNamespace(),
+    )
+
+    assert output.shape == (0, num_heads, head_size)
+    assert lse is None
+    impl._run_mqa_kernel.assert_not_called()
+
+    # Test _run_mqa_kernel short-circuit
+    res = FlashAttnMLASparseImpl._run_mqa_kernel(
+        impl,
+        q_nope,
+        q_rope,
+        torch.empty(1, device=DEVICE_TYPE),
+        topk,
+        torch.empty(0, device=DEVICE_TYPE),
+        64,
+    )
+    assert res.shape == (0, num_heads, head_size)
+
+
 def test_flashinfer_sm120_hisparse_decode_uses_index_group():
     num_tokens = 4
     q = torch.empty(num_tokens, 2, 4, device=DEVICE_TYPE)

--- a/vllm/v1/attention/backends/mla/flashattn_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla_sparse.py
@@ -193,6 +193,15 @@ class FlashAttnMLASparseImpl(SparseMLACommonImpl[FlashAttnMLASparseMetadata]):
             )
         q_nope, q_rope = q
         num_actual_toks = q_rope.shape[0]
+        if num_actual_toks == 0:
+            return (
+                torch.empty(
+                    (0, self.num_heads, self.head_size),
+                    dtype=q_nope.dtype,
+                    device=q_nope.device,
+                ),
+                None,
+            )
 
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
@@ -302,6 +311,13 @@ class FlashAttnMLASparseImpl(SparseMLACommonImpl[FlashAttnMLASparseMetadata]):
         *,
         cache_is_flat: bool = False,
     ) -> torch.Tensor:
+        if q_rope.shape[0] == 0:
+            return torch.empty(
+                (0, self.num_heads, self.head_size),
+                dtype=q_nope.dtype,
+                device=q_nope.device,
+            )
+
         kv_rows = (
             kv_cache if cache_is_flat else flat_kv_row_view(kv_cache, block_size)[0]
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes https://github.com/vllm-project/vllm/issues/56563

Fixes high-volume CUDA error log spam (`Error: Failed to initialize the TMA descriptor 1`) when using the `FLASH_ATTN_MLA_SPARSE` attention backend alongside speculative decoding (such as MTP) on NVIDIA Hopper (H100) hardware.

### Problem Root Cause
* When MTP speculative decoding or multi-token draft steps generate empty (zero-token) segments, `FlashAttnMLASparseImpl` dispatches zero-token query/key inputs down to `flash_attn_varlen_func`.
* Host-side TMA setup functions call `cuTensorMapEncodeTiled`, which rejects zero-extent or zero-address descriptors with `CUDA_ERROR_INVALID_VALUE` (1), logging roughly 88 copies of standard error spam per step and adding CPU overhead on the decode critical path.

### Solution
* **Python Backend Guard (`flashattn_mla_sparse.py`):**
  - Updated `FlashAttnMLASparseImpl.forward_mqa` and `_run_mqa_kernel` in `vllm/v1/attention/backends/mla/flashattn_mla_sparse.py` to detect empty token slices (`num_actual_toks == 0` / `q_rope.shape[0] == 0`) at entry.
  - Short-circuits execution and immediately returns an empty tensor of shape `(0, num_heads, head_size)` without performing logical-to-physical index conversions or dispatching to `flash_attn_varlen_func` C++ FFI.

## Test Plan

Run the unit test for zero-token segments in `tests/v1/attention/test_sparse_mla_backends.py`:

```bash
pytest tests/v1/attention/test_sparse_mla_backends.py -k test_flashattn_mla_sparse_zero_tokens
```

### Contributing & AI Usage Disclosure
I have read and agree to the vLLM contributing guidelines and read https://docs.vllm.ai/en/latest/contributing.
AI Usage: I used AI tools to assist with analyzing codebase execution flow and syntax; however, I have thoroughly reviewed, verified and tested the underlying engineering fix myself and can explain all technical details independently.
