### PR TITLE
[KV Cache] Reuse Decode FA blocks during Mooncake SWA refill

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -197,6 +197,15 @@ class KVConnectorBase_V1(ABC):
         return False
 
     @property
+    def supports_divergent_local_swa_hits(self) -> bool:
+        """Whether remote prefill restores missing SWA windows per group.
+
+        The connector must transfer each group's missing suffix independently,
+        including the entire SWA window when only full attention hits locally.
+        """
+        return False
+
+    @property
     def requires_kv_delivery(self) -> bool:
         """Whether this connector hands off KV that must be reliably delivered.
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -477,6 +477,10 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
 
 
 class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
+    @property
+    def supports_divergent_local_swa_hits(self) -> bool:
+        return True
+
     def __init__(
         self,
         vllm_config: VllmConfig,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -220,6 +220,12 @@ class MultiConnector(KVConnectorBase_V1, SupportsHMA):
         )
 
     @property
+    def supports_divergent_local_swa_hits(self) -> bool:
+        return bool(self._connectors) and all(
+            c.supports_divergent_local_swa_hits for c in self._connectors
+        )
+
+    @property
     def requires_kv_delivery(self) -> bool:
         return any(c.requires_kv_delivery for c in self._connectors)
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -916,8 +916,11 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         and group_block_size > self.hash_block_size
                         else group_block_size
                     )
+                    # The peek is discarded before reuse. Bound it by the
+                    # available hashes, not the final recomputation boundary.
                     _max_length = min(
-                        curr_hit_length + eagle_margin, max_cache_hit_length
+                        curr_hit_length + eagle_margin,
+                        len(block_hashes) * self.hash_block_size,
                     )
                 hit_blocks, _new_hit_length = manager_cls.find_longest_cache_hit(
                     block_hashes=block_hashes,
@@ -980,6 +983,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self,
         block_hashes: list[BlockHash],
         max_cache_hit_length: int,
+        *,
+        peek_past_max_length: bool = False,
     ) -> tuple[tuple[list[KVCacheBlock], ...], tuple[int, ...]]:
         """Like find_longest_cache_hit but evaluates each group independently.
 
@@ -993,9 +998,22 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 
         for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
             manager = self.single_type_managers[group_ids[0]]
+            lookup_length = max_cache_hit_length
+            if peek_past_max_length and use_eagle and not isinstance(spec, MambaSpec):
+                margin = (
+                    self.hash_block_size
+                    if self.enable_partial_hash_hits
+                    and manager_cls.supports_fine_grained_hash_lookup
+                    and manager.block_size > self.hash_block_size
+                    else manager.block_size
+                )
+                lookup_length = min(
+                    lookup_length + margin,
+                    len(block_hashes) * self.hash_block_size,
+                )
             blocks, group_hit = manager_cls.find_longest_cache_hit(
                 block_hashes=block_hashes,
-                max_length=max_cache_hit_length,
+                max_length=lookup_length,
                 kv_cache_group_ids=group_ids,
                 block_pool=manager.block_pool,
                 kv_cache_spec=spec,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -20,8 +20,10 @@ from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     CrossAttentionSpec,
     EncoderOnlyAttentionSpec,
+    FullAttentionSpec,
     KVCacheConfig,
     MambaSpec,
+    SlidingWindowSpec,
     get_kv_cache_spec_kind,
     get_kv_cache_spec_sliding_window,
 )
@@ -306,7 +308,7 @@ class KVCacheManager:
         return blocks, num_new_computed_tokens, shared_prefix_boundary
 
     def get_computed_blocks_for_connector(
-        self, request: Request
+        self, request: Request, *, allow_swa: bool = False
     ) -> tuple[KVCacheBlocks, int, int, bool]:
         """Local prefix-cache lookup for a request scheduled with a KV connector.
 
@@ -320,15 +322,34 @@ class KVCacheManager:
         boundary if the connector supplies it, so the caller must fall back to
         ``get_computed_blocks`` to reconcile when no external tokens are found.
 
-        Non-hybrid models and already-convergent hits use ``get_computed_blocks``.
+        ``allow_swa`` selects the separate SWA capability: only FA/SWA remote
+        prefills with a complete handoff may reuse divergent groups. It must
+        not implicitly opt a connector into the recurrent-state capability.
+        Other requests use ``get_computed_blocks``.
 
         Returns:
             The ``get_computed_blocks`` triple (blocks, number of local computed
             tokens, shared-prefix boundary) plus ``hit_diverged``.
         """
         coordinator = self.coordinator
