### PR TITLE
[Security] Bind LMCache token keys to media hash, cache salt, and LoRA

### DIFF
--- a/tests/v1/core/test_output.py
+++ b/tests/v1/core/test_output.py
@@ -144,3 +144,22 @@ def test_strip_covered_mm_data_shm_address_item() -> None:
     stripped = strip_covered_mm_data([feature], num_computed_tokens=250)
 
     assert stripped[0].data is address_item
+
+
+def test_from_request_copies_cache_salt() -> None:
+    from unittest.mock import MagicMock
+
+    request = MagicMock()
+    request.request_id = "r0"
+    request.prompt_token_ids = [1, 2, 3]
+    request.mm_features = []
+    request.num_computed_tokens = 0
+    request.sampling_params = None
+    request.pooling_params = None
+    request.lora_request = None
+    request.prompt_embeds = None
+    request.prompt_is_token_ids = None
+    request.cache_salt = "tenant-a"
+
+    data = NewRequestData.from_request(request, ([],))
+    assert data.cache_salt == "tenant-a"

--- a/tests/v1/kv_connector/unit/test_lmcache_integration.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_integration.py
@@ -227,3 +227,85 @@ def test_scheduler_output_interface():
 
     assumes(CachedRequestData, "req_ids", is_instance_of=list)
     assumes(CachedRequestData, "new_block_ids", is_instance_of=list)
+
+
+def _lmcache_token_keys():
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_token_keys import (
+        apply_mm_hashes_to_token_ids,
+        mm_hash_to_token_value,
+        request_identity_mixer,
+    )
+
+    return (
+        apply_mm_hashes_to_token_ids,
+        mm_hash_to_token_value,
+        request_identity_mixer,
+    )
+
+
+def test_mm_hashes_sharing_low_16_bits_are_distinct():
+    """Distinct media identifiers must not collapse after occupying token ids."""
+    import torch
+
+    from vllm.multimodal.inputs import PlaceholderRange
+
+    apply_mm_hashes_to_token_ids, mm_hash_to_token_value, _ = _lmcache_token_keys()
+
+    hash_a = "0" * 56 + "0000abcd"
+    hash_b = "0" * 56 + "ffffabcd"
+    assert int(hash_a, 16) & 0xFFFF == int(hash_b, 16) & 0xFFFF
+    assert mm_hash_to_token_value(hash_a) != mm_hash_to_token_value(hash_b)
+
+    pos = [PlaceholderRange(offset=1, length=2)]
+    tokens_a = torch.tensor([10, 11, 12, 13], dtype=torch.long)
+    tokens_b = tokens_a.clone()
+    apply_mm_hashes_to_token_ids(tokens_a, [hash_a], pos)
+    apply_mm_hashes_to_token_ids(tokens_b, [hash_b], pos)
+    assert not torch.equal(tokens_a, tokens_b)
+
+
+def test_cache_salt_and_lora_partition_lmcache_token_keys():
+    """Requests that differ only in cache_salt or LoRA must not share keys."""
+    import torch
+
+    apply_mm_hashes_to_token_ids, _, mixer = _lmcache_token_keys()
+
+    base = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+    salted_a = apply_mm_hashes_to_token_ids(base.clone(), [], [], cache_salt="tenant-a")
+    salted_b = apply_mm_hashes_to_token_ids(base.clone(), [], [], cache_salt="tenant-b")
+    salted_a_again = apply_mm_hashes_to_token_ids(
+        base.clone(), [], [], cache_salt="tenant-a"
+    )
+    lora_a = apply_mm_hashes_to_token_ids(base.clone(), [], [], lora_name="adapter-a")
+    lora_b = apply_mm_hashes_to_token_ids(base.clone(), [], [], lora_name="adapter-b")
+    unsalted = apply_mm_hashes_to_token_ids(base.clone(), [], [])
+
+    assert not torch.equal(salted_a, salted_b)
+    assert torch.equal(salted_a, salted_a_again)
+    assert not torch.equal(lora_a, lora_b)
+    assert torch.equal(unsalted, base)
+    assert mixer("tenant-a", None) != mixer("tenant-b", None)
+    assert mixer(None, "adapter-a") != mixer(None, "adapter-b")
+    assert mixer(None, None) is None
+
+
+def test_store_and_lookup_apply_the_same_lmcache_token_binding():
+    """Scheduler lookup and worker store must emit identical token-id keys."""
+    import torch
+
+    from vllm.multimodal.inputs import PlaceholderRange
+
+    apply_mm_hashes_to_token_ids, _, _ = _lmcache_token_keys()
+
+    prompt = torch.tensor([7, 8, 9, 10, 11, 12], dtype=torch.long)
+    mm_hashes = ["0" * 56 + "1234abcd"]
+    mm_positions = [PlaceholderRange(offset=2, length=2)]
+    kwargs = dict(
+        mm_hashes=mm_hashes,
+        mm_positions=mm_positions,
+        cache_salt="tenant-a",
+        lora_name="adapter-a",
+    )
+    lookup_tokens = apply_mm_hashes_to_token_ids(prompt.clone(), **kwargs)
+    store_tokens = apply_mm_hashes_to_token_ids(prompt.clone(), **kwargs)
+    assert torch.equal(lookup_tokens, store_tokens)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/utils.py
@@ -5,9 +5,12 @@ import os
 import threading
 from typing import TYPE_CHECKING, Union
 
