### PR TITLE
[Bugfix][Quantization] Fix online MoE weight conversion `KeyError: 'weight_scale'` with Humming

### DIFF
--- a/tests/quantization/test_online.py
+++ b/tests/quantization/test_online.py
@@ -36,6 +36,8 @@ from vllm.model_executor.kernels.linear.mxfp8.marlin import (
 )
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
+from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
+from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import Mxfp4MoeBackend
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     LinearBase,
@@ -75,6 +77,7 @@ from vllm.model_executor.layers.quantization.online.mxfp4 import (
 )
 from vllm.model_executor.layers.quantization.online.mxfp8 import (
     Mxfp8OnlineLinearMethod,
+    Mxfp8OnlineMoEMethod,
 )
 from vllm.model_executor.layers.quantization.online.nvfp4 import (
     Nvfp4OnlineMoEMethod,
@@ -122,6 +125,81 @@ GRANITE_MODEL_NAME = "ibm-granite/granite-3.0-1b-a400m-base"
 PARTIALLY_PREQUANTIZED_MODEL_NAME = (
     "nm-testing/tinysmokeqwen3moe-W4A16-first-only-CTstable"
 )
+
+
+@pytest.mark.parametrize(
+    "method_cls,backend_attr,backend,converter_path",
+    [
+        pytest.param(
+            Fp8PerTensorOnlineMoEMethod,
+            "fp8_backend",
+            Fp8MoeBackend.HUMMING,
+            "vllm.model_executor.layers.fused_moe.oracle.fp8."
+            "convert_to_fp8_moe_kernel_format",
+            id="fp8",
+        ),
+        pytest.param(
+            Mxfp8OnlineMoEMethod,
+            "fp8_backend",
+            Fp8MoeBackend.HUMMING,
+            "vllm.model_executor.layers.fused_moe.oracle.fp8."
+            "convert_to_fp8_moe_kernel_format",
+            id="mxfp8",
+        ),
+        pytest.param(
+            Mxfp4OnlineMoEMethod,
+            "mxfp4_backend",
+            Mxfp4MoeBackend.HUMMING,
+            "vllm.model_executor.layers.quantization.online.mxfp4."
+            "convert_weight_to_mxfp4_moe_kernel_format",
+            id="mxfp4",
+        ),
+    ],
+)
+def test_online_moe_stages_quantized_weights_for_humming(
+    method_cls,
+    backend_attr: str,
+    backend,
+    converter_path: str,
+    monkeypatch,
+) -> None:
+    method = object.__new__(method_cls)
+    setattr(method, backend_attr, backend)
+    method.weight_scale_name = "weight_scale"
+    method.experts_cls = None
+    method.get_fused_moe_quant_config = Mock(return_value=None)
+
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "w13_weight",
+        torch.nn.Parameter(torch.empty(2, 8, 4, dtype=torch.bfloat16)),
+    )
+    layer.register_parameter(
+        "w2_weight",
+        torch.nn.Parameter(torch.empty(2, 4, 4, dtype=torch.bfloat16)),
+    )
+    is_mxfp4 = method_cls is Mxfp4OnlineMoEMethod
+    weight_dtype = torch.uint8 if is_mxfp4 else torch.float8_e4m3fn
+    scale_dtype = (
+        torch.float32 if method_cls is Fp8PerTensorOnlineMoEMethod else torch.uint8
+    )
+    packed_factor = 2 if is_mxfp4 else 1
+    w13 = torch.empty(2, 8, 4 // packed_factor, dtype=weight_dtype)
+    w2 = torch.empty(2, 4, 4 // packed_factor, dtype=weight_dtype)
+    w13_scale = torch.empty(2, 8, 1, dtype=scale_dtype)
+    w2_scale = torch.empty(2, 4, 1, dtype=scale_dtype)
+
+    def convert(**kwargs):
+        state = layer.state_dict()
+        assert state["w13_weight"].data_ptr() == w13.data_ptr()
+        assert state["w2_weight"].data_ptr() == w2.data_ptr()
+        assert state["w13_weight_scale"].data_ptr() == w13_scale.data_ptr()
+        assert state["w2_weight_scale"].data_ptr() == w2_scale.data_ptr()
+        converted = (w13, w2, w13_scale, w2_scale)
+        return (*converted, None, None) if is_mxfp4 else converted
+
+    monkeypatch.setattr(converter_path, convert)
+    method._setup_kernel(layer, w13, w2, w13_scale, w2_scale, None, None)
 
 
 def test_online_nvfp4_reuses_kernel_when_weights_are_reprocessed(

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -25,6 +25,7 @@ from vllm.model_executor.kernels.linear.scaled_mm import (
 from vllm.model_executor.layers.fused_moe import RoutedExperts
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+    Fp8MoeBackend,
     select_fp8_moe_backend,
 )
 from vllm.model_executor.layers.linear import (
@@ -488,6 +489,9 @@ class _Fp8OnlineMoEBase(OnlineMoEMethodBase):
             convert_to_fp8_moe_kernel_format,
             make_fp8_moe_kernel,
         )
+
+        if self.fp8_backend == Fp8MoeBackend.HUMMING:
+            self._stage_humming_quantized_weights(layer, w13, w2, w13_scale, w2_scale)
 
         # Shuffle weights to runtime format.
         w13, w2, w13_scale, w2_scale = convert_to_fp8_moe_kernel_format(

--- a/vllm/model_executor/layers/quantization/online/moe_base.py
+++ b/vllm/model_executor/layers/quantization/online/moe_base.py
@@ -14,7 +14,7 @@ from vllm.model_executor.layers.fused_moe.moe_output import UnfinalizedMoEOutput
 from vllm.model_executor.model_loader.reload.layerwise import (
     initialize_online_processing,
 )
-from vllm.model_executor.utils import set_weight_attrs
+from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
 
 class OnlineMoEMethodBase(FusedMoEMethodBase):
@@ -125,6 +125,26 @@ class OnlineMoEMethodBase(FusedMoEMethodBase):
             and layer.w2_bias.shape[1] > hidden_size
         ):
             layer.w2_bias[:, hidden_size:] = 0
+
+    @staticmethod
+    def _stage_humming_quantized_weights(
+        layer: torch.nn.Module,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        w13_scale: torch.Tensor,
+        w2_scale: torch.Tensor,
+    ) -> None:
+        """Expose online-quantized tensors to Humming's layer-based converter.
+
+        Other MoE format converters consume the tensors passed to them directly.
+        Humming instead discovers its input through ``layer.state_dict()``.  Stage
+        the canonical tensors on the layer so it does not inspect the original
+        full-precision online-loading parameters.
+        """
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w2_weight", w2)
+        replace_parameter(layer, "w13_weight_scale", w13_scale)
+        replace_parameter(layer, "w2_weight_scale", w2_scale)
 
     @abstractmethod
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:

--- a/vllm/model_executor/layers/quantization/online/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp4.py
@@ -210,6 +210,9 @@ class Mxfp4OnlineMoEMethod(OnlineMoEMethodBase):
         w13_bias: torch.Tensor | None,
         w2_bias: torch.Tensor | None,
     ) -> None:
+        if self.mxfp4_backend == Mxfp4MoeBackend.HUMMING:
+            self._stage_humming_quantized_weights(layer, w13, w2, w13_scale, w2_scale)
+
         w13, w2, w13_scale, w2_scale, w13_bias, w2_bias = (
             convert_weight_to_mxfp4_moe_kernel_format(
                 mxfp4_backend=self.mxfp4_backend,

--- a/vllm/model_executor/layers/quantization/online/mxfp8.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp8.py
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
         FusedMoEQuantConfig,
         RoutedExperts,
     )
-    from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
 
 from vllm.model_executor.kernels.linear import init_mxfp8_linear_kernel
+from vllm.model_executor.layers.fused_moe.oracle.fp8 import Fp8MoeBackend
 from vllm.model_executor.layers.fused_moe.oracle.mxfp8 import (
     select_mxfp8_moe_backend,
 )
@@ -33,7 +33,6 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     mxfp8_e4m3_quantize,
 )
 from vllm.model_executor.utils import replace_parameter
-from vllm.platforms import current_platform
 
 
 class Mxfp8OnlineLinearMethod(OnlineLinearBase):
@@ -176,6 +175,9 @@ class Mxfp8OnlineMoEMethod(OnlineMoEMethodBase):
             make_fp8_moe_kernel,
         )
 
+        if self.fp8_backend == Fp8MoeBackend.HUMMING:
+            self._stage_humming_quantized_weights(layer, w13, w2, w13_scale, w2_scale)
+
         # Shuffle weights to runtime format.
         w13, w2, w13_scale, w2_scale = convert_to_fp8_moe_kernel_format(
             fp8_backend=self.fp8_backend,
@@ -235,9 +237,6 @@ class Mxfp8OnlineMoEMethod(OnlineMoEMethodBase):
         if getattr(layer, "_already_called_process_weights_after_loading", False):
             return
 
-        fp8_dtype = current_platform.fp8_dtype()
-        w13 = torch.empty_like(layer.w13_weight, dtype=fp8_dtype)
-        w2 = torch.empty_like(layer.w2_weight, dtype=fp8_dtype)
         layer.w13_input_scale = None
         layer.w2_input_scale = None
 


### PR DESCRIPTION
This failure is deterministic whenever generic online FP8, MXFP8, or MXFP4
MoE quantization selects Humming: its converter reads the layer before the
generated quantized weights and scales have been registered there.

## Purpose

Online FP8, MXFP8, and MXFP4 MoE quantization produces quantized weights and
scales as temporary tensors, then passes them to the selected backend's format
converter. Most converters consume those arguments directly. Humming instead
builds its conversion input from `layer.state_dict()`.

At that point, the layer still contains the full-precision weights used for
online loading and does not contain the newly generated weight scales. As a
result, selecting Humming for an online-quantized MoE model fails during model
loading. For example, online MXFP8 loading reaches Humming's ModelOpt schema
without `weight_scale` and raises:

```text
KeyError: 'weight_scale'
```

Stage the online-quantized weights and scales on the layer before invoking the
Humming converter. This gives Humming the same canonical quantized tensors that
the other converters receive as arguments. The normal post-conversion
replacement remains unchanged.

The fix covers all generic online MoE formats supported by Humming:

- FP8
- MXFP8
- MXFP4

The MXFP8 path also created two full-size FP8 tensors that were immediately
discarded before quantization. Remove those unused allocations. For the
Qwen3-30B-A3B MoE dimensions (128 experts, 2,048 hidden size, and 768 expert
intermediate size), this avoids 576 MiB of transient device allocations per
layer being processed.

## Reproduction

On the parent commit, the following command deterministically fails while
loading the first MoE layer with `KeyError: 'weight_scale'`:

```bash
vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507 \
  --quantization online \
  --quantization-config '{"moe":"mxfp8"}' \
  --moe-backend humming \
  --max-model-len 128 \
  --max-num-seqs 1 \
  --gpu-memory-utilization 0.95 \
  --enforce-eager
```

```
Mxfp8OnlineMoEMethod.process_weights_after_loading
→ convert_to_fp8_moe_kernel_format
→ convert_to_humming_moe_kernel_format
→ ModeloptMxfp8WeightSchema.convert_humming
→ KeyError: 'weight_scale'
```

`--quantization online` ensures that the generic online quantization path is
used, while the explicit MoE configuration selects MXFP8 for every routed
expert layer.

## Why this is not a duplicate

No open PR currently fixes this conversion boundary. PR #42997 adds Humming's
native online quantization path; it does not bridge the generic `online`
quantization methods to Humming's layer-based format converter. PR #51808
addresses online quantization configuration overrides and does not change
backend conversion.

## Test Plan

```bash
python -m pytest tests/quantization/test_online.py -q \
  -k 'stages_quantized_weights_for_humming'

pre-commit run --files \
  tests/quantization/test_online.py \
  vllm/model_executor/layers/quantization/online/fp8.py \
  vllm/model_executor/layers/quantization/online/moe_base.py \
  vllm/model_executor/layers/quantization/online/mxfp4.py \
  vllm/model_executor/layers/quantization/online/mxfp8.py
```

The regression tests exercise the shared FP8 setup path, MXFP8, and MXFP4 and
assert that Humming's converter observes the exact online-quantized weight and
scale tensors through `layer.state_dict()`.

The model-loading path was also validated on an NVIDIA A100 with
`Qwen/Qwen3-30B-A3B-Instruct-2507`, using online MXFP8 for MoE and Humming as the
MoE backend.

## Test Result

- Focused regression tests: 3 passed, 47 deselected.
- All changed-file pre-commit checks passed, including Ruff, formatting, mypy,
  SPDX, forbidden-import checks, and repository-specific validation.
- Before this change, the real model failed while processing the first MoE
  layer with `KeyError: 'weight_scale'`.
- After this change, all 16 weight shards and all 48 MoE layers completed
  Humming weight conversion. Weight loading used 30.78 GiB and completed in
  496.08 seconds; the original missing-scale failure did not recur.

## Compatibility

Weight staging is limited to the Humming branch of generic online MoE
quantization. Other MoE backends retain their existing conversion behavior;
the only shared change is removal of the unused MXFP8 allocations. No
user-facing configuration or documentation changes are required.

## AI-assisted contribution

This contribution was developed with AI assistance.
