### PR TITLE
[Bugfix][Pooling] Release cached queries when Flash scoring is cancelled

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_late_interaction_serving.py
+++ b/tests/entrypoints/pooling/scoring/test_late_interaction_serving.py
@@ -1,14 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+import torch
+from fastapi import Request
+from fastapi.responses import Response
 
+from vllm.entrypoints.pooling.scoring.api_router import create_score, do_rerank
+from vllm.entrypoints.pooling.scoring.protocol import RerankRequest, ScoreTextRequest
 from vllm.entrypoints.pooling.scoring.serving import ServingScores
 from vllm.entrypoints.pooling.typing import PoolingServeContext
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import tokens_input
 from vllm.pooling_params import PoolingParams
+from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.output_processor import OutputProcessor, RequestOutputCollector
+from vllm.v1.pool.late_interaction_runner import LateInteractionRunner
 
 
 def _make_context() -> PoolingServeContext:
@@ -41,8 +53,7 @@ def _query_key(context: PoolingServeContext) -> str:
 @pytest.mark.asyncio
 async def test_colliding_request_ids_use_distinct_query_cache_keys():
     serving = object.__new__(ServingScores)
-    serving._prepare_generators = AsyncMock()
-    serving._collect_batch = AsyncMock()
+    serving._collect_late_interaction_batch = AsyncMock()
 
     first = _make_context()
     second = _make_context()
@@ -51,7 +62,7 @@ async def test_colliding_request_ids_use_distinct_query_cache_keys():
         await serving._flash_late_interaction_encode_docs(context)
 
     prepared_contexts = [
-        call.args[0] for call in serving._prepare_generators.await_args_list
+        call.args[0] for call in serving._collect_late_interaction_batch.await_args_list
     ]
     first_query_key = _query_key(prepared_contexts[0])
     first_doc_key = _query_key(prepared_contexts[1])
@@ -63,3 +74,231 @@ async def test_colliding_request_ids_use_distinct_query_cache_keys():
     assert first_query_key != second_query_key
     assert "caller-controlled-id" not in first_query_key
     assert "caller-controlled-id" not in second_query_key