+        transfer_params = request.kv_transfer_params or {}
+        swa_remote_prefill = (
+            allow_swa
+            and bool(transfer_params.get("do_remote_prefill"))
+            and all(
+                key in transfer_params
+                for key in ("remote_engine_id", "remote_bootstrap_addr", "transfer_id")
+            )
+            and not coordinator.enable_partial_hash_hits
+            and all(
+                isinstance(g.kv_cache_spec, (FullAttentionSpec, SlidingWindowSpec))
+                for g in self.kv_cache_config.kv_cache_groups
+            )
+        )
+        if allow_swa and not swa_remote_prefill:
+            return *self.get_computed_blocks(request), False
         if not (
-            self.kv_cache_config.has_mamba_layers
+            (self.kv_cache_config.has_mamba_layers or swa_remote_prefill)
             and isinstance(coordinator, HybridKVCacheCoordinator)
             and coordinator.full_attention_group_id is not None
         ):
@@ -339,7 +360,9 @@ class KVCacheManager:
 
         fa_group_id = coordinator.full_attention_group_id
         computed, per_group_hits = coordinator.find_longest_cache_hit_per_group(
-            request.block_hashes, request.num_tokens - 1
+            request.block_hashes,
+            request.num_tokens - 1,
+            peek_past_max_length=swa_remote_prefill,
         )
         if any(hit > per_group_hits[fa_group_id] for hit in per_group_hits):
             # A lagging group hit deeper than full attention means its
@@ -348,6 +371,18 @@ class KVCacheManager:
             return *self.get_computed_blocks(request), False
 
         num_local = per_group_hits[fa_group_id]
+        if swa_remote_prefill:
+            num_local = min(
+                per_group_hits[i]
+                for i, group in enumerate(self.kv_cache_config.kv_cache_groups)
+                if isinstance(group.kv_cache_spec, FullAttentionSpec)
+            )
+            computed = tuple(
+                group_blocks[
+                    : num_local // coordinator.single_type_managers[i].block_size
+                ]
+                for i, group_blocks in enumerate(computed)
+            )
         blocks = self.create_kv_cache_blocks(computed)
         # Per-group lookups do not detect an uncached shared prefix (boundary 0).
         return blocks, num_local, 0, min(per_group_hits) < num_local

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -532,6 +532,10 @@ class Scheduler(SchedulerInterface):
         connector = self.connector
         if connector is not None and connector.supports_divergent_local_hybrid_hits:
             return self.kv_cache_manager.get_computed_blocks_for_connector(request)
