### PR TITLE
[Bugfix][ROCm][Model] Quantize GLM-5.3-Flash indexer query with platform fp8 dtype

### DIFF
--- a/tests/kernels/test_fwht128_quant_fp8_platform_dtype.py
+++ b/tests/kernels/test_fwht128_quant_fp8_platform_dtype.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""fwht128_quant_fp8 must emit the platform fp8 dtype.
+
+On ROCm the indexer query produced by ``fwht128_quant_fp8`` flows into
+``rocm_fp8_mqa_logits``. gfx942 AITER's flydsl kernel cannot compile with a
+``float8_e4m3fn`` query, and the hardcoded 448 clamp is the e4m3fn max,
+wrong for e4m3fnuz. These tests pin the output dtype and the clamp source;
+the numeric Hadamard check runs wherever Triton is active.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+pytestmark = [
+    pytest.mark.skip_global_cleanup,
+]
+
+
+def test_fwht_allocates_platform_fp8_dtype(monkeypatch):
+    """The wrapper must derive the output dtype from the platform, not e4m3fn.
+
+    Intercepts torch.empty inside fwht128_quant_fp8 so no accelerator is
+    needed; the zero-row early-return path still allocates both outputs.
+    """
+    from vllm.models.glm5next.nvidia.ops import kpool_compress as nvidia_ops
+
+    seen_dtypes = []
+    real_empty = torch.empty
+
+    def spy_empty(*args, **kwargs):
+        if kwargs.get("dtype") in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
+            seen_dtypes.append(kwargs["dtype"])
+        return real_empty(*args, **kwargs)
+
+    q = torch.zeros(0, 128, dtype=torch.bfloat16)
+    monkeypatch.setattr(nvidia_ops.torch, "empty", spy_empty)
+    try:
+        q_fp8, _ = nvidia_ops.fwht128_quant_fp8(q)
+    finally:
+        monkeypatch.setattr(nvidia_ops.torch, "empty", real_empty)
+
+    assert seen_dtypes, "expected an fp8 allocation"
+    assert seen_dtypes[-1] == current_platform.fp8_dtype(), (
+        f"output dtype must be the platform fp8 dtype "
+        f"{current_platform.fp8_dtype()}, got {seen_dtypes[-1]}"
+    )
+    assert q_fp8.shape == (0, 128)
+
+
+def test_fwht_kernel_clamp_uses_parameterized_max():
+    """Source-contract check for the absmax clamp (accelerator-free CI).
+
+    On machines without Triton this is the only guard that the kernel takes
+    its clamp bound from the FP8_MAX constexpr; where the numeric test runs,
+    it covers the behavioral side.
+    """
+
+    from vllm.models.glm5next.nvidia.ops import kpool_compress as nvidia_ops
+
+    with open(nvidia_ops.__file__) as f:
+        src = f.read()
+    fwht_kernel_src = src.split("def _fwht_quant_kernel")[1].split("\ndef ")[0]
+    assert "448" not in fwht_kernel_src, (
+        "kernel must not hardcode the e4m3fn max; use the FP8_MAX constexpr"
+    )
+    assert "FP8_MAX" in fwht_kernel_src
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="needs a CUDA/ROCm accelerator for the Triton kernel",
+)
+@pytest.mark.skipif(
+    __import__("vllm.triton_utils.importing", fromlist=["HAS_TRITON"]).HAS_TRITON
+    is False,
+    reason="Triton disabled in this environment",
+)
+def test_fwht128_quant_fp8_matches_torch_reference():
+    """Quantization-aware comparison against an unfused Hadamard reference.
+
+    fp8 e4m3's worst-case relative step is 2^-4, so dequantized outputs must
+    recover the reference transform within that bound; scales must match the
+    ue8m0 power-of-two formula exactly.
+    """
+    from scipy.linalg import hadamard
+
+    from vllm.models.glm5next.nvidia.ops.kpool_compress import (
+        fwht128_quant_fp8,
+    )
+
+    torch.manual_seed(0)
+    device = "cuda"
+    fp8_dtype = current_platform.fp8_dtype()
+    fp8_max = float(torch.finfo(fp8_dtype).max)
+
+    for magnitude in (3.0, 6.0, 12.0):
+        n_rows = 257  # non-multiple of BLOCK_R
+        q = torch.randn(n_rows, 128, dtype=torch.bfloat16, device=device)
+        q = q * magnitude
+
+        q_fp8, q_scale = fwht128_quant_fp8(q)
+
+        assert q_fp8.dtype == fp8_dtype
+        assert not torch.isnan(q_fp8.to(torch.float32)).any()
+        assert q_fp8.to(torch.float32).abs().max() <= fp8_max
+
+        h = torch.from_numpy(hadamard(128)).to(device=device, dtype=torch.float32)
+        x = (q.to(torch.float32) @ h) * (1.0 / 128.0**0.5)
+        x = x.to(torch.bfloat16).to(torch.float32)
+
+        absmax = torch.clamp(x.abs().amax(dim=-1, keepdim=True), min=1e-4)
+        scale_ref = torch.exp2(torch.ceil(torch.log2(absmax / fp8_max)))
+        assert torch.equal(q_scale, scale_ref)
+
+        deq = q_fp8.to(torch.float32) * q_scale
+        rel = ((deq - x).abs() / x.abs().clamp(min=1e-2)).max()
+        assert rel <= 0.07, f"dequant rel err {rel} exceeds fp8 step bound"

