### PR TITLE
[Bugfix][KV Offload] Submit CPU stores on no-forward steps

### DIFF
--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -48,7 +48,6 @@ from vllm.v1.simple_kv_offload.cuda_mem_ops import (
     CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
     CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
     build_params,
-    pin_tensor,
 )
 from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
 from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadMetadata
@@ -67,8 +66,11 @@ SLEEP_CYCLES = 50_000_000
 
 def _make_backend() -> tuple[DmaCopyBackend, torch.Tensor, torch.Tensor]:
     gpu = {"k": torch.zeros((NUM_BLOCKS, BLOCK_BYTES), dtype=torch.int8, device="cuda")}
-    cpu = {"k": torch.zeros((NUM_BLOCKS, BLOCK_BYTES), dtype=torch.int8, device="cpu")}
-    pin_tensor(cpu["k"])
+    cpu = {
+        "k": torch.zeros(
+            (NUM_BLOCKS, BLOCK_BYTES), dtype=torch.int8, device="cpu", pin_memory=True
+        )
+    }
     low_pri, _ = torch.cuda.Stream.priority_range()
     backend = DmaCopyBackend()
     backend.init(

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -10,6 +10,7 @@ read partially written / stale blocks and silently corrupt the CPU cache.
 from __future__ import annotations
 
 import time
+from contextlib import nullcontext
 from unittest.mock import MagicMock
 
 import pytest
@@ -21,7 +22,13 @@ if not current_platform.is_cuda_alike():
     pytest.skip("Requires CUDA or ROCm", allow_module_level=True)
 
 from tests.v1.attention.utils import dense_kv_cache_tensor, dense_kv_cache_views
+from tests.v1.kv_connector.unit.test_kv_connector_lifecycle import (
+    _make_empty_scheduler_output,
+)
 from vllm.config import CacheConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
+    SimpleCPUOffloadConnector,
+)
 from vllm.v1.core.kv_cache_utils import (
     get_kv_cache_config_from_groups,
     is_kv_cache_spec_uniform,
@@ -46,6 +53,7 @@ from vllm.v1.simple_kv_offload.cuda_mem_ops import (
 from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
 from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadMetadata
 from vllm.v1.simple_kv_offload.worker import SimpleCPUOffloadWorker
+from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
 from vllm.v1.worker.utils import allocate_kv_cache
 
 NUM_BLOCKS = 64
@@ -70,6 +78,41 @@ def _make_backend() -> tuple[DmaCopyBackend, torch.Tensor, torch.Tensor]:
         torch.cuda.Stream(priority=low_pri),
     )
     return backend, gpu["k"], cpu["k"]
+
+
+def test_no_forward_step_completes_cpu_store(monkeypatch):
+    """A finished request's final store must drain without another model step."""
+    backend, gpu, cpu = _make_backend()
+    worker = SimpleCPUOffloadWorker(None, None, cpu_capacity_bytes=0)
+    worker._backend = backend
+    connector = SimpleCPUOffloadConnector.__new__(SimpleCPUOffloadConnector)
+    connector.worker_handler = worker
+    output = _make_empty_scheduler_output()
+    output.kv_connector_metadata = SimpleCPUOffloadMetadata(
+        store_event=0, store_gpu_blocks=[0], store_cpu_blocks=[0]
+    )
+    module = "vllm.v1.worker.kv_connector_model_runner_mixin"
+    monkeypatch.setattr(f"{module}.get_kv_transfer_group", lambda: connector)
+    monkeypatch.setattr(f"{module}.set_forward_context", lambda *a: nullcontext())
+    monkeypatch.setattr(f"{module}.get_forward_context", lambda: None)
+    try:
+        gpu.fill_(91)
+        result = KVConnectorModelRunnerMixin.kv_connector_no_forward(output, None)
+        completion = (
+            result.kv_connector_output.kv_connector_worker_meta
+            if result.kv_connector_output is not None
+            else None
+        )
+        deadline = time.monotonic() + 5
+        while completion is None and time.monotonic() < deadline:
+            connector.get_finished(set())
+            completion = connector.build_connector_worker_meta()
+            time.sleep(0.001)
+        assert completion is not None, "CPU store never completed on the empty step"
+        assert completion.completed_store_events == {0: 1}
+        assert torch.equal(cpu[0], gpu[0].cpu())
+    finally:
+        backend.shutdown()
 
 
 def _drive_store(

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -53,6 +53,7 @@ from vllm.v1.simple_kv_offload.cuda_mem_ops import (
 from vllm.v1.simple_kv_offload.disk_backend import DiskBackend
 from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadMetadata
 from vllm.v1.simple_kv_offload.worker import SimpleCPUOffloadWorker
+from vllm.v1.worker.gpu.kv_connector import ActiveKVConnector
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
 from vllm.v1.worker.utils import allocate_kv_cache
 
@@ -80,7 +81,8 @@ def _make_backend() -> tuple[DmaCopyBackend, torch.Tensor, torch.Tensor]:
     return backend, gpu["k"], cpu["k"]
 
 
-def test_no_forward_step_completes_cpu_store(monkeypatch):
+@pytest.mark.parametrize("use_v2", [False, True])
+def test_no_forward_step_completes_cpu_store(monkeypatch, use_v2):
     """A finished request's final store must drain without another model step."""
     backend, gpu, cpu = _make_backend()
     worker = SimpleCPUOffloadWorker(None, None, cpu_capacity_bytes=0)
@@ -97,7 +99,17 @@ def test_no_forward_step_completes_cpu_store(monkeypatch):
     monkeypatch.setattr(f"{module}.get_forward_context", lambda: None)
     try:
         gpu.fill_(91)
-        result = KVConnectorModelRunnerMixin.kv_connector_no_forward(output, None)
+        if use_v2:
+            active = ActiveKVConnector.__new__(ActiveKVConnector)
+            active.kv_connector = connector
+            active._disabled = False
+            active._pending_load_start = False
+            module = "vllm.v1.worker.gpu.kv_connector"
+            monkeypatch.setattr(f"{module}.is_forward_context_available", lambda: True)
+            monkeypatch.setattr(f"{module}.get_forward_context", lambda: None)
+            result = active.no_forward(output)
+        else:
+            result = KVConnectorModelRunnerMixin.kv_connector_no_forward(output, None)
         completion = (
             result.kv_connector_output.kv_connector_worker_meta
             if result.kv_connector_output is not None

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -115,6 +115,46 @@ def test_no_forward_step_completes_cpu_store(monkeypatch):
         backend.shutdown()
 
 
+def test_deferred_store_waits_for_draft_forward(monkeypatch):
+    """Target completion must not submit the store before draft finalization."""
+    backend, gpu, cpu = _make_backend()
+    worker = SimpleCPUOffloadWorker(None, None, cpu_capacity_bytes=0)
+    worker._backend = backend
+    connector = SimpleCPUOffloadConnector.__new__(SimpleCPUOffloadConnector)
+    connector.worker_handler = worker
+    output = _make_empty_scheduler_output()
+    output.kv_connector_metadata = SimpleCPUOffloadMetadata(
+        store_event=0, store_gpu_blocks=[0], store_cpu_blocks=[0]
+    )
+    module = "vllm.v1.worker.kv_connector_model_runner_mixin"
+    monkeypatch.setattr(f"{module}.get_kv_transfer_group", lambda: connector)
+    monkeypatch.setattr(f"{module}.has_kv_transfer_group", lambda: True)
+    monkeypatch.setattr(f"{module}.get_forward_context", lambda: None)
+    launch = MagicMock(wraps=backend.launch_copy)
+    monkeypatch.setattr(backend, "launch_copy", launch)
+    try:
+        with KVConnectorModelRunnerMixin._get_kv_connector_output(
+            output, defer_finalize=True
+        ):
+            gpu.fill_(17)
+        launch.assert_not_called()
+        gpu.fill_(91)
+        KVConnectorModelRunnerMixin.finalize_kv_connector()
+        assert launch.call_count == 1
+        completion = None
+        deadline = time.monotonic() + 5
+        while completion is None and time.monotonic() < deadline:
+            connector.get_finished(set())
+            completion = connector.build_connector_worker_meta()
+            time.sleep(0.001)
+        assert completion is not None
+        assert completion.completed_store_events == {0: 1}
+        assert torch.equal(cpu[0], gpu[0].cpu())
+        assert launch.call_count == 1
+    finally:
+        backend.shutdown()
+
+
 def _drive_store(
     backend: DmaCopyBackend,
     gpu: torch.Tensor,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -214,17 +214,17 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
         attn_metadata: "AttentionMetadata",
         **kwargs: Any,
     ) -> None:
-        pass  # Always save asynchronously, issued in wait_for_save()
+        pass  # Always save asynchronously, issued in get_finished().
 
     def wait_for_save(self) -> None:
-        if self.worker_handler is not None:
-            self.worker_handler.wait_for_save()
+        pass  # Stores are submitted by get_finished(), including no-forward steps.
 
     def get_finished(
         self,
         finished_req_ids: set[str],
     ) -> tuple[set[str] | None, set[str] | None]:
         if self.worker_handler is not None:
+            self.worker_handler.wait_for_save()
             return self.worker_handler.get_finished(finished_req_ids)
         return None, None
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -214,17 +214,17 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
         attn_metadata: "AttentionMetadata",
         **kwargs: Any,
     ) -> None:
-        pass  # Always save asynchronously, issued in get_finished().
+        pass  # Always save asynchronously, issued in wait_for_save()
 
     def wait_for_save(self) -> None:
-        pass  # Stores are submitted by get_finished(), including no-forward steps.
+        if self.worker_handler is not None:
+            self.worker_handler.wait_for_save()
 
     def get_finished(
         self,
         finished_req_ids: set[str],
     ) -> tuple[set[str] | None, set[str] | None]:
         if self.worker_handler is not None:
-            self.worker_handler.wait_for_save()
             return self.worker_handler.get_finished(finished_req_ids)
         return None, None
 

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -67,6 +67,7 @@ class SimpleCPUOffloadWorker:
 
         # Metadata for the current step
         self._connector_metadata: SimpleCPUOffloadMetadata | None = None
+        self._store_submitted = False
 
         # Compute-done event recorded before each store; reused across steps
         # (get_finished runs once per step, copy queue is FIFO).
@@ -244,12 +245,15 @@ class SimpleCPUOffloadWorker:
 
     def bind_connector_metadata(self, metadata: SimpleCPUOffloadMetadata) -> None:
         self._connector_metadata = metadata
+        self._store_submitted = False
         if metadata.load_event >= 0:
             self._pending_load_event_indices.add(metadata.load_event)
         if metadata.store_event >= 0:
             self._pending_store_event_indices.add(metadata.store_event)
 
     def clear_connector_metadata(self) -> None:
+        # No-forward steps skip the normal wait_for_save hook.
+        self.wait_for_save()
         self._connector_metadata = None
 
     def start_load_kv(self) -> None:
@@ -278,7 +282,11 @@ class SimpleCPUOffloadWorker:
         #45704 for the bug and #39306 for the srcAccessOrder rationale.
         """
         metadata = self._connector_metadata
-        if metadata is not None and metadata.store_gpu_blocks:
+        if (
+            metadata is not None
+            and metadata.store_gpu_blocks
+            and not self._store_submitted
+        ):
             backend = self._backend
             assert backend is not None
             if self._store_compute_done is None:
@@ -292,6 +300,7 @@ class SimpleCPUOffloadWorker:
                 events_list=self._store_events,
                 wait_event=self._store_compute_done,
             )
+            self._store_submitted = True
 
     def get_finished(
         self, finished_req_ids: set[str]


### PR DESCRIPTION
Finished requests can emit CPU stores on a no-forward step that skips `wait_for_save()`. Clearing the metadata drops the copy; a later completion watermark can falsely acknowledge it. Submit remaining stores before clearing metadata, once per step, while preserving deferred draft-forward timing.

SimpleCPUOffload only; separate from #55142's Mooncake fix.

Rebased onto main `e19a3e172e` (PR head `3513a59c15`). Validation:
- 91 offload/connector tests passed directly on the rebased checkout, including legacy/V2 empty-step copies and deferred draft finalization. Pre-commit passed.
- GLM-5.2-NVFP4 PCP4+TP1+EP4+DCP4 → TP4 on the rebased runtime: P/D GPU and CPU-offload both 28/32 GSM8K; direct TP4 26/32. All 32 GPU/CPU pairs match in answers, token IDs and token log probabilities, with confirmed CPU hits (16,384 restored tokens). Scores match the pre-rebase run.
- Long-context replay restores 6,144 CPU tokens and recovers the requested code; continuations can differ without deterministic top-k ordering. No transfer errors or pending stores; 33 no-forward stores submitted on each prefiller rank.

Model validation includes separate NIXL/interleave fixes, with no optional top-k determinism changes. The 32-question sample is not a full accuracy benchmark.

```bash
chg run -g 1 -- .venv/bin/python -m pytest tests/v1/simple_kv_offload/{test_worker,test_scheduler,test_kv_events}.py tests/v1/kv_connector/unit/{test_simple_cpu_offload_connector,test_kv_connector_lifecycle,test_nixl_simple_cpu_offload}.py -q
.venv/bin/pre-commit run --files vllm/v1/simple_kv_offload/worker.py tests/v1/simple_kv_offload/test_worker.py
chg run -g 8 -- .venv/bin/python /tmp/pr56621-main-validation/model_driver.py
```

AI assistance: OpenAI Codex. Draft pending human review and validation.
