### PR TITLE
[Bugfix] Hold orphan DSML invokes provisional until they close

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -445,6 +445,97 @@ class TestMissingToolCallsWrapper:
         assert result.content is None
 
 
+class TestTruncatedOrphanInvoke:
+    """An orphan invoke (no ``tool_calls`` wrapper) is only weak evidence of
+    a tool call, so it stays provisional until ``</｜DSML｜invoke>`` closes
+    it. If the stream ends first — truncation at the length limit, or prose
+    that quotes the syntax — the consumed text is replayed as content and no
+    tool call is emitted (#56482).
+    """
+
+    def _parser(self, mock_tokenizer) -> DeepSeekV4Parser:
+        return DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": False}
+        )
+
+    def test_truncated_at_name_non_streaming(self, mock_tokenizer, mock_request):
+        text = "I will run a command now: " + DSML_INVOKE_PREFIX + "bash"
+        result = self._parser(mock_tokenizer).extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is False
+        assert not result.tool_calls
+        assert result.content == text
+
+    def test_truncated_mid_args_non_streaming(self, mock_tokenizer, mock_request):
+        text = (
+            "note "
+            + DSML_INVOKE_PREFIX
+            + "bash"
+            + DSML_INVOKE_NAME_END
+            + "\n"
+            + _param("command", "true", "rm -rf /tmp/x")
+        )
+        result = self._parser(mock_tokenizer).extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is False
+        assert not result.tool_calls
+        assert result.content == text
+
+    @pytest.mark.parametrize("chunk_size", [1, 3, None], ids=lambda c: f"chunk={c}")
+    def test_truncated_streaming_replays_text(
+        self, mock_tokenizer, mock_request, chunk_size
+    ):
+        text = "I will run a command now: " + DSML_INVOKE_PREFIX + "bash"
+        chunks = list(text) if chunk_size == 1 else [text]
+        if chunk_size == 3:
+            chunks = [text[i : i + 3] for i in range(0, len(text), 3)]
+
+        parser = self._parser(mock_tokenizer)
+        results = simulate_tool_streaming(parser, mock_request, chunks)
+        # The stream ends here without a closing tag; the server signals
+        # that through finish_streaming(), which replays the held text.
+        results.append((parser.finish_streaming(), text))
+
+        assert collect_function_name(results) is None
+        assert collect_content(results) == text
+
+    def test_closed_orphan_still_recovers(self, mock_tokenizer, mock_request):
+        text = (
+            "pre\n"
+            + DSML_INVOKE_PREFIX
+            + "terminal"
+            + DSML_INVOKE_NAME_END
+            + "\n"
+            + _param("command", "true", "echo hi")
+            + "\n"
+            + DSML_INVOKE_END
+        )
+        result = self._parser(mock_tokenizer).extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is True
+        assert [tc.function.name for tc in result.tool_calls] == ["terminal"]
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args == {"command": "echo hi"}
+        assert result.content == "pre\n"
+
+    def test_wrapped_truncation_keeps_old_semantics(self, mock_tokenizer, mock_request):
+        """Inside an explicit ``tool_calls`` wrapper the intent is clear, so
+        a truncated invoke is still surfaced as a call, as before."""
+        text = (
+            DSML_TOOL_START
+            + "\n"
+            + DSML_INVOKE_PREFIX
+            + "get_weather"
+            + DSML_INVOKE_NAME_END
+            + "\n"
+            + _param("location", "true", "NYC")
+        )
+        result = self._parser(mock_tokenizer).extract_tool_calls(text, mock_request)
+
+        assert result.tools_called is True
+        assert result.tool_calls[0].function.name == "get_weather"
+
+
 # ── Thinking mode initial state ──────────────────────────────────────
 
 

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -189,9 +189,14 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
                 ParserState.TOOL_NAME,
                 (EventType.TOOL_CALL_START,),
             ),