-import torch
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig as V1Config
+
+from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_token_keys import (
+    apply_mm_hashes_to_token_ids as apply_mm_hashes_to_token_ids,
+)
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
@@ -56,32 +59,6 @@ def lmcache_get_or_create_config() -> V1Config:
                     # Update config from environment variables
                     _config_instance.update_config_from_env()
     return _config_instance
-
-
-def hex_hash_to_int16(s: str) -> int:
-    """
-    Convert a hex hash string to a 16-bit integer.
-    """
-    return int(s, 16) & 0xFFFF
-
-
-def apply_mm_hashes_to_token_ids(
-    token_ids: torch.Tensor,
-    mm_hashes: list[str],
-    mm_positions: list["PlaceholderRange"],
-) -> torch.Tensor:
-    """
-    Overwrite token_ids in-place for multimodal placeholders using
-    efficient slice assignments.
-    """
-    n = token_ids.size(0)
-    for hash_str, placeholder in zip(mm_hashes, mm_positions):
-        start, length = placeholder.offset, placeholder.length
-        if start >= n:
-            continue
-        end = min(start + length, n)
-        token_ids[start:end] = hex_hash_to_int16(hash_str)
-    return token_ids
 
 
 def mla_enabled(model_config: "ModelConfig") -> bool:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -142,6 +142,10 @@ class RequestTracker:
     mm_hashes: list[str] | None = None
     mm_positions: list["PlaceholderRange"] | None = None
 
+    # Extra identity mixed into LMCache token-id keys
+    cache_salt: str | None = None
+    lora_name: str | None = None
+
     # The configs of the request, includes tags and other configs
     request_configs: dict | None = None
 
@@ -196,6 +200,9 @@ class RequestTracker:
             request_configs = None
 
         mm_hashes, mm_positions = extract_mm_features(new_request, modify=True)
+        lora_name = (
+            new_request.lora_request.lora_name if new_request.lora_request else None
+        )
 
         assert new_request.prompt_token_ids is not None
         return RequestTracker(
@@ -207,6 +214,8 @@ class RequestTracker:
             disagg_spec=disagg_spec,
             mm_hashes=mm_hashes,
             mm_positions=mm_positions,
+            cache_salt=new_request.cache_salt,
+            lora_name=lora_name,
             skip_save=skip_save,
             request_configs=request_configs,
         )
@@ -340,14 +349,16 @@ class ReqMeta:
         # Calculate the token ids and slot mappings for load and save
         token_ids = input_token_ids[:num_tokens_to_save]
 
