### PR TITLE
[Bugfix][GDN] Fall back when the fused kernel image is unavailable

### DIFF
--- a/csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu
+++ b/csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu
@@ -419,6 +419,13 @@ void launch_gdn_decode_post_conv_mtp(
 
 }  // namespace
 
+bool fused_gdn_decode_kernel_available() {
+  cudaFuncAttributes attributes;
+  const cudaError_t error = cudaFuncGetAttributes(
+      &attributes, gdn_decode_post_conv_mtp_kernel<float, 1, false>);
+  return error == cudaSuccess;
+}
+
 void fused_gdn_decode_post_conv_mtp(
     torch::stable::Tensor const& mixed_qkv, torch::stable::Tensor const& a,
     torch::stable::Tensor const& b, torch::stable::Tensor const& a_log,

--- a/csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu
+++ b/csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu
@@ -419,7 +419,10 @@ void launch_gdn_decode_post_conv_mtp(
 
 }  // namespace
 
-bool fused_gdn_decode_kernel_available() {
+bool fused_gdn_decode_kernel_available(
+    torch::stable::Tensor const& device_tensor) {
+  torch::stable::accelerator::DeviceGuard const device_guard(
+      device_tensor.get_device_index());
   cudaFuncAttributes attributes;
   const cudaError_t error = cudaFuncGetAttributes(
       &attributes, gdn_decode_post_conv_mtp_kernel<float, 1, false>);

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -393,6 +393,8 @@ void fused_kda_decode(
 #endif
 
 #ifdef VLLM_ENABLE_FUSED_GDN_DECODE
+bool fused_gdn_decode_kernel_available();
+
 void fused_gdn_decode_post_conv_mtp(
     torch::stable::Tensor const& mixed_qkv, torch::stable::Tensor const& a,
     torch::stable::Tensor const& b, torch::stable::Tensor const& a_log,

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -393,7 +393,8 @@ void fused_kda_decode(
 #endif
 
 #ifdef VLLM_ENABLE_FUSED_GDN_DECODE
-bool fused_gdn_decode_kernel_available();
+bool fused_gdn_decode_kernel_available(
+    torch::stable::Tensor const& device_tensor);
 
 void fused_gdn_decode_post_conv_mtp(
     torch::stable::Tensor const& mixed_qkv, torch::stable::Tensor const& a,

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -528,6 +528,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
 #endif
 
 #ifdef VLLM_ENABLE_FUSED_GDN_DECODE
+  ops.def("fused_gdn_decode_kernel_available() -> bool");
   ops.def(
       "fused_gdn_decode_post_conv_mtp("
       "Tensor mixed_qkv, Tensor a, Tensor b, Tensor A_log, Tensor dt_bias, "
@@ -841,6 +842,8 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
 #endif
 
 #ifdef VLLM_ENABLE_FUSED_GDN_DECODE
+  ops.impl("fused_gdn_decode_kernel_available",
+           TORCH_BOX(&fused_gdn_decode_kernel_available));
   ops.impl("fused_gdn_decode_post_conv_mtp",
            TORCH_BOX(&fused_gdn_decode_post_conv_mtp));
 #endif

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -528,7 +528,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
 #endif
 
 #ifdef VLLM_ENABLE_FUSED_GDN_DECODE
-  ops.def("fused_gdn_decode_kernel_available() -> bool");
+  ops.def("fused_gdn_decode_kernel_available(Tensor device_tensor) -> bool");
   ops.def(
       "fused_gdn_decode_post_conv_mtp("
       "Tensor mixed_qkv, Tensor a, Tensor b, Tensor A_log, Tensor dt_bias, "

--- a/tests/kernels/mamba/test_gdn_fused_mtp.py
+++ b/tests/kernels/mamba/test_gdn_fused_mtp.py
@@ -182,6 +182,32 @@ def test_fused_mtp_head_ratio_guard(num_v_heads: int, expected: bool) -> None:
     )
 
 
+def test_fused_decode_falls_back_without_kernel_image() -> None:
+    """The fused path must fall back when its cubin lacks the active device."""
+    if not hasattr(torch.ops._C, "fused_gdn_decode_post_conv_mtp"):
+        pytest.skip("fused GDN decode MTP op is not built")
+
+    vllm_config = _make_vllm_config()
+    vllm_config.model_config.dtype = torch.bfloat16
+    layer = types.SimpleNamespace(
+        gqa_interleaved_layout=False,
+        head_k_dim=K,
+        head_v_dim=V,
+        norm=types.SimpleNamespace(activation="silu"),
+        get_state_dtype=lambda: (torch.bfloat16, torch.float32),
+    )
+    with patch.object(
+        qwen_gdn_linear_attn.ops,
+        "fused_gdn_decode_kernel_available",
+        return_value=False,
+    ):
+        reason = QwenGatedDeltaNetAttention._fused_gdn_decode_unsupported_reason(
+            cast(QwenGatedDeltaNetAttention, layer), vllm_config
+        )
+
+    assert reason == "fused GDN decode kernel has no image for the current device"
+
+
 @torch.inference_mode()
 def test_fused_forward_uses_packed_entrypoint() -> None:
     """Fused mode keeps projected QKVZ and BA packed through the model op."""

--- a/tests/kernels/mamba/test_gdn_fused_mtp.py
+++ b/tests/kernels/mamba/test_gdn_fused_mtp.py
@@ -193,6 +193,7 @@ def test_fused_decode_falls_back_without_kernel_image() -> None:
         gqa_interleaved_layout=False,
         head_k_dim=K,
         head_v_dim=V,
+        A_log=torch.empty(1, dtype=torch.float32, device="cuda"),
         norm=types.SimpleNamespace(activation="silu"),
         get_state_dtype=lambda: (torch.bfloat16, torch.float32),
     )
@@ -200,11 +201,12 @@ def test_fused_decode_falls_back_without_kernel_image() -> None:
         qwen_gdn_linear_attn.ops,
         "fused_gdn_decode_kernel_available",
         return_value=False,
-    ):
+    ) as kernel_available:
         reason = QwenGatedDeltaNetAttention._fused_gdn_decode_unsupported_reason(
             cast(QwenGatedDeltaNetAttention, layer), vllm_config
         )
 
+    kernel_available.assert_called_once_with(layer.A_log)
     assert reason == "fused GDN decode kernel has no image for the current device"
 
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2807,6 +2807,11 @@ def fused_gdn_decode_post_conv_mtp(
     return out
 
 
+def fused_gdn_decode_kernel_available() -> bool:
+    op = getattr(torch.ops._C, "fused_gdn_decode_kernel_available", None)
+    return op is not None and bool(op())
+
+
 def concat_and_cache_mla(
     kv_c: torch.Tensor,
     k_pe: torch.Tensor,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2807,9 +2807,9 @@ def fused_gdn_decode_post_conv_mtp(
     return out
 
 
-def fused_gdn_decode_kernel_available() -> bool:
+def fused_gdn_decode_kernel_available(device_tensor: torch.Tensor) -> bool:
     op = getattr(torch.ops._C, "fused_gdn_decode_kernel_available", None)
-    return op is not None and bool(op())
+    return op is not None and bool(op(device_tensor))
 
 
 def concat_and_cache_mla(

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -554,6 +554,8 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
         if not hasattr(torch.ops._C, "fused_gdn_decode_post_conv_mtp"):
             return "torch.ops._C.fused_gdn_decode_post_conv_mtp is not built"
+        if not ops.fused_gdn_decode_kernel_available():
+            return "fused GDN decode kernel has no image for the current device"
         return None
 
     def create_qkvz_proj(

--- a/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py
@@ -554,7 +554,7 @@ class QwenGatedDeltaNetAttention(GatedDeltaNetAttention):
             )
         if not hasattr(torch.ops._C, "fused_gdn_decode_post_conv_mtp"):
             return "torch.ops._C.fused_gdn_decode_post_conv_mtp is not built"
-        if not ops.fused_gdn_decode_kernel_available():
+        if not ops.fused_gdn_decode_kernel_available(self.A_log):
             return "fused GDN decode kernel has no image for the current device"
         return None
 


### PR DESCRIPTION
## Summary

Fixes #56206. When the fused GDN decode operator is registered but the current CUDA device has no compatible kernel image, automatically fall back to the existing Triton GDN decode implementation instead of attempting to launch an unavailable fused kernel.

This is a runtime follow-up to #53835. #53835 adds SM110 to the fused GDN decode build targets; this PR keeps that build change intact and adds runtime kernel-image detection and fallback for devices where the fused image is unavailable.

## Testing

- `pre-commit run --files csrc/libtorch_stable/gdn/fused_gdn_decode_kernel.cu csrc/libtorch_stable/ops.h csrc/libtorch_stable/torch_bindings.cpp tests/kernels/mamba/test_gdn_fused_mtp.py vllm/_custom_ops.py vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py`
- `uv run --no-project python -m compileall -q vllm/_custom_ops.py vllm/model_executor/layers/mamba/gdn/qwen_gdn_linear_attn.py tests/kernels/mamba/test_gdn_fused_mtp.py`
- `git diff --check origin/main...HEAD`



## Contribution notes

- Duplicate-work check: this does not duplicate #53835; that PR changes the fused GDN decode build architecture list, while this PR adds runtime availability detection and fallback.
- AI assistance was used in preparing this PR. The human submitter is responsible for reviewing every changed line, running the relevant tests, and being able to defend and maintain the change.