### PR TITLE
[Bugfix][Spec Decode][Mooncake] Fix MooncakeStore cache misses from EAGLE/DSpark-drop-induced Mamba/a…

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py
@@ -735,6 +735,7 @@ def test_from_request_tracker_no_load_saves_normally():
     assert req_meta is not None
     assert req_meta.can_save is True
     assert req_meta.load_spec is None
+    assert req_meta.completed_token_len == 48
     assert tracker.num_saved_tokens == 48
 
 
@@ -991,6 +992,7 @@ def test_pending_partial_tail_emits_offload_only_reqmeta():
     assert req_meta.token_len_chunk == 0
     assert req_meta.boundary_state_offloads == [(1, 7, 12)]
     assert req_meta.num_prompt_tokens == 12
+    assert req_meta.completed_token_len == 12
     assert req_meta.block_ids == ([0],)
     store_job_id = req_meta.store_job_id
     assert scheduler._pinned_saves[store_job_id][0] == [7]
@@ -1007,6 +1009,7 @@ def test_finished_partial_tail_is_pre_pinned_as_store_job():
     request = SimpleNamespace(
         request_id="req-0",
         block_hashes=[b"h0", b"h1", b"h2"],
+        num_computed_tokens=12,
     )
     scheduler._request_trackers["req-0"] = RequestTracker(
         req_id="req-0",
@@ -1052,6 +1055,7 @@ def test_finished_partial_tail_is_pre_pinned_as_store_job():
     assert req_meta.block_ids == block_ids
     assert req_meta.block_hashes == request.block_hashes
     assert req_meta.boundary_state_offloads == [(1, 9, 12)]
+    assert req_meta.completed_token_len == 12
     assert scheduler._pinned_saves[req_meta.store_job_id][0] == [9]
     assert scheduler._gpu_block_pool.blocks[9].ref_cnt == 1
     assert scheduler._finished_partial_tail_metas == {}

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -844,6 +844,7 @@ def _make_partial_tail_send_thread(
         hash_block_size=4,
         lcm_block_size=16,
         mamba_group_ids={1},
+        eagle_peek_margin_by_group={},
     )
     db = ChunkedTokenDatabase(
         KeyMetadata("test-model", 0, 0, 0, 0),
@@ -867,6 +868,40 @@ def _make_partial_tail_send_thread(
         replicate_config=replicate_config,
         enable_group_semantics=enable_group_semantics,
         supports_group_ids=supports_group_ids,
+    )
+
+
+def _make_eagle_boundary_send_thread(store):
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    full = FullAttentionSpec(block_size=16, num_kv_heads=8, head_size=64, dtype=None)
+    mamba = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [KVCacheGroupSpec(["full"], full), KVCacheGroupSpec(["mamba"], mamba)],
+        scheduler_block_size=16,
+        hash_block_size=4,
+        use_eagle=True,
+    )
+
+    def make_db(group_id: int, base_addr: int):
+        db = ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=group_id),
+            block_size=16,
+            hash_block_size=4,
+        )
+        db.set_kv_caches_base_addr([base_addr])
+        db.set_block_len([256])
+        return db
+
+    return _make_store_sending_thread(
+        store,
+        coord=coord,
+        token_databases=[make_db(0, 0x1000), make_db(1, 0x2000)],
     )
 
 
@@ -1177,6 +1212,95 @@ def test_block_aligned_snapshot_offload_uses_provided_block():
     # block_ids[1] and with no FA gap coverage.
     assert keys == [thread.token_databases[1].key_for(BlockHash(hs[7]))]
     assert addrs == [[0x2000 + 7 * 256]]