-        # If the request has multimodal hashes, apply them to the token ids
-        if tracker.mm_hashes:
+        # Bind multimodal identity, cache_salt, and LoRA into the token-id key
+        # so store and lookup agree on extra cache dimensions.
+        if tracker.mm_hashes or tracker.cache_salt or tracker.lora_name:
             token_ids_tensor = torch.tensor(token_ids)
-            assert tracker.mm_positions is not None, (
-                "tracker got mm_hashes but no mm_positions"
-            )
             apply_mm_hashes_to_token_ids(
-                token_ids_tensor, tracker.mm_hashes, tracker.mm_positions
+                token_ids_tensor,
+                tracker.mm_hashes or [],
+                tracker.mm_positions or [],
+                cache_salt=tracker.cache_salt,
+                lora_name=tracker.lora_name,
             )
             token_ids = token_ids_tensor.tolist()
 
@@ -1171,12 +1182,18 @@ class LMCacheConnectorV1Impl:
 
         token_ids = request.prompt_token_ids
 
-        # If the request has multimodal hashes, apply them to the token ids
+        # Bind multimodal identity, cache_salt, and LoRA into the token-id key.
         mm_hashes, mm_positions = extract_mm_features(request)
-        if mm_hashes and mm_positions:
-            # TODO(Jiayi): Optimize this
+        lora_name = request.lora_request.lora_name if request.lora_request else None
+        if mm_hashes or request.cache_salt or lora_name:
             token_ids_tensor = torch.tensor(request.prompt_token_ids)
-            apply_mm_hashes_to_token_ids(token_ids_tensor, mm_hashes, mm_positions)
+            apply_mm_hashes_to_token_ids(
+                token_ids_tensor,
+                mm_hashes,
+                mm_positions,
+                cache_salt=request.cache_salt,
+                lora_name=lora_name,
+            )
             token_ids = token_ids_tensor.tolist()
 
         if request.sampling_params:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_token_keys.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_token_keys.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import hashlib
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from vllm.multimodal.inputs import PlaceholderRange
+
+# Signed int64 positive range so values survive torch.long assignment.
+_TOKEN_VALUE_MASK = (1 << 63) - 1
+
+
+def mm_hash_to_token_value(s: str) -> int:
+    """Convert a multimodal content identifier into a 63-bit token value.
+
+    Identifiers are typically hex digests. Non-hex strings are hashed first
+    so caller-supplied UUIDs still expand to a wide integer. Truncating to
+    16 bits would let distinct media collide in the LMCache token-id key.
+    """
+    try:
+        value = int(s, 16)
+    except ValueError:
+        value = int.from_bytes(hashlib.sha256(s.encode("utf-8")).digest(), "big")
+    return value & _TOKEN_VALUE_MASK
+
+
+def request_identity_mixer(
+    cache_salt: str | None = None, lora_name: str | None = None
+) -> int | None:
+    """Return a 63-bit mixer, or None when there is no extra identity."""
+    if not cache_salt and not lora_name:
+        return None
+    material = f"{cache_salt or ''}\0{lora_name or ''}".encode()
+    digest = hashlib.sha256(material).digest()[:8]
+    return int.from_bytes(digest, "big") & _TOKEN_VALUE_MASK
+
+
+def apply_mm_hashes_to_token_ids(
+    token_ids: torch.Tensor,
+    mm_hashes: list[str],
+    mm_positions: list["PlaceholderRange"],
+    cache_salt: str | None = None,
+    lora_name: str | None = None,
+) -> torch.Tensor:
+    """Bind LMCache token-id keys to multimodal and request identity.
+
+    Overwrites placeholder spans with the full-width media identifier, then
+    XOR-mixes cache_salt and LoRA name into every token so those dimensions
+    partition every LMCache chunk, not only placeholder blocks.
+    """
+    n = token_ids.size(0)
+    for hash_str, placeholder in zip(mm_hashes, mm_positions):
+        start, length = placeholder.offset, placeholder.length
+        if start >= n:
+            continue
+        end = min(start + length, n)
+        token_ids[start:end] = mm_hash_to_token_value(hash_str)
+    mixer = request_identity_mixer(cache_salt, lora_name)
+    if mixer is not None and n > 0:
+        token_ids.bitwise_xor_(mixer)
+    return token_ids

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -45,6 +45,7 @@ class NewRequestData:
     lora_request: LoRARequest | None
     prompt_embeds: "torch.Tensor | None" = None
     prompt_is_token_ids: list[bool] | None = None
