### PR TITLE
[CI] Update DeepSeek V4.1 MegaMoE routing test

### DIFF
--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -18,10 +18,7 @@ from vllm.models.deepseek_v4.nvidia.model import (
 )
 from vllm.models.deepseek_v4.nvidia.mtp import DeepSeekV4MTP
 from vllm.models.deepseek_v4.nvidia.ops.prepare_megamoe import prepare_megamoe_inputs
-from vllm.models.deepseek_v4_1.common.mm_preprocess import (
-    IMAGE_PAD_ID,
-    IMAGE_SENTINEL_BASE_ID,
-)
+from vllm.models.deepseek_v4_1.common.mm_preprocess import IMAGE_SENTINEL_BASE_ID
 from vllm.models.deepseek_v4_1.nvidia.model import DeepseekV4MoE as DeepseekV41MoE
 from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.deepseek_v41 import DeepseekV41Config
@@ -78,7 +75,7 @@ def test_deepseek_v41_moe_routes_without_hash_table(
         moe = DeepseekV41MoE(v41_moe_config, prefix=f"model.layers.{layer_id}.ffn")
         hidden_states = torch.randn(4, config.hidden_size)
         input_ids = (
-            torch.tensor([42, IMAGE_SENTINEL_BASE_ID, IMAGE_PAD_ID, 129257])
+            torch.tensor([42, IMAGE_SENTINEL_BASE_ID, IMAGE_SENTINEL_BASE_ID, 129257])
             if vision
             else None
         )
@@ -100,7 +97,7 @@ def test_deepseek_v41_moe_routes_without_hash_table(
     ).sqrt()
     bias = moe.gate.e_score_correction_bias
     if vision:
-        image_mask = (input_ids == IMAGE_SENTINEL_BASE_ID) | (input_ids == IMAGE_PAD_ID)
+        image_mask = input_ids == IMAGE_SENTINEL_BASE_ID
         bias = torch.where(image_mask[:, None], moe.gate.bias_vl, bias)
     expected_ids = (scores + bias).topk(top_k, dim=-1).indices
     expected_weights = scores.gather(1, expected_ids)


### PR DESCRIPTION
## Summary

Update the MegaMoE vision-routing test for DeepSeek V4.1's pad-free image token stream.

## Why

PR #56554 removed `IMAGE_PAD_ID`, but `tests/models/test_deepseek_v4_mega_moe.py` still imported and used it. B200 DeepSeek V4 Kernels now fails during collection before this test can run.

The updated fixture represents image-span positions with the checkpoint's single `IMAGE_SENTINEL_BASE_ID`, matching the current preprocessing contract while preserving the test's router-bias coverage.

## Duplicate check

I searched open vLLM PRs and issues for PR #56554, `IMAGE_PAD_ID`, and the exact MegaMoE test. No open change addresses this failure. PR #56594 separately fixes the CuTeDSL bounds-test failure from PR #53566, so that overlapping change was removed from this PR.

## Tests

- `pytest tests/models/test_deepseek_v4_mega_moe.py -q` — collected cleanly; 28 skipped locally without CUDA
- `pre-commit run --files tests/models/test_deepseek_v4_mega_moe.py` — passed

Exact B200 hardware CI remains required. Model evaluation is not applicable because this changes a test fixture only.

## AI assistance

OpenAI Codex assisted with failure analysis and preparing this change. A human maintainer must review every changed line and validate the hardware CI before marking this PR ready.