+
+
+@pytest.mark.parametrize(
+    ("completed_token_len", "writes_attention_proof"),
+    [(35, False), (36, True)],
+)
+def test_eagle_aligned_boundary_writes_only_completed_attention_proof(
+    completed_token_len: int, writes_attention_proof: bool
+):
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_eagle_boundary_send_thread(store)
+    thread._saved_offset["req-a"] = 32
+
+    hs = [bytes([i + 1]) * 4 for i in range(9)]
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5]),
+        block_hashes=hs,
+        can_save=True,
+        completed_token_len=completed_token_len,
+        boundary_state_offloads=[(1, 7, 32)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    db_full, db_mamba = thread.token_databases
+    mamba_put = (db_mamba.key_for(BlockHash(hs[7])), [0x2000 + 7 * 256])
+    if writes_attention_proof:
+        assert list(zip(keys, addrs, strict=True)) == [
+            (db_full.key_for(BlockHash(hs[8])), [0x1000 + 3 * 256]),
+            mamba_put,
+        ]
+    else:
+        assert list(zip(keys, addrs, strict=True)) == [mamba_put]
+
+
+def test_eagle_sub_block_boundary_writes_attention_at_next_hash_unit():
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_eagle_boundary_send_thread(store)
+    thread._saved_offset["req-a"] = 16
+
+    hs = [bytes([i + 1]) * 4 for i in range(8)]
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2], [5]),
+        block_hashes=hs,
+        can_save=True,
+        completed_token_len=32,
+        boundary_state_offloads=[(1, 7, 28)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    db_full, db_mamba = thread.token_databases
+    assert list(zip(keys, addrs, strict=True)) == [
+        (db_full.key_for(BlockHash(hs[7])), [0x1000 + 2 * 256]),
+        (db_mamba.key_for(BlockHash(hs[6])), [0x2000 + 7 * 256]),
+    ]
+
+
+def test_multiple_eagle_boundaries_deduplicate_attention_puts():
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_eagle_boundary_send_thread(store)
+
+    hs = [bytes([i + 1]) * 4 for i in range(10)]
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5]),
+        block_hashes=hs,
+        can_save=True,
+        completed_token_len=40,
+        boundary_state_offloads=[(1, 9, 32), (1, 7, 36)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys = store.batch_is_exist.call_args.args[0]
+    assert len(keys) == len(set(keys))
+    db_full = thread.token_databases[0]
+    assert keys.count(db_full.key_for(BlockHash(hs[3]))) == 1
+    assert keys.count(db_full.key_for(BlockHash(hs[7]))) == 1
 
 
 def test_mixed_snapshot_and_sub_block_offloads():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -905,6 +905,46 @@ def _make_eagle_boundary_send_thread(store):
     )
 
 
