### PR TITLE
[Bugfix][Gemma4] Keep image kwargs out of video preprocessing

### DIFF
--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -3,6 +3,7 @@
 
 from collections.abc import Mapping
 
+import numpy as np
 import pytest
 import torch
 from PIL import Image as PILImage
@@ -13,6 +14,7 @@ from vllm.model_executor.models.gemma4_mm import (
     Gemma4ImagePixelInputs,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.cache import MultiModalProcessorOnlyCache
 from vllm.multimodal.inputs import MultiModalFieldConfig
 from vllm.utils.mem_constants import GiB_bytes
 
@@ -197,6 +199,72 @@ def test_get_prompt_updates_respects_nested_max_soft_tokens(model_id: str):
     ).full
 
     assert replacement == expected
+
+
+@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
+@pytest.mark.parametrize("kwargs_on_init", [False, True])
+@pytest.mark.parametrize(
+    "image_kwargs", [{"rescale_factor": 1 / 127.5}, {"max_soft_tokens": 560}]
+)
+@pytest.mark.parametrize("video_uuid", [None, "same-video"])
+def test_video_cache_is_independent_of_image_kwargs(
+    model_id: str,
+    kwargs_on_init: bool,
+    image_kwargs: dict[str, object],
+    video_uuid: str | None,
+):
+    """Image overrides must not change video frames or depend on cache warmth."""
+    kwargs = {"images_kwargs": image_kwargs}
+    ctx = build_model_context(
+        model_id,
+        limit_mm_per_prompt={"image": 1, "video": 1},
+        mm_processor_cache_gb=1,
+    )
+    cache = MultiModalProcessorOnlyCache(ctx.model_config)
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config, cache=cache)
+    hf_processor = processor.info.get_hf_processor()
+    image = PILImage.new("RGB", (48, 48), color=(128, 128, 128))
+    frames = np.stack([np.asarray(image)] * 2)
+    metadata = {"fps": 2.0, "frames_indices": [0, 1]}
+    mm_items = processor.info.parse_mm_data(
+        {"image": image, "video": [(frames, metadata)]}
+    )
+
+    def process(mm_kwargs):
+        return processor(
+            hf_processor.image_token + hf_processor.video_token,
+            mm_items,
+            mm_uuid_items={"video": [video_uuid]},
+            hf_processor_mm_kwargs=mm_kwargs,
+        )
+
+    baseline = process({})
+    if kwargs_on_init:
+        ctx = build_model_context(
+            model_id,
+            mm_processor_kwargs=kwargs,
+            limit_mm_per_prompt={"image": 1, "video": 1},
+            mm_processor_cache_gb=1,
+        )
+        cache = MultiModalProcessorOnlyCache(ctx.model_config)
+        processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config, cache=cache)
+    request_kwargs = {} if kwargs_on_init else kwargs
+    process(request_kwargs)
+    cached = process(request_kwargs)
+    cache.clear_cache()
+    fresh = process(request_kwargs)
+
+    def pixels(result, modality, field):
+        return result["mm_kwargs"][modality][0][field].data
+
+    video_pixels = pixels(fresh, "video", "pixel_values_videos")
+    assert torch.equal(pixels(cached, "video", "pixel_values_videos"), video_pixels)
+    assert torch.equal(pixels(baseline, "video", "pixel_values_videos"), video_pixels)
+    assert baseline["mm_hashes"]["video"] == fresh["mm_hashes"]["video"]
+    assert not torch.equal(
+        pixels(baseline, "image", "pixel_values"),
+        pixels(fresh, "image", "pixel_values"),
+    )
 
 
 @pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -629,6 +629,9 @@ class Gemma4MultiModalProcessor(BaseMultiModalProcessor[Gemma4ProcessingInfo]):
 
                 # Process frames as images with max_soft_tokens=70
                 video_mm_kwargs = dict(hf_processor_mm_kwargs)
