### PR TITLE
[Bugfix][Spec Decode] Pass draft_vllm_config to draft metadata builders (#45669)

### DIFF
--- a/tests/v1/spec_decode/test_llm_base_proposer.py
+++ b/tests/v1/spec_decode/test_llm_base_proposer.py
@@ -31,6 +31,7 @@ class _FakeAttentionGroup:
         self.kernel_block_size = None
 
     def create_metadata_builders(self, vllm_config, device, kernel_block_size=None):
+        self.vllm_config = vllm_config
         self.kernel_block_size = kernel_block_size
 
     def get_metadata_builder(self):
@@ -110,3 +111,28 @@ def test_draft_layer_iteration_is_deterministic(monkeypatch: pytest.MonkeyPatch)
         assert len(proposer.draft_attn_groups) == 1
         assert proposer.draft_attn_groups[0].layer_names == expected_order
         assert proposer.block_size == KERNEL_BLOCK_SIZE
+
+
+def test_initialize_attn_backend_passes_draft_vllm_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Metadata builders for draft attention groups must receive
+    draft_vllm_config instead of target vllm_config to avoid attention
+    head mismatch issues (fixes #45669)."""
+    layer_names = {"draft.0.self_attn.attn"}
+    proposer = _make_proposer(monkeypatch, layer_names)
+
+    target_cfg = SimpleNamespace(name="target_config")
+    draft_cfg = SimpleNamespace(name="draft_config")
+    proposer.vllm_config = target_cfg
+    proposer._draft_vllm_config = draft_cfg
+
+    proposer.initialize_attn_backend(
+        _make_kv_cache_config(layer_names),
+        kernel_block_sizes=[KERNEL_BLOCK_SIZE],
+    )
+
+    assert len(proposer.draft_attn_groups) == 1
+    assert proposer.draft_attn_groups[0].vllm_config is draft_cfg
+    assert proposer.draft_attn_groups[0].vllm_config is not target_cfg
+

--- a/vllm/v1/spec_decode/draft_model.py
+++ b/vllm/v1/spec_decode/draft_model.py
@@ -96,10 +96,9 @@ class DraftModelProposer(SpecDecodeBaseProposer):
     def _get_model(self) -> nn.Module:
         from vllm.compilation.backends import set_model_tag
 
-        draft_vllm_config = self._create_draft_vllm_config()
         with set_model_tag("draft_model"):
             model = get_model(
-                vllm_config=draft_vllm_config,
+                vllm_config=self.draft_vllm_config,
                 prefix="draft_model",
             )
         return model

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1292,6 +1292,18 @@ class SpecDecodeBaseProposer:
 
         return base
 
+    @property
+    def draft_vllm_config(self) -> VllmConfig:
+        if hasattr(self, "_draft_vllm_config"):
+            return self._draft_vllm_config
+        if (
+            getattr(self, "vllm_config", None) is not None
+            and getattr(self, "speculative_config", None) is not None
+        ):
+            self._draft_vllm_config = self._create_draft_vllm_config()
+            return self._draft_vllm_config
+        return getattr(self, "vllm_config", None)
+
     def _get_model(self) -> nn.Module:
         """
         Default method to call get_model(). Can be overridden by subclasses which
@@ -1299,10 +1311,9 @@ class SpecDecodeBaseProposer:
         """
         from vllm.compilation.backends import set_model_tag
 
-        draft_vllm_config = self._create_draft_vllm_config()
         with set_model_tag("eagle_head"):
             model = get_model(
-                vllm_config=draft_vllm_config,
+                vllm_config=self.draft_vllm_config,
                 model_config=self.speculative_config.draft_model_config,
                 load_config=self.speculative_config.draft_load_config,
             )
@@ -1753,7 +1764,7 @@ class SpecDecodeBaseProposer:
                         kv_cache_group_id=self.kv_cache_gid,
                     )
                     attn_group.create_metadata_builders(
-                        self.vllm_config,
+                        self.draft_vllm_config,
                         self.device,
                         kernel_block_size=kernel_block_size,
                     )


### PR DESCRIPTION
## Purpose
Fixes #45669

### Root Cause
In `SpecDecodeBaseProposer.initialize_attn_backend`, the attention groups for the draft model are initialized using:

```python
    attn_group.create_metadata_builders(
        self.vllm_config,  # Target model config
        self.device,
        kernel_block_size=kernel_block_size,
    )
```

### Fix 
  1. Expose a cached draft_vllm_config property on SpecDecodeBaseProposer (defensively falling back if mocked in unit tests).
  2. Pass `self.draft_vllm_config` to `attn_group.create_metadata_builders()`
  3. Use `self.draft_vllm_config` consistently in `_get_model()`

## Test Plan
```bash
pytest tests/v1/spec_decode/test_llm_base_proposer.py -v

pytest tests/v1/spec_decode/test_draft_attention_backend_override.py \
           tests/v1/spec_decode/test_draft_moe_backend_override.py \
           tests/v1/spec_decode/test_vocab_mapping.py -v

```
## Test Result
```bash
    tests/v1/spec_decode/test_llm_base_proposer.py::test_block_size_uses_kernel_block_size PASSED
    tests/v1/spec_decode/test_llm_base_proposer.py::test_block_size_falls_back_to_kv_cache_spec PASSED
    tests/v1/spec_decode/test_llm_base_proposer.py::test_draft_layer_iteration_is_deterministic PASSED
    tests/v1/spec_decode/test_llm_base_proposer.py::test_initialize_attn_backend_passes_draft_vllm_config PASSED

    ======================== 4 passed in 2.74s ========================

    tests/v1/spec_decode/test_draft_attention_backend_override.py PASSED (3/3)
    tests/v1/spec_decode/test_draft_moe_backend_override.py PASSED (3/3)
    tests/v1/spec_decode/test_vocab_mapping.py PASSED (5/5)

    ================= 11 passed, 1 skipped in 29.55s ==================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

