### PR TITLE
[Model] Fix K2-Horizon MoVA weight loading and support GPTQ INT4

### DIFF
--- a/tests/models/test_k2_horizon.py
+++ b/tests/models/test_k2_horizon.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed import parallel_state
+from vllm.model_executor.layers.quantization.auto_gptq import (
+    AutoGPTQConfig,
+    AutoGPTQLinearMethod,
+)
+from vllm.model_executor.models import k2_horizon
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_default_torch_dtype
+
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_xpu(), reason="Requires the XPU GPTQ weight layout"
+)
+
+
+@pytest.fixture(params=[(1, 0), (2, 0), (2, 1)])
+def mova_attention(monkeypatch: pytest.MonkeyPatch, request):
+    """Build the MoVA value projection without initializing an attention kernel."""
+    monkeypatch.setattr(
+        parallel_state,
+        "_TP",
+        SimpleNamespace(world_size=request.param[0], rank_in_group=request.param[1]),
+    )
+    monkeypatch.setattr(
+        k2_horizon, "Attention", lambda *args, **kwargs: nn.Identity()
+    )
+
+    quant_config = AutoGPTQConfig(
+        weight_bits=4,
+        group_size=64,
+        desc_act=False,
+        is_sym=True,
+        lm_head_quantized=False,
+        dynamic={},
+        full_config={},
+        modules_in_block_to_quantize=[
+            f"self_attn.v_experts.{expert}" for expert in range(4)
+        ],
+    )
+    runtime_config = SimpleNamespace(
+        model_config=SimpleNamespace(dtype=torch.float16),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=2048),
+    )
+    with (
+        set_current_vllm_config(VllmConfig()),
+        set_default_torch_dtype(torch.float16),
+        torch.device("xpu"),
+    ):
+        return k2_horizon.K2HorizonMoVAAttention(
+            vllm_config=runtime_config,
+            hidden_size=128,
+            num_heads=2,
+            num_kv_heads=2,
+            rope_parameters={"rope_type": "default"},
+            rope_head_dim=64,
+            query_key_norm=False,
+            num_experts=4,
+            num_experts_per_tok=2,
+            moe_gate_bias=False,
+            router_score_func="softmax",
+            router_scaling_factor=1.0,
+            quant_config=quant_config,
+            prefix="model.layers.0.self_attn",
+        )
+
+
+def test_mova_value_experts_use_gptq_method(mova_attention):
+    """The fused value projection inherits its experts' GPTQ allocation."""
+    assert isinstance(
+        mova_attention.v_experts_fused.quant_method, AutoGPTQLinearMethod
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 4])
+@torch.inference_mode()
+def test_mova_gptq_shards_match_dense_reference_and_graph(mova_attention, num_tokens):
+    """Packed expert loading and graph replay preserve sparse MoVA outputs."""
+    layer = mova_attention
+    fused = layer.v_experts_fused
+    torch.manual_seed(17)
+    values = torch.randint(0, 16, (4, 128, 128), device="xpu", dtype=torch.int32)
+    scales = torch.rand(4, 2, 128, device="xpu", dtype=torch.float16) * 0.01
+    shifts = torch.arange(0, 32, 4, device="xpu", dtype=torch.int32)
+    packed = (values.reshape(4, 16, 8, 128) << shifts[None, None, :, None]).sum(2)
+    for expert in range(4):
+        for name, weight in (
+            ("qweight", packed[expert].to(torch.int32)),
+            ("scales", scales[expert]),
+            ("qzeros", torch.full((2, 16), 0x77777777, device="xpu", dtype=torch.int32)),
+        ):
+            param = getattr(fused, name)
+            param.weight_loader(param, weight, expert)
+    fused.quant_method.process_weights_after_loading(fused)
+    layer.v_router.weight.normal_(std=0.05)
+
+    dense = ((values.float() - 8) * scales.float().repeat_interleave(64, dim=1))
+    dense = dense.transpose(1, 2).to(torch.float16)
+    dense = dense[:, layer.tp_rank * layer.kv_size : (layer.tp_rank + 1) * layer.kv_size]
+    x = torch.randn(num_tokens, 128, device="xpu", dtype=torch.float16)
+
+    def reference():
+        scores = F.linear(x, layer.v_router.weight).float().softmax(-1)
+        weights, indices = scores.topk(2, dim=-1)
+        weights = (weights / weights.sum(-1, keepdim=True)).to(x.dtype)
+        all_values = torch.stack([F.silu(F.linear(x, w)) for w in dense], dim=1)
+        selected = all_values.gather(1, indices[..., None].expand(-1, -1, layer.kv_size))
+        return (selected * weights[..., None]).sum(1)
+
+    torch.testing.assert_close(layer.compute_mova_v_sparse(x), reference(), atol=5e-3, rtol=2e-2)
+    graph = torch.xpu.XPUGraph()
+    with torch.xpu.graph(graph):
+        output = layer.compute_mova_v_sparse(x)
+    for _ in range(2):
+        x.normal_()
+        graph.replay()
+        torch.testing.assert_close(output, reference(), atol=5e-3, rtol=2e-2)