+    assert (
+        prepared_contexts[1].prompt_request_ids
+        != prepared_contexts[3].prompt_request_ids
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("n_queries", [1, 2], ids=["rerank", "score"])
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "normal",
+        "query_output",
+        "query_add",
+        "doc_output",
+        "doc_error",
+        "double_abort",
+        "double_rpc",
+    ],
+)
+async def test_late_interaction_releases_queries_after_producers_stop(
+    n_queries, scenario
+):
+    """Exercise route cancellation, encoding and cache ownership without a model."""
+    runner = LateInteractionRunner()
+    reached, cleanup_entered, release = (asyncio.Event() for _ in range(3))
+    all_docs_added = asyncio.Event()
+    blocked = asyncio.Event()
+    producers = []
+    pending = set()
+    external_aborts, rpcs = [], []
+    send_interrupted = False
+    handler_task = None
+    error = VLLMValidationError("document rejected")
+
+    class ControlledEngine:
+        encode = AsyncLLM.encode
+        log_requests = False
+        is_tracing_enabled = AsyncMock(return_value=False)
+
+        def __init__(self):
+            self.output_processor = OutputProcessor(None, log_stats=False)
+            self.engine_core = SimpleNamespace(abort_requests_async=self.send_abort)
+
+        async def add_request(self, request_id, prompt, params, **kwargs):
+            task = asyncio.current_task()
+            assert task is not None
+            producers.append(task)
+            internal_id = f"{request_id}-internal"
+            pending.add(internal_id)
+            collector = RequestOutputCollector(params.output_kind, internal_id)
+            self.output_processor.add_request(
+                EngineCoreRequest(
+                    request_id=internal_id,
+                    external_req_id=request_id,
+                    prompt_token_ids=prompt["prompt_token_ids"],
+                    mm_features=None,
+                    sampling_params=None,
+                    pooling_params=params,
+                    arrival_time=0,
+                    lora_request=None,
+                    cache_salt=None,
+                    data_parallel_rank=None,
+                ),
+                prompt=None,
+                queue=collector,
+            )
+            runner.register_request(internal_id, params)
+            index = prompt["prompt_token_ids"][0]
+            if index == n_queries + 1:
+                all_docs_added.set()
+            if scenario == "doc_error" and index == n_queries:
+                await all_docs_added.wait()
+                raise error
+            hold_doc = index == n_queries + 1 and scenario in {
+                "doc_output",
+                "doc_error",
+                "double_abort",
+            }
+            if hold_doc:
+                reached.set()
+                return collector
+
+            output = runner.postprocess_pooler_output(
+                [torch.eye(2)], [params], [internal_id], [True]
+            )[0]
+            pending.remove(internal_id)
+            runner.on_requests_finished([internal_id])
+            hold_query = index == n_queries - 1 and scenario in {
+                "query_output",
+                "query_add",
+                "double_rpc",
+            }
+            if hold_query:
+                reached.set()
+                if scenario == "query_add":
+                    await blocked.wait()
+                return collector
+            self.output_processor.process_outputs(
+                [
+                    EngineCoreOutput(
+                        request_id=internal_id,
+                        new_token_ids=[],
+                        pooling_output=output,
+                        finish_reason=FinishReason.STOP,
+                    )
+                ]
+            )
+            return collector
+
+        async def abort(self, request_ids, internal=False):
+            if not internal:
+                assert all(task.done() for task in producers)
+                external_aborts.append(request_ids)
+            await AsyncLLM.abort(self, request_ids, internal)
+
+        async def send_abort(self, request_ids):
+            nonlocal send_interrupted
+            if request_ids and scenario == "double_abort":
+                # AsyncLLM.abort already removed the external ID mapping.
+                assert not self.output_processor.external_req_ids
+                cleanup_entered.set()
+                try:
+                    await release.wait()
+                except asyncio.CancelledError:
+                    send_interrupted = True
+                    raise
+            pending.difference_update(request_ids)
+            runner.on_requests_finished(request_ids)
+
+        async def collective_rpc(self, method, *, args, wait_for_inflight_batches):
+            assert all(task.done() for task in producers)
+            assert not pending
+            assert method == "release_late_interaction_queries"
+            assert wait_for_inflight_batches is True
+            rpcs.append(args[0])
+            if scenario == "double_rpc":
+                cleanup_entered.set()
+                await release.wait()
+            runner.release_queries(args[0])
+
+    request = (
+        RerankRequest(model="model", query="q", documents=["d1", "d2"])
+        if n_queries == 1
+        else ScoreTextRequest(model="model", text_1=["q1", "q2"], text_2=["d1", "d2"])
+    )
+    ctx = _make_context()
+    ctx.request, ctx.n_queries = request, n_queries
+    ctx.engine_inputs = [
+        {
+            "prompts": tokens_input(prompt_token_ids=[i]),
+            "params": PoolingParams(task="token_embed"),
+            "lora_requests": None,
+            "priorities": 0,
+        }
+        for i in range(n_queries + 2)
+    ]
+    serving = object.__new__(ServingScores)
+    serving.enable_flash_late_interaction = True
+    serving.io_processor = Mock()
+    serving.model_config = SimpleNamespace(pooler_config=None)
+    serving.engine_client = ControlledEngine()
+    serving._preprocessing = AsyncMock()
+    serving._postprocessing_async = AsyncMock(return_value=Response())
+    serving._log_inputs = Mock()
+
+    async def init_context(*args, **kwargs):
+        nonlocal handler_task
+        handler_task = asyncio.current_task()
+        return ctx
+
+    serving._init_ctx = init_context
+
+    async def receive():
+        if scenario in {"normal", "doc_error"}:
+            await blocked.wait()
+        await reached.wait()
+        return {"type": "http.disconnect"}
+
+    raw_request = Request(
+        {
+            "type": "http",
+            "headers": [],
+            "app": SimpleNamespace(state=SimpleNamespace(serving_scores=serving)),
+        },
+        receive=receive,
+    )
+    ctx.raw_request = raw_request
+    route = do_rerank if n_queries == 1 else create_score
+
+    async def run_scenario():
+        if scenario == "doc_error":
+            with pytest.raises(VLLMValidationError) as exc:
+                await route(request, raw_request)
+            assert exc.value is error
+        else:
+            response = await route(request, raw_request)
+            if scenario == "normal":
+                assert response.status_code == 200
+                assert len(ctx.final_res_batch) == 2
+                assert all(
+                    result.outputs.data.item() == 2 for result in ctx.final_res_batch
+                )
+            else:
+                assert response is None
+                assert handler_task is not None
+                if scenario in {"double_abort", "double_rpc"}:
+                    await cleanup_entered.wait()
+                    handler_task.cancel()
+                    await asyncio.sleep(0)
+                    release.set()
+                with pytest.raises(asyncio.CancelledError):
+                    await handler_task
+
+    await asyncio.wait_for(run_scenario(), timeout=5)
+    assert not send_interrupted
+    assert not pending
+    assert not runner._query_cache
+    assert not runner._query_uses
+    assert not runner._doc_query_keys
+    assert not serving.engine_client.output_processor.external_req_ids
+    if scenario == "normal":
+        assert not external_aborts and not rpcs
+    else:
+        assert external_aborts == [
+            ctx.late_interaction_query_keys + (ctx.late_interaction_doc_keys or [])
+        ]
+        assert rpcs == [ctx.late_interaction_query_keys]

