### PR TITLE
[Bugfix][Kernel] Break native top-k cutoff ties by token index

### DIFF
--- a/csrc/libtorch_stable/sampler.cu
+++ b/csrc/libtorch_stable/sampler.cu
@@ -512,7 +512,9 @@ static __device__ void topKPerRowJob(const int* indices, const float* logits,
         auto logit = smemFinal.items.logits[i];
         for (int j = 0; j < smemFinalDstIdx[0]; j++) {
           auto otherLogit = smemFinal.items.logits[j];
-          if (logit < otherLogit || (logit == otherLogit && i < j)) {
+          if (logit < otherLogit ||
+              (logit == otherLogit &&
+               smemFinal.items.indices[i] > smemFinal.items.indices[j])) {
             outIndex++;
           }
         }

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -271,53 +271,6 @@ def test_top_k_per_row(
     ), "CUDA top_k_per_row_prefill results don't match torch.topk"
 
 
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
-@pytest.mark.parametrize("top_k", [512, 2048])
-@pytest.mark.parametrize("decode", [False, True])
-def test_top_k_cutoff_tie_prefers_lower_token_index(top_k, decode):
-    """A cutoff tie must not depend on atomic insertion order."""
-    torch.manual_seed(15)
-    logits = torch.zeros((4, 4096), device="cuda", dtype=torch.float32)
-    starts = torch.zeros(4, device="cuda", dtype=torch.int32)
-    ends = torch.full_like(starts, 4096)
-    indices = torch.empty((4, top_k), device="cuda", dtype=torch.int32)
-    for _ in range(8):
-        positions = torch.stack([torch.randperm(4096, device="cuda") for _ in range(4)])
-        above_cutoff = positions[:, : top_k - 1]
-        at_cutoff = positions[:, top_k - 1 : top_k + 1]
-        logits.zero_()
-        logits.scatter_(1, above_cutoff, 2)
-        logits.scatter_(1, at_cutoff, 1)
-        expected = (
-            torch.cat([above_cutoff, at_cutoff.min(dim=1, keepdim=True).values], dim=1)
-            .sort(dim=1)
-            .values.to(torch.int32)
-        )
-        if decode:
-            torch.ops._C.top_k_per_row_decode(
-                logits,
-                1,
-                ends[:, None],
-                indices,
-                4,
-                logits.stride(0),
-                logits.stride(1),
-                top_k,
-            )
-        else:
-            torch.ops._C.top_k_per_row_prefill(
-                logits,
-                starts,
-                ends,
-                indices,
-                4,
-                logits.stride(0),
-                logits.stride(1),
-                top_k,
-            )
-        torch.testing.assert_close(indices.sort(dim=-1).values, expected)
-
-
 def _run_top_k_per_row_decode_test(
     top_k: int,
     batch_size: int,

--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -271,6 +271,53 @@ def test_top_k_per_row(
     ), "CUDA top_k_per_row_prefill results don't match torch.topk"
 
 
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+@pytest.mark.parametrize("top_k", [512, 2048])
+@pytest.mark.parametrize("decode", [False, True])
+def test_top_k_cutoff_tie_prefers_lower_token_index(top_k, decode):
+    """A cutoff tie must not depend on atomic insertion order."""
+    torch.manual_seed(15)
+    logits = torch.zeros((4, 4096), device="cuda", dtype=torch.float32)
+    starts = torch.zeros(4, device="cuda", dtype=torch.int32)
+    ends = torch.full_like(starts, 4096)
+    indices = torch.empty((4, top_k), device="cuda", dtype=torch.int32)
+    for _ in range(8):
+        positions = torch.stack([torch.randperm(4096, device="cuda") for _ in range(4)])
+        above_cutoff = positions[:, : top_k - 1]
+        at_cutoff = positions[:, top_k - 1 : top_k + 1]
+        logits.zero_()
+        logits.scatter_(1, above_cutoff, 2)
+        logits.scatter_(1, at_cutoff, 1)
+        expected = (
+            torch.cat([above_cutoff, at_cutoff.min(dim=1, keepdim=True).values], dim=1)
+            .sort(dim=1)
+            .values.to(torch.int32)
+        )
+        if decode:
+            torch.ops._C.top_k_per_row_decode(
+                logits,
+                1,
+                ends[:, None],
+                indices,
+                4,
+                logits.stride(0),
+                logits.stride(1),
+                top_k,
+            )
+        else:
+            torch.ops._C.top_k_per_row_prefill(
+                logits,
+                starts,
+                ends,
+                indices,
+                4,
+                logits.stride(0),
+                logits.stride(1),
+                top_k,
+            )
+        torch.testing.assert_close(indices.sort(dim=-1).values, expected)
+
+
 def _run_top_k_per_row_decode_test(
     top_k: int,
     batch_size: int,


### PR DESCRIPTION
Break native `top_k_per_row` insertion-sort cutoff ties by token index. Previously, tied candidates were ranked by their temporary shared-memory slot, so atomic arrival order could change which token survived the cutoff. Prefer the lower token index.

This is a comparator fix with no new kernel or launch. It does not stabilize the complete output order or change the radix-sort final pass. Separate from #55122 (persistent selector), #53287/#55314 (candidate overflow), and #55872 (opt-in FlashInfer backend); none changes this comparator.

Prior validation on B300, using the identical `sampler.cu` on the source-built investigation branch (`codex/nixl-pcp-dcp-offload-test`, commit `279e9406`):

```bash
.venv/bin/python -m pytest tests/kernels/test_top_k_per_row.py -k cutoff_tie -q
```

All four cases failed before the fix and passed afterward (prefill/decode, k=512/2048). Those diagnostic tests remain on the investigation branch; this draft contains only the comparator change. Pre-commit, including clang-format, ruff and mypy, passed. A fresh build/test of the extracted branch is pending.

Model evidence from the **combined** PCP/offload investigation: GLM-5.2-NVFP4, PCP4+TP1+EP4+DCP4 → TP4 scored 28/32 GSM8K with either GPU caching or CPU offload, versus 26/32 direct TP4. All 32 GPU/CPU pairs matched tokens and log probabilities. That run also included separate ordering/layout/offload fixes; it does not isolate this patch's model-quality effect.

AI assistance: OpenAI Codex. Reviewed by submitter 
