### PR TITLE
[Bugfix] Don't assert the GPU lacks native FP4 in the Marlin fallback warning

### DIFF
--- a/vllm/model_executor/kernels/linear/nvfp4/marlin.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/marlin.py
@@ -32,10 +32,9 @@ class MarlinNvFp4LinearKernel(NvFp4LinearKernel):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         logger.warning_once(
-            "Your GPU does not have native support for FP4 computation but "
-            "FP4 quantization is being used. Weight-only FP4 compression "
-            "will be used leveraging the Marlin kernel. This may degrade "
-            "performance for compute-heavy workloads."
+            "FP4 quantization is being used, but no native FP4 kernel was selected for "
+            "this layer. Weight-only FP4 compression will be used leveraging the "
+            "Marlin kernel. This may degrade performance for compute-heavy workloads."
         )
         prepare_fp4_layer_for_marlin(layer)
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
@@ -201,10 +201,10 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
             pass
         else:
             logger.warning_once(
-                "Your GPU does not have native support for FP4 computation "
-                "but FP4 quantization is being used. Weight-only FP4 "
-                "compression will be used leveraging the Marlin kernel. "
-                "This may degrade performance for compute-heavy workloads."
+                "FP4 quantization is being used, but no native FP4 kernel was selected "
+                "for this layer. Weight-only FP4 compression will be used leveraging "
+                "the Marlin kernel. This may degrade performance for compute-heavy "
+                "workloads."
             )
             prepare_moe_fp4_layer_for_marlin(layer)
 

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -346,10 +346,9 @@ def prepare_nvfp4_moe_layer_for_marlin(
     torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
 ]:
     logger.warning_once(
-        "Your GPU does not have native support for FP4 computation but "
-        "FP4 quantization is being used. Weight-only FP4 compression will "
-        "be used leveraging the Marlin kernel. This may degrade "
-        "performance for compute-heavy workloads."
+        "FP4 quantization is being used, but no native FP4 kernel was selected for "
+        "this layer. Weight-only FP4 compression will be used leveraging the Marlin "
+        "kernel. This may degrade performance for compute-heavy workloads."
     )
 
     input_dtype = get_marlin_input_dtype(prefix="")


### PR DESCRIPTION
## Purpose

Three call sites emit this on the NVFP4/MXFP4 weight-only Marlin fallback path:

> Your GPU does not have native support for FP4 computation but FP4 quantization is being used. Weight-only FP4 compression will be used leveraging the Marlin kernel. This may degrade performance for compute-heavy workloads.

The first clause is a hardware claim, and on Blackwell consumer parts it is false. On SM120 the *same process* can and does issue native block-scaled NVFP4 kernels — so a user can see this warning while another layer in the same server is running native FP4.

What the message is actually reporting is a **backend-selection** outcome: this layer fell back to weight-only Marlin. The rest of the message (Marlin, possible degradation on compute-heavy workloads) is correct and is kept verbatim.

### Evidence that the claim is wrong on SM120

Nsight Systems trace: WSL2 / Ubuntu 24.04, vLLM 0.24.0, PyTorch 2.11.0+cu130, CUDA 13.0, Nsight Systems 2026.4.1, RTX 5090 Laptop (SM120), NVFP4 MoE checkpoint, `--moe-backend cutlass --linear-backend cutlass`. The MoE path shows 600 launches of:

```text
GemmUniversal<GroupProblemShape<tuple<int,int,int>>,
MainloopSm120ArrayTmaWarpSpecializedBlockScaled,
float_e2m1_t, float_ue4m3_t,
SM120::BLOCKSCALED::SM120_16x8x64_TN_VS<
  float_e2m1_t, float_e2m1_t, float, float_ue4m3_t, 16>>
```

with `compute_expert_blockscale_offsets` (300 launches) and `__get_group_gemm_starts<float_e2m1_t, ..., float_ue4m3_t>` (600 launches) alongside it. That is a native block-scaled NVFP4 grouped GEMM consuming FP4 operands and UE4M3 block scales — not a dequantize-to-BF16 fallback.

**Disclosure, so nobody wastes time failing to reproduce this on a stock wheel:** that trace was taken against a locally modified vLLM package. The Windows `QuantizeMethodBase.tie_weights` implementation was ported into the Linux wheel to work around a tied-weight gap, and `--linear-backend cutlass` was pinned to route around a missing NVCC on the dense path. Neither change touches MoE backend selection or the grouped kernel, so the kernel identity above stands — but a stock wheel will hit the tied-weight gap first.

Scope limit, stated plainly: Nsight Systems proves which kernel was *instantiated*. Proving the issued instruction mix would need Nsight Compute. The claim here is only "the SM120 block-scaled NVFP4 MMA atom was instantiated," which is enough to contradict "does not have native support."

### Change

Same message at all three sites, re-wrapped to each site's indent:

```text
"FP4 quantization is being used, but no native FP4 kernel was selected for
this layer. Weight-only FP4 compression will be used leveraging the Marlin
kernel. This may degrade performance for compute-heavy workloads."
```

- `vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py`
- `vllm/model_executor/kernels/linear/nvfp4/marlin.py`
- `vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py`

The third is the MXFP4 path; the wording is identical there and has the same problem, so it is changed for consistency.

### Alternative considered

A conditional message — call `cutlass_fp4_supported()` (already in `vllm/model_executor/layers/quantization/utils/nvfp4_utils.py`) and keep the "your GPU does not support FP4" wording only when it returns `False`. That is strictly more informative on pre-Blackwell parts, where the original sentence is true and useful.

I went with the flat rewording because it is a zero-predicate, zero-behaviour diff, and because the MXFP4 site would need a different predicate than the NVFP4 one. Happy to switch to the conditional if a reviewer prefers it — say the word and I'll push it.

## Test Plan

Message-only change with no behaviour change, so no test is added. Verified that each of the three original strings appeared exactly once before replacement, and that the replacement reconstructs one identical message at every site.

## Test Result

`ruff check` and `ruff format --check` clean on all three files (ruff 0.14.0, matching the pinned pre-commit hook). Diff is 10 insertions, 12 deletions, entirely inside `logger.warning_once(...)` calls.