+def _make_eagle_swa_boundary_send_thread(store):
+    from vllm.v1.kv_cache_interface import MambaSpec, SlidingWindowSpec
+
+    swa = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=64,
+        dtype=None,
+        sliding_window=32,
+    )
+    mamba = MambaSpec(
+        block_size=16,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    coord = mooncake_store_worker.MooncakeStoreCoordinator(
+        [KVCacheGroupSpec(["swa"], swa), KVCacheGroupSpec(["mamba"], mamba)],
+        scheduler_block_size=16,
+        hash_block_size=4,
+        use_eagle=True,
+    )
+
+    def make_db(group_id: int, base_addr: int):
+        db = ChunkedTokenDatabase(
+            KeyMetadata("test-model", 0, 0, 0, 0, group_id=group_id),
+            block_size=16,
+            hash_block_size=4,
+        )
+        db.set_kv_caches_base_addr([base_addr])
+        db.set_block_len([256])
+        return db
+
+    return _make_store_sending_thread(
+        store,
+        coord=coord,
+        token_databases=[make_db(0, 0x1000), make_db(1, 0x2000)],
+    )
+
+
 def _make_partial_tail_req(block_ids: list[int]) -> ReqMeta:
     return ReqMeta(
         req_id="req-a",
@@ -1276,6 +1316,43 @@ def test_eagle_sub_block_boundary_writes_attention_at_next_hash_unit():
         (db_full.key_for(BlockHash(hs[7])), [0x1000 + 2 * 256]),
         (db_mamba.key_for(BlockHash(hs[6])), [0x2000 + 7 * 256]),
     ]
+
+
+@pytest.mark.parametrize(
+    ("completed_token_len", "writes_swa_proof"),
+    [(47, False), (48, True)],
+)
+def test_eagle_swa_boundary_uses_physical_block_margin(
+    completed_token_len: int, writes_swa_proof: bool
+):
+    store = MagicMock()
+    store.batch_is_exist.side_effect = lambda keys: [0] * len(keys)
+    store.batch_put_from_multi_buffers.side_effect = lambda keys, *a: [256] * len(keys)
+    thread = _make_eagle_swa_boundary_send_thread(store)
+    thread._saved_offset["req-a"] = 32
+
+    hs = [bytes([i + 1]) * 4 for i in range(12)]
+    req = ReqMeta(
+        req_id="req-a",
+        token_len_chunk=0,
+        block_ids=([1, 2, 3], [5]),
+        block_hashes=hs,
+        can_save=True,
+        completed_token_len=completed_token_len,
+        boundary_state_offloads=[(1, 7, 32)],
+    )
+    assert thread._maybe_offload_boundary_states(req)
+
+    keys, addrs, _sizes, _ = store.batch_put_from_multi_buffers.call_args.args
+    db_swa, db_mamba = thread.token_databases
+    mamba_put = (db_mamba.key_for(BlockHash(hs[7])), [0x2000 + 7 * 256])
+    if writes_swa_proof:
+        assert list(zip(keys, addrs, strict=True)) == [
+            (db_swa.key_for(BlockHash(hs[11])), [0x1000 + 3 * 256]),
+            mamba_put,
+        ]
+    else:
+        assert list(zip(keys, addrs, strict=True)) == [mamba_put]
 
 
 def test_multiple_eagle_boundaries_deduplicate_attention_puts():

--- a/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_store_worker.py
@@ -1274,6 +1274,7 @@ def test_eagle_aligned_boundary_writes_only_completed_attention_proof(
         block_ids=([1, 2, 3], [5]),
         block_hashes=hs,
         can_save=True,
+        num_prompt_tokens=37,
         completed_token_len=completed_token_len,
         boundary_state_offloads=[(1, 7, 32)],
     )
@@ -1338,6 +1339,7 @@ def test_eagle_swa_boundary_uses_physical_block_margin(
         block_ids=([1, 2, 3], [5]),
         block_hashes=hs,
         can_save=True,
+        num_prompt_tokens=49,
         completed_token_len=completed_token_len,
         boundary_state_offloads=[(1, 7, 32)],
     )
@@ -1368,6 +1370,7 @@ def test_multiple_eagle_boundaries_deduplicate_attention_puts():
         block_ids=([1, 2, 3], [5]),
         block_hashes=hs,
         can_save=True,
+        num_prompt_tokens=40,
         completed_token_len=40,
         boundary_state_offloads=[(1, 9, 32), (1, 7, 36)],
     )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/coordinator.py
@@ -167,6 +167,25 @@ class MooncakeStoreCoordinator:
         self.eagle_group_ids = {
             gid for g in attention_groups if g.use_eagle for gid in g.group_ids
         }
