### PR TITLE
[CI] Fix Qwen3 Omni DSpark load test config

### DIFF
--- a/tests/model_executor/test_qwen3_omni.py
+++ b/tests/model_executor/test_qwen3_omni.py
@@ -354,6 +354,7 @@ def test_dspark_shares_target_embedding_with_smaller_draft_vocabulary():
         parallel_config=SimpleNamespace(tensor_parallel_size=1),
         attention_config=SimpleNamespace(backend=None),
         cache_config=SimpleNamespace(),
+        load_config=SimpleNamespace(),
         model_config=SimpleNamespace(get_vocab_size=Mock(return_value=100)),
     )
 
@@ -366,6 +367,10 @@ def test_dspark_shares_target_embedding_with_smaller_draft_vocabulary():
         patch.object(dspark_utils, "replace", side_effect=fake_replace),
         patch(
             "vllm.v1.worker.gpu.spec_decode.eagle.utils.get_pp_group",
+            return_value=SimpleNamespace(world_size=1),
+        ),
+        patch(
+            "vllm.v1.worker.gpu.spec_decode.utils.get_pp_group",
             return_value=SimpleNamespace(world_size=1),
         ),
         patch(


### PR DESCRIPTION
## Summary

Give the Qwen3 Omni DSpark embedding-sharing test the load configuration and both pipeline-group stubs required by the current draft-model loader.

## Why

PR #54416 made DSpark call `get_pp_safe_draft_load_config(vllm_config.load_config)`. The existing Qwen3 Omni test mock still lacked `load_config` and only stubbed the pipeline group used by embedding sharing, so H200 MIG Model Executor fails deterministically in `test_dspark_shares_target_embedding_with_smaller_draft_vocabulary`.

This keeps the test focused on embedding sharing while satisfying the loader's current configuration contract.

## Duplicate check

I searched open vLLM PRs and issues for Qwen3 Omni, DSpark, and the missing load-config failure. No open change addresses this test.

## Tests

- `pytest tests/model_executor/test_qwen3_omni.py::test_dspark_shares_target_embedding_with_smaller_draft_vocabulary -q` — 1 passed
- `pre-commit run --files tests/model_executor/test_qwen3_omni.py` — passed

Model evaluation is not applicable because this changes a unit-test mock only.

## AI assistance

OpenAI Codex assisted with failure analysis and preparing this change. A human maintainer must review every changed line and validate CI before marking this PR ready.