--- a/tests/v1/engine/test_collective_rpc.py
+++ b/tests/v1/engine/test_collective_rpc.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections import deque
+from concurrent.futures import Future
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.engine.core_client import AsyncMPClient, DPLBAsyncMPClient
+
+
+class OneShotFuture(Future):
+    """Model the single consumption required by Ray compiled graph outputs."""
+
+    def __init__(self, output, order, name, error=None):
+        super().__init__()
+        self.output = output
+        self.order = order
+        self.name = name
+        self.error = error
+        self.consumed = False
+
+    def result(self, timeout=None):
+        assert not self.consumed
+        self.consumed = True
+        self.order.append(self.name)
+        if self.error is not None:
+            raise self.error
+        return self.output
+
+
+@pytest.mark.parametrize("wait", [False, True])
+@pytest.mark.parametrize("separate_exec_future", [False, True])
+def test_collective_rpc_preserves_pending_outputs(wait, separate_exec_future):
+    order: list[int | str] = []
+    outputs = [object(), object()]
+    futures: list[Future] = [
+        OneShotFuture(output, order, i) for i, output in enumerate(outputs)
+    ]
+    exec_futures: list[Future] = (
+        [Future(), Future()] if separate_exec_future else futures
+    )
+    scheduled = [object(), object()]
+    queue = deque(reversed(list(zip(futures, scheduled, exec_futures))), maxlen=2)
+    original = list(queue)
+    executor = MagicMock()
+    executor.collective_rpc.side_effect = lambda *args: order.append("rpc")
+    core = SimpleNamespace(batch_queue=queue, model_executor=executor)
+
+    EngineCore.collective_rpc(core, "release", wait_for_inflight_batches=wait)
+
+    assert order == ([0, 1, "rpc"] if wait else ["rpc"])
+    assert queue.maxlen == 2
+    if not wait:
+        assert list(queue) == original
+        return
+    for i, (future, scheduler_output, exec_future) in enumerate(reversed(queue)):
+        assert scheduler_output is scheduled[i]
+        assert future.result() is outputs[i]
+        assert future.result() is outputs[i]
+        assert exec_future is (exec_futures[i] if separate_exec_future else future)
+    executor.collective_rpc.assert_called_once_with("release", None, (), None)
+
+
+def test_collective_rpc_preserves_failed_output():
+    error = RuntimeError("model execution failed")
+    future = OneShotFuture(None, [], "query", error)
+    core = SimpleNamespace(
+        batch_queue=deque([(future, object(), future)]), model_executor=MagicMock()
+    )
+
+    with pytest.raises(RuntimeError, match="model execution failed"):
+        EngineCore.collective_rpc(core, "release", wait_for_inflight_batches=True)
+
+    saved, _, exec_future = core.batch_queue[0]
+    assert saved is exec_future
+    for _ in range(2):
+        with pytest.raises(RuntimeError) as exc:
+            saved.result()
+        assert exc.value is error
+    core.model_executor.collective_rpc.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_collective_rpc_barrier_reaches_each_dp_engine():
+    order: list[str] = []
+    engines = {}
+    for name in ("engine-0", "engine-1"):
+        future = OneShotFuture(object(), order, name)
+        executor = MagicMock()
+        executor.collective_rpc.side_effect = lambda *args, n=name: order.append(
+            f"{n}-rpc"
+        )
+        engines[name] = SimpleNamespace(
+            batch_queue=deque([(future, object(), future)]), model_executor=executor
+        )
+
+    async def call_utility(method, *args, engine):
+        assert method == "collective_rpc"
+        return EngineCore.collective_rpc(engines[engine], *args)
+
+    client = SimpleNamespace(
+        core_engines=list(engines), _call_utility_async=call_utility
+    )
+    client.call_utility_async = partial(DPLBAsyncMPClient.call_utility_async, client)
+    client.collective_rpc_async = partial(AsyncMPClient.collective_rpc_async, client)
+    llm = SimpleNamespace(engine_core=client)
+
+    await AsyncLLM.collective_rpc(llm, "release", wait_for_inflight_batches=True)
+
+    assert order == ["engine-0", "engine-0-rpc", "engine-1", "engine-1-rpc"]