+        self.eagle_peek_margin_by_group = {
+            gid: self._eagle_peek_margin(g.spec, g.manager_cls)
+            for g in attention_groups
+            if g.use_eagle and not isinstance(g.spec, MambaSpec)
+            for gid in g.group_ids
+        }
+
+    def _eagle_peek_margin(
+        self,
+        spec: KVCacheSpec,
+        manager_cls: type[SingleTypeKVCacheManager],
+    ) -> int:
+        if (
+            self.enable_partial_hash_hits
+            and manager_cls.supports_fine_grained_hash_lookup
+            and spec.block_size > self.hash_block_size
+        ):
+            return self.hash_block_size
+        return spec.block_size
 
     def find_longest_cache_hit(
         self,
@@ -394,13 +413,7 @@ class MooncakeStoreCoordinator:
                 # never drops a block, so a widened bound would match past the
                 # attention-verified hit and resume from speculative state (#43559).
                 if drop_eagle_block and not isinstance(spec, MambaSpec):
-                    eagle_margin = (
-                        self.hash_block_size
-                        if self.enable_partial_hash_hits
-                        and manager_cls.supports_fine_grained_hash_lookup
-                        and spec.block_size > self.hash_block_size
-                        else spec.block_size
-                    )
+                    eagle_margin = self._eagle_peek_margin(spec, manager_cls)
                     _max_length = min(curr_hit_length + eagle_margin, max_length)
                 hit_blocks, _new_hit_length = manager_cls.find_longest_cache_hit(
                     block_hashes=block_hashes,  # type: ignore[arg-type]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/data.py
@@ -753,6 +753,8 @@ class ReqMeta:
     # Absolute request offset represented by token_ids[0].
     token_ids_start: int = 0
     num_prompt_tokens: int | None = None
+    # Prefix whose GPU state is valid once current_event completes.
+    completed_token_len: int = 0
     # Identifies this store job for the engine's lifetime. A request id cannot
     # serve that purpose: it is reused once a preempted request resumes, so it
     # would release the wrong job's blocks.
@@ -824,6 +826,7 @@ class ReqMeta:
             token_ids=token_ids,
             token_ids_start=token_ids_start,
             num_prompt_tokens=tracker.prefill_end_tokens,
+            completed_token_len=input_token_len,
         )
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/scheduler.py
@@ -534,6 +534,7 @@ class MooncakeStoreScheduler:
             block_hashes=list(request.block_hashes),
             can_save=True,
             num_prompt_tokens=tracker.prefill_end_tokens,
+            completed_token_len=request.num_computed_tokens,
             store_job_id=store_job_id,
             boundary_state_offloads=partial_tail_offloads,
         )
@@ -591,6 +592,7 @@ class MooncakeStoreScheduler:
                     block_hashes=req_tuple[0].block_hashes,
                     can_save=True,
                     num_prompt_tokens=tracker.prefill_end_tokens,
+                    completed_token_len=tracker.token_len,
                     boundary_state_offloads=accepted,
                 )
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -730,10 +730,10 @@ class KVCacheStoreSendingThread(KVTransferThread):
         boundary: the normal save floors to ``lcm_block_size``, so a
         smaller-block group's full blocks in that gap are never persisted
         elsewhere, and the consumer's lookup needs every group at every probed
-        boundary. Eagle attention whose peek margin is one hash unit includes
-        the block that lookup drops; mamba remains keyed at the reusable
-        boundary. A mamba "align" group contributes only its boundary block,
-        from the core-provided CoW block.
+        boundary. Eagle attention includes the completed margin that lookup
+        drops; mamba remains keyed at the reusable boundary. A mamba "align"
+        group contributes only its boundary block, from the core-provided CoW
+        block.
         """
         boundaries = {boundary for _, _, boundary in entries}
         if len(boundaries) != 1:
@@ -756,7 +756,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
             group_boundary = boundary
             eagle_margin = self.coord.eagle_peek_margin_by_group.get(g_idx)
             if (
-                eagle_margin == hash_block_size
+                eagle_margin is not None
                 and boundary + eagle_margin <= req_meta.completed_token_len
             ):
                 group_boundary += eagle_margin
@@ -832,10 +832,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 (group_id, block_id, boundary)
             )
 
-        hash_unit_peek = any(
-            margin == self.coord.hash_block_size
-            for margin in self.coord.eagle_peek_margin_by_group.values()
-        )
         puts: list[tuple[str, list[int], list[int], KeyMetadata]] = []
         for boundary, entries in entries_by_boundary.items():
             snapshots = [
@@ -844,10 +840,9 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 if boundary % self.token_databases[entry[0]].block_size == 0
             ]
             has_sub_block = len(snapshots) != len(entries)
-            can_write_proof = (
-                hash_unit_peek
-                and boundary + self.coord.hash_block_size
-                <= req_meta.completed_token_len
+            can_write_proof = any(
+                boundary + margin <= req_meta.completed_token_len
+                for margin in self.coord.eagle_peek_margin_by_group.values()
             )
             if self.coord.enable_partial_hash_hits and (
                 has_sub_block or can_write_proof

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -721,24 +721,24 @@ class KVCacheStoreSendingThread(KVTransferThread):
             )
         return puts
 
-    def _sub_block_tail_puts(
+    def _boundary_tail_puts(
         self, req_meta: ReqMeta, entries: list[tuple[int, int, int]]
     ) -> list[tuple[str, list[int], list[int], KeyMetadata]]:
-        """Puts for the request's sub-block partial tail (its last prompt hash
-        boundary), so a later request can hit the sub-block prefix.
+        """Puts for a boundary and its safely completed attention tail.
 
         Covers every group's blocks from the normal save's lcm floor to the
         boundary: the normal save floors to ``lcm_block_size``, so a
         smaller-block group's full blocks in that gap are never persisted
         elsewhere, and the consumer's lookup needs every group at every probed
-        boundary. Full blocks are keyed by their block-end hash and the partial
-        boundary block by the boundary sub-hash; a mamba "align" group
-        contributes only its boundary block, from the core-provided CoW block.
+        boundary. Eagle attention whose peek margin is one hash unit includes
+        the block that lookup drops; mamba remains keyed at the reusable
+        boundary. A mamba "align" group contributes only its boundary block,
+        from the core-provided CoW block.
         """
         boundaries = {boundary for _, _, boundary in entries}
         if len(boundaries) != 1:
             raise ValueError(
-                "Sub-block partial-tail offloads for one request must share a boundary"
+                "Boundary-tail offloads in one batch must share a boundary"
             )
         boundary = boundaries.pop()
         hash_block_size = self.coord.hash_block_size
