### PR TITLE
[CI][Test][Spec Decode] Fix DSpark loader mock after PP-safe load config

### DIFF
--- a/tests/model_executor/test_qwen3_omni.py
+++ b/tests/model_executor/test_qwen3_omni.py
@@ -355,6 +355,7 @@ def test_dspark_shares_target_embedding_with_smaller_draft_vocabulary():
         attention_config=SimpleNamespace(backend=None),
         cache_config=SimpleNamespace(),
         model_config=SimpleNamespace(get_vocab_size=Mock(return_value=100)),
+        load_config=SimpleNamespace(load_format="auto"),
     )
 
     def fake_replace(config, **changes):
@@ -366,6 +367,10 @@ def test_dspark_shares_target_embedding_with_smaller_draft_vocabulary():
         patch.object(dspark_utils, "replace", side_effect=fake_replace),
         patch(
             "vllm.v1.worker.gpu.spec_decode.eagle.utils.get_pp_group",
+            return_value=SimpleNamespace(world_size=1),
+        ),
+        patch(
+            "vllm.v1.worker.gpu.spec_decode.utils.get_pp_group",
             return_value=SimpleNamespace(world_size=1),
         ),
         patch(


### PR DESCRIPTION
## Purpose

`tests/model_executor/test_qwen3_omni.py::test_dspark_shares_target_embedding_with_smaller_draft_vocabulary` fails on `main`, taking the Intel CI `Model Executor (Intel)` step down for every PR that runs it.

`dca96bf97b` (#54416) added a PP-safe draft loader config to `load_dspark_model`:

```python
load_config=get_pp_safe_draft_load_config(vllm_config.load_config),
```

The test builds its `VllmConfig` as a `SimpleNamespace` and never grew that field, so the call raises:

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'load_config'. Did you mean: 'model_config'?
vllm/v1/worker/gpu/spec_decode/dspark/utils.py:77
```

This is a test-side gap only; the production change in #54416 is correct.

## Fix

Two changes, both needed:

1. Add `load_config=SimpleNamespace(load_format="auto")` to the fake `vllm_config`.
2. Patch `vllm.v1.worker.gpu.spec_decode.utils.get_pp_group` as well as the existing `eagle.utils` patch. `get_pp_safe_draft_load_config` lives in `spec_decode.utils` and resolves the group through that module's own binding, so without this patch the call reaches the real, uninitialized process group and asserts before it ever inspects `load_format`. With `world_size=1` the function short-circuits and returns the config unchanged, which is what the test wants.

## Test Plan

```bash
pytest -q tests/model_executor/test_qwen3_omni.py::test_dspark_shares_target_embedding_with_smaller_draft_vocabulary
```

## Test Result

Reproduced first on a clean checkout of `main` (`3bb23e2def`) with no other changes: the `AttributeError` above, `1 failed`.

With this change: `1 passed`.

The other tests in this file need `torchvision`, which is absent from my local env; they are unaffected by this change, which touches one test function only.

## AI assistance

AI assistance was used to diagnose and write this change. I reviewed every changed line, ran the test above before and after, and confirmed the failure reproduces on unmodified `main`.

## Duplicate check

No open PR or issue covers this. Searched open PRs referencing `#54416`, and open PRs/issues matching `test_qwen3_omni`, `dspark load_config`, and `load_config SimpleNamespace`; #55985 and #54875 reference fastsafetensors but touch neither this test nor `dspark/utils.py`.