--- a/tests/v1/worker/test_late_interaction_runner.py
+++ b/tests/v1/worker/test_late_interaction_runner.py
@@ -41,6 +41,7 @@ def test_postprocess_scores_and_releases_query_cache():
     assert isinstance(query_output, list)
     assert query_output[0] is not None
     assert query_output[0].shape == torch.Size([])
+    runner.on_requests_finished({"query-req"})
 
     doc_params = _make_pooling_params(
         build_late_interaction_doc_params(query_key=query_key)
@@ -134,6 +135,56 @@ def test_finished_request_releases_unscored_doc_use():
             req_ids=["doc-req-retry"],
             finished_mask=[True],
         )
+
+
+@pytest.mark.parametrize("doc_state", ["not_submitted", "registered", "finished"])
+def test_release_queries_preserves_other_requests(doc_state):
+    runner = LateInteractionRunner()
+    embeddings = torch.eye(2)
+    query_keys = ["cancelled-query", "other-query"]
+    runner.postprocess_pooler_output(
+        raw_pooler_output=[embeddings, embeddings],
+        pooling_params=[
+            _make_pooling_params(
+                build_late_interaction_query_params(query_key=key, query_uses=2)
+            )
+            for key in query_keys
+        ],
+        req_ids=["cancelled-query-req", "other-query-req"],
+        finished_mask=[True, True],
+    )
+    cancelled_doc_params, other_doc_params = [
+        _make_pooling_params(build_late_interaction_doc_params(query_key=key))
+        for key in query_keys
+    ]
+    if doc_state != "not_submitted":
+        runner.register_request("cancelled-doc", cancelled_doc_params)
+    if doc_state == "finished":
+        runner.on_requests_finished({"cancelled-doc"})
+    runner.register_request("other-doc", other_doc_params)
+
+    runner.release_queries(["cancelled-query", "unknown-query", "cancelled-query"])
+    runner.release_queries(["cancelled-query"])
+    runner.on_requests_finished({"cancelled-query-req", "cancelled-doc"})
+
+    assert set(runner._query_cache) == {"other-query"}
+    assert runner._query_uses == {"other-query": 2}
+    assert runner._doc_query_keys == {"other-doc": "other-query"}
+
+    output = runner.postprocess_pooler_output(
+        raw_pooler_output=[embeddings],
+        pooling_params=[other_doc_params],
+        req_ids=["other-doc"],
+        finished_mask=[True],
+    )
+    assert isinstance(output, list)
+    assert output[0] is not None
+    assert torch.allclose(output[0], compute_maxsim_score(embeddings, embeddings))
+    runner.register_request("other-doc-2", other_doc_params)
+    runner.on_requests_finished({"other-doc", "other-doc-2"})
+    assert not runner._query_cache
+    assert not runner._query_uses
+    assert not runner._doc_query_keys
 
 
 def test_invalid_query_uses_raises():

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -249,8 +249,10 @@ class EngineClient(ABC):
         timeout: float | None = None,
         args: tuple = (),
         kwargs: dict | None = None,
