### PR TITLE
[Bugfix][Metrics] Release LoRA tracking when streaming input closes

### DIFF
--- a/docs/design/metrics.md
+++ b/docs/design/metrics.md
@@ -390,6 +390,9 @@ The label names used are:
 - `max_lora` - the static "max number of LoRAs in a single batch."
   configuration.
 
+Streaming-input requests are removed from LoRA tracking once both the input
+stream and its final output have completed, regardless of which completes first.
+
 Encoding a running/waiting counts for multiple adapters in a
 comma-separated string seems quite misguided - we could use labels to
 distinguish between per-adapter counts. This should be revisited.

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -23,6 +23,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.v1.engine import (
     EngineCoreEvent,
     EngineCoreEventType,
+    EngineCoreOutput,
     EngineCoreOutputs,
     EngineCoreRequest,
     FinishReason,
@@ -1077,6 +1078,85 @@ def test_iteration_stats(dummy_test_vectors):
 
     assert iteration_stats.num_prompt_tokens == 0
     assert iteration_stats.num_generation_tokens == num_active
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("log_stats", [True, False])
+@pytest.mark.parametrize(
+    "end_of_input", ["non_streaming", "before_output", "after_output"]
+)
+def test_finished_requests_release_lora_tracking(end_of_input: str, log_stats: bool):
+    """Closing a stream after its last output must release only that request's load."""
+    processor = OutputProcessor(tokenizer=None, log_stats=log_stats)
+    lora = LoRARequest("adapter", 1, "/path/to/adapter")
+    requests = [
+        EngineCoreRequest(
+            request_id=f"request-{idx}",
+            external_req_id=f"external-{idx}",
+            prompt_token_ids=[1],
+            mm_features=None,
+            sampling_params=SamplingParams(detokenize=False),
+            pooling_params=None,
+            arrival_time=0,
+            lora_request=lora,
+            cache_salt=None,
+            data_parallel_rank=None,
+            resumable=end_of_input != "non_streaming",
+        )
+        for idx in range(2)
+    ]
+    for request in requests:
+        processor.add_request(request, None)
+    processor.process_outputs(
+        [
+            EngineCoreOutput(
+                request_id=request.request_id,
+                new_token_ids=[2],
+                events=[EngineCoreEvent.new_event(EngineCoreEventType.SCHEDULED, 1.0)],
+            )
+            for request in requests
+        ],
+        engine_core_timestamp=1.0,
+        iteration_stats=IterationStats() if log_stats else None,
+    )
+    stats = SchedulerStats()
+    processor.update_scheduler_stats(stats)
+    assert stats.running_lora_adapters == ({"adapter": 2} if log_stats else {})
+
+    for idx, request in enumerate(requests):
+        if end_of_input == "before_output":
+            request.resumable = False
+            processor.add_request(request, None)
+
+        processor.process_outputs(
+            [
+                EngineCoreOutput(
+                    request_id=request.request_id,
+                    new_token_ids=[3],
+                    finish_reason=FinishReason.LENGTH,
+                )
+            ],
+            engine_core_timestamp=2.0,
+            iteration_stats=IterationStats() if log_stats else None,
+        )
+        if end_of_input == "after_output":
+            assert processor.has_request(request.request_id)
+            stats = SchedulerStats()
+            processor.update_scheduler_stats(stats)
+            assert stats.running_lora_adapters == (
+                {"adapter": len(requests) - idx} if log_stats else {}
+            )
+            request.resumable = False
+            processor.add_request(request, None)
+
+        remaining = len(requests) - idx - 1
+        assert processor.get_num_unfinished_requests() == remaining
+        stats = SchedulerStats()
+        processor.update_scheduler_stats(stats)
+        assert stats.running_lora_adapters == (
+            {"adapter": remaining} if log_stats and remaining else {}
+        )
+    assert not processor.lora_states.requests
 
 
 @pytest.mark.parametrize("log_stats", [True, False])

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -753,6 +753,7 @@ class OutputProcessor:
     def _finish_request(self, req_state: RequestState) -> None:
         req_id = req_state.request_id
         self.request_states.pop(req_id)
+        self.lora_states.request_finished(req_id, req_state.lora_name)
 
         internal_ids = self.external_req_ids[req_state.external_req_id]
         internal_ids.remove(req_id)
@@ -869,8 +870,6 @@ class OutputProcessor:
             req_stats=req_state.stats,
             num_cached_tokens=req_state.num_cached_tokens,
         )
-        self.lora_states.request_finished(req_state.request_id, req_state.lora_name)
-
         ParentRequest.observe_finished_request(
             req_state.parent_req, iteration_stats, req_state.stats.num_generation_tokens
         )


### PR DESCRIPTION
## Purpose

Move LoRA cleanup into `_finish_request()` so closing input after the final output releases completed request IDs and clears stale adapter load.

## Test Plan

```bash
export OMP_NUM_THREADS=1 VLLM_TARGET_DEVICE=cpu
.venv/bin/python -m pytest --confcutdir=tests/v1/engine tests/v1/engine/test_output_processor.py -k 'test_finished_requests_release_lora_tracking or test_delta_output_without_new_tokens_returns_empty_logprobs' -q
.venv/bin/python -m pytest --confcutdir=tests/v1/metrics tests/v1/metrics/test_stats.py -q
pre-commit run --files vllm/v1/engine/output_processor.py tests/v1/engine/test_output_processor.py docs/design/metrics.md
pre-commit run mypy-3.12 --hook-stage manual --files vllm/v1/engine/output_processor.py tests/v1/engine/test_output_processor.py
```

## Test Result

- Regression: 1 failed, 7 passed  -> 8 passed after
- Metrics: 12 passed

CPU only

AI helped in the development of tests and code
