### PR TITLE
[Bugfix][Frontend] Honor stop_token_ids on the Responses API

### DIFF
--- a/tests/entrypoints/openai/responses/test_sampling_params.py
+++ b/tests/entrypoints/openai/responses/test_sampling_params.py
@@ -170,3 +170,101 @@ class TestResponsesRequestSamplingParams:
         assert "Cannot specify both structured_outputs and text.format" in str(
             exc_info.value
         )
+
+
+class TestResponsesStopTokenIds:
+    """Test stop_token_ids merging in ResponsesRequest.to_sampling_params()."""
+
+    @pytest.fixture
+    def minimal_responses_request(self):
+        return ResponsesRequest(
+            model="test-model",
+            input="hello",
+        )
+
+    def test_default_stop_token_ids_applied(self, minimal_responses_request):
+        """Server-default stop_token_ids are applied when client sends none."""
+        default_sampling_params = {
+            "stop_token_ids": [200012, 200002],
+        }
+
+        sampling_params = minimal_responses_request.to_sampling_params(
+            default_max_tokens=100,
+            default_sampling_params=default_sampling_params,
+        )
+
+        assert set(sampling_params.stop_token_ids) == {200012, 200002}
+
+    def test_client_stop_token_ids_merged_with_defaults(self):
+        """Client-specified stop_token_ids are merged with server defaults."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="hello",
+            stop_token_ids=[99999],
+        )
+        default_sampling_params = {
+            "stop_token_ids": [200012, 200002],
+        }
+
+        sampling_params = request.to_sampling_params(
+            default_max_tokens=100,
+            default_sampling_params=default_sampling_params,
+        )
+
+        assert set(sampling_params.stop_token_ids) == {200012, 200002, 99999}
+        assert sampling_params.stop_token_ids == [99999, 200012, 200002]
+
+    def test_no_stop_token_ids_anywhere(self, minimal_responses_request):
+        """When neither client nor server specifies stop_token_ids, result is empty."""
+        sampling_params = minimal_responses_request.to_sampling_params(
+            default_max_tokens=100,
+            default_sampling_params={},
+        )
+
+        assert not sampling_params.stop_token_ids
+
+    def test_only_client_stop_token_ids(self):
+        """Client stop_token_ids work when no server defaults exist."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="hello",
+            stop_token_ids=[42, 43],
+        )
+
+        sampling_params = request.to_sampling_params(
+            default_max_tokens=100,
+            default_sampling_params={},
+        )
+
+        assert set(sampling_params.stop_token_ids) == {42, 43}
+
+    def test_duplicate_stop_token_ids_deduplicated(self):
+        """Overlapping stop_token_ids between client and server are deduplicated."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="hello",
+            stop_token_ids=[200012, 55555],
+        )
+        default_sampling_params = {
+            "stop_token_ids": [200012, 200002],
+        }
+
+        sampling_params = request.to_sampling_params(
+            default_max_tokens=100,
+            default_sampling_params=default_sampling_params,
+        )
+
+        assert set(sampling_params.stop_token_ids) == {200012, 200002, 55555}
+        assert sampling_params.stop_token_ids == [200012, 55555, 200002]
+        assert len(sampling_params.stop_token_ids) == 3
+
+    def test_stop_token_ids_field_is_not_ignored(self):
+        """Constructing ResponsesRequest with stop_token_ids binds the field."""
+        request = ResponsesRequest(
+            model="test-model",
+            input="hello",
+            stop_token_ids=[200012],
+        )
+
+        assert request.stop_token_ids == [200012]
+        assert "stop_token_ids" not in (request.model_extra or {})

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -184,6 +184,7 @@ class ResponsesRequest(OpenAIBaseModel):
     truncation: Literal["auto", "disabled"] | None = "disabled"
     user: str | None = None
     skip_special_tokens: bool = True
+    stop_token_ids: list[int] | None = []
     include_stop_str_in_output: bool = False
     presence_penalty: float | None = Field(
         default=None,
@@ -429,6 +430,16 @@ class ResponsesRequest(OpenAIBaseModel):
         if isinstance(stop, str):
             stop = [stop]
 
+        stop_token_ids = self.stop_token_ids
+        default_stop_ids = default_sampling_params.get("stop_token_ids")
+        if default_stop_ids:
+            if not stop_token_ids:
+                stop_token_ids = list(default_stop_ids)
+            else:
+                stop_token_ids = list(
+                    dict.fromkeys([*stop_token_ids, *default_stop_ids])
+                )
+
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}
         if self.kv_transfer_params:
             extra_args["kv_transfer_params"] = self.kv_transfer_params
@@ -443,6 +454,7 @@ class ResponsesRequest(OpenAIBaseModel):
             max_tokens=max_tokens,
             logprobs=self.top_logprobs if self.is_include_output_logprobs() else None,
             stop=stop,
+            stop_token_ids=stop_token_ids,
             frequency_penalty=frequency_penalty,
             presence_penalty=presence_penalty,
             repetition_penalty=repetition_penalty,


### PR DESCRIPTION
## Purpose

`/v1/responses` had no `stop_token_ids` field. `OpenAIBaseModel` uses `extra="allow"`, so a client-sent value (`extra_body={"stop_token_ids": [...]}`) was logged as ignored and never reached `SamplingParams`.

This adds the field on `ResponsesRequest` and applies the same client-first `dict.fromkeys` merge that Chat Completions / Completions use when `default_sampling_params` contains `stop_token_ids` (#22519 / #35076).

Serving already calls `to_sampling_params(..., self.default_sampling_params)` (`OpenAIServingResponses` and `/v1/responses/render`).

## Why this is not a duplicate

Searched open PRs for `Responses stop_token_ids`. Nearby work is different:

- #55483 honors `include_stop_str_in_output` after a stop **token id already matched**.
- #35076 / #44009 cover Chat/Completions / Harmony default propagation, not the Responses request schema.
- #48084 (`min_p`), #51152 (`spaces_between_special_tokens`), and #54469 (`thinking_token_budget` server defaults) are other extra sampling fields and are not changed here.

This does **not** change `ModelConfig.get_diff_sampling_param()`. That helper still only forwards `repetition_penalty` / `temperature` / `top_k` / `top_p` / `min_p` / `max_new_tokens`. Extra EOS from a model's `generation_config.json` (including gpt-oss `</call>`) is applied later in the engine via `SamplingParams.update_from_generation_config`, for every API. The hole this PR closes is the Responses request field / extra-body path.

## Test Plan

CPU-only protocol unit tests; no model download.

```
PYTHONPATH=. .venv/bin/python -m pytest tests/entrypoints/openai/responses/test_sampling_params.py --noconftest -q
```

Result: **14 passed**.

Coverage:

- server defaults applied when the client sends none
- client ids merged with defaults (client first, then new defaults)
- neither specified → empty
- client-only ids
- overlapping ids deduplicated (`[200012, 55555]` + `[200012, 200002]` → `[200012, 55555, 200002]`)
- constructing `ResponsesRequest(stop_token_ids=[...])` binds the field (not `model_extra`)

```
ruff check vllm/entrypoints/openai/responses/protocol.py tests/entrypoints/openai/responses/test_sampling_params.py
```

All checks passed.

## Notes

AI assistance was used for repository triage and drafting the patch. I reviewed every changed line and ran the tests above.

Signed-off-by: YeonwooSung <neos960518@gmail.com>