+        *,
+        wait_for_inflight_batches: bool = False,
     ):
-        """Perform a collective RPC call to the given path."""
+        """Run a worker RPC, optionally waiting for submitted batches first."""
         raise NotImplementedError
 
     async def handle_fault(

--- a/vllm/entrypoints/pooling/base/serving.py
+++ b/vllm/entrypoints/pooling/base/serving.py
@@ -141,7 +141,7 @@ class PoolingBaseServing(ABC, BaseServing):
     async def _prepare_generators(
         self,
         ctx: PoolingServeContext,
-    ):
+    ) -> list[AsyncGenerator[PoolingRequestOutput, None]]:
         if ctx.engine_inputs is None:
             raise ValueError("Engine inputs not available")
 
@@ -183,6 +183,7 @@ class PoolingBaseServing(ABC, BaseServing):
             generators.append(generator)
 
         ctx.result_generator = merge_async_iterators(*generators)
+        return generators
 
     async def _collect_batch(
         self,

--- a/vllm/entrypoints/pooling/scoring/serving.py
+++ b/vllm/entrypoints/pooling/scoring/serving.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
+from contextlib import suppress
+from typing import Any
+
 from fastapi.responses import JSONResponse, Response
 
 from vllm import PoolingParams
@@ -10,6 +14,7 @@ from vllm.logger import init_logger
 from vllm.outputs import PoolingRequestOutput, ScoringRequestOutput
 from vllm.tasks import SCORE_TYPE_MAP, SupportedTask
 from vllm.utils import random_uuid
+from vllm.utils.async_utils import collect_from_async_generator
 from vllm.v1.pool.late_interaction import (
     build_late_interaction_doc_params,
     build_late_interaction_query_params,
@@ -193,12 +198,63 @@ class ServingScores(PoolingServing):
         ctx = await self._init_ctx(self.io_processor, *args, **kwargs)
         await self._preprocessing(self.io_processor, ctx)
 
-        # stage 1: encode queries and cache token embeddings on workers.
-        await self._flash_late_interaction_encode_queries(ctx)
-        # stage 2: encode docs and return scalar scores from workers.
-        await self._flash_late_interaction_encode_docs(ctx)
+        try:
+            # stage 1: encode queries and cache token embeddings on workers.
+            await self._flash_late_interaction_encode_queries(ctx)
+            # stage 2: encode docs and return scalar scores from workers.
+            await self._flash_late_interaction_encode_docs(ctx)
+        except (Exception, asyncio.CancelledError):
+            cleanup = asyncio.create_task(self._release_late_interaction_queries(ctx))
+            try:
+                await self._await_late_interaction_cleanup(cleanup)
+            except Exception:
+                logger.exception("Failed to release late-interaction query cache")
+            raise
 
         return await self._postprocessing_async(self.io_processor, ctx)
+
+    @staticmethod
+    async def _await_late_interaction_cleanup(task: asyncio.Future[Any]) -> None:
+        """Finish cleanup even if the handler is cancelled again."""
+        while not task.done():
+            with suppress(asyncio.CancelledError):
+                await asyncio.shield(task)
+        task.result()
+
+    async def _release_late_interaction_queries(self, ctx: ScoringServeContext):
+        query_keys = ctx.late_interaction_query_keys
+        if not query_keys:
+            return
+        # Also abort requests cancelled before add_request returned a collector.
+        await self.engine_client.abort(
+            query_keys + (ctx.late_interaction_doc_keys or [])
+        )
+        await self.engine_client.collective_rpc(
+            "release_late_interaction_queries",
+            args=(query_keys,),
+            wait_for_inflight_batches=True,
+        )
+
+    async def _collect_late_interaction_batch(self, ctx: ScoringServeContext):
+        generators = await self._prepare_generators(ctx)
+        tasks = [
+            asyncio.create_task(collect_from_async_generator(generator))
+            for generator in generators
+        ]
+        batch_future = asyncio.gather(*tasks)
+        try:
+            batches = await asyncio.shield(batch_future)
+        except (Exception, asyncio.CancelledError):
+            # Stop and join every producer before aborting and releasing keys.
+            for task in tasks:
+                task.cancel()
+            await self._await_late_interaction_cleanup(
+                asyncio.gather(batch_future, *tasks, return_exceptions=True)
+            )
+            raise
+        if any(not batch for batch in batches):
+            raise ValueError("Failed to generate results for all prompts")
+        ctx.final_res_batch = [batch[-1] for batch in batches]
 
     async def _flash_late_interaction_encode_queries(self, ctx: ScoringServeContext):
         assert ctx.n_queries is not None
@@ -241,8 +297,7 @@ class ServingScores(PoolingServing):
             prompt_extras=ctx.prompt_extras,
         )
 
-        await self._prepare_generators(query_ctx)
-        await self._collect_batch(query_ctx)
+        await self._collect_late_interaction_batch(query_ctx)
         ctx.query_final_res_batch = query_ctx.final_res_batch
 
     async def _flash_late_interaction_encode_docs(self, ctx: ScoringServeContext):
@@ -257,7 +312,8 @@ class ServingScores(PoolingServing):
         query_keys = ctx.late_interaction_query_keys
         if query_keys is None:
             raise RuntimeError("Late-interaction query keys were not initialized.")
-        doc_keys = [f"{ctx.request_id}-doc-{i}" for i in range(n_docs)]
+        doc_keys = [f"{query_keys[0]}-doc-{i}" for i in range(n_docs)]
+        ctx.late_interaction_doc_keys = doc_keys
 
         for i in range(n_docs):
             query_idx = 0 if n_queries == 1 else i
@@ -282,7 +338,6 @@ class ServingScores(PoolingServing):
             prompt_extras=ctx.prompt_extras,
         )
 
