### PR TITLE
[ROCm][V4.1] Let the sparse indexer consume device query lengths

### DIFF
--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -186,9 +186,11 @@ class DeepseekV32IndexerBackend(AttentionBackend):
     def supports_device_cpu_query_lens_mismatch(cls) -> bool:
         # Only the varlen paged MQA logits kernel takes per-request query
         # lengths from device tensors natively. Hopper can instead flatten each
-        # query into a single-token row using device-built metadata. ROCm
-        # flattening reuses that same Triton metadata kernel, so adaptive
-        # verification can write query_start_loc on device here too.
+        # query into a single-token row. That path diffs device query_start_loc
+        # and expands with _prepare_decode_tensors. ROCm DSpark already uses
+        # that flatten path (native decode is only next_n in {1, 2}), so the
+        # same helper is True here and adaptive verification can write
+        # query_start_loc on device.
         return _supports_varlen_paged_mqa_logits() or (
             _supports_flattened_device_query_lens()
         )
@@ -625,9 +627,12 @@ def _supports_varlen_paged_mqa_logits() -> bool:
 
 
 def _supports_flattened_device_query_lens() -> bool:
-    # Hopper DeepGEMM flatten path. ROCm DSpark already flattens (native
-    # decode is only next_n in {1, 2}), and the Triton metadata kernel
-    # from #56562 can build per-token rows from device query_start_loc.
+    # Hopper DeepGEMM flatten path. ROCm already flattens DSpark the same
+    # way: _supports_native_decode is only next_n in {1, 2}, so next_n=6
+    # goes through _prepare_decode_tensors. Returning True here does not
+    # change that flatten. It only tells maybe_create_adaptive_verification_manager
+    # that this backend can consume device query_start_loc, which Hopper
+    # already diffs in build() before the flatten.
     if current_platform.is_rocm():
         return True
     return (
@@ -709,23 +714,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         self.reorder_batch_threshold = None
         self.use_flattening = _use_flattening(self.vllm_config)
         self.supports_varlen = _supports_varlen_paged_mqa_logits()
-        spec_config = self.vllm_config.speculative_config
-        # SM100 varlen already builds decode metadata from device
-        # query_start_loc. ROCm flattening does not, unless we take the
-        # same Triton kernel. Adaptive verification writes those lengths
-        # on device, so ROCm must use that kernel when the flag is on.
-        self.use_device_decode_metadata = self.supports_varlen or (
-            current_platform.is_rocm()
-            and self.use_flattening
-            and spec_config is not None
-            and spec_config.enable_adaptive_verification
-        )
         logger.info_once(
             "DSA indexer decode path: use_flattening=%s supports_varlen=%s "
-            "use_device_decode_metadata=%s (next_n=%d, use_fp4_cache=%s)",
+            "(next_n=%d, use_fp4_cache=%s)",
             self.use_flattening,
             self.supports_varlen,
-            self.use_device_decode_metadata,
             next_n,
             self.indexer_uses_fp4,
         )
@@ -1153,7 +1146,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
         decode_metadata = None
         if num_decodes > 0:
-            if not self.use_device_decode_metadata:
+            if not self.supports_varlen:
                 torch.diff(
                     common_attn_metadata.query_start_loc[: num_decodes + 1],
                     out=self.decode_lens_buffer[:num_decodes],
@@ -1196,7 +1189,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 and step_next_n_ok
             )
 
-            if not self.use_device_decode_metadata:
+            if not self.supports_varlen:
                 global_seq_lens_for_decode = self._prepare_global_decode_seq_lens(
                     global_seq_lens=global_seq_lens_for_decode,
                     decode_lens=decode_lens,
@@ -1208,7 +1201,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 )
 
             decode_indices = None
-            if self.use_device_decode_metadata:
+            if self.supports_varlen:
                 from vllm.v1.attention.ops.metadata import (
                     _indexer_decode_metadata_kernel,
                 )

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -186,7 +186,9 @@ class DeepseekV32IndexerBackend(AttentionBackend):
     def supports_device_cpu_query_lens_mismatch(cls) -> bool:
         # Only the varlen paged MQA logits kernel takes per-request query
         # lengths from device tensors natively. Hopper can instead flatten each
-        # query into a single-token row using device-built metadata.
+        # query into a single-token row using device-built metadata. ROCm
+        # flattening reuses that same Triton metadata kernel, so adaptive
+        # verification can write query_start_loc on device here too.
         return _supports_varlen_paged_mqa_logits() or (
             _supports_flattened_device_query_lens()
         )
@@ -623,6 +625,11 @@ def _supports_varlen_paged_mqa_logits() -> bool:
 
 
 def _supports_flattened_device_query_lens() -> bool:
+    # Hopper DeepGEMM flatten path. ROCm DSpark already flattens (native
+    # decode is only next_n in {1, 2}), and the Triton metadata kernel
+    # from #56562 can build per-token rows from device query_start_loc.
+    if current_platform.is_rocm():
+        return True
     return (
         current_platform.is_cuda()
         and current_platform.is_device_capability_family(90)
@@ -702,11 +709,23 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         self.reorder_batch_threshold = None
         self.use_flattening = _use_flattening(self.vllm_config)
         self.supports_varlen = _supports_varlen_paged_mqa_logits()
+        spec_config = self.vllm_config.speculative_config
+        # SM100 varlen already builds decode metadata from device
+        # query_start_loc. ROCm flattening does not, unless we take the
+        # same Triton kernel. Adaptive verification writes those lengths
+        # on device, so ROCm must use that kernel when the flag is on.
+        self.use_device_decode_metadata = self.supports_varlen or (
+            current_platform.is_rocm()
+            and self.use_flattening
+            and spec_config is not None
+            and spec_config.enable_adaptive_verification
+        )
         logger.info_once(
             "DSA indexer decode path: use_flattening=%s supports_varlen=%s "
-            "(next_n=%d, use_fp4_cache=%s)",
+            "use_device_decode_metadata=%s (next_n=%d, use_fp4_cache=%s)",
             self.use_flattening,
             self.supports_varlen,
+            self.use_device_decode_metadata,
             next_n,
             self.indexer_uses_fp4,
         )
@@ -1134,7 +1153,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
         decode_metadata = None
         if num_decodes > 0:
-            if not self.supports_varlen:
+            if not self.use_device_decode_metadata:
                 torch.diff(
                     common_attn_metadata.query_start_loc[: num_decodes + 1],
                     out=self.decode_lens_buffer[:num_decodes],
@@ -1177,7 +1196,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 and step_next_n_ok
             )
 
-            if not self.supports_varlen:
+            if not self.use_device_decode_metadata:
                 global_seq_lens_for_decode = self._prepare_global_decode_seq_lens(
                     global_seq_lens=global_seq_lens_for_decode,
                     decode_lens=decode_lens,
@@ -1189,7 +1208,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 )
 
             decode_indices = None
-            if self.supports_varlen:
+            if self.use_device_decode_metadata:
                 from vllm.v1.attention.ops.metadata import (
                     _indexer_decode_metadata_kernel,
                 )


### PR DESCRIPTION
## Summary

The published DeepSeek-V4.1-Flash DSpark JSON sets `enable_adaptive_verification:true`. On ROCm that dies in `maybe_create_adaptive_verification_manager` during `initialize_kv_cache`, after the weights load:

```
ValueError: Adaptive verification trims verification requests on device, which the DeepseekV41IndexerBackend attention backend does not support. Pass enable_adaptive_verification=false in the speculative config, or use a backend that does.
```

`DeepseekV41IndexerBackend` hard-wires the V3.2 indexer (`get_attn_backend` in `vllm/models/deepseek_v4_1/attention.py` returns that class). `supports_device_cpu_query_lens_mismatch()` was True only for CUDA DeepGEMM SM100 varlen or SM90 flatten. The attention selector never runs for this model.

## What this PR does

- Return True from `_supports_flattened_device_query_lens()` on ROCm. That is the Hopper analogue. ROCm DSpark already flattens (`_supports_native_decode` is only `next_n` in `{1, 2}`), and `build()` already diffs device `query_start_loc` then expands with `_prepare_decode_tensors`.
- Do not route ROCm through `_indexer_decode_metadata_kernel` from vllm-project/vllm#56562. That kernel is the SM100 varlen path. Hopper flatten does not use it. HIP `rocm_aiter_sparse_attn_indexer` already reads `decode_metadata.decode_lens` / `seq_lens` / `block_table` from the flatten (`vllm/v1/attention/ops/rocm_aiter_mla_sparse.py`).
- NVIDIA is unchanged.

The recipe workaround (AMD `enable_adaptive_verification:false`) is vllm-project/recipes#963. This PR is the engine-side fix so that flag can stay true.

## Validation

- Reproduced the `ValueError` on MI355X TP4 with Hub nightly `eed1f3d0c` (`sha256:960228cfcb5de9f4cd22d28998d1125be62b546c3d220a884f570343e99ffcee`) and the published DSpark JSON. The failing helpers are in that tree.
- Did not yet serve with this patch and `enable_adaptive_verification:true`.

## Test plan

- [ ] On gfx950, serve DeepSeek-V4.1-Flash TP4 with the recipe DSpark JSON (`enable_adaptive_verification:true`) and this patch
- [ ] Confirm the `ValueError` is gone and DSpark decode runs
- [ ] Recipe `17*19` curl returns `323`
- [ ] CUDA SM90/SM100 indexer paths unchanged
