### PR TITLE
[Bugfix][GLM5.3-Flash] Handle zero RoPE head dimension in FlashAttention sparse MLA

### DIFF
--- a/vllm/v1/attention/backends/mla/flashattn_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla_sparse.py
@@ -309,8 +309,16 @@ class FlashAttnMLASparseImpl(SparseMLACommonImpl[FlashAttnMLASparseMetadata]):
         cu_seqlens_q = torch.arange(
             0, q_rope.shape[0] + 1, dtype=torch.int32, device=q_rope.device
         )
-        k_cache = kv_rows[:, self.kv_lora_rank :].unsqueeze(1).unsqueeze(1)
         v_cache = kv_rows[:, : self.kv_lora_rank].unsqueeze(1).unsqueeze(1)
+        if self.qk_rope_head_dim == 0:
+            # FA3's QV path requires the 64-wide Q/K specialization. For NoPE MLA,
+            # zero Q preserves QV-only attention scores
+            # while providing a valid TMA shape.
+            _FA3_QV_HEAD_DIM = 64
+            q_rope = q_nope.new_zeros(*q_nope.shape[:-1], _FA3_QV_HEAD_DIM)
+            k_cache = v_cache[..., :_FA3_QV_HEAD_DIM]
+        else:
+            k_cache = kv_rows[:, self.kv_lora_rank :].unsqueeze(1).unsqueeze(1)
 
         out = flash_attn_varlen_func(
             q=q_rope,


### PR DESCRIPTION


## Purpose
[Bugfix][GLM5.3-Flash] Handle zero RoPE head dimension in FlashAttention sparse MLA

```
VLLM_ENGINE_READY_TIMEOUT_S=3600 vllm serve  /mnt/nvme/shared/models/ZhipuAI/GLM-5.3-Flash \                         
  --tensor-parallel-size 8 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":5}' \
  --tool-call-parser glm47 --enable-auto-tool-choice --reasoning-parser glm45 \
  --max-model-len 262144 --max-num-seqs 512 --attention-backend FLASH_ATTN_MLA_SPARSE --load-format instanttensor
```
## Test Plan
before
```
,Error: Failed to initialize the TMA descriptor 01,
1024,0)
boxDim         (64,64,1,1,1)
elementStrides (1,1,1,1,1)
interleave     0
swizzle        3
l2Promotion    2
oobFill        0
Error: Failed to initialize the TMA descriptor 1
TMA Desc Addr:   0x7fffa3273880
format         9
dim            4
gmem_address   0
globalDim      (0,1,1,327680,1)
globalStrides  (2,0,0,1024,0)
boxDim         (64,64,1,1,1)
elementStrides (1,1,1,1,1)
interleave     0
swizzle        3
l2Promotion    2
oobFill        0
Error: Failed to initialize the TMA descriptor 1
^CNVCC compilation failed: 
NVCC compilation failed: 
NVCC compilation failed: 
NVCC compilation failed: 
NVCC compilation failed: 
NVCC compilation failed: 
NVCC compilation failed: 
NVCC compilation failed: 
Capturing CUDA graphs (PIECEWISE):  45%|███████████████████████                            | 24/53 [00:55<01:07,  2.33s/it]
^C^C(APIServer pid=1877375) Traceback (most recent call last):
(APIServer pid=1877375)   File "/home/chauncey/vllm/.venv/bin/vllm", line 10, in <module>
(APIServer pid=1877375)     sys.exit(main())
(APIServer pid=1877375)              ^^^^^^
(APIServer pid=1877375)   File "/home/chauncey/vllm/vllm/entrypoints/cli/main.py", line 106, in main
(APIServer pid=1877375)     args.dispatch_function(args)
(APIServer pid=1877375)   File "/home/chauncey/vllm/vllm/entrypoints/cli/serve.py", line 153, in cmd
(APIServer pid=1877375)     uvloop.run(run_server(args))
(APIServer pid=1877375)   File "/home/chauncey/vllm/.venv/lib/python3.12/site-packages/uvloop/__init__.py", line 96, in run
(APIServer pid=1877375)     return __asyncio.run(
(APIServer pid=1877375)            ^^^^^^^^^^^^^^
(APIServer pid=1877375)   File "/home/chauncey/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/asyncio/runners.py", line 195, in run
(APIServer pid=1877375)     return runner.run(main)
(APIServer pid=1877375)            ^^^^^^^^^^^^^^^^
(APIServer pid=1877375)   File "/home/chauncey/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/asyncio/runners.py", line 118, in run
(APIServer pid=1877375)     return self._loop.run_until_complete(task)
(APIServer pid=1877375)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1877375)   File "uvloop/loop.pyx", line 1512, in uvloop.loop.Loop.run_until_complete
(APIServer pid=1877375)   File "uvloop/loop.pyx", line 1505, in uvloop.loop.Loop.run_until_complete
(APIServer pid=1877375)   File "uvloop/loop.pyx", line 1379, in uvloop.loop.Loop.run_forever
(APIServer pid=1877375)   File "uvloop/loop.pyx", line 557, in uvloop.loop.Loop._run
(APIServer pid=1877375)   File "uvloop/loop.pyx", line 476, in uvloop.loop.Loop._on_idle
(APIServer pid=1877375)   File "uvloop/cbhandles.pyx", line 83, in uvloop.loop.Handle._run
(APIServer pid=1877375)   File "uvloop/cbhandles.pyx", line 61, in uvloop.loop.Handle._run
(APIServer pid=1877375)   File "/home/chauncey/vllm/.venv/lib/python3.12/site-packages/uvloop/__init__.py", line 48, in wrapper
(APIServer pid=1877375)     return await main

```

```
lm_eval run \
  --model local-completions \
  --model_args model=/mnt/nvme/shared/models/ZhipuAI/GLM-5.3-Flash,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=64,tokenized_requests=False \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size 1 \
  --gen_kwargs temperature=0 \
  --output_path /home/chauncey/vllm/downloads/glm5.3_flash_profile/gsm8k_lm_eval \
  --log_samples \
  --seed 12345
```
## Test Result
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9227|±  |0.0074|
|     |       |strict-match    |     5|exact_match|↑  |0.9212|±  |0.0074|

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

