### PR TITLE
[Perf][Spec Decode] Enable torch.compile for Kimi-K3 DSpark

### DIFF
--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn as nn
 
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
+from vllm.config import CompilationMode
+from vllm.config.compilation import CompilationConfig
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
 from vllm.model_executor.models.registry import ModelRegistry
@@ -15,9 +17,9 @@ from vllm.models.kimi_k3.nvidia import dspark_mla
 from vllm.models.kimi_k3.nvidia.dspark_mla import K3DSparkForCausalLM, K3DSparkModel
 
 
-def test_dspark_mla_uses_compile_free_model_entrypoint():
+def test_dspark_mla_model_supports_torch_compile():
     assert ModelRegistry._try_load_model_cls("K3DSparkModel") is K3DSparkForCausalLM
-    assert not issubclass(K3DSparkModel, TorchCompileWithNoGuardsWrapper)
+    assert issubclass(K3DSparkModel, TorchCompileWithNoGuardsWrapper)
 
 
 @pytest.mark.parametrize(
@@ -143,6 +145,7 @@ def test_k3_dspark_uses_replicated_markov_head(monkeypatch: pytest.MonkeyPatch):
             draft_model_config=SimpleNamespace(hf_config=config)
         ),
         scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+        compilation_config=CompilationConfig(mode=CompilationMode.NONE),
     )
 
     K3DSparkModel(vllm_config=vllm_config, start_layer_id=0, prefix="model")

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 
 import vllm._custom_ops as ops
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -128,6 +129,7 @@ class K3DSparkDecoderLayer(nn.Module):
         return hidden_states, residual
 
 
+@support_torch_compile
 class K3DSparkModel(nn.Module):
     def __init__(
         self,


### PR DESCRIPTION
## Purpose

Enable vLLM compilation for the Kimi-K3 DSpark draft model by applying `@support_torch_compile` to `K3DSparkModel`. This allows the DSpark forward graph to participate in Inductor graph partitioning and configured fusion passes instead of remaining compile-free.

The change is intentionally limited to the measured DSpark model. It does not claim compile support for the separate Kimi-K3 target model.

## Test Plan

- Update the existing model-registry contract test to require `K3DSparkModel` to inherit `TorchCompileWithNoGuardsWrapper`.
- Keep the direct-construction test valid with compilation disabled.
- Run Ruff and Python syntax checks.
- Run a 1200-second Kimi-K3 production A/B on 8x MI355X at TP8, conc=1, speculative depth 3, FP8 KV, and synthetic acceptance length 3.75. The experiment enables Inductor graph partitioning and MLA RoPE/KV-cache fusion.

## Test Result

Changed tests: `2 passed, 23 deselected`. Ruff passed and both files were already formatted.

Production A/B:

| configuration | interactivity p90 | p90 ITL | throughput/GPU |
|---|---:|---:|---:|
| depth 3 baseline | 144.82 tok/s | 6.91 ms | 2043.29 tok/s |
| depth 3 + compiled DSpark graph/fusion config | 154.57 tok/s | 6.47 ms | 2057.70 tok/s |

This is **+6.7% interactivity p90**, **-6.4% p90 ITL**, and **+0.7% throughput/GPU**. Logs confirm that the DSpark graph was AOT-compiled and `rope_kvcache_cat_mla` was enabled.

Production run: https://github.com/AMD-MLPerf/InferenceX/actions/runs/34737347128

The production arm changes both this decorator and the compilation configuration required to exercise it, so the result measures the enabled compiled path as a whole rather than attributing the entire delta to the decorator alone.