+    cache_salt: str | None = None
 
     # Only used for v2 model runner.
     prefill_token_ids: list[int] | None = None
@@ -72,6 +73,7 @@ class NewRequestData:
             lora_request=request.lora_request,
             prompt_embeds=request.prompt_embeds,
             prompt_is_token_ids=request.prompt_is_token_ids,
+            cache_salt=request.cache_salt,
             prefill_token_ids=prefill_token_ids,
         )
 


### PR DESCRIPTION
## Summary
The in-tree LMCache connector derived external cache keys from prompt token IDs after overwriting multimodal placeholders with a 16-bit truncation of the media identifier, and it never mixed `cache_salt` or LoRA identity into those keys. Distinct media that shared the low 16 hash bits, or requests that differed only in salt or adapter, could therefore hit or overwrite each other's stored KV. This change writes a 63-bit media identifier into placeholder spans and XOR-mixes cache salt and LoRA name into every token on both the scheduler lookup path and the worker store path.

## Changes
- `vllm/distributed/kv_transfer/kv_connector/v1/lmcache_token_keys.py`: new helpers for full-width media identifiers and request-identity mixing.
- `vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/utils.py`: re-export the binder used by the native adapter.
- `vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py`: apply the binder in `get_num_new_matched_tokens` and `ReqMeta.from_request_tracker`.
- `vllm/v1/core/sched/output.py`: carry `cache_salt` on `NewRequestData` so store-side keying can see it.

## Codepath coverage
- Scheduler lookup (`get_num_new_matched_tokens`) and worker/store metadata (`ReqMeta.from_request_tracker`) both call the same binder.
- HTTP, SageMaker `/invocations`, gRPC, and batch all become `Request` objects that hit those two methods when `LMCacheConnectorV1` is enabled.
- Unsalted, non-LoRA text-only keys are unchanged. Existing multimodal LMCache entries are invalidated by the wider identifier, which is intended.
- The default `use_native=False` path still loads `lmcache.integration.vllm.vllm_v1_adapter` from the external `lmcache` package; that copy needs the same binding upstream. This PR fixes the in-tree native adapter (`use_native=True`) and the helpers vLLM owns.

## Duplicate-work check
Searched open and merged PRs for `hex_hash_to_int16`, `apply_mm_hashes_to_token_ids`, `lmcache_integration`, `cache_salt lmcache`, and `LMCacheConnectorV1 hash`. Nearby open work is on other connectors or LMCache-MP (`#54342` HF3FS, `#53496` ExampleConnector, `#45549`/`#44097`/`#40041` LMCache-MP). None of those close 16-bit media truncation or dropped salt/LoRA on the in-process LMCache token-id key.

## Tests
- `test_mm_hashes_sharing_low_16_bits_are_distinct`: identifiers that collide in 16 bits stay distinct after binding.
- `test_cache_salt_and_lora_partition_lmcache_token_keys`: different salts/adapters produce different keys; unsalted text-only tokens are unchanged.
- `test_store_and_lookup_apply_the_same_lmcache_token_binding`: lookup and store helpers emit identical keys.
- `test_from_request_copies_cache_salt`: `NewRequestData` carries the request salt.

Commands:
```
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_lmcache_integration.py::test_mm_hashes_sharing_low_16_bits_are_distinct tests/v1/kv_connector/unit/test_lmcache_integration.py::test_cache_salt_and_lora_partition_lmcache_token_keys tests/v1/kv_connector/unit/test_lmcache_integration.py::test_store_and_lookup_apply_the_same_lmcache_token_binding tests/v1/core/test_output.py -v
```
Result: 10 passed.

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)