@@ -753,19 +753,28 @@ class KVCacheStoreSendingThread(KVTransferThread):
         for g_idx, db in enumerate(self.token_databases):
             if not self.group_participates[g_idx]:
                 continue
+            group_boundary = boundary
+            eagle_margin = self.coord.eagle_peek_margin_by_group.get(g_idx)
+            if (
+                eagle_margin == hash_block_size
+                and boundary + eagle_margin <= req_meta.completed_token_len
+            ):
+                group_boundary += eagle_margin
+            if group_boundary // hash_block_size - 1 >= len(req_meta.block_hashes):
+                continue
             group_blocks = req_meta.block_ids[g_idx]
             # Distribute across ranks by the same rule as normal chunks.
             put_step = self.group_put_steps[g_idx]
             put_step_rank = (self.tp_rank + g_idx) % put_step
             # Always include the boundary block: its sub-hash key is written
             # only here, even if normal saves already advanced past it.
-            last_block = cdiv(boundary, db.block_size) - 1
+            last_block = cdiv(group_boundary, db.block_size) - 1
             for block_idx in range(
                 min(saved // db.block_size, last_block), last_block + 1
             ):
                 if block_idx % put_step != put_step_rank:
                     continue
-                valid_end = min((block_idx + 1) * db.block_size, boundary)
+                valid_end = min((block_idx + 1) * db.block_size, group_boundary)
                 key_hash = req_meta.block_hashes[valid_end // hash_block_size - 1]
                 if g_idx in mamba_offloads:
                     if valid_end != boundary:
@@ -802,11 +811,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
         mamba groups from the positional normal save, aligned boundaries
         included (see :meth:`_boundary_snapshot_puts`).
 
-        The two entry kinds are keyed and sourced differently, so they are
-        prepared separately and put in one batch:
+        The two entry kinds use different Mamba sources:
 
         - block-aligned for its group: a committed boundary-state snapshot,
-          the handed-off block itself;
+          the handed-off block itself; its attention proof is included only
+          when the completed prefix covers the required EAGLE peek margin;
         - not block-aligned: the sub-block CoW partial tail, which also has to
           cover the other groups' blocks in the normal save's lcm gap.
 
@@ -817,18 +826,40 @@ class KVCacheStoreSendingThread(KVTransferThread):
         if not offloads or not req_meta.block_hashes:
             return True
 
-        snapshots: list[tuple[int, int, int]] = []
-        sub_block: list[tuple[int, int, int]] = []
+        entries_by_boundary: dict[int, list[tuple[int, int, int]]] = {}
         for group_id, block_id, boundary in offloads:
-            entry = (group_id, block_id, boundary)
-            if boundary % self.token_databases[group_id].block_size == 0:
-                snapshots.append(entry)
-            else:
-                sub_block.append(entry)
+            entries_by_boundary.setdefault(boundary, []).append(
+                (group_id, block_id, boundary)
+            )
 
-        puts = self._boundary_snapshot_puts(req_meta, snapshots)
-        if sub_block and self.coord.enable_partial_hash_hits:
-            puts.extend(self._sub_block_tail_puts(req_meta, sub_block))
+        hash_unit_peek = any(
+            margin == self.coord.hash_block_size
+            for margin in self.coord.eagle_peek_margin_by_group.values()
+        )
+        puts: list[tuple[str, list[int], list[int], KeyMetadata]] = []
+        for boundary, entries in entries_by_boundary.items():
+            snapshots = [
+                entry
+                for entry in entries
+                if boundary % self.token_databases[entry[0]].block_size == 0
+            ]
+            has_sub_block = len(snapshots) != len(entries)
+            can_write_proof = (
+                hash_unit_peek
+                and boundary + self.coord.hash_block_size
+                <= req_meta.completed_token_len
+            )
+            if self.coord.enable_partial_hash_hits and (
+                has_sub_block or can_write_proof
+            ):
+                puts.extend(self._boundary_tail_puts(req_meta, entries))
+            else:
+                puts.extend(self._boundary_snapshot_puts(req_meta, snapshots))
+
+        unique_puts: dict[str, tuple[str, list[int], list[int], KeyMetadata]] = {}
+        for put in puts:
+            unique_puts.setdefault(put[0], put)
+        puts = list(unique_puts.values())
 
         if not puts:
             return True

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/worker.py
@@ -803,6 +803,29 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 puts.append((db.key_for(key_hash), addr, size, db.metadata))
         return puts
 
+    def _is_eagle_replay_boundary(self, req_meta: ReqMeta, boundary: int) -> bool:
+        """Whether an aligned Mamba state is a prompt replay endpoint."""
+        if (
+            req_meta.num_prompt_tokens is None
+            or not self.coord.eagle_peek_margin_by_group
+        ):
+            return False
+        fine_grained = self.coord.enable_partial_hash_hits and all(
+            group.manager_cls.supports_fine_grained_hash_lookup
+            or group.spec.block_size == self.coord.hash_block_size
+            for group in self.coord.attention_groups
+        )
+        alignment = (
+            self.coord.hash_block_size if fine_grained else self.coord.lcm_block_size
+        )
+        prompt_tokens = req_meta.num_prompt_tokens
+        resend = (prompt_tokens - 1) // alignment * alignment
+        extension = prompt_tokens // alignment * alignment
+        return boundary in {
+            max(resend - alignment, 0),
+            max(extension - alignment, 0),
+        }
+
     def _maybe_offload_boundary_states(self, req_meta: ReqMeta) -> bool:
         """Persist connector-pinned mamba "align" boundary states handed off
         for this request, deduped against the store.
@@ -814,8 +837,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
         The two entry kinds use different Mamba sources:
 
         - block-aligned for its group: a committed boundary-state snapshot,
-          the handed-off block itself; its attention proof is included only
-          when the completed prefix covers the required EAGLE peek margin;
+          the handed-off block itself; only a prompt replay boundary includes
+          an attention companion;
         - not block-aligned: the sub-block CoW partial tail, which also has to
           cover the other groups' blocks in the normal save's lcm gap.
 
@@ -840,7 +863,8 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 if boundary % self.token_databases[entry[0]].block_size == 0
             ]
             has_sub_block = len(snapshots) != len(entries)
-            can_write_proof = any(
+            is_replay_boundary = self._is_eagle_replay_boundary(req_meta, boundary)
+            can_write_proof = is_replay_boundary and any(
                 boundary + margin <= req_meta.completed_token_len
                 for margin in self.coord.eagle_peek_margin_by_group.values()
             )


### PR DESCRIPTION
## Purpose

Fix MooncakeStore cache misses caused by an EAGLE-induced boundary mismatch between Mamba/KDA states and attention KV cache.

For a reusable Mamba/KDA token boundary `B`, EAGLE attention lookup probes the original cache boundary `B + H` (`H` is the prefix-match-unit) and then drops one hash unit `H` due to the _eagle drop_, while other cache type (i.e., Mamba) directly looks up state at `B`.

For a request at its prompt's tail, the existing boundary offload path (`_sub_block_tail_puts`) stores Mamba and Attention both at `B`.
Thus, when the same or the subsequent request lookup MooncakeStore, it get Attention at `B`, and drop `H` due to eagle drop, then lookup Mamba at `B-H`and missed. (When the HBM prefix cache is evicted.)

This PR makes the store layout match lookup behavior:

- Store Mamba/KDA state at `B`.
- Store eligible EAGLE attention KV at `B + H`.
- Only store `B + H` when GPU computation has completed through that position.

## Changes

- Share the per-group EAGLE peek-margin calculation between lookup and store.
- Add `completed_token_len` to store metadata so the worker only publishes an attention companion when `B + H` has been computed.
- Handle each boundary independently and deduplicate overlapping MooncakeStore keys.

The `H` is the EAGLE peek margin for each attention group.
For fine-grained lookup, `H` is the hash block size; for block-granularity groups, it may be the group's physical block size.

The boundary handoff logic covers three cases:

| Boundary case | Mamba/KDA | Eagle-group attention written by the boundary handoff |
|---|---|---|
| Sub-block boundary | Store at `B` | Store through `B + H` when completed; otherwise only through `B` |
| Block-aligned prompt replay boundary | Store at `B` | Store the `B + H` companion when completed; otherwise publish no companion |
| Block-aligned internal checkpoint | Store at `B` | Publish no additional attention companion as the original code |

`_sub_block_tail_puts` is renamed to `_boundary_tail_puts` because it now
handles both sub-block boundaries and block-aligned prompt replay boundaries
that require an EAGLE attention companion.

## Test Plan

- Kimi-K3, TP 8, DCP 8, DSpark (Inferact/Kimi-K3-DSpark), MooncakeStore (standalone mode), and other settings following vllm recipe (e.g., prefix-match-unit 128).
  Test with some requests, then /reset_prefix_cache clean the HBM cache, send the same requests again.
- unit tests.

## Test Result

| Request, prompt length | version | send 1st time | after HBM cache reset and send 2nd time|
|---|---|---|---|
| A, 7449 | main | `cached_tokens: 0`<br>`created_cache_tokens: 7296` | `cached_tokens: 0`<br>`created_cache_tokens: 7296` |
| A, 7449 | this PR | same as above | `cached_tokens: 7296`<br>`created_cache_tokens: 0` |
| B, 23196 | main | `cached_tokens: 0`<br>`created_cache_tokens: 23040` | `cached_tokens: 0`<br>`created_cache_tokens: 23040` |
| B, 23196 | this PR | — | `cached_tokens: 23040`<br>`created_cache_tokens: 0` |
| C, 41300 | main | `cached_tokens: 0`<br>`created_cache_tokens: 41088` | `cached_tokens: 30464`<br>`created_cache_tokens: 10624` |
| C, 41300 | this PR | — | `cached_tokens: 41088`<br>`created_cache_tokens: 0` |

Thus, for the `main` current code, request A and B totally missed from MooncakeStore.
Request C got partial hit at an internal point (FlashKDA internal checkpoint), but still missed a large portion.

unit tests passed:
- tests/v1/kv_connector/unit/test_mooncake_store_worker.py
- tests/v1/kv_connector/unit/test_mooncake_store_scheduler.py

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

## Duplicate-work check

No open PR implementing the same MooncakeStore write-side B / B + H boundary pairing was found.

There are some PRs targeting at the similar issue around _eagle drop_, including #51295, #55036, #53945, etc.
But not related to external KV offloading as Mooncake.
- #51358 (merged): save mamba state at `B`, but not save tail attention KV at `B+H`.


## AI assistance
AI was used for problem analysis, code implementation and review.