### PR TITLE
[Test] Retry transient GSM8K dataset downloads

### DIFF
--- a/tests/evals/gsm8k/gsm8k_eval.py
+++ b/tests/evals/gsm8k/gsm8k_eval.py
@@ -18,7 +18,9 @@ import aiohttp
 import numpy as np
 import regex as re
 import requests
+from requests.adapters import HTTPAdapter
 from tqdm.asyncio import tqdm
+from urllib3.util.retry import Retry
 
 from vllm.assets.base import VLLM_S3_BUCKET_URL
 
@@ -34,12 +36,22 @@ def download_and_cache_file(url: str, filename: str | None = None) -> str:
         return filename
 
     print(f"Downloading from {url} to {filename}")
-    response = requests.get(url, stream=True)
-    response.raise_for_status()
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=(500, 502, 503, 504),
+        allowed_methods=("GET",),
+    )
+    with requests.Session() as session:
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        response = session.get(url, stream=True, timeout=30)
+        response.raise_for_status()
 
-    with open(filename, "wb") as f:
-        for chunk in response.iter_content(chunk_size=1024):
-            f.write(chunk)
+        with open(filename, "wb") as f:
+            for chunk in response.iter_content(chunk_size=1024):
+                f.write(chunk)
 
     return filename
 


### PR DESCRIPTION
## Why

Main build [#88482](https://buildkite.com/vllm/ci/builds/88482#01a09435-e1e5-4f04-91f5-952c0addaac5) lost the A100 Humming FP16 shard after a one-off `503 Service Unavailable` while fetching the static GSM8K dataset from the vLLM S3 bucket. The URL recovered immediately, but the helper currently makes one unbounded request, turning a transient asset-server response into a full eval failure.

Use a requests retry adapter for GET connection/read failures and HTTP 500/502/503/504 responses, with three retries and backoff. Add a 30-second per-socket timeout so a stalled asset request also terminates predictably.

## Duplicate check

I searched open PRs and issues for `download_and_cache_file`, `gsm8k S3 retry`, and related retry terms; no existing change addresses this helper.

## Testing

- Local HTTP smoke test: server returned 503 twice and 200 on the third request; the helper retried three requests and wrote the expected file
- pre-commit on `tests/evals/gsm8k/gsm8k_eval.py`: passed, including ruff and mypy
- `git diff --check`: passed

No model evaluation is needed because this changes only CI dataset download error handling, not model output or serving behavior.

## AI assistance

This change was prepared with AI assistance. A human maintainer must review every changed line and validate the relevant CI result before marking the PR ready.
