### PR TITLE
[CI/Build] Use FileStore for DeepEP test rendezvous

### DIFF
--- a/tests/kernels/moe/parallel_utils.py
+++ b/tests/kernels/moe/parallel_utils.py
@@ -5,7 +5,6 @@ DeepEP test utilities
 """
 
 import dataclasses
-import os
 import traceback
 from collections.abc import Callable
 from typing import Concatenate
@@ -16,7 +15,7 @@ from torch.multiprocessing import spawn  # pyright: ignore[reportPrivateImportUs
 from typing_extensions import ParamSpec
 
 from vllm.utils.import_utils import has_deep_ep, has_deep_ep_v2
-from vllm.utils.network_utils import get_open_port
+from vllm.utils.network_utils import get_file_store_init_method
 
 if has_deep_ep():
     from vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_ht import (
@@ -107,7 +106,7 @@ def parallel_launch(
                 world_size,
                 world_size,
                 0,
-                f"tcp://{os.getenv('LOCALHOST', 'localhost')}:{get_open_port()}",
+                get_file_store_init_method(),
                 worker,
             )
             + args,


### PR DESCRIPTION
## Summary

- Replace the probe-close-rebind TCP rendezvous in the DeepEP parallel test helper with a unique PyTorch `FileStore` URL.
- Remove the window where another process can claim the probed port before rank 0 binds it.

This addresses the `EADDRINUSE` failure from B200 FusedMoE alert 916 / main build #88300. The unchanged exact retry passed all 20 tests, confirming the failure was a harness flake.

## Why this doesn't duplicate an open PR

Searched open vLLM PRs and issues for DeepEP, FileStore, rendezvous, TCPStore, and `EADDRINUSE`; no existing change addresses this probe-close-rebind race.

## Test plan

- Human submitter reviewed every changed line and ran the relevant tests.
- `pre-commit run --files tests/kernels/moe/parallel_utils.py` — passed all applicable hooks.
- Exact B200 FusedMoE retry in Buildkite #88300 — 20 passed (unpatched baseline/reproduction evidence).

No model evaluation is needed because this changes only test-process rendezvous.

## AI assistance disclosure

The diagnosis and patch were developed with OpenAI Codex assistance. The human submitter reviewed the complete diff and ran relevant tests before submission.