-        await self._prepare_generators(doc_ctx)
-        await self._collect_batch(doc_ctx)
+        await self._collect_late_interaction_batch(doc_ctx)
 
         ctx.final_res_batch = doc_ctx.final_res_batch

--- a/vllm/entrypoints/pooling/typing.py
+++ b/vllm/entrypoints/pooling/typing.py
@@ -115,6 +115,7 @@ class PoolingServeContext(Generic[PoolingRequestT]):
     ## for flash-late-interaction
     query_final_res_batch: list[PoolingRequestOutput] | None = None
     late_interaction_query_keys: list[str] | None = None
+    late_interaction_doc_keys: list[str] | None = None
 
 
 @dataclass

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1101,12 +1101,16 @@ class AsyncLLM(EngineClient):
         timeout: float | None = None,
         args: tuple = (),
         kwargs: dict | None = None,
+        *,
+        wait_for_inflight_batches: bool = False,
     ):
-        """
-        Perform a collective RPC call to the given path.
-        """
+        """Run a worker RPC, optionally waiting for submitted batches first."""
         return await self.engine_core.collective_rpc_async(
-            method, timeout, args, kwargs
+            method,
+            timeout,
+            args,
+            kwargs,
+            wait_for_inflight_batches=wait_for_inflight_batches,
         )
 
     async def wait_for_requests_to_drain(self, drain_timeout: int = 300):

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -967,7 +967,25 @@ class EngineCore:
         timeout: float | None = None,
         args: tuple = (),
         kwargs: dict[str, Any] | None = None,
+        wait_for_inflight_batches: bool = False,
     ) -> list[_R]:
+        if wait_for_inflight_batches and self.batch_queue:
+            # Ray model execution and worker RPCs run on different threads.
+            # Consume each pending output once, in execution order, and retain
+            # it for the scheduler's subsequent update_from_output().
+            for index in reversed(range(len(self.batch_queue))):
+                future, scheduler_output, exec_future = self.batch_queue[index]
+                completed: Future[ModelRunnerOutput] = Future()
+                try:
+                    completed.set_result(future.result())
+                except Exception as exc:
+                    completed.set_exception(exc)
+                self.batch_queue[index] = (
+                    completed,
+                    scheduler_output,
+                    completed if exec_future is future else exec_future,
+                )
+                completed.result()
         return self.model_executor.collective_rpc(method, timeout, args, kwargs)
 
     def set_weight_version(self, weight_version: str) -> None:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -244,6 +244,8 @@ class EngineCoreClient(ABC):
         timeout: float | None = None,
         args: tuple = (),
         kwargs: dict[str, Any] | None = None,
