### PR TITLE
[CI/Build] Give the Torch ABI audit time to start

### DIFF
--- a/.buildkite/test_areas/torch_abi.yaml
+++ b/.buildkite/test_areas/torch_abi.yaml
@@ -4,7 +4,7 @@ depends_on:
 steps:
 - label: ":nvidia: (L4) Torch Stable ABI Audit"
   key: torch-stable-abi-audit
-  timeout_in_minutes: 5
+  timeout_in_minutes: 10
   source_file_dependencies:
   - .buildkite/check-torch-abi.py
   - csrc/


### PR DESCRIPTION
## Summary

- Increase the L4 Torch Stable ABI Audit timeout from 5 to 10 minutes.
- Leave enough budget for the audit after a cold postmerge-image pull.

Alert 918 / main build #88353 spent about 4m40s pulling the image, then was killed only 26 seconds after `check-torch-abi.py` started. Its unchanged exact retry passed in 4m25s, confirming the audit itself is green and the 5-minute end-to-end budget is unsafe.

## Why this doesn't duplicate an open PR

Searched open vLLM PRs and issues for the Torch Stable ABI Audit, cold image pulls, and timeout changes; no existing PR addresses this job's timeout budget.

## Test plan

- Human submitter reviewed every changed line and ran the relevant tests.
- `pre-commit run --files .buildkite/test_areas/torch_abi.yaml` — passed all applicable hooks.
- Exact Torch Stable ABI Audit retry in Buildkite #88353 — passed in 4m25s (unpatched baseline evidence).

No model evaluation is needed because this changes only a CI timeout.

## AI assistance disclosure

The diagnosis and patch were developed with OpenAI Codex assistance. The human submitter reviewed the complete diff and ran relevant tests before submission.
