### PR TITLE
[Bugfix][Kernel] Honor leading strides in SM120 blockwise FP8 GEMM

### DIFF
--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm120_fp8_dispatch.cuh
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/c3x/scaled_mm_blockwise_sm120_fp8_dispatch.cuh
@@ -204,6 +204,14 @@ void cutlass_gemm_caller_blockwise(torch::stable::Tensor& out, torch::stable::Te
   c_stride =
       cutlass::make_cute_packed_stride(StrideC{}, swap_ab ? cute::make_shape(n, m, 1) : cute::make_shape(m, n, 1));
 
+  // Preserve the runtime leading strides of valid padded tensor views instead
+  // of the packed values reconstructed from shape. The swapped epilogue views
+  // the row-major output as its column-major transpose, so its leading stride
+  // belongs in the second stride component.
+  cute::get<0>(a_stride) = a.stride(0);
+  cute::get<0>(b_stride) = b.stride(1);
+  cute::get<swap_ab ? 1 : 0>(c_stride) = out.stride(0);
+
   LayoutSFA layout_SFA = swap_ab ?
       ScaleConfig::tile_atom_to_shape_SFA(make_shape(n, m, k, 1)) :
       ScaleConfig::tile_atom_to_shape_SFA(make_shape(m, n, k, 1));

--- a/tests/kernels/quantization/test_cutlass_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutlass_scaled_mm.py
@@ -259,6 +259,49 @@ def test_cutlass_fp8_blockwise_scale_gemm(
     cutlass_fp8_gemm_helper(m, n, k, a_scale_group_shape, b_scale_group_shape, use_bias)
 
 
+# The SM120 blockwise caller dispatches swap_ab when M <= 64, so cover both
+# sides of that boundary in addition to a small odd M.
+@pytest.mark.parametrize("m", [3, 64, 128])
+@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "pad_a,pad_b,pad_out",
+    [
+        (False, False, False),
+        (True, False, False),
+        (False, True, False),
+        (False, False, True),
+        (True, True, True),
+    ],
+    ids=["packed", "padded-a", "padded-b", "padded-out", "padded-all"],
+)
+@pytest.mark.skipif(
+    not current_platform.is_device_capability_family(120),
+    reason="The blockwise leading-stride fix is specific to the SM120 caller.",
+)
+def test_cutlass_fp8_sm120_blockwise_strided_subsets(
+    m: int, out_dtype: torch.dtype, pad_a: bool, pad_b: bool, pad_out: bool
+):
+    """Padded operands must match packed GEMM without overwriting output padding."""
+    torch.manual_seed(0)
+    n, k, padding = 384, 256, 128
+    a = to_fp8(torch.randn((m, k + padding * pad_a), device="cuda"))[:, :k]
+    b = to_fp8(torch.randn((n, k + padding * pad_b), device="cuda")).t()[:k, :]
+    scale_a = torch.rand((k // 128, m), device="cuda").t()
+    scale_b = torch.rand((n // 128, k // 128), device="cuda").t()
+    output_storage = torch.full(
+        (m, n + padding * pad_out), -123.0, device="cuda", dtype=out_dtype
+    )
+    out = output_storage[:, :n]
+    reference = ops.cutlass_scaled_mm(
+        a.contiguous(), b.t().contiguous().t(), scale_a, scale_b, out_dtype
+    )
+
+    torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b, None)
+
+    torch.testing.assert_close(out, reference, rtol=0, atol=0)
+    assert torch.all(output_storage[:, n:] == -123.0)
+
+
 @pytest.mark.parametrize("m,n,k", MNK_FACTORS)
 @pytest.mark.parametrize(
     "a_scale_group_shape", [PER_TOKEN_GROUP_SHAPE, TENSORWISE_GROUP_SHAPE]


### PR DESCRIPTION
## Purpose

`scaled_mm_blockwise_sm120_fp8_dispatch.cuh` builds A/B/C strides with `make_cute_packed_stride` from the logical shape, so a padded view such as `(8, 256)` with stride `(384, 1)` is read with row stride 256. Pass `a.stride(0)`, `b.stride(1)` and `out.stride(0)` through instead. With `swap_ab` (`M <= 64` here) the output is the column-major transpose, so its leading stride goes in component 1. Packed inputs are unchanged.

Partially addresses #55534. This is the last caller in the issue's coverage table. #55537, #56248 and #56480 fix the other C3x callers and do not touch this file; the only overlap is `test_cutlass_scaled_mm.py`, which I will rebase once the first of them lands.

## Test Plan

New `test_cutlass_fp8_sm120_blockwise_strided_subsets`: M = 3 / 64 / 128 (both sides of the `swap_ab` cut), N = 384, K = 256, BF16 and FP16, packed / padded-A / padded-B / padded-out / all-padded with 128 elements of padding. Exact match against packed operands, output padding checked untouched. Skipped outside capability family 12.x.

```sh
pytest tests/kernels/quantization/test_cutlass_scaled_mm.py -q -k sm120_blockwise_strided_subsets
pytest tests/kernels/quantization/test_cutlass_scaled_mm.py -q -k blockwise
```

## Test Result

RTX 5090 (SM120), driver 580.159.03, CUDA 13.0, torch 2.13.0+cu130, Python 3.12, CUTLASS 4.7.1. `_C_stable_libtorch` built with `TORCH_CUDA_ARCH_LIST=12.0`; baseline and patched differ only in this header.

| Build | `-k sm120_blockwise_strided_subsets` | `-k blockwise` |
|---|---|---|
| baseline | 24 failed, 6 passed | — |
| patched | 30 passed | 53 passed |

Baseline failures are the 24 padded layouts; the 6 packed layouts pass on both builds. Sample mismatches on baseline:

```
M=3,   padded-A:   768 / 1152 (66.7%)
M=3,   padded-out: 1149 / 1152 (99.7%)
M=128, padded-*:   ~49100 / 49152
Greatest absolute difference: 152.0
```

Written with AI assistance; I reviewed the diff and ran the validation above.