+            # Recovery path for models that omit the tool_calls wrapper.
+            # A bare invoke prefix in plain content is weak evidence, so
+            # the call stays provisional until </invoke> closes it; text
+            # from a truncated or quoted invoke is replayed as content.
             (ParserState.CONTENT, "INVOKE_PREFIX"): Transition(
                 ParserState.TOOL_NAME,
                 (EventType.TOOL_CALL_START,),
+                provisional=True,
             ),
             (ParserState.TOOL_NAME, "INVOKE_NAME_END"): Transition(
                 ParserState.TOOL_ARGS,

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -40,6 +40,11 @@ class Transition:
     next_state: ParserState
     events: tuple[EventType, ...] = field(default_factory=tuple)
     skip_in_token_id_mode: bool = False
+    # Hold every event back until a TOOL_CALL_END commits the call.
+    # If the stream ends before that, the consumed text is replayed as
+    # plain content instead. Used for recovery paths that start a tool
+    # call from CONTENT, where the opening marker alone is weak evidence.
+    provisional: bool = False
 
 
 @dataclass(frozen=True)

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -107,6 +107,14 @@ class StreamingParserEngine:
         for each streaming delta:
             events = engine.feed(delta_text, delta_token_ids)
             # convert events to DeltaMessage
+
+    Provisional tool calls: a transition with ``provisional=True`` starts
+    a tool call on weak evidence, such as a bare invoke opener with no
+    wrapper. Until a ``TOOL_CALL_END`` arrives, every event goes into
+    ``_prov_events`` instead of the caller, and the consumed raw text is
+    kept in ``_prov_raw``. The end event releases the buffer in one
+    batch. If ``finish()`` runs first, the buffer is discarded, state and
+    ``tool_index`` are restored, and the raw text is replayed as content.
     """
 
     def __init__(
@@ -212,6 +220,13 @@ class StreamingParserEngine:
         self._message_header_buffer = ""
         self._message_header_token_count = 0
         self._in_skipped_tool_span = False
+        # Provisional tool call (see class docstring): buffered events,
+        # consumed raw text, and the state / tool_index to restore on
+        # rollback. ``_prov_events is None`` means the mode is off.
+        self._prov_events: list[SemanticEvent] | None = None
+        self._prov_raw: list[str] = []
+        self._prov_state = ParserState.CONTENT
+        self._prov_tool_index = -1
         self._reset_args_state()
 
     def feed(
@@ -224,8 +239,11 @@ class StreamingParserEngine:
 
         # Fast path: skip scanner and lexer when the delta is plain
         # content with no special tokens and no terminal-starting chars.
+        # Not taken in provisional mode: content must reach the buffer
+        # through _on_content, not the caller.
         if (
             delta_text
+            and self._prov_events is None
             and not self._lexer.buffer
             and not self._scanner._deferred_terminals
             and self._lexer._literal_first_chars.isdisjoint(delta_text)
@@ -247,7 +265,12 @@ class StreamingParserEngine:
         if len(scanner_items) == 1 and isinstance(scanner_items[0], TextChunk):
             item = scanner_items[0]
             lex_tokens = self._lexer.feed(item.text, item.token_texts, item.token_count)
-            if len(lex_tokens) == 1 and lex_tokens[0].terminal == CONTENT_TERMINAL:
+            # Same provisional-mode exclusion as the fast path above.
+            if (
+                len(lex_tokens) == 1
+                and lex_tokens[0].terminal == CONTENT_TERMINAL
+                and self._prov_events is None
+            ):
                 events = self._emit_for_state(
                     lex_tokens[0].value,
                     token_count=lex_tokens[0].token_count,
@@ -271,9 +294,16 @@ class StreamingParserEngine:
                 events.extend(self._on_terminal(item.terminal, item.text))
             elif isinstance(item, TextChunk):
                 if not item.text and item.token_count:
-                    events.extend(
-                        self._emit_for_state("", token_count=item.token_count)
+                    # Token-count-only events; in provisional mode they
+                    # belong to the buffer, or a stray ARG event would
+                    # reach the caller and open a tool slot downstream.
+                    empty_events = self._emit_for_state(
+                        "", token_count=item.token_count
                     )
+                    if self._prov_events is not None:
+                        self._prov_events.extend(empty_events)
+                    else:
+                        events.extend(empty_events)
                 else:
                     events.extend(
                         self._process_lex_tokens(
@@ -288,6 +318,18 @@ class StreamingParserEngine:
         events = self._process_scanner_items(self._scanner.flush_pending())
 
         events.extend(self._process_lex_tokens(self._lexer.flush()))
+
+        if self._prov_events is not None:
+            # A provisional tool call never closed. Drop its buffered
+            # events and replay the consumed text as plain content.
+            raw = "".join(self._prov_raw)
+            self._prov_events = None
+            self._prov_raw = []
+            self.tool_index = self._prov_tool_index
+            self.state = self._prov_state
+            self._reset_args_state()
+            if raw:
+                events.extend(self._emit_for_state(raw))
 
         if self._args_buffer:
             events.append(
@@ -397,6 +439,36 @@ class StreamingParserEngine:
     def _on_terminal(
         self, terminal: str, value: str, token_count: int = 0
     ) -> list[SemanticEvent]:
+        if self._prov_events is None:
+            transition = self.config.transitions.get((self.state, terminal))
+            if (
+                transition is None
+                or not transition.provisional
+                or self.skip_tool_parsing
+            ):
+                return self._handle_terminal(terminal, value, token_count)
+            # Enter provisional mode: hold events back until the call
+            # closes, and remember the raw text in case it never does.
+            self._prov_events = []
+            self._prov_raw = []
+            self._prov_state = self.state
+            self._prov_tool_index = self.tool_index
+
+        # Provisional mode: record the raw text, buffer the events, and
+        # release everything once the call closes.
+        self._prov_raw.append(value)
+        buffered = self._handle_terminal(terminal, value, token_count)
+        self._prov_events.extend(buffered)
+        if any(e.type == EventType.TOOL_CALL_END for e in buffered):
+            committed = self._prov_events
+            self._prov_events = None
+            self._prov_raw = []
+            return committed
+        return []
+
+    def _handle_terminal(
+        self, terminal: str, value: str, token_count: int = 0
+    ) -> list[SemanticEvent]:
         key = (self.state, terminal)
         transition = self.config.transitions.get(key)
 
@@ -498,6 +570,10 @@ class StreamingParserEngine:
 
     def _on_content(self, text: str, token_count: int = 0) -> list[SemanticEvent]:
         if not text:
+            return []
+        if self._prov_events is not None:
+            self._prov_raw.append(text)
+            self._prov_events.extend(self._emit_for_state(text, token_count))
             return []
         return self._emit_for_state(text, token_count)
 


### PR DESCRIPTION
# Purpose

FIX #56482

The recovery path from #55954 commits a tool call as soon as `<｜DSML｜invoke name="` appears in plain content. It never waits for the closing tag. A truncated or quoted invoke therefore turns into a ghost call with empty arguments, and the consumed text is lost.

This PR makes that transition provisional, at the engine level:

- Events from a provisional call go into a buffer. The raw consumed text is recorded next to them.
- `</｜DSML｜invoke>` commits the call. The buffered events are released in one batch.
- If the stream ends before the close, the buffer is dropped and the raw text is replayed as plain content, character for character.

The wrapped path is unchanged. An explicit `<｜DSML｜tool_calls>` wrapper is strong evidence of intent, so a truncated call there still surfaces, as before.

On the second half of the issue (undeclared tool names): `ParserEngineConfig.validate_tool_names` already exists and would cover it, but the current test suite expects undeclared names to pass on the wrapped path (`get_weather` with only `stub` declared). I left the flag off to keep this change behavior-neutral there. A follow-up can add per-path validation if you want it.

# Test Plan

- New tests in `tests/parser/engine/test_deepseek_v4.py` (`TestTruncatedOrphanInvoke`): truncation at the name, truncation mid-arguments, streamed replay at chunk sizes 1 / 3 / all, a closed orphan still recovers, and wrapped truncation keeps the old semantics.
- Full parser suite on CPU (Apple Silicon, no CUDA): `pytest tests/parser/` → 4547 passed. Two exclusions, both unrelated to this change: `tests/parser/cohere` needs the private `cohere_melody` package, and the 24 `test_harmony.py::TestAdjustRequest` cases fail on an unmodified checkout in my environment (xgrammar version skew).
- `ruff check` and `ruff format` pass on the four changed files.

# Test Result

`tests/parser/engine/test_deepseek_v4.py`: 104 passed — 97 already there, 7 new. No existing test was modified.