+                # Override configured image options too: these inputs are video
+                # frames, whose cache keys exclude images_kwargs.
+                video_mm_kwargs["images_kwargs"] = {}
                 video_mm_kwargs["max_soft_tokens"] = _VIDEO_MAX_SOFT_TOKENS
 
                 dummy_prompt = ("\t" + processor.image_token) * len(frames)


### PR DESCRIPTION
## Purpose

Gemma4 processes video frames through the HF image processor, but currently forwards image-only overrides to that call. For example, a mixed image/video request with:

```python
mm_processor_kwargs={"images_kwargs": {"max_soft_tokens": 560}}
```

fails because the video path also passes `max_soft_tokens=70` as a top-level argument:

```text
ValueError: Keyword argument max_soft_tokens was passed two times:
in a dictionary for images_kwargs and as a **kwarg.
```

The same parameter leak can make cached and freshly processed video tensors differ. After #54918, video cache keys correctly exclude `images_kwargs`, but Gemma4 still lets options such as `images_kwargs.rescale_factor` change the video pixels. Changing an image-only option can therefore reuse video data that differs from a fresh result.

This patch clears `images_kwargs` for the video-frame call. The explicit empty override also prevents configured image options from being merged back in. Image inputs continue to receive their overrides, and videos keep the existing per-frame token budget.

Related work: #54527 fixes modality-specific parameter reads in other models, and #53610 refactors processor input handling; neither isolates Gemma4's video-frame kwargs. This also differs from #50788, which requests a configurable video token budget. The duplicate-argument error predates #54918; the cache inconsistency is an interaction with its hash scoping.

## Test Plan

The new regression test uses a mixed image/video input and covers request and configured kwargs, with and without a video UUID. It checks that image overrides still affect images, leave video tensors unchanged, and produce the same video result with a warm or cleared cache.

The test can be run with the official processor assets using:

```bash
.venv/bin/python -m pytest tests/models/multimodal/processing/test_gemma4.py \
  -k video_cache_is_independent_of_image_kwargs -q
```

## Test Result

Local CPU validation on `e52be1a62d`, using Transformers 5.16.1:

- Before the fix: all 8 new regression cases fail.
- After the fix: 33 Gemma4 processing cases pass, including all 8 new cases. One test requiring external image assets was excluded.
- Generic hash and parameter-scoping tests: 8 pass.
- Applicable pre-commit checks pass. Actionlint was skipped after its dependency download failed; this patch changes only Python files.

The Gemma4 runs used a local wrapper that redirects checkpoint loading to generated processor/config files and a minimal tokenizer. HF preprocessing and vLLM's registry, caching and prompt expansion use their real implementations. Official model asset validation remains incomplete because downloads failed, and no GPU inference or model accuracy evaluation was run.

<details>
<summary>Commands used for local validation</summary>

The Gemma4 wrapper and generated assets are local investigation helpers, not files added by this patch.

```bash
VLLM_TARGET_DEVICE=cpu HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. \
.venv/bin/python ../reviewer-approved-investigation/run_local_gemma4_tests.py \
  --baseline tests/models/multimodal/processing/test_gemma4.py \
  -k video_cache_is_independent -q --tb=short

VLLM_TARGET_DEVICE=cpu HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. \
.venv/bin/python ../reviewer-approved-investigation/run_local_gemma4_tests.py \
  tests/models/multimodal/processing/test_gemma4.py \
  -k 'not test_limit_mm_per_prompt' -q

VLLM_TARGET_DEVICE=cpu HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
.venv/bin/python -m pytest tests/multimodal/test_processing.py \
  -k 'processor_inputs_hashes or overlay_modality or merge_then_overlay' -q

SKIP=actionlint .venv/bin/pre-commit run --files \
  vllm/model_executor/models/gemma4_mm.py \
  tests/models/multimodal/processing/test_gemma4.py
```

</details>

AI assistance was used, and I reviewed all changes and tests.

