### PR TITLE
[Performance] Bypass V2 batch request sort for constant keys

### DIFF
--- a/tests/v1/worker/test_gpu_batch_ordering.py
+++ b/tests/v1/worker/test_gpu_batch_ordering.py
@@ -12,6 +12,7 @@ batch's shape, and must not be classified as a uniform decode batch.
 """
 
 import ast
+import random
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -19,6 +20,7 @@ from typing import Any
 import numpy as np
 import torch
 
+import vllm.v1.worker.gpu.model_runner as model_runner
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner, sort_batch_req_ids
@@ -79,6 +81,182 @@ def _uniform_token_count(
     runner = _make_runner(req_states, decode_query_len=query_len)
     _, uniform_tok_count = runner.gather_batch_req_state(scheduler_output, dummy_run)
     return uniform_tok_count
+
+
+def _make_scheduler_output(
+    num_tokens_per_req: dict[str, int],
+    draft_tokens: dict[str, list[int]] | None = None,
+) -> Any:
+    return SimpleNamespace(
+        num_scheduled_tokens=num_tokens_per_req,
+        total_num_scheduled_tokens=sum(num_tokens_per_req.values()),
+        scheduled_spec_decode_tokens=draft_tokens or {},
+    )
+
+
+def _assert_batch_state_order(
+    batch_state: Any,
+    runner: Any,
+    num_tokens_per_req: dict[str, int],
+    expected_req_ids: list[str],
+) -> None:
+    assert batch_state.req_ids == expected_req_ids
+    np.testing.assert_array_equal(
+        batch_state.num_scheduled_tokens,
+        np.array(
+            [num_tokens_per_req[req_id] for req_id in expected_req_ids],
+            dtype=np.int32,
+        ),
+    )
+    np.testing.assert_array_equal(
+        batch_state.idx_mapping_np,
+        np.array(
+            [runner.req_states.req_id_to_index[req_id] for req_id in expected_req_ids],
+            dtype=np.intp,
+        ),
+    )
+
+
+def _track_sort_calls(
+    monkeypatch: Any,
+) -> list[tuple[dict[str, int], dict[str, list[int]], int]]:
+    calls = []
+
+    def tracking_sort(
+        num_tokens_per_req: dict[str, int],
+        draft_tokens: dict[str, list[int]],
+        decode_query_len: int,
+    ) -> list[str]:
+        calls.append((num_tokens_per_req, draft_tokens, decode_query_len))
+        return sort_batch_req_ids(num_tokens_per_req, draft_tokens, decode_query_len)
+
+    monkeypatch.setattr(model_runner, "sort_batch_req_ids", tracking_sort)
+    return calls
+
+
+def test_constant_key_batch_order_bypass_matches_stable_sort(monkeypatch):
+    rng = random.Random(20260913)
+
+    def fail_sort(*_args: Any, **_kwargs: Any) -> list[str]:
+        raise AssertionError("constant-key batch must not call sort_batch_req_ids")
+
+    monkeypatch.setattr(model_runner, "sort_batch_req_ids", fail_sort)
+
+    for query_len in (1, 5):
+        for num_reqs in (1, 3, 17):
+            req_ids = [f"q{query_len}_r{i}" for i in range(num_reqs)]
+            rng.shuffle(req_ids)
+            num_tokens_per_req = {req_id: query_len for req_id in req_ids}
+            expected_req_ids = sort_batch_req_ids(num_tokens_per_req, {}, query_len)
+            assert expected_req_ids == req_ids
+
+            runner = _make_runner(
+                {req_id: (100, 100) for req_id in req_ids},
+                decode_query_len=query_len,
+            )
+            batch_state, uniform_tok_count = runner.gather_batch_req_state(
+                _make_scheduler_output(num_tokens_per_req),
+                dummy_run=False,
+            )
+
+            _assert_batch_state_order(
+                batch_state, runner, num_tokens_per_req, expected_req_ids
+            )
+            assert batch_state.num_tokens == query_len * num_reqs
+            assert uniform_tok_count == query_len
+
+
+def test_constant_key_bypass_is_key_only_not_prefill_semantic(monkeypatch):
+    req_ids = ["prefill_b", "prefill_a", "prefill_c"]
+    query_len = 5
+    num_tokens_per_req = {req_id: query_len for req_id in req_ids}
+    expected_req_ids = sort_batch_req_ids(num_tokens_per_req, {}, query_len)
+
+    def fail_sort(*_args: Any, **_kwargs: Any) -> list[str]:
+        raise AssertionError("constant-key batch must not call sort_batch_req_ids")
+
+    monkeypatch.setattr(model_runner, "sort_batch_req_ids", fail_sort)
+
+    runner = _make_runner(
+        {req_id: (0, 20) for req_id in req_ids},
+        decode_query_len=query_len,
+    )
+    batch_state, uniform_tok_count = runner.gather_batch_req_state(
+        _make_scheduler_output(num_tokens_per_req),
+        dummy_run=False,
+    )
+
+    _assert_batch_state_order(batch_state, runner, num_tokens_per_req, expected_req_ids)
+    assert batch_state.has_prefill
+    assert uniform_tok_count is None
+
+
+def test_batch_order_falls_back_to_sort_for_nonempty_draft(monkeypatch):
+    calls = _track_sort_calls(monkeypatch)
+    query_len = 5
+    num_tokens_per_req = {"plain_a": 5, "draft": 5, "plain_b": 5}
+    draft_tokens = {"draft": [11, 12]}
+    expected_req_ids = sort_batch_req_ids(num_tokens_per_req, draft_tokens, query_len)
+    runner = _make_runner(
+        {req_id: (100, 100) for req_id in num_tokens_per_req},
+        decode_query_len=query_len,
+    )
+
+    batch_state, uniform_tok_count = runner.gather_batch_req_state(
+        _make_scheduler_output(num_tokens_per_req, draft_tokens),
+        dummy_run=False,
+    )
+
+    assert len(calls) == 1
+    _assert_batch_state_order(batch_state, runner, num_tokens_per_req, expected_req_ids)
+    assert batch_state.num_tokens == sum(num_tokens_per_req.values())
+    assert uniform_tok_count == query_len
+
+
+def test_batch_order_falls_back_to_sort_for_nonuniform_counts(monkeypatch):
+    calls = _track_sort_calls(monkeypatch)
+    query_len = 5
+    num_tokens_per_req = {"tail": 1, "decode_b": 5, "prefill": 9, "decode_a": 5}
+    expected_req_ids = sort_batch_req_ids(num_tokens_per_req, {}, query_len)
+    runner = _make_runner(
+        {req_id: (100, 100) for req_id in num_tokens_per_req},
+        decode_query_len=query_len,
+    )
+
+    batch_state, uniform_tok_count = runner.gather_batch_req_state(
+        _make_scheduler_output(num_tokens_per_req),
+        dummy_run=False,
+    )
+
+    assert len(calls) == 1
+    _assert_batch_state_order(batch_state, runner, num_tokens_per_req, expected_req_ids)
+    assert batch_state.num_tokens == sum(num_tokens_per_req.values())
+    assert uniform_tok_count is None
+
+
+def test_batch_order_falls_back_to_sort_for_mixed_gate_false_shape(monkeypatch):
+    calls = _track_sort_calls(monkeypatch)
+    query_len = 5
+    num_tokens_per_req = {"decode": 5, "prefill_tail": 4, "prefill_full": 12}
+    expected_req_ids = sort_batch_req_ids(num_tokens_per_req, {}, query_len)
+    runner = _make_runner(
+        {
+            "decode": (100, 100),
+            "prefill_tail": (0, 20),
+            "prefill_full": (0, 20),
+        },
+        decode_query_len=query_len,
+    )
+
+    batch_state, uniform_tok_count = runner.gather_batch_req_state(
+        _make_scheduler_output(num_tokens_per_req),
+        dummy_run=False,
+    )
+
+    assert len(calls) == 1
+    _assert_batch_state_order(batch_state, runner, num_tokens_per_req, expected_req_ids)
+    assert batch_state.has_prefill
+    assert uniform_tok_count is None
 
 
 def test_spec_decode_batch_is_uniform_decode():

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1173,9 +1173,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         draft_tokens = scheduler_output.scheduled_spec_decode_tokens
         # batch_idx -> req_id
-        req_ids = sort_batch_req_ids(
-            num_tokens_per_req, draft_tokens, self.decode_query_len
-        )
+        if (
+            not draft_tokens
+            and max_query_len == self.decode_query_len
+            and num_toks == num_reqs * self.decode_query_len
+        ):
+            req_ids = list(num_tokens_per_req)
+        else:
+            req_ids = sort_batch_req_ids(
+                num_tokens_per_req, draft_tokens, self.decode_query_len
+            )
 
         numtoks_iter = map(num_tokens_per_req.__getitem__, req_ids)
         num_scheduled_tokens = np.fromiter(numtoks_iter, dtype=np.int32, count=num_reqs)


### PR DESCRIPTION
## Summary

Avoid Python stable sorting in Model Runner V2 only when the existing sort key is mechanically proven constant for every scheduled request. In that case stable sort is equivalent to preserving `num_scheduled_tokens` insertion order; all other cases continue to use `sort_batch_req_ids` unchanged.

The fast-path predicate uses only current sort-input facts:
- no scheduled draft tokens;
- `max_query_len == decode_query_len`;
- total scheduled tokens equal `num_reqs * decode_query_len`.

This intentionally does not use semantic decode/prefill classification.

## Validation

Focused coverage adds randomized insertion-order cases for query lengths 1 and 5, multiple request counts, a constant-key prefill-like case, and fallback cases for draft tokens, nonuniform counts, and mixed/prefill-like geometry. It also checks downstream request/token/index ordering.

Local static validation passes:
- `ruff format --check` on both touched files;
- `ruff check` on both touched files;
- `git diff --check`.

The focused pytest file could not be collected in the available host environment because its installed Torch 2.5.1 lacks `torch._inductor.custom_graph_pass` required by current vLLM. This PR does not claim a local pytest pass; upstream CI is expected to run in the dependency-complete environment.

Prior isolated CPU component falsification showed exact ordering equivalence under the predicate and positive host-sort savings at large request counts. No full-runner, TTFT/TPOT, throughput, NPU, end-to-end, deployment, or production claim is made here.
