### PR TITLE
[Bugfix] Redact credentials from benchmark logs

### DIFF
--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -32,8 +32,11 @@ from bench_dataset import (
 from bench_utils import TEXT_SEPARATOR, Color, logger
 from transformers import AutoTokenizer  # type: ignore
 
+from vllm.benchmarks.lib.utils import redact_sensitive_namespace
+
 NUM_TOKENS_FROM_DATASET = 0
 TERM_SIGNAL = None
+_SENSITIVE_ARG_FIELDS = ("api_key", "header")
 
 
 class ConversationSampling(str, Enum):
@@ -1548,7 +1551,7 @@ async def main() -> None:
 
     args = parser.parse_args()
 
-    logger.info(args)
+    logger.info(redact_sensitive_namespace(args, _SENSITIVE_ARG_FIELDS))
 
     logger.info(f"{Color.GREEN}Input parameters:{Color.RESET}")
     logger.info(f"url={args.url}")

--- a/vllm/benchmarks/lib/utils.py
+++ b/vllm/benchmarks/lib/utils.py
@@ -9,6 +9,17 @@ from contextlib import contextmanager
 from typing import Any
 
 
+def redact_sensitive_namespace(
+    args: argparse.Namespace, fields: tuple[str, ...]
+) -> argparse.Namespace:
+    """Return a copy of CLI arguments with selected values redacted."""
+    redacted_args = argparse.Namespace(**vars(args))
+    for field in fields:
+        if getattr(redacted_args, field, None) is not None:
+            setattr(redacted_args, field, "***")
+    return redacted_args
+
+
 def extract_field(
     args: argparse.Namespace, extra_info: dict[str, Any], field_name: str
 ) -> str:

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -51,13 +51,18 @@ from vllm.benchmarks.lib.endpoint_request_func import (
     RequestFuncOutput,
 )
 from vllm.benchmarks.lib.ready_checker import wait_for_endpoint
-from vllm.benchmarks.lib.utils import convert_to_pytorch_benchmark_format, write_to_json
+from vllm.benchmarks.lib.utils import (
+    convert_to_pytorch_benchmark_format,
+    redact_sensitive_namespace,
+    write_to_json,
+)
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.gc_utils import freeze_gc_heap
 from vllm.utils.network_utils import join_host_port
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000
+_SENSITIVE_ARG_FIELDS = ("header",)
 
 
 def _merge_overrides(base: dict | None, override: dict | None) -> dict | None:
@@ -1536,7 +1541,7 @@ def save_to_pytorch_benchmark_format(
     # later if needed
     ignored_metrics = ["ttfts", "itls", "generated_texts", "errors"]
     pt_records = convert_to_pytorch_benchmark_format(
-        args=args,
+        args=redact_sensitive_namespace(args, _SENSITIVE_ARG_FIELDS),
         metrics={k: [results[k]] for k in metrics if k in results},
         extra_info={
             k: results[k]
@@ -2013,7 +2018,7 @@ def main(args: argparse.Namespace) -> dict[str, Any]:
 
 
 async def main_async(args: argparse.Namespace) -> dict[str, Any]:
-    print(args)
+    print(redact_sensitive_namespace(args, _SENSITIVE_ARG_FIELDS))
     if args.max_concurrency is not None and args.max_concurrency <= 0:
         raise ValueError("--max-concurrency must be greater than 0")
 


### PR DESCRIPTION
## Purpose

`vllm bench serve` printed its full argument namespace, including values passed through `--header`, while the multi-turn benchmark logged both `--api-key` and `--header`. This could expose credentials in local or CI logs. The fix uses one small shared helper to log a sanitized copy while leaving the original arguments unchanged for requests. The same sanitized copy is used for optional PyTorch benchmark metadata so credentials are not moved from stdout into an artifact.

## Reproducer

```bash
PATH="$PWD/.venv/bin:$PATH" .venv/bin/vllm bench serve \
  --model unused \
  --dataset-name random \
  --num-prompts 1 \
  --header 'Authorization=Bearer redaction-test' \
  --max-concurrency 0

PATH="$PWD/.venv/bin:$PATH" .venv/bin/python \
  benchmarks/multi_turn/benchmark_serving_multi_turn.py \
  --input-file unused.json \
  --model unused \
  --api-key multi-api-redaction-test \
  --header 'Authorization=Bearer multi-header-redaction-test' \
  --warmup-percentages invalid
```

The deliberately invalid final arguments stop both commands immediately after their startup diagnostics, without sending a request.

## Output on **main** vs on **branch**

### Main

```text
... header=['Authorization=Bearer redaction-test'], max_concurrency=0 ...
... api_key='multi-api-redaction-test', header=[('Authorization', 'Bearer multi-header-redaction-test')] ...
```

### Branch

```text
... header='***', max_concurrency=0 ...
... api_key='***', header='***' ...
```

The original parsed values remain unchanged and are still passed to the HTTP request path.

## Test Plan

```bash
# Deterministic checks for serve stdout, PyTorch metadata, multi-turn logs,
# and preservation of the original Namespace values.
PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -c '<redaction assertions>'

PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --files \
  vllm/benchmarks/lib/utils.py \
  vllm/benchmarks/serve.py \
  benchmarks/multi_turn/benchmark_serving_multi_turn.py

PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --all-files

PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest \
  tests/benchmarks/test_serve_cli.py -q --disable-warnings --tb=short
```

Results:

- Serve stdout redaction and argument passthrough: passed.
- Serve PyTorch artifact redaction and argument passthrough: passed.
- Multi-turn startup redaction: passed.
- File-scoped pre-commit: passed.
- Full pre-commit: all non-dependency hooks passed.

## AI assistance disclosure

OpenAI Codex (GPT-5) assisted in drafting the code. 