### PR TITLE
[Bugfix][Benchmark] Count overlapping requests for peak concurrency

### DIFF
--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from vllm.benchmarks.lib.endpoint_request_func import RequestFuncOutput
+from vllm.benchmarks.serve import calculate_metrics
+
+
+@pytest.mark.parametrize(
+    "intervals,expected",
+    [
+        ([(0.0, 0.125), (0.25, 0.375), (0.5, 0.625)], 1),
+        ([(0.0, 0.5), (0.5, 1.0)], 1),
+        ([(0.0, 0.75), (0.25, 0.5), (0.5, 1.0)], 2),
+        ([(0.0, 2.0), (0.5, 1.5), (0.75, 1.0)], 3),
+    ],
+)
+def test_peak_concurrency_counts_overlapping_requests(intervals, expected):
+    outputs = [
+        RequestFuncOutput(
+            success=True,
+            start_time=start,
+            latency=end - start,
+            ttft=end - start,
+            output_tokens=1,
+        )
+        for start, end in intervals
+    ]
+    metrics, _ = calculate_metrics(
+        input_requests=[],
+        outputs=outputs,
+        dur_s=2.0,
+        tokenizer=None,
+        selected_percentiles=[],
+        goodput_config_dict={},
+    )
+    assert metrics.max_concurrent_requests == expected

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -347,7 +347,7 @@ class BenchmarkMetrics:
     median_e2el_ms: float
     std_e2el_ms: float
     percentiles_e2el_ms: list[tuple[float, float]]
-    # Max output tokens per second and concurrent requests at that peak
+    # Peak output tokens per second and peak number of overlapping requests.
     max_output_tokens_per_s: float
     max_concurrent_requests: int
     rtfx: float = 0.0  # Inverse Real-Time Factor for ASR benchmarks
@@ -681,6 +681,7 @@ def calculate_metrics(
         duration_seconds = int(np.ceil(max_end_time - min_start_time)) + 1
         tokens_per_second = np.zeros(duration_seconds)
         concurrent_requests_per_second = np.zeros(duration_seconds)
+        request_events: list[tuple[float, int]] = []
 
         for i, output in enumerate(successful_outputs):
             # Calculate token generation timestamp using
@@ -702,15 +703,22 @@ def calculate_metrics(
             request_end_second = int(
                 (output.start_time + output.latency) - min_start_time
             )
+            if output.latency > 0:
+                request_events.append((output.start_time, 1))
+                request_events.append((output.start_time + output.latency, -1))
 
             for second in range(request_start_second, request_end_second + 1):
                 concurrent_requests_per_second[second] += 1
 
-        # Find the maximum tokens per second and corresponding
-        # concurrent requests
+        # Process completions before arrivals at the same timestamp.
+        concurrent_requests = 0
+        for _, delta in sorted(request_events):
+            concurrent_requests += delta
+            max_concurrent_requests = max(max_concurrent_requests, concurrent_requests)
+
+        # Find the maximum tokens per second.
         if len(tokens_per_second) > 0:
             max_output_tokens_per_s = float(np.max(tokens_per_second))
-            max_concurrent_requests = int(np.max(concurrent_requests_per_second))
 
         if TERM_PLOTLIB_AVAILABLE:
             import termplotlib as tpl
@@ -724,7 +732,7 @@ def calculate_metrics(
             fig.plot(
                 np.arange(len(concurrent_requests_per_second)),
                 concurrent_requests_per_second,
-                title="Concurrent requests per second",
+                title="Requests active during each second",
             )
             fig.show()
         else:


### PR DESCRIPTION
## Purpose

Three sequential requests finishing within one second report peak concurrency 3. The current buckets count requests that touch a second, even if they never overlap.

Compute the peak from sorted start/end events, processing completions before simultaneous arrivals. Keep the bucket plot with a descriptive label.

Duplicate checks for `max_concurrent_requests`, `concurrent_requests_per_second`, and benchmark concurrency found no matching fix. #50677 addresses token/chunk throughput, a separate metric.

AI assistance was used.

## Test Plan

`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest --confcutdir=tests/benchmarks tests/benchmarks/test_serve_metrics.py tests/benchmarks/test_plot_filters.py -q`

## Test Result

New cases: 3 failed / 1 passed before, 4 passed after. Combined suites: 31 passed on Apple M2 Pro CPU. No model evaluation applies to this post-run statistics change.