### PR TITLE
[Bugfix][Spec Decode] Don't overwrite a declared DSpark architecture with the Qwen3.5 MTP rewrite

### DIFF
--- a/tests/models/test_qwen3_5_mtp_config.py
+++ b/tests/models/test_qwen3_5_mtp_config.py
@@ -119,3 +119,30 @@ def test_mtp_override_downloads_real_hf_hub_configs(
     assert cfg.model_type == "qwen3_5_mtp"
     assert cfg.architectures == [expected_arch]
     assert cfg.n_predict == 1
+def _dspark_config(model_type: str) -> PretrainedConfig:
+    """A DSpark draft built on a Qwen3.5 target.
+
+    It carries the same ``mtp_num_hidden_layers`` field as an MTP head but
+    declares its own architecture, which must be preserved.
+    """
+    return PretrainedConfig(
+        model_type=model_type,
+        architectures=["Qwen3DSparkModel"],
+        mtp_num_hidden_layers=1,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    ["qwen3_5", "qwen3_5_moe", "qwen3_5_text", "qwen3_5_moe_text"],
+)
+def test_mtp_override_preserves_declared_dspark_architecture(
+    model_type: str,
+) -> None:
+    """A declared DSpark architecture must survive the MTP override.
+
+    Otherwise the DSpark dispatch no longer recognises the draft and falls
+    through to the DeepSeek-V4 model, which fails on ``config.hc_mult``.
+    """
+    cfg = SpeculativeConfig.hf_config_override(_dspark_config(model_type))
+    assert cfg.architectures == ["Qwen3DSparkModel"]

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -900,6 +900,9 @@ class SpeculativeConfig:
             "qwen3_5_moe",
             "qwen3_5_text",
             "qwen3_5_moe_text",
+        ) and (hf_config.architectures or [None])[0] not in (
+            "Qwen3DSparkModel",
+            _QWEN3_OMNI_DSPARK_ARCHITECTURE,
         ):
             # Checkpoints that ship only the text config resolve to the
             # `qwen3_5_text` / `qwen3_5_moe_text` model types and carry the


### PR DESCRIPTION
## Purpose

A DSpark draft checkpoint that declares `"architectures": ["Qwen3DSparkModel"]` has that declaration overwritten with `["Qwen3_5MTP"]` when its `model_type` is in the Qwen3.5 family. The DSpark dispatch then no longer recognises the draft, falls through to the DeepSeek-V4 DSpark model, and fails on a config field that only exists on DeepSeek configs.

`SpeculativeConfig.hf_config_override` keys the MTP rewrite on `model_type` alone and unconditionally replaces `architectures`:

```python
if hf_config.model_type in (
    "qwen3_5", "qwen3_5_moe", "qwen3_5_text", "qwen3_5_moe_text",
):
    ...
    hf_config.update({
        "n_predict": n_predict,
        "architectures": ["Qwen3_5MoeMTP" if is_moe else "Qwen3_5MTP"],
    })
```

The DSpark dispatch later finds none of its known architectures and concludes the draft must be the DeepSeek-V4 variant:

```python
elif self.method == "dspark" and (
    "Qwen3DSparkModel" not in self.draft_model_config.architectures
    and ...
):
    self.draft_model_config.hf_config.architectures = ["DSparkDraftModel"]
```

which loads `DSparkDeepseekV4Model` and raises:

```
  File "vllm/models/deepseek_v4/nvidia/dspark.py", line 73, in __init__
AttributeError: 'Qwen3_5TextConfig' object has no attribute 'hc_mult'
```

The rewrite is needed for genuine MTP checkpoints, which commonly ship with the base model's `model_type` and never declare themselves as MTP. The assumption that a Qwen3.5-family draft must therefore be MTP predates DSpark drafts for that family. DSpark configs also carry `mtp_num_hidden_layers` and `target_layer_ids`, so they closely resemble MTP heads apart from the
`architectures` field the rewrite discards.

This PR skips the rewrite when the checkpoint already declares a DSpark architecture, following the pattern other branches in the same function use (`GlmOcrForConditionalGeneration`, `NemotronH_*`, which key off `hf_config.architectures[0]`). `architectures` can be `None` on sub-configs, hence the guard rather than a bare index.

Scope: this restores correct dispatch. I have not verified that a Qwen3.5 DSpark checkpoint runs end-to-end afterwards, so this PR claims only the dispatch fix; there may be further issues behind this one.

## Duplicate check

I searched open vLLM issues and PRs for `Qwen3_5MTP dspark`, `hc_mult`, and `Qwen3.5 DSpark`. No existing change addresses this dispatch path. #56600 touches Qwen3 Omni DSpark but only a unit-test mock in `tests/model_executor/test_qwen3_omni.py`, not the config override.

## Test Plan

Adds `test_mtp_override_preserves_declared_dspark_architecture` to `tests/models/test_qwen3_5_mtp_config.py`, parametrized over all four `qwen3_5*` model types. CPU-only, no weights downloaded.

```bash
pytest tests/models/test_qwen3_5_mtp_config.py -v
```

The 10 pre-existing tests in that file cover the genuine-MTP path and must keep passing, since this change modifies the condition guarding it.

## Test Result

Before the fix — the 4 new cases fail:

```
FAILED test_mtp_override_preserves_declared_dspark_architecture[qwen3_5]
  AssertionError: assert ['Qwen3_5MTP'] == ['Qwen3DSparkModel']
FAILED test_mtp_override_preserves_declared_dspark_architecture[qwen3_5_moe]
  AssertionError: assert ['Qwen3_5MoeMTP'] == ['Qwen3DSparkModel']
FAILED test_mtp_override_preserves_declared_dspark_architecture[qwen3_5_text]
FAILED test_mtp_override_preserves_declared_dspark_architecture[qwen3_5_moe_text]
4 failed, 10 deselected
```

After the fix — all 14 pass, including the 10 pre-existing MTP tests:

```
14 passed, 14 warnings in 3.41s
```

Real-world checkpoints confirming the trigger is `model_type`, both declaring `["Qwen3DSparkModel"]`:

| checkpoint | `model_type` | after `hf_config_override` |
|---|---|---|
| `r3lax/Qwen3.5-0.8B-DSpark` | `qwen3_5_text` | `['Qwen3_5MTP']` before / `['Qwen3DSparkModel']` after |
| `openbmb/MiniCPM5-2B-DSpark` | `qwen3` | `['Qwen3DSparkModel']` (unaffected, loads and runs today) |

## AI assistance

AI assistance (Claude Code) was used to diagnose the bug and draft the fix and test. I reproduced the failure locally, applied the change, and verified that all 14 tests in the file pass, including the 10 pre-existing MTP tests.