+        *,
+        wait_for_inflight_batches: bool = False,
     ) -> list[_R]:
         raise NotImplementedError
 
@@ -318,6 +320,8 @@ class EngineCoreClient(ABC):
         timeout: float | None = None,
         args: tuple = (),
         kwargs: dict[str, Any] | None = None,
+        *,
+        wait_for_inflight_batches: bool = False,
     ) -> list[_R]:
         raise NotImplementedError
 
@@ -437,8 +441,12 @@ class InprocClient(EngineCoreClient):
         timeout: float | None = None,
         args: tuple = (),
         kwargs: dict[str, Any] | None = None,
+        *,
+        wait_for_inflight_batches: bool = False,
     ) -> list[_R]:
-        return self.engine_core.collective_rpc(method, timeout, args, kwargs)
+        return self.engine_core.collective_rpc(
+            method, timeout, args, kwargs, wait_for_inflight_batches
+        )
 
     def dp_engines_running(self) -> bool:
         return False
@@ -1034,8 +1042,12 @@ class SyncMPClient(MPClient):
         timeout: float | None = None,
         args: tuple = (),
         kwargs: dict[str, Any] | None = None,
+        *,
+        wait_for_inflight_batches: bool = False,
     ) -> list[_R]:
-        return self.call_utility("collective_rpc", method, timeout, args, kwargs)
+        return self.call_utility(
+            "collective_rpc", method, timeout, args, kwargs, wait_for_inflight_batches
+        )
 
     def save_sharded_state(
         self, path: str, pattern: str | None = None, max_size: int | None = None
@@ -1295,9 +1307,11 @@ class AsyncMPClient(MPClient):
         timeout: float | None = None,
         args: tuple = (),
         kwargs: dict[str, Any] | None = None,
+        *,
+        wait_for_inflight_batches: bool = False,
     ) -> list[_R]:
         return await self.call_utility_async(
-            "collective_rpc", method, timeout, args, kwargs
+            "collective_rpc", method, timeout, args, kwargs, wait_for_inflight_batches
         )
 
     async def handle_fault(

--- a/vllm/v1/pool/late_interaction_runner.py
+++ b/vllm/v1/pool/late_interaction_runner.py
@@ -29,6 +29,18 @@ class LateInteractionRunner:
         self._query_uses.clear()
         self._doc_query_keys.clear()
 
+    def release_queries(self, query_keys: list[str]) -> None:
+        """Release queries after their scoring requests have stopped."""
+        keys = set(query_keys)
+        for query_key in keys:
+            self._query_cache.pop(query_key, None)
+            self._query_uses.pop(query_key, None)
+        self._doc_query_keys = {
+            req_id: query_key
+            for req_id, query_key in self._doc_query_keys.items()
+            if query_key not in keys
+        }
+
     def register_request(
         self, req_id: str, pooling_params: PoolingParams | None
     ) -> None:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -953,6 +953,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.pooling_runner is not None:
             self.pooling_runner.clear()
 
+    def release_late_interaction_queries(self, query_keys: list[str]) -> None:
+        if self.pooling_runner is not None:
+            self.pooling_runner.release_late_interaction_queries(query_keys)
+
     @torch.inference_mode()
     def profile_cudagraph_memory(self) -> int:
         """Estimate the GPU memory required to capture CUDA graphs."""

--- a/vllm/v1/worker/gpu/pool/pooling_runner.py
+++ b/vllm/v1/worker/gpu/pool/pooling_runner.py
@@ -93,6 +93,9 @@ class PoolingRunner:
     def clear(self) -> None:
         self.late_interaction_runner.clear()
 
+    def release_late_interaction_queries(self, query_keys: list[str]) -> None:
+        self.late_interaction_runner.release_queries(query_keys)
+
     def _get_pooling_metadata(
         self,
         input_batch: InputBatch,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1021,6 +1021,9 @@ class GPUModelRunner(
         self.encoder_cache.clear()
         self.late_interaction_runner.clear()
 
+    def release_late_interaction_queries(self, query_keys: list[str]) -> None:
+        self.late_interaction_runner.release_queries(query_keys)
+
     def _get_positions(self, num_tokens: Any):
         if isinstance(num_tokens, int):
             if self.uses_mrope:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -946,6 +946,9 @@ class Worker(WorkerBase):
     def reset_encoder_cache(self) -> None:
         self.model_runner.reset_encoder_cache()
 
+    def release_late_interaction_queries(self, query_keys: list[str]) -> None:
+        self.model_runner.release_late_interaction_queries(query_keys)
+
     def get_model(self) -> nn.Module:
         return self.model_runner.get_model()
 


### PR DESCRIPTION
## Purpose

Flash late-interaction scoring caches query embeddings before submitting document requests. If a client disconnects between those stages, the query has already finished, so aborting it does not release the cached embeddings. Valid requests can therefore leave GPU memory allocated with no documents left to consume it.

This PR stops and joins the request's encoding tasks, aborts its remaining requests, and releases its query cache through the existing worker RPC channel. Cleanup handles partial document completion, errors and repeated cancellation, and supports both MRV1 and MRV2. Document request IDs use the query's private namespace so cleanup cannot abort another request with the same caller-supplied ID.

The existing `collective_rpc` API gains an opt-in `wait_for_inflight_batches` flag. Cleanup uses it to wait for submitted model batches before deleting cached queries, preserving their results for the scheduler. This prevents an in-flight batch from writing the cache after it has been released.

The query-cache lifetime gap was also raised in [this discussion on #36159](https://github.com/vllm-project/vllm/pull/36159#discussion_r2906379613). Cancellation makes it reachable with valid, nonempty inputs.

I found no open PR addressing this worker cache cleanup. [#50830](https://github.com/vllm-project/vllm/pull/50830) handles generic iterator cleanup; [#55602](https://github.com/vllm-project/vllm/pull/55602) and [#55790](https://github.com/vllm-project/vllm/pull/55790) address request cancellation wrappers. This fix manages the Flash query cache lifecycle and does not depend on those changes.

## Test Plan

```bash
VLLM_TARGET_DEVICE=cpu PYTHONDONTWRITEBYTECODE=1 \
.venv/bin/python -m pytest --noconftest -q -p no:cacheprovider \
  tests/entrypoints/pooling/scoring/test_late_interaction_serving.py \
  tests/v1/worker/test_late_interaction_runner.py \
  tests/v1/engine/test_collective_rpc.py \
  tests/utils_/test_async_utils.py
```

The regressions cover cancellation before query output or collector delivery, partially completed documents, child errors, repeated cancellation during cleanup, request isolation, and RPC batch ordering.

For the GPU smoke test, run `answerdotai/answerai-colbert-small-v1` on an A10 with each model runner. Pause immediately before document submission, close the client's TCP connection to `/rerank`, and inspect worker cache and allocated memory. Also cancel one request while another is active, then check that the other request completes with the same scores.

## Test Result

- **30 tests passed.** Pre-commit checks on all changed files and manual mypy 3.12 passed.
- **Real HTTP/GPU smoke passed for MRV1 and MRV2.** After three cancellations and an additional cancellation alongside a normal request, each baseline run retained 4 query embeddings (466,560 bytes); each fixed run retained none. Allocated memory returned to its initial level.
- The concurrent normal request and normal requests before/after cancellation produced exactly the same scores as the baseline.
- A separate CUDA runner test retained 6 MiB after four cancellations on the baseline and 0 bytes after cleanup on the fix; the other query's MaxSim result was unchanged.

GPU validation used the complete target Python package with an existing image's native/CUDA artifacts, on one A10 with TP=DP=PP=1. This was a functional scoring smoke test.

AI assistance: Codex was used for implementation, testing and review.