--- a/vllm/model_executor/models/k2_horizon.py
+++ b/vllm/model_executor/models/k2_horizon.py
@@ -27,6 +27,7 @@
 import math
 import typing
 from collections.abc import Callable, Iterable
+from copy import deepcopy
 from itertools import islice
 from typing import Any
 
@@ -45,6 +46,7 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
 )
 from vllm.logger import init_logger
+from vllm.model_executor.kernels.linear.mixed_precision.xpu import XPUwNa16LinearKernel
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
@@ -70,9 +72,14 @@ from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.auto_gptq import (
+    AutoGPTQConfig,
+    AutoGPTQLinearMethod,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -709,18 +716,43 @@ class K2HorizonMoVAAttention(nn.Module):
                 self.v_router.bias.float(), requires_grad=False
             )
 
-        self.v_experts = nn.ModuleList(
-            [
-                ColumnParallelLinear(
-                    hidden_size,
-                    self.kv_size * tp_size,
-                    bias=False,
-                    quant_config=quant_config,
-                    prefix=f"{prefix}.v_experts.{value}",
-                )
-                for value in range(num_experts)
-            ]
+        expert_quant_config = quant_config
+        if isinstance(quant_config, AutoGPTQConfig):
+            expert_quant_config = deepcopy(quant_config)
+            expert_quant_config.packed_modules_mapping = {
+                **quant_config.packed_modules_mapping,
+                "v_experts_fused": [f"v_experts.{i}" for i in range(num_experts)],
+            }
+        self.v_experts_fused = MergedColumnParallelLinear(
+            hidden_size,
+            [self.kv_size * tp_size] * num_experts,
+            bias=False,
+            quant_config=expert_quant_config,
+            prefix=f"{prefix}.v_experts_fused",
         )
+        method = self.v_experts_fused.quant_method
+        self.mova_group_size = None
+        if isinstance(method, AutoGPTQLinearMethod):
+            config = method.quant_config
+            if (
+                not isinstance(method.kernel, XPUwNa16LinearKernel)
+                or config.weight_bits != 4
+                or not config.is_sym
+                or config.desc_act
+            ):
+                raise NotImplementedError(
+                    "Quantized MoVA requires symmetric GPTQ INT4 without "
+                    "activation ordering and the XPU WNA16 backend."
+                )
+            if self.total_num_kv_heads < tp_size:
+                raise NotImplementedError(
+                    "Quantized MoVA does not support replicated KV heads."
+                )
+            self.mova_group_size = (
+                hidden_size if config.group_size == -1 else config.group_size
+            )
+        elif not isinstance(method, UnquantizedLinearMethod):
+            raise NotImplementedError("Unsupported quantization method for MoVA.")
 
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
@@ -775,28 +807,6 @@ class K2HorizonMoVAAttention(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = get_tensor_model_parallel_rank()
 
-        w1_shape = torch.Size(
-            [
-                self.num_experts,
-                self.total_num_kv_heads * self.head_dim,
-                hidden_size,
-            ]
-        )
-        config_dtype = _get_config_dtype_str(
-            use_fp8_w8a8=False,
-            use_int8_w8a16=False,
-            use_int4_w4a16=False,
-            dtype=vllm_config.model_config.dtype,
-        )
-        self.fused_mova_config = try_get_optimal_moe_config(
-            w1_shape=w1_shape,
-            w2_shape=torch.Size([w1_shape[0], w1_shape[2], w1_shape[1]]),
-            top_k=self.num_experts_per_tok,
-            dtype=config_dtype,
-            M=vllm_config.scheduler_config.max_num_batched_tokens,
-            block_shape=None,
-        )
-
     def compute_mova_v_sparse(self, hidden_states):
         router_logits, _ = self.v_router(hidden_states)
 
@@ -808,18 +818,54 @@ class K2HorizonMoVAAttention(nn.Module):
             scaling_factor=self.router_scaling_factor,
         )
 
-        w1 = torch.stack(
-            [expert.weight for expert in self.v_experts], dim=0
-        ).contiguous()
+        use_int4 = self.mova_group_size is not None
+        w1_scale = None
+        block_shape = None
+        if use_int4:
+            # XPU's linear post-load conversion packs K contiguously per output.
+            w1 = self.v_experts_fused.qweight.view(torch.uint8).view(
+                self.num_experts, self.kv_size, self.hidden_size // 2
+            )
+            w1_scale = self.v_experts_fused.scales.t().view(
+                self.num_experts,
+                self.kv_size,
+                self.hidden_size // self.mova_group_size,
+            )
+            block_shape = [0, self.mova_group_size]
+        else:
+            w1 = self.v_experts_fused.weight.view(
+                self.num_experts, self.kv_size, self.hidden_size
+            )
+        config_dtype = _get_config_dtype_str(
+            use_fp8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=use_int4,
+            dtype=hidden_states.dtype,
+        )
+        config = try_get_optimal_moe_config(
+            w1_shape=w1.shape,
+            w2_shape=(
+                self.num_experts,
+                self.hidden_size,
+                self.kv_size // 2 if use_int4 else self.kv_size,
+            ),
+            top_k=self.num_experts_per_tok,
+            dtype=config_dtype,
+            M=hidden_states.shape[0],
+            block_shape=block_shape,
+        )
 
         v = fused_mova_impl(
-            config=self.fused_mova_config,
+            config=config,
             hidden_states=hidden_states.contiguous(),
             w1=w1,
             topk_weights=routing_weights.contiguous(),
             topk_ids=selected_values.contiguous(),
             global_num_experts=self.num_experts,
             expert_map=None,
+            use_int4_w4a16=use_int4,
+            w1_scale=w1_scale,
+            block_shape=block_shape,
         )
 
         return v
@@ -1161,30 +1207,33 @@ class K2HorizonModel(nn.Module, EagleModelMixin):
                 loaded_params.add(name)
                 continue
 
-            # MoVA v experts
+            # MoVA v_experts merged into v_experts_fused (shard_id = expert_id).
             if ".self_attn.v_experts." in name:
-                if is_pp_missing_parameter(name, self):
+                prefix_name, suffix = name.split(".self_attn.v_experts.", 1)
+                expert_id_str, param_suffix = suffix.split(".", 1)
+                fused_name = (
+                    f"{prefix_name}.self_attn.v_experts_fused.{param_suffix}"
+                )
+                if is_pp_missing_parameter(fused_name, self):
                     continue
-                if name not in params_dict:
+                if fused_name not in params_dict:
                     continue
 
-                param = params_dict[name]
-                tp_rank = get_tensor_model_parallel_rank()
                 tp_size = get_tensor_model_parallel_world_size()
                 num_kv_heads = self.config.num_key_value_heads
+                if num_kv_heads < tp_size:
+                    num_kv_head_replicas = tp_size // num_kv_heads
+                    loaded_weight = (
+                        loaded_weight.reshape(
+                            num_kv_heads, -1, *loaded_weight.shape[1:]
+                        )
+                        .repeat_interleave(num_kv_head_replicas, dim=0)
+                        .reshape(-1, *loaded_weight.shape[1:])
+                    )
 
-                if loaded_weight.shape != param.shape:
-                    if num_kv_heads >= tp_size:
-                        loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]
-                    else:
-                        num_kv_head_replicas = tp_size // num_kv_heads
-                        kv_rank = tp_rank // num_kv_head_replicas
-                        loaded_weight = loaded_weight.chunk(num_kv_heads, dim=0)[
-                            kv_rank
-                        ]
-
-                default_weight_loader(param, loaded_weight)
-                loaded_params.add(name)
+                param = params_dict[fused_name]
+                param.weight_loader(param, loaded_weight, int(expert_id_str))
+                loaded_params.add(fused_name)
                 continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:


### PR DESCRIPTION
## Purpose
Fix K2-Horizon MoVA value-expert weight loading for quantized models (GPTQ) and Tensor Parallelism (TP), and add XPU WNA16 INT4 support.

## Problem & Background
1. **GPTQ could not load at all**: Upstream K2-Horizon defined `v_experts` as a `ColumnParallelLinear` module list. `compute_mova_v_sparse` expects a plain `.weight` attribute:
   ```python
   w1 = torch.stack([expert.weight for expert in self.v_experts], dim=0).contiguous()
   ```
   For AutoGPTQ checkpoints, only `qweight`, `scales`, and `qzeros` exist, triggering an immediate `AttributeError: 'ColumnParallelLinear' object has no attribute 'weight'`.
   As a workaround, users had to exclude MoVA from quantization during AutoRound/GPTQ using `--fp_layers "v_experts,v_router"`, leaving all value-experts unquantized in BF16 and blowing up model size to ~30GB.
2. **TP sharding broken**: Upstream's `load_weights` used a hand-rolled `chunk(dim=0)` for `v_experts`. For quantized weights, the output dimension is on axis 1 instead of axis 0, resulting in shape assertion failures at TP > 1.

## Solution
1. **Fused value-experts**: Replace the separate `ColumnParallelLinear` list with a single `MergedColumnParallelLinear` (`v_experts_fused`) mapped per expert (`shard_id = expert_id`), following the pattern used by `qk_proj` and `gate_up_proj`. This allows vLLM's standard weight loader to handle TP sharding cleanly for both unquantized and quantized weights.
2. **XPU INT4 MoVA support**: In `compute_mova_v_sparse`, add support for symmetric GPTQ INT4 with the XPU WNA16 backend. Unpack `qweight` into contiguous K per output and transpose `scales` to match the fused MoE kernel expectations (`block_shape = [0, group_size]`).
3. **Dynamic batch configuration**: Derive optimal MoE configuration dynamically via `try_get_optimal_moe_config` based on `hidden_states.shape[0]` instead of a static compile-time config.

