### PR TITLE
Enable ModelOpt FP8 on SM75

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -437,7 +437,7 @@ class ModelOptFp8Config(ModelOptQuantConfigBase):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        return 80
+        return 75
 
     @classmethod
     def override_quantization_method(


### PR DESCRIPTION
## Purpose

Enable ModelOpt FP8 checkpoints on NVIDIA GPUs with compute capability 7.5.

ModelOpt FP8 already has a compiled SM75 execution path through `MarlinFP8ScaledMMLinearKernel`, which widens activations to FP16. The generic ModelOpt FP8 capability check previously rejects SM75 before kernel selection. This changes that minimum capability from 8.0 to 7.5.

## Test Plan

Run `nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8` end to end on a Titan RTX (SM75) using:

- vLLM 0.28.1rc1
- FP16 activations and FP16 KV cache
- `--linear-backend auto`
- `--max-model-len 262144`
- compiled execution with CUDA graph capture sizes `[1, 2]`
- 1K-input/1K-output and 50K-input/1K-output requests

Verify that ModelOpt admission succeeds, automatic dispatch selects the FP8 Marlin kernel, model loading completes, CUDA graphs are captured, and both requests complete.

## Test Result

Tested on an NVIDIA Titan RTX (SM75) with the official `nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8` checkpoint:

```bash
vllm serve nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8 \
  --trust-remote-code \
  --dtype float16 \
  --tensor-parallel-size 1 \
  --gpu-memory-utilization 0.97 \
  --linear-backend auto \
  --moe-backend auto \
  --no-enable-prefix-caching \
  --max-num-seqs 2 \
  --max-num-batched-tokens 4096 \
  --max-model-len 262144 \
  --kv-cache-dtype float16 \
  --block-size 128 \
  --compilation-config \
  '{"cudagraph_capture_sizes":[1,2],"inductor_compile_config":
  {"enable_auto_functionalized_v2":true}}'

### Before this PR

Startup failed before model loading:

ValueError: The quantization method modelopt is not supported for the
current GPU. Minimum capability: 80. Current capability: 75.

### After this PR

The same SM75 configuration passes ModelOpt admission and automatically
selects the existing compiled fallback:

Selected MarlinFP8ScaledMMLinearKernel for ModelOptFp8LinearMethod

The end-to-end validation completed successfully:

- Loaded the official 4.91 GiB checkpoint.
- Model loading used 5.01 GiB and completed in 13.72 seconds.
- torch.compile completed in 20.64 seconds.
- Piecewise and full CUDA graphs were captured for batch sizes 1 and 2.
- The available KV cache held 890,489 tokens at a 262,144-token maximum
  context.

- 1K input / 1K output completed without errors at 103.30 output tokens/s.
- 50K input / 1K output completed without errors at 10.19 output tokens/s.

---

- [x] Purpose described
- [x] Test plan provided
- [x] Current test result provided
- [x] Documentation impact considered


