### PR TITLE
[CI] Stabilize Qwen3.8 AIME accuracy check

### DIFF
--- a/tests/evals/qwen4_exp/README.md
+++ b/tests/evals/qwen4_exp/README.md
@@ -1,7 +1,10 @@
 # Qwen4Exp accuracy evaluation
 
 This suite starts a Qwen3.8-Flash-Next-FP8 OpenAI-compatible server once and
-uses EvalScope to evaluate GSM8K and AIME25.
+uses EvalScope to evaluate GSM8K and AIME25. A dataset can set
+`max_score_trials` to conditionally run another fixed-seed trial when its
+initial score is below the configured floor; the test applies the same floor
+to the combined score.
 
 ```bash
 # B200

--- a/tests/evals/qwen4_exp/configs/Qwen3.8-Flash-Next-FP8.yaml
+++ b/tests/evals/qwen4_exp/configs/Qwen3.8-Flash-Next-FP8.yaml
@@ -8,6 +8,7 @@ datasets:
   aime25:
     metric_threshold: 0.90
     tolerance: 0.05
+    max_score_trials: 2
 eval_batch_size: 32
 startup_max_wait_seconds: 1800
 generation_config:

--- a/tests/evals/qwen4_exp/test_accuracy.py
+++ b/tests/evals/qwen4_exp/test_accuracy.py
@@ -3,7 +3,9 @@
 """GSM8K and AIME25 accuracy evaluation for Qwen3.8-Flash-Next-FP8."""
 
 import shlex
+import sys
 from pathlib import Path
+from statistics import fmean
 from typing import Any
 
 import yaml
@@ -12,18 +14,26 @@ from tests.utils import RemoteOpenAIServer
 
 
 def run_evalscope(
-    eval_config: dict[str, Any], base_url: str, work_dir: Path
+    eval_config: dict[str, Any],
+    base_url: str,
+    work_dir: Path,
+    datasets: list[str] | None = None,
+    seed: int | None = None,
 ) -> dict[str, float]:
     from evalscope.run import run_task
+
+    generation_config = dict(eval_config["generation_config"])
+    if seed is not None:
+        generation_config["seed"] = seed
 
     reports = run_task(
         {
             "model": eval_config["model_name"],
             "api_url": base_url,
             "api_key": "EMPTY_TOKEN",
-            "datasets": list(eval_config["datasets"]),
+            "datasets": datasets or list(eval_config["datasets"]),
             "eval_batch_size": eval_config.get("eval_batch_size", 32),
-            "generation_config": eval_config["generation_config"],
+            "generation_config": generation_config,
             "work_dir": str(work_dir),
             "no_timestamp": True,
         }
@@ -32,6 +42,24 @@ def run_evalscope(
         raise TypeError(f"Expected EvalScope reports to be a dict, got {type(reports)}")
 
     return {dataset: float(report.score) for dataset, report in reports.items()}
+
+
+def _datasets_needing_retry(
+    eval_config: dict[str, Any],
+    score_history: dict[str, list[float]],
+    next_trial: int,
+) -> list[str]:
+    retry_datasets = []
+    for dataset, metric_config in eval_config["datasets"].items():
+        minimum_score = metric_config["metric_threshold"] - metric_config.get(
+            "tolerance", 0.0
+        )
+        if (
+            next_trial < metric_config.get("max_score_trials", 1)
+            and fmean(score_history[dataset]) < minimum_score
+        ):
+            retry_datasets.append(dataset)
+    return retry_datasets
 
 
 def test_qwen4_exp_accuracy(config_filename: Path, tmp_path: Path):
@@ -51,18 +79,97 @@ def test_qwen4_exp_accuracy(config_filename: Path, tmp_path: Path):
         max_wait_seconds=eval_config.get("startup_max_wait_seconds", 1800),
     ) as remote_server:
         scores = run_evalscope(eval_config, remote_server.url_for("v1"), tmp_path)
+        score_history = {dataset: [score] for dataset, score in scores.items()}
+
+        max_trials = max(
+            config.get("max_score_trials", 1)
+            for config in eval_config["datasets"].values()
+        )
+        for trial in range(1, max_trials):
+            retry_datasets = _datasets_needing_retry(eval_config, score_history, trial)
+            if not retry_datasets:
+                break
+
+            base_seed = eval_config["generation_config"].get("seed")
+            if type(base_seed) is not int:
+                raise ValueError("max_score_trials requires an integer generation seed")
+            retry_seed = base_seed + trial
+            print(f"Retrying {', '.join(retry_datasets)} with seed {retry_seed}")
+            retry_scores = run_evalscope(
+                eval_config,
+                remote_server.url_for("v1"),
+                tmp_path / f"trial-{trial + 1}",
+                datasets=retry_datasets,
+                seed=retry_seed,
+            )
+            for dataset, score in retry_scores.items():
+                score_history[dataset].append(score)
 
     for dataset, metric_config in eval_config["datasets"].items():
-        score = scores[dataset]
+        trial_scores = score_history[dataset]
+        score = fmean(trial_scores)
         threshold = metric_config["metric_threshold"]
         tolerance = metric_config.get("tolerance", 0.0)
         minimum_score = threshold - tolerance
 
         print(
             f"{dataset}: measured={score:.4f}, expected={threshold:.4f}, "
-            f"tolerance={tolerance:.4f}"
+            f"tolerance={tolerance:.4f}, trials={trial_scores}"
         )
         assert score >= minimum_score, (
             f"{dataset} score too low: {score:.4f} < {threshold:.4f} - "
             f"{tolerance:.4f} = {minimum_score:.4f}"
         )
+
+
+def test_qwen4_exp_accuracy_retries_failed_dataset(monkeypatch, tmp_path: Path):
+    eval_config = {
+        "model_name": "test-model",
+        "datasets": {
+            "gsm8k": {"metric_threshold": 0.96},
+            "aime25": {
+                "metric_threshold": 0.90,
+                "tolerance": 0.05,
+                "max_score_trials": 2,
+            },
+        },
+        "generation_config": {"seed": 1236},
+    }
+    config_filename = tmp_path / "config.yaml"
+    config_filename.write_text(yaml.safe_dump(eval_config), encoding="utf-8")
+
+    eval_results = iter(
+        [
+            {"gsm8k": 0.98, "aime25": 25 / 30},
+            {"aime25": 26 / 30},
+        ]
+    )
+    calls = []
+
+    def fake_run_evalscope(eval_config, base_url, work_dir, datasets=None, seed=None):
+        calls.append((datasets, seed, work_dir))
+        return next(eval_results)
+
+    class FakeRemoteOpenAIServer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def url_for(self, path):
+            return f"http://test/{path}"
+
+    test_module = sys.modules[__name__]
+    monkeypatch.setattr(test_module, "RemoteOpenAIServer", FakeRemoteOpenAIServer)
+    monkeypatch.setattr(test_module, "run_evalscope", fake_run_evalscope)
+
+    test_qwen4_exp_accuracy(config_filename, tmp_path)
+
+    assert calls == [
+        (None, None, tmp_path),
+        (["aime25"], 1237, tmp_path / "trial-2"),
+    ]


### PR DESCRIPTION
## Why

The B200 Qwen3.8 accuracy lane in main build [#88565](https://buildkite.com/vllm/ci/builds/88565#01a0976c-f094-49b8-94bf-ea945f70e7e3) failed AIME25 at 25/30 (0.8333), one question below its unchanged 0.85 floor. The independent B200 lane in [#88612](https://buildkite.com/vllm/ci/builds/88612#01a0995b-7d9a-4fa3-88b0-fe3f73ef3b42) has now repeated the exact 25/30 boundary while GSM8K passed at 0.9780. This is a stochastic 30-question evaluation (`temperature: 0.7`): the exact B200 lane in [#88482](https://buildkite.com/vllm/ci/builds/88482#01a09435-e1e8-408c-b9f0-b6a4c57ce63b) and the same-commit H200 lane in [#88565](https://buildkite.com/vllm/ci/builds/88565#01a0976c-f098-46e5-b9b4-9f18dd2ae8b0) both scored 28/30 (0.9333). An earlier H200 daily in #86424 also hit the same 25/30 boundary.

For datasets that opt into `max_score_trials`, conditionally rerun only a below-floor dataset with the next fixed seed and evaluate the combined score. A normal passing run is unchanged; one 25/30 trial now needs at least 26/30 on the second seed, while two 25/30 trials still fail. The 0.85 acceptance floor is not lowered.

## Duplicate check

I searched open PRs and issues for `Qwen3.8 AIME accuracy`, `AIME25 accuracy`, and the failing model name. No open change addresses this boundary flake.

## Testing

- `python -m pytest tests/evals/qwen4_exp/test_accuracy.py::test_qwen4_exp_accuracy_retries_failed_dataset --config-list-file=configs/models-b200.txt -q` (1 passed)
- applicable pre-commit hooks on all three changed files, including ruff, mypy, and markdownlint (passed)
- `git diff --check` (passed)

Model evidence from unchanged main:

- #88482 B200: GSM8K 0.9795, AIME25 0.9333
- #88565 B200: GSM8K 0.9810, AIME25 0.8333
- #88565 H200: GSM8K 0.9788, AIME25 0.9333
- #88612 B200: GSM8K 0.9780, AIME25 0.8333

The model/hardware evaluation cannot run locally; the exact B200/H200 Buildkite lanes are required before this draft is marked ready.

## AI assistance

This change was prepared with AI assistance. A human maintainer must review every changed line and validate the relevant CI result before marking the PR ready.
