### PR TITLE
fix(structured_output): reject allOf in xgrammar backend schema

### DIFF
--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -27,8 +27,19 @@ from vllm.v1.structured_output.utils import (
 
 if TYPE_CHECKING:
     import xgrammar as xgr
+    _GrammarMatcher = xgr.GrammarMatcher
+    _CompiledGrammar = xgr.CompiledGrammar
 else:
-    xgr = LazyLoader("xgr", globals(), "xgrammar")
+    try:
+        import xgrammar as xgr
+        _GrammarMatcher = xgr.GrammarMatcher
+        _CompiledGrammar = xgr.CompiledGrammar
+        HAS_XGRAMMAR = True
+    except ImportError:
+        xgr = None
+        _GrammarMatcher = Any
+        _CompiledGrammar = Any
+        HAS_XGRAMMAR = False
 
 logger = init_logger(__name__)
 
@@ -36,6 +47,9 @@ logger = init_logger(__name__)
 @dataclass
 class XgrammarBackend(StructuredOutputBackend):
     def __post_init__(self):
+        if not HAS_XGRAMMAR:
+            raise RuntimeError("xgrammar is not available on this platform")
+
         self.disable_any_whitespace = (
             self.vllm_config.structured_outputs_config.disable_any_whitespace
         )
@@ -147,8 +161,8 @@ class XgrammarGrammar(StructuredOutputGrammar):
     # for jump-forward decoding
 
     vocab_size: int
-    matcher: xgr.GrammarMatcher = field(hash=False)
-    ctx: xgr.CompiledGrammar = field(hash=False)
+    matcher: _GrammarMatcher = field(hash=False)
+    ctx: _CompiledGrammar = field(hash=False)
     num_processed_tokens: int = field(
         default_factory=lambda: 0, repr=False, hash=False, init=False
     )
@@ -304,6 +318,9 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
     """
     if sampling_params.structured_outputs is None:
         return
+
+    if not HAS_XGRAMMAR:
+        raise RuntimeError("xgrammar is not available on this platform")
 
     so_params = sampling_params.structured_outputs
 

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -257,6 +257,9 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
         if not isinstance(obj, dict):
             return False
 
+        if "allOf" in obj and isinstance(obj["allOf"], list) and len(obj["allOf"]) != 1:
+            return True
+
         # Check for numeric ranges
         if obj.get("type") in ("integer", "number") and ("multipleOf" in obj):
             return True


### PR DESCRIPTION
Fixes #56556. A JSON schema that uses `allOf` with multiple branches is silently ignored by xgrammar. This commit adds a check for `allOf` in `has_xgrammar_unsupported_json_features` so that vLLM can fallback to another backend instead of accepting invalid JSON silently.