### PR TITLE
[CI] Extend Arm CPU kernel shard timeout

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh
+++ b/.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh
@@ -112,7 +112,9 @@ print_packages
 export CONTAINER_NAME
 export -f kernel_tests model_tests serving_tests
 case "$SHARD_ID" in
-  0) timeout 30m bash -c kernel_tests ;;
+  # The kernel shard contains several large parametrized suites and can exceed
+  # 30 minutes on otherwise healthy Arm runners.
+  0) timeout 60m bash -c kernel_tests ;;
   1) timeout 30m bash -c model_tests ;;
   2) timeout 30m bash -c serving_tests ;;
 esac


### PR DESCRIPTION
## Why

The Arm CPU kernel shard is being terminated by its own 30-minute wrapper while tests are still making progress. Main builds [#88419](https://buildkite.com/vllm/ci/builds/88419#01a09246-6f50-42a5-a9a3-70feb717d1d0) and [#88482](https://buildkite.com/vllm/ci/builds/88482#01a09435-e14e-4288-9cc8-b203a0ec379a) both ended about 32 minutes after job start, with the test command disappearing mid-suite and no pytest failure summary.

Nightly main [#88612](https://buildkite.com/vllm/ci/builds/88612#01a0995b-7d07-44cf-b814-f6a10e49d018) reproduced the same boundary twice on different Arm runners. The original attempt ended after 31m46s during a CPU fused-MoE case, after an earlier 846-test invocation passed; its one unchanged retry [also ended](https://buildkite.com/vllm/ci/builds/88612#01a099b2-cb27-413a-9d7c-df4d8097c7fd) after 31m37s during a CPU attention case. Both were still reporting passing/skipped tests, then cleanup ran with exit 1 and no failure, traceback, or pytest summary. Four runs stopping in different suites at the same wall-time boundary confirm the `timeout 30m` wrapper rather than a deterministic test failure.

Give only the kernel shard a 60-minute test budget. The model and serving shards keep their existing 30-minute limits.

## Duplicate check

I searched open PRs and issues for `arm cpu timeout`, `Arm CPU Test Shard`, and `run-cpu-test-arm`; no existing change addresses this timeout.

## Testing

- `bash -n .buildkite/scripts/hardware_ci/run-cpu-test-arm.sh`
- pre-commit on `.buildkite/scripts/hardware_ci/run-cpu-test-arm.sh` (including shellcheck): passed
- `git diff --check`: passed

The Arm hardware suite is not available locally; the exact Buildkite shard is required for end-to-end validation.

## AI assistance

This change was prepared with AI assistance. A human maintainer must review every changed line and validate the relevant CI result before marking the PR ready.
