### PR TITLE
[ROCm][Bugfix] Restrict multi-stream shared experts to gfx950

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -57,6 +57,16 @@ class SharedExperts(torch.nn.Module):
 
         self._mk_can_overlap_shared_experts = mk_can_overlap_shared_experts
 
+        # Outside gfx950, running the shared experts on the aux stream prevents
+        # new communicators from finishing their initialization while an
+        # Elastic EP rescale is in flight, so the rescale never completes. Keep
+        # multi-stream off there until that interaction is fixed.
+        self._is_multistream_safe = True
+        if current_platform.is_rocm():
+            from vllm.platforms.rocm import on_gfx950
+
+            self._is_multistream_safe = on_gfx950()
+
         # Allow disabling of the separate shared experts stream for
         # debug purposes.
         # TODO: Remove this after more extensive testings with TP/DP
@@ -112,6 +122,7 @@ class SharedExperts(torch.nn.Module):
             and self._stream is not None
             and hidden_states.shape[0]
             <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD
+            and self._is_multistream_safe
         )
 
         if should_run_shared_in_aux_stream:


### PR DESCRIPTION
## Purpose

[#56098](https://github.com/vllm-project/vllm/pull/56098) enabled the MoE shared-experts auxiliary stream across ROCm. On gfx942, that causes Elastic EP scaling to hang: [AMD CI build 12870](https://buildkite.com/vllm/amd-ci/builds/12870/list) failed three eager parameterizations of `test_elastic_ep_scaling`, and `enforce_eager_light` fails 5 of 5 runs locally on `main`.

Tracing the rescale through `StatelessGroupCoordinator` and `PyNcclCommunicator` shows that all four ranks of the new DP group return from `ncclCommInitRank`, but the first `all_reduce` never completes and c10d times out after 300 seconds. With
the aux stream disabled, the same collective completes within 35 ms; `ncclCommInitRank` takes about 10 seconds in both cases.

This change restricts shared-expert auxiliary-stream overlap on ROCm to gfx950, so #56098's behavior is preserved there. The temporary gate prevents the gfx942 Elastic EP scaling failure until the interaction between the aux stream and RCCL initialization is resolved.

## Test Plan

Four MI300X GPUs:

```bash
cd /vllm-workspace/tests
pytest -v -s distributed/test_elastic_ep.py
```

## Test Result

**Before:** 0 of 5 runs of `test_elastic_ep_scaling[enforce_eager_light]` passed,
each failing after a 300 s `[c10d] waitForInput` timeout followed by
`Scale failed: The actor died unexpectedly before finishing this task.`

**After:** the full file passes, 5 of 5 tests in 26m30s.

AI assistance was used.