### PR TITLE
fix(offload): skip hash resolution for non-prefix-cacheable groups

### DIFF
--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -839,9 +839,14 @@ class SimpleCPUOffloadScheduler:
             # the middle of the request.
             group_size = self.group_block_sizes[g]
             ready = min(len(group_gpu_ids), aligned_tokens // group_size)
-            resolved_hashes = resolve_block_hashes(
-                request.block_hashes, self.hash_block_size, group_size
-            )
+            if not self.cpu_kv_cache_config.kv_cache_groups[
+                g
+            ].kv_cache_spec.prefix_cacheable:
+                resolved_hashes = []
+            else:
+                resolved_hashes = resolve_block_hashes(
+                    request.block_hashes, self.hash_block_size, group_size
+                )
             curr_mm_idx = 0
             secondary_mm_idx = 0
             start = state.num_stored_blocks[g]


### PR DESCRIPTION
Fixes #56396.

The simple CPU offload manager assumes all groups are prefix-cacheable when trying to resolve hashes in `_select_eager_blocks_to_store`. For circular buffer / SWA groups, this causes an `AssertionError` because the global hash granularity (e.g. 32) is coarser than the group's block size (e.g. 8).

This PR skips hash resolution and falls back to an empty hash list for non-prefix-cacheable groups, avoiding the modulo crash.