--- a/vllm/models/glm5next/nvidia/ops/kpool_compress.py
+++ b/vllm/models/glm5next/nvidia/ops/kpool_compress.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
 # The GLM-5.3-Flash indexer head dimension is fixed at 128.
@@ -65,6 +66,7 @@ def _fwht_quant_kernel(
     sout_ptr,
     n_rows,
     BLOCK_R: tl.constexpr,
+    FP8_MAX: tl.constexpr,
 ):
     """Fused Hadamard-128 rotation + per-row absmax FP8 (ue8m0) quant.
 
@@ -98,8 +100,8 @@ def _fwht_quant_kernel(
     x = tl.reshape(x, (BLOCK_R, 128))
 
     absmax = tl.maximum(tl.max(tl.abs(x), axis=1), 1e-4)
-    scale = tl.exp2(tl.ceil(tl.log2(absmax * (1.0 / 448.0))))
-    y = tl.minimum(tl.maximum(x / scale[:, None], -448.0), 448.0)
+    scale = tl.exp2(tl.ceil(tl.log2(absmax * (1.0 / FP8_MAX))))
+    y = tl.minimum(tl.maximum(x / scale[:, None], -FP8_MAX), FP8_MAX)
 
     tl.store(qout_ptr + rows[:, None] * 128 + offs[None, :], y, mask=rmask[:, None])
     tl.store(sout_ptr + rows, scale, mask=rmask)
@@ -115,19 +117,24 @@ def fwht128_quant_fp8(q: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         q: ``[rows, 128]`` bf16 — one head vector per row.
 
     Returns:
-        (q_fp8 ``[rows, 128]`` float8_e4m3fn, scale ``[rows, 1]`` float32).
+        (q_fp8 ``[rows, 128]`` platform fp8 dtype (e4m3fn on CUDA,
+        e4m3fnuz on ROCm), scale ``[rows, 1]`` float32).
     """
     assert q.ndim == 2 and q.shape[1] == 128, q.shape
     assert q.dtype == torch.bfloat16
     assert q.is_contiguous()
     n_rows = q.shape[0]
-    q_fp8 = torch.empty((n_rows, 128), dtype=torch.float8_e4m3fn, device=q.device)
+    fp8_dtype = current_platform.fp8_dtype()
+    q_fp8 = torch.empty((n_rows, 128), dtype=fp8_dtype, device=q.device)
     q_scale = torch.empty((n_rows, 1), dtype=torch.float32, device=q.device)
     if n_rows == 0:
         return q_fp8, q_scale
     BLOCK_R = 32
     grid = (triton.cdiv(n_rows, BLOCK_R),)