+        if connector is not None and connector.supports_divergent_local_swa_hits:
+            return self.kv_cache_manager.get_computed_blocks_for_connector(
+                request, allow_swa=True
+            )
 
         blocks, num_local, shared_prefix_boundary = (
             self.kv_cache_manager.get_computed_blocks(request)


### PR DESCRIPTION
## Purpose

This PR lets a Mooncake Decode consumer reuse resident full-attention KV blocks when local prefix-cache hits diverge across full-attention and sliding-window groups, while Mooncake refills only the missing per-group suffix. Without this change, the hybrid lookup collapses to zero and retransfers the full FA prefix even though thousands of FA blocks are already reusable locally.

We found this with GPT-OSS-20B plus EAGLE3 under Prefill/Decode disaggregation over Mooncake RDMA. With a 65,504-token shared prefix and 64-token request-specific suffix, Prefill local APC was hot and Decode external prefix cache hit every request, but Decode local APC remained zero on a single TP2 Decode engine. A serial exact-prompt reproducer also failed, so this was not caused only by concurrency, DP routing, or cache pressure.

There are two related boundary problems. First, EAGLE lookup needs to inspect one extra hash unit and then discard it, but the peek was capped by the final `num_tokens - 1` reuse boundary; for a block-aligned prompt this forced FA to retreat one block and made the retained SWA window start one block too late. Second, for shared-prefix siblings with different suffixes, FA could match 65,488 tokens while the SWA group lacked the historical window at that boundary; requiring every group to hit locally discarded the valid FA prefix even though Mooncake already transfers each group's missing suffix independently.

The fix bounds the discarded EAGLE peek by the available full-block hashes, adds a fail-closed connector capability for divergent FA/SWA local hits, keeps the deepest boundary covered by all FA groups, and lets the normal Mooncake allocation and per-group tail matching refill only unhashed blocks. The path is limited to remote-prefill requests with complete handoff metadata, full-attention/sliding-window groups, and no partial-hash mode. Unsupported requests and requests with no external completion continue to use the existing common-boundary lookup. `MultiConnector` enables the capability only when every child connector supports it.

The GPU A/B used #56449 at `d117baf` as its baseline because that was the active runtime under investigation. The production change in this PR is rebased directly onto current `main` and does not include #56449.

## Relationship to Existing Work

#42524 is the closest design analogue, but it implements partial-group Decode caching for Mamba with NIXL. #52287 preserves EAGLE SWA replay windows in the offloading scheduler rather than direct Mooncake P/D transfer. #54713 and #53802 align hybrid replay/checkpoint retention and registration with reachable positions. #44882 proposes coalescing concurrent cold external materialization; this PR instead reuses FA blocks that are already resident and does not coalesce in-flight loads. #56449 was the runtime baseline for this investigation and retains additional EAGLE SWA replay slack, but it does not preserve a deeper FA hit when the SWA group still needs remote completion. No open PR found in the duplicate-work search implements this connector-gated FA/SWA reuse path for direct Mooncake P/D.

## End-to-End Test Plan

- Hardware: 4 NVIDIA H20 GPUs total; Prefill TP2 on one node and Decode TP2 on one node.
- Target model: `openai/gpt-oss-20b`.
- Draft model: `RedHatAI/gpt-oss-20b-speculator.eagle3`, 3 speculative tokens.
- Transport: Mooncake RDMA with prefix caching enabled.
- Workload: exact token-ID prompts with a 65,504-token shared prefix, request-specific suffixes, `temperature=0`, and `ignore_eos=true`.
- Comparison: B1/A/B2, where A is #56449 at `d117baf` and B is this PR; only Decode code changes, Prefill remains fixed, every prompt is warmed on Prefill before each formal group, and B1/B2 runtime file hashes are identical.
- Formal groups: c1/output128 with 8 requests, c8/output128 with 40 requests, and c16/output1500 with 80 requests per variant.
- Correctness command: `python3 /tmp/check_decode_apc_outputs.py --seed 78501 --out /tmp/r3-output-check.json`.
- Performance command: `bash /tmp/run_decode_apc_perf.sh <variant>`.

## End-to-End Test Result

The controlled block-level probe changed each 65,568-token sibling from zero Decode local-hit tokens and 65,568 external tokens to 65,488 local-hit tokens and an 80-token external extent. The physical receive plan changed from 4,098 FA blocks plus 9 SWA blocks to 5 FA blocks plus 9 SWA blocks, while 4,093 resident FA blocks were reused. An exact 4,160-token replay changed from zero local-hit tokens to 4,144 local-hit tokens, with only 16 external tokens remaining.

| Measurement per 65,568-token sibling | #56449 baseline | This PR |
|---|---:|---:|
| Decode local token extent | 0 | 65,488 |
| Decode external token extent | 65,568 | 80 |
| Resident FA blocks reused | 0 | 4,093 |
| FA blocks received | 4,098 | 5 |
| SWA blocks received | 9 | 9 |

The correctness run covered 4k and 64k prefixes, varied unaligned suffix lengths, serial requests, eight-way concurrent requests, and direct Decode requests without remote handoff. Facts were placed near the beginning and middle of the shared prefix, outside the SWA tail. All 50 requests completed with the requested output length; all 32 PD outputs matched the direct Prefill reference token-for-token through EOS, and both direct Decode fallback outputs matched their references. The final exact-repeat and 64k/c8 probes also passed on the scoped production commit.

Across B1/A/B2, all 384 formal requests succeeded and streamed exactly 378,432 requested output tokens. Prefill local APC was 99.951% in every formal group. Decode local APC changed from 0% to approximately 99.90%.

| Group | Metric | #56449 baseline | This PR, B1/B2 mean | Change |
|---|---|---:|---:|---:|
| c1/output128 | Mean TTFT | 255.42 ms | 203.91 ms | -20.17% |
| c1/output128 | Output throughput | 155.36 tok/s | 166.40 tok/s | +7.11% |
| c8/output128 | Mean TTFT | 389.83 ms | 341.84 ms | -12.31% |
| c8/output128 | Output throughput | 498.87 tok/s | 510.95 tok/s | +2.42% |
| c16/output1500 | Mean TTFT | 847.54 ms | 451.02 ms | -46.78% |
| c16/output1500 | Output throughput | 817.82 tok/s | 830.94 tok/s | +1.60% |

Mean TPOT was effectively unchanged: c1 `4.446 -> 4.401 ms`, c8 `12.378 -> 12.485 ms`, and c16 `18.793 -> 18.769 ms`. The gain is therefore primarily reduced KV transfer/allocation and first-token latency rather than faster steady-state token computation.

For c8, peak active Decode KV block occupancy fell from 8.574% to 1.113% (-87.02%). For c16, it fell from 17.479% to 1.478% (-91.54%), and external token extent fell from 5,245,440 to 5,376 (-99.8975%). These percentages describe occupied blocks in the preallocated KV pool, not a reduction in reserved GPU VRAM.

AI assistance was used for runtime diagnosis, code development, test orchestration, and drafting. The submitter reviewed the changed code and the reported end-to-end evidence.
