### PR TITLE
[Doc] Add controlled Rust frontend decode Graph validation guide

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -43,6 +43,9 @@ For example:
 VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B
 ```
 
+For a controlled eager-versus-decode-Graph comparison, see
+[the CUDA Graph validation guide](docs/decode_graph_validation.md).
+
 ### External Engine
 
 `vllm-rs serve` can be run standalone with `--data-parallel-size-local 0` when the Python engines

--- a/rust/docs/decode_graph_validation.md
+++ b/rust/docs/decode_graph_validation.md
@@ -1,0 +1,110 @@
+# Validate decode CUDA Graph configuration
+
+The Rust frontend forwards engine configuration to the Python vLLM engine.
+An experiment that explicitly passes `--enforce-eager` disables CUDA Graphs;
+its result should be distinguished from the upstream default configuration.
+This guide shows how to compare that explicit control with decode-only Graphs
+while keeping the frontend binary, model and request workload fixed.
+
+## Start either configuration
+
+Build the Rust frontend with `./build_rust.sh` and install the matching Python
+checkout. Use the same local model snapshot and binary for both arms. Set
+`MODEL_SNAPSHOT` to a downloaded, fixed revision of `Qwen/Qwen3-0.6B`.
+Run one arm at a time on the same idle GPU and restart the entire server between
+arms; stop the server you started before launching the other configuration.
+
+```bash
+export MODEL_SNAPSHOT=/path/to/Qwen3-0.6B
+export VLLM_USE_RUST_FRONTEND=1
+export VLLM_BATCH_INVARIANT=1
+export TOKIO_WORKER_THREADS=2
+export VLLM_RS_REQUEST_WORKER_THREADS=2
+export RAYON_NUM_THREADS=2
+export TOKENIZERS_PARALLELISM=false
+export OMP_NUM_THREADS=2
+export MKL_NUM_THREADS=2
+export OPENBLAS_NUM_THREADS=2
+
+common_args=(
+  "$MODEL_SNAPSHOT"
+  --served-model-name Qwen/Qwen3-0.6B
+  --host 127.0.0.1 --port 8000
+  --api-server-count 1 --tensor-parallel-size 1
+  --generation-config vllm --seed 0 --dtype bfloat16
+  --max-num-seqs 8 --max-model-len 2048
+  --no-enable-prefix-caching --kv-cache-memory-bytes 536870912
+  --enable-auto-tool-choice --tool-call-parser hermes
+  --reasoning-parser qwen3
+)
+
+# A: explicit eager control.
+vllm serve "${common_args[@]}" --enforce-eager
+
+# P: after stopping A, start a fresh server with the same common arguments.
+vllm serve "${common_args[@]}" \
+  --compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8]}'
+```
+
+`mode=0` disables compilation; `FULL_DECODE_ONLY` requests full Graphs for
+uniform decode batches, with eager prefill. Capture sizes above the tested batch
+range can change memory and startup costs. Do not pass `--enforce-eager` to the
+Graph arm. Confirm the resolved configuration and successful capture in server
+logs, then inspect an independent trace for actual Graph replay during decode.
+A configuration string or capture-complete log alone does not prove replay.
+
+## Compare a fixed workload
+
+Preserve full request bodies, response bodies and process/configuration logs.
+Use temperature zero, a fixed seed and fixed model/template files. For
+completions, request `logprobs: 5`, `max_tokens: 128`, `ignore_eos: true` and
+`stream: false`. Check exactly 128 completion tokens in each response.
+
+Include real tool-call chat and a separate short-chat holdout. For the latter,
+request 16 tokens, `ignore_eos: true`, `logprobs: true`, `top_logprobs: 5` and
+`chat_template_kwargs: {"enable_thinking": false}`. Verify usage, finish reasons,
+tool names and arguments, and all requested token/logprob fields. Normalize only
+top-level response `id`/`created` and generated tool-call IDs. Keep every other
+field in the comparison, including warmups and failed responses.
+
+The confirmation protocol below separates tuning from measurement:
+
+1. Freeze the request set and performance criteria before confirmation. Use
+   concurrency two; each arm has four warmups per workload, then 32 completions,
+   32 tool chats and 16 short-chat requests.
+2. Run four APPA and four PAAP quartets in a shuffled order with a fixed seed.
+   Each letter starts a fresh engine process; symmetric on-disk caches may stay
+   warm. Exclude the independent replay trace from performance samples.
+3. Compare all responses against the first arm by workload, phase and request
+   index. A missing, duplicate, failed or differing response fails correctness.
+4. Compute a geometric P/A ratio within each quartet. Bootstrap whole quartets,
+   rather than treating correlated requests as independent samples. In the
+   confirmation below, 20,000 samples with seed 20260912 were used.
+5. Require all eight quartets to be valid, primary throughput improvement CI
+   lower bound above 2%, and every workload's p95 regression CI upper bound at
+   most 5%. Baseline throughput drift within any quartet must be at most 10%.
+   Retain failed or interrupted runs instead of replacing them until a pass.
+
+## Observed configuration comparison
+
+On source `06e57f622cf53ed1c3f8d8295cdd48ea2c133bd1`, both arms used the same
+unmodified Rust binary, fixed Qwen3-0.6B files, BF16, TP1, batch invariance,
+prefix caching disabled and a 512 MiB KV budget.
+
+| GPU | Completion throughput P/A | 95% CI | Valid quartets |
+| --- | ---: | ---: | ---: |
+| NVIDIA RTX 5060 Ti | 3.3194× | 3.2941–3.3551× | 8/8 |
+| NVIDIA RTX PRO 4000 Blackwell | 4.0939× | 4.0722–4.1178× | 8/8 |
+
+Each independent GPU confirmation completed 32 fresh engine processes,
+2,944 HTTP requests and 2,852 strict comparisons with zero differences or
+HTTP errors. All three workload p95 guards passed. Separate replay traces
+were excluded from these timings. The hardware cohorts were not pooled.
+
+These measurements compare an explicit eager test configuration with a
+Graph configuration. They do not measure a Rust code change or an improvement
+over upstream defaults. A 16-request short-chat cohort has a nearest-rank p95
+at its maximum, so it is not a well-sampled production tail estimate.
+Non-streaming responses do not provide TTFT, ITL or TPOT. Tool chat did not
+request token logprobs in this confirmation. Recheck correctness, actual replay
+and latency for other models, releases, hardware and workload shapes.


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/vllm-project/vllm/pull/56622/files) against `main`.

**Main sync (2026-09-14):** current head `9f74c0c2ada2e0e4742083ddab00d1817ff68547` merges `main` at `23cfaad49701c497def53552b23317335431f72a`. The CUDA Graph guide is unchanged; the README keeps the new upstream RL weight-synchronization section and reflows its existing long lines for the current Markdown lint rule. Changed-file pre-commit and `git diff --check` passed. The documented flags and `FULL_DECODE_ONLY` semantics were checked against current managed-engine forwarding and compilation configuration. No new GPU run is claimed for this documentation sync.

## Purpose

Document a controlled eager-versus-decode-CUDA-Graph comparison through the Rust frontend, including copyable server commands, complete-response checks, independent replay proof and a finite confirmation protocol. The current README explains startup but does not show how an explicit `--enforce-eager` experiment differs from upstream defaults.

This PR adds documentation only. It does not modify the engine, frontend defaults, CUDA kernels or Rust request processing. Searches of open PR titles for Rust/decode configuration and response comparison found no duplicate of this guide.

## Test Plan

- `pre-commit run --files rust/README.md rust/docs/decode_graph_validation.md`
- Check flags against the current managed-engine argument forwarding and compilation configuration definitions.
- Match reported measurements to the archived independent GPU confirmations.

## Test Result

All changed-file pre-commit hooks passed. The commands and configuration fields were inspected against the publication checkout; no new GPU run is claimed for this documentation commit.

Earlier fixed-source confirmation used Qwen3-0.6B BF16 TP1, batch invariance, prefix caching disabled, a 512 MiB KV budget, the same unmodified Rust binary in both arms, and source `06e57f622cf53ed1c3f8d8295cdd48ea2c133bd1`. Control: explicit `--enforce-eager`; treatment: `mode=0`, `FULL_DECODE_ONLY`, capture sizes `[1,2,4,8]`.

| GPU | Completion throughput P/A | Whole-quartet bootstrap 95% CI |
| --- | ---: | ---: |
| RTX 5060 Ti | 3.3194× | 3.2941–3.3551× |
| RTX PRO 4000 Blackwell | 4.0939× | 4.0722–4.1178× |

Each cohort completed eight independent quartets, 32 engine starts, 2,944 HTTP requests and 2,852 strict response comparisons with zero differences/errors; all three p95 workload guards passed. Separate traces verified actual decode replay and were excluded from performance samples. This is configuration improvement versus an explicit eager test baseline, not a Rust patch gain or comparison against upstream defaults. Non-streaming HTTP does not measure TTFT/ITL/TPOT, and the short-chat tail is under-sampled.


AI assistance was used for conflict resolution and validation.