### PR TITLE
[Bugfix][Parser] Preserve literal Qwen tool markers and following answers

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -2053,8 +2053,8 @@ class TestTruncatedToolOpenerStreamParity:
         assert content == streamed == "Checking the weather. "
 
     def test_content_around_unpromoted_tool_block_stays_ordered(self, mock_request):
-        """Text surrounding a complete-but-unparsable tool block keeps its
-        original order in the non-streaming path, matching streaming."""
+        """A wrapper with prose instead of a function header remains literal
+        text in both paths, including the surrounding content."""
         chunks = ["A ", "<tool_call>", "garbage", "</tool_call>", " B"]
         text = "".join(chunks)
 
@@ -2064,7 +2064,7 @@ class TestTruncatedToolOpenerStreamParity:
         streamed = self._stream_content(mock_request, chunks)
 
         assert not tool_calls
-        assert content == streamed == "A  B"
+        assert content == streamed == text
 
     def test_complete_tool_call_still_promoted(self, mock_request):
         """Sanity check: a complete tool call still parses in the

--- a/tests/parser/engine/test_qwen3_reasoning.py
+++ b/tests/parser/engine/test_qwen3_reasoning.py
@@ -16,11 +16,13 @@ import pytest
 from tests.parser.engine.conftest import make_mock_tokenizer
 from tests.parser.engine.streaming_helpers import simulate_reasoning_streaming
 from vllm.parser.abstract_parser import DelegatingParser
+from vllm.parser.engine.events import EventType
 from vllm.parser.engine.parser_engine_config import ParserState
 from vllm.parser.engine.registered_adapters import (
     Qwen3ParserReasoningAdapter,
     Qwen3ParserToolAdapter,
 )
+from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
 from vllm.parser.qwen3 import Qwen3Parser, qwen3_config
 
 _THINK_START_ID = 50
@@ -56,7 +58,107 @@ def parser(mock_tokenizer):
     return Qwen3Parser(mock_tokenizer)
 
 
+@pytest.mark.parametrize("thinking", [True, False])
+@pytest.mark.parametrize("chunk_size", [1, 7, 1000])
+def test_malformed_tool_preamble_is_lossless_across_chunks(thinking, chunk_size):
+    text = "Quoted `<tool_call>` prose </tool_call> still visible."
+    engine = StreamingParserEngine(qwen3_config(thinking=thinking), None)
+    events = []
+    for offset in range(0, len(text), chunk_size):
+        events.extend(engine.feed(text[offset : offset + chunk_size], []))
+    events.extend(engine.finish())
+    kind = EventType.REASONING_CHUNK if thinking else EventType.TEXT_CHUNK
+    assert "".join(e.value for e in events if e.type == kind) == text
+    assert not any(e.type == EventType.TOOL_CALL_START for e in events)
+
+
+def test_malformed_special_token_then_real_tool_preserves_tool_index(mock_tokenizer):
+    engine = StreamingParserEngine(qwen3_config(), mock_tokenizer)
+    events = engine.feed("<tool_call>", [_TOOL_CALL_ID])
+    assert not events
+    events += engine.feed("` quoted marker. ", [])
+    events += engine.feed("<tool_call>", [_TOOL_CALL_ID])
+    events += engine.feed("\n<function=bash><parameter=cmd>pwd</parameter>", [])
+    events += engine.feed("</function></tool_call>", [_TOOL_CALL_END_ID])
+    events += engine.finish()
+    assert (
+        "".join(e.value for e in events if e.type == EventType.REASONING_CHUNK)
+        == "<tool_call>` quoted marker. "
+    )
+    starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
+    assert len(starts) == 1
+    assert starts[0].tool_index == 0
+    assert "".join(e.value for e in events if e.type == EventType.TOOL_NAME) == "bash"
+
+
+@pytest.mark.parametrize("chunk_size", [1, 2, 7, 64, 1000])
+@pytest.mark.parametrize(
+    "reasoning",
+    [
+        "The literal marker is `<tool_call>` in prose.",
+        "The wrapper is `<tool_call>quoted</tool_call>` in prose.",
+    ],
+)
+def test_quoted_tool_marker_preserves_following_final_answer(reasoning, chunk_size):
+    """A malformed wrapper must not swallow the real reasoning end or answer."""
+    text = reasoning + "</think>The answer is 42."
+    engine = StreamingParserEngine(qwen3_config(), None)
+    events = []
+    for offset in range(0, len(text), chunk_size):
+        events.extend(engine.feed(text[offset : offset + chunk_size], []))
+    events.extend(engine.finish())
+    assert (
+        "".join(e.value for e in events if e.type == EventType.REASONING_CHUNK)
+        == reasoning
+    )
+    assert (
+        "".join(e.value for e in events if e.type == EventType.TEXT_CHUNK)
+        == "The answer is 42."
+    )
+    assert not any(e.type == EventType.TOOL_CALL_START for e in events)
+
+
+def test_quoted_special_token_preserves_following_final_answer(mock_tokenizer):
+    engine = StreamingParserEngine(qwen3_config(), mock_tokenizer)
+    events = engine.feed("The literal marker is `", [])
+    events += engine.feed("<tool_call>", [_TOOL_CALL_ID])
+    events += engine.feed("` in prose.", [])
+    events += engine.feed("</think>", [_THINK_END_ID])
+    events += engine.feed("The answer is 42.", [])
+    events += engine.finish()
+    assert (
+        "".join(e.value for e in events if e.type == EventType.REASONING_CHUNK)
+        == "The literal marker is `<tool_call>` in prose."
+    )
+    assert (
+        "".join(e.value for e in events if e.type == EventType.TEXT_CHUNK)
+        == "The answer is 42."
+    )
+    assert not any(e.type == EventType.TOOL_CALL_START for e in events)
+
+
 class TestNonStreaming:
+    def test_quoted_tool_marker_preserves_following_final_answer(self, parser):
+        reasoning = "The literal marker is `<tool_call>` in prose."
+        actual_reasoning, content = parser.extract_reasoning(
+            reasoning + "</think>The answer is 42.", None
+        )
+        assert actual_reasoning == reasoning
+        assert content == "The answer is 42."
+
+    @pytest.mark.parametrize(
+        "candidate",
+        [
+            "<tool_call>` ordinary prose continues",
+            "<tool_call>quoted text</tool_call>",
+        ],
+    )
+    def test_malformed_tool_preamble_preserves_reasoning(self, parser, candidate):
+        text = "The literal marker is `" + candidate
+        reasoning, content = parser.extract_reasoning(text, None)
+        assert reasoning == text
+        assert content is None
+
     def test_reasoning_then_content(self, parser):
         text = "<think>Let me analyze.</think>The answer is 42."
         reasoning, content = parser.extract_reasoning(text, None)

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -101,6 +101,9 @@ class ParserEngineConfig:
     # Reject tool calls whose names are absent from the request tools.
     validate_tool_names: bool = False
 
+    # Delay a tool wrapper until its whitespace-only preamble reaches TOOL_NAME.
+    validate_tool_preamble: bool = False
+
     def terminal_literal(self, name: str) -> str | None:
         """Canonical spelling of terminal *name*, or ``None`` if undeclared."""
         value = self.terminals.get(name)

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -212,6 +212,9 @@ class StreamingParserEngine:
         self._message_header_buffer = ""
         self._message_header_token_count = 0
         self._in_skipped_tool_span = False
+        self._pending_tool_start: tuple[str, str, int] | None = None
+        self._tool_preamble_buffer = ""
+        self._tool_preamble_token_count = 0
         self._reset_args_state()
 
     def feed(
@@ -288,6 +291,8 @@ class StreamingParserEngine:
         events = self._process_scanner_items(self._scanner.flush_pending())
 
         events.extend(self._process_lex_tokens(self._lexer.flush()))
+
+        events.extend(self._confirm_tool_preamble())
 
         if self._args_buffer:
             events.append(
@@ -395,8 +400,28 @@ class StreamingParserEngine:
         return markers
 
     def _on_terminal(
-        self, terminal: str, value: str, token_count: int = 0
+        self,
+        terminal: str,
+        value: str,
+        token_count: int = 0,
+        *,
+        confirmed_tool_start: bool = False,
     ) -> list[SemanticEvent]:
+        if self._pending_tool_start is not None:
+            next_transition = self.config.transitions.get(
+                (ParserState.TOOL_PREAMBLE, terminal)
+            )
+            if next_transition is not None and next_transition.next_state in (
+                ParserState.TOOL_NAME,
+                ParserState.CONTENT,
+            ):
+                events = self._confirm_tool_preamble()
+                events.extend(self._on_terminal(terminal, value, token_count))
+                return events
+            events = self._flush_tool_preamble()
+            events.extend(self._on_terminal(terminal, value, token_count))
+            return events
+
         key = (self.state, terminal)
         transition = self.config.transitions.get(key)
 
@@ -410,6 +435,15 @@ class StreamingParserEngine:
 
         if self.skip_reasoning_parsing and terminal in self._reasoning_markup_terminals:
             return self._emit_for_state(value, token_count)
+
+        if (
+            self.config.validate_tool_preamble
+            and not confirmed_tool_start
+            and self.state in (ParserState.CONTENT, ParserState.REASONING)
+            and transition.next_state == ParserState.TOOL_PREAMBLE
+        ):
+            self._pending_tool_start = (terminal, value, token_count)
+            return []
 
         if self.skip_tool_parsing and terminal in self._tool_terminals:
             # Inkling reuses one terminal for tool, text, and reasoning exits.
@@ -469,6 +503,26 @@ class StreamingParserEngine:
         return self._apply_transition(transition, value, token_count)
 
     def _emit_for_state(self, text: str, token_count: int = 0) -> list[SemanticEvent]:
+        if self._pending_tool_start is not None:
+            self._tool_preamble_buffer += text
+            self._tool_preamble_token_count += token_count
+            if text.strip():
+                candidate = self._tool_preamble_buffer.lstrip()
+                for (state, terminal), tr in self.config.transitions.items():
+                    if (
+                        state == ParserState.TOOL_PREAMBLE
+                        and tr.next_state == ParserState.TOOL_NAME
+                        and (literal := self.config.terminals.get(terminal))
+                        and any(
+                            value.startswith(candidate)
+                            for value in (
+                                (literal,) if isinstance(literal, str) else literal
+                            )
+                        )
+                    ):
+                        return []
+                return self._flush_tool_preamble()
+            return []
         if self.state == ParserState.MESSAGE_HEADER:
             self._message_header_buffer += text
             self._message_header_token_count += token_count
@@ -495,6 +549,30 @@ class StreamingParserEngine:
                 )
             ]
         return []
+
+    def _flush_tool_preamble(self) -> list[SemanticEvent]:
+        if self._pending_tool_start is None:
+            return []
+        _, opener, opener_count = self._pending_tool_start
+        text = opener + self._tool_preamble_buffer
+        count = opener_count + self._tool_preamble_token_count
+        self._pending_tool_start = None
+        self._tool_preamble_buffer = ""
+        self._tool_preamble_token_count = 0
+        return self._emit_for_state(text, count)
+
+    def _confirm_tool_preamble(self) -> list[SemanticEvent]:
+        if self._pending_tool_start is None:
+            return []
+        opener = self._pending_tool_start
+        text = self._tool_preamble_buffer
+        count = self._tool_preamble_token_count
+        self._pending_tool_start = None
+        self._tool_preamble_buffer = ""
+        self._tool_preamble_token_count = 0
+        events = self._on_terminal(*opener, confirmed_tool_start=True)
+        events.extend(self._emit_for_state(text, count))
+        return events
 
     def _on_content(self, text: str, token_count: int = 0) -> list[SemanticEvent]:
         if not text:

--- a/vllm/parser/nemotron_v3.py
+++ b/vllm/parser/nemotron_v3.py
@@ -35,6 +35,7 @@ def nemotron_v3_config(thinking: bool = True) -> ParserEngineConfig:
     return dataclasses.replace(
         qwen3_config(thinking=thinking, turn_boundary_tokens=CHATML_TURN_BOUNDARIES),
         name="nemotron_v3",
+        validate_tool_preamble=False,
         strip_trailing_reasoning_whitespace=True,
     )
 

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -198,6 +198,7 @@ def qwen3_config(
         stream_arg_deltas=True,
         strip_trailing_reasoning_whitespace=False,
         tool_args_json=False,
+        validate_tool_preamble=name == "qwen3",
     )
 
 


### PR DESCRIPTION
Fixes #56658.

Qwen output that quotes `<tool_call>` followed by ordinary prose can lose the rest of the response during parsing. If the marker occurs in reasoning, the parser can also discard the later `</think>` and a complete final answer. This patch preserves the literal text in its original channel while retaining valid tool calls.

The streaming engine defers a Qwen tool opener until a function-header prefix confirms it. Ordinary prose instead flushes the candidate as text. The option defaults off, is enabled for the `qwen3` configuration, and explicitly remains off for Nemotron's derived configuration. Current-main reasoning-bypass behavior is preserved. Established empty-wrapper and genuinely truncated-opener handling remain unchanged.

This is a parser correction on already-generated text. No sampler, EOS policy, thinking limit, server configuration, or model kernel changes are included. A quoted example containing a complete valid tool-call structure remains a protocol ambiguity; this does not claim to recognize arbitrary Markdown/code quotations.

## Validation

Tested on main snapshot `c2ea9f1a5f10caec36eac91c461fcec6564f5394` in a disposable CPU-only container with current-main Python source overlaid on the pinned official v0.29 dependency image. The tests import the installed parser and adapters normally and retain upstream's mock-tokenizer fixtures. This is not a complete current-main GPU build or fresh served-model evaluation.

Full current parser-engine suite with this PR's tests:

- Before runtime patch: **4,278 passed, 22 failed**.
- After runtime patch: **4,300 passed, 0 failed**.
- All test identities match between arms; no skipped cases or newly failing existing cases.

There are 21 added regression cases. One existing test's expected result changes from deleting an invalid wrapper (`A  B`) to preserving its literal text (`A <tool_call>garbage</tool_call> B`); it still checks streaming/non-streaming parity and ordering. Tests for incomplete function openers and valid calls retain their expectations.

Command: `.venv/bin/python -m pytest --confcutdir=tests/parser/engine tests/parser/engine -q --tb=short`.

Applicable pre-commit hooks pass, including Ruff, formatting, typos, SPDX, import/configuration checks and mypy for Python 3.10. The separate mypy-3.12 manual gate also passes. A temporary copy of the hook configuration excludes repositories whose hooks only target unchanged languages/file paths; the repository configuration is unchanged.

The downstream integration at [blazux/qwen3.8-Flash-DGX#20](https://github.com/blazux/qwen3.8-Flash-DGX/pull/20) separately passed all 3,822 parser-engine tests on the official v0.29.0 image. Its preview-image comparison and caveats are linked in #56658. The downstream maintainer independently reproduced the bug with real-tokenizer and served-model examples; that evidence is linked in the issue. No model-accuracy claim is made from these parser tests.

## Related work

No open PR referencing #56658 was found in the duplicate check. #53297 fixes a similar content-loss symptom in ERNIE/DeepSeek V3.1/Granite rather than Qwen's streaming engine. #55848 handles literal closing tags in Hermes JSON strings. #53739 handles the flush of already-streamed tool arguments. #55562 changes reasoning EOS policy. None implements this Qwen opener validation.

AI assistance was used to implement, port, inspect and test this patch. Human review and a human-run validation are still pending. This is submitted as a draft and does not claim those steps have happened.