-    _fwht_quant_kernel[grid](q, q_fp8, q_scale, n_rows, BLOCK_R=BLOCK_R, num_warps=2)
+    fp8_max = torch.finfo(fp8_dtype).max
+    _fwht_quant_kernel[grid](
+        q, q_fp8, q_scale, n_rows, BLOCK_R=BLOCK_R, FP8_MAX=fp8_max, num_warps=2
+    )
     return q_fp8, q_scale
 
 


### PR DESCRIPTION
## Purpose

`fwht128_quant_fp8` hardcodes `float8_e4m3fn` for the GLM-5.3-Flash indexer query and a 448 absmax clamp inside the Triton kernel. The function is called unconditionally from `Glm5NextAttention.forward` — including on ROCm, where the query flows into `rocm_fp8_mqa_logits`:

- On gfx942, AITER's flydsl `fp8_mqa_logits` kernel takes the `convert_q_fn` path for a `float8_e4m3fn` query and crashes at kernel emission:

```
AttributeError: 'int' object has no attribute '_CAPIPtr'
  File ".../aiter/ops/flydsl/kernels/mqa_logits/fp8_mqa_logits.py", line 242, in kernel
    row_a[mi][kk] = _fn_to_fnuz_i64(raw) if convert_q_fn else raw
```

  Any request with chunked prefill (e.g. a 40K-token prompt) kills the worker and the engine crash-loops. Reproduced standalone: `flydsl_fp8_mqa_logits` with an FN-dtype query crashes at compile on gfx942.

- The 448 clamp is the e4m3fn max; e4m3fnuz's max differs, so rows whose absmax lands above the fnuz max would encode NaN/inf even where the FN path compiles.

The K-cache side already quantizes with `current_platform.fp8_dtype()` (`indexer_k_quant_and_cache_triton` IS_FNUZ; the AMD kpool ops module does the same via its `FP8_DTYPE` constant) — the query side is the odd one out.

## Changes

- `fwht128_quant_fp8` allocates the output with `current_platform.fp8_dtype()`.
- The kernel takes the matching max as an `FP8_MAX` constexpr instead of the hardcoded 448.
- CUDA behavior unchanged (`fp8_dtype()` is e4m3fn there).

Duplicate-work check: open GLM-5.3-Flash PRs (#55358 refactor, #56176 MXFP4, #55423 DFlash2) do not touch the fp8 dtype or clamp. File-level overlap with #55358 is a single import line — that PR relocates `sparse_attn_indexer_kpool` (the layer), while this patch touches only `vllm/models/glm5next/nvidia/ops/kpool_compress.py` (the ops module #55358 moves an import of, not the file itself).

## Test Plan

```
pytest tests/kernels/test_fwht128_quant_fp8_platform_dtype.py -v
```

Tests 1-2 are CPU-only (dtype allocation spy + kernel source contract). Test 3 (numeric Hadamard comparison) runs where Triton is active.

## Test Result

CPU-only tests: **2 passed** locally; negative control (fix stashed): `test_fwht_kernel_clamp_uses_parameterized_max` fails on the hardcoded 448.

On 8× MI308X (gfx942, `vllm/vllm-openai-rocm:nightly` + this patch), all three pass:

```
test_fwht_allocates_platform_fp8_dtype PASSED
test_fwht_kernel_clamp_uses_parameterized_max PASSED
test_fwht128_quant_fp8_matches_torch_reference PASSED  (3 magnitudes × 257 rows)
======================= 3 passed, 15 warnings in 34.30s ========================
```

The numeric test asserts (a) output dtype = platform fp8, (b) scales exactly match the ue8m0 power-of-two formula, (c) dequantized values recover the Hadamard reference within the fp8 relative-step bound (≤ 0.07), (d) no NaN and range ≤ fp8 max — a pre-fix e4m3fn allocation on ROCm fails (a) and a pre-fix 448 clamp violates (d) for fnuz.

End-to-end on 8× MI308X, GLM-5.3-Flash TP8 + MTP-3: pre-fix, every ≥16K-token request crashes the worker; post-fix, 40K/65K/128K long-context probes complete cleanly with correct output.

AI assistance was used for investigation, implementation, and this description.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