## Duplicate Work Check
- Searched open PRs for `k2_horizon`: only #55335 exists (focuses on partial-RoPE permutation folding).
- No open PR addresses MoVA quantization or TP loading.

## Testing & Validation
- Added unit test in `tests/models/test_k2_horizon.py` covering weight loading and forward passes.
- Verified end-to-end serving on 2x Intel Arc Pro B70 with quantized checkpoint `urakozz/IFM-K2-Horizon-MoVA-36B-A4B-W4A16-AutoRound-GPTQ`:
  - Configuration: Pipeline Parallelism (PP=2), TP=1, max-model-len 330k, FP8 KV cache, XPU graph capture (`FULL_DECODE_ONLY`).
  - Served command:
    ```bash
    vllm serve urakozz/IFM-K2-Horizon-MoVA-36B-A4B-W4A16-AutoRound-GPTQ \
      --tensor-parallel-size 1 --pipeline-parallel-size 2 \
      --max-model-len 330k --kv-cache-dtype fp8 --max-num-seqs 2 \
      --reasoning-parser k2_horizon --enable-auto-tool-choice --tool-call-parser k2_horizon \
      --language-model-only --trust-remote-code --enable-prefix-caching \
      --gpu-memory-utilization 0.97 \
      --compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4,8]}'
    ```
  - Confirmed coherent generation and correct tool/reasoning parsing.

