### PR TITLE
[MRV2] Run pooling post processing on non-final PP ranks

### DIFF
--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -173,7 +173,8 @@ def test_execute_model_waits_previous_pp_send_before_forward(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Previous device handles are waited before the forward pass; the
-    metadata handle is left to the GroupCoordinator's reaper."""
+    metadata handle is left to the GroupCoordinator's reaper. Pooling
+    postprocessing runs after the next send has been enqueued."""
     import torch
 
     from vllm.sequence import IntermediateTensors
@@ -199,6 +200,12 @@ def test_execute_model_waits_previous_pp_send_before_forward(
         log.append("forward")
         return IntermediateTensors({"hidden_states": torch.zeros(1)})
 
+    pooling_output = object()
+
+    def pool():
+        log.append("pool")
+        return pooling_output
+
     worker = SimpleNamespace(
         vllm_config=SimpleNamespace(
             compilation_config=SimpleNamespace(
@@ -208,8 +215,10 @@ def test_execute_model_waits_previous_pp_send_before_forward(
                 pipeline_parallel_size=2, distributed_executor_backend="mp"
             ),
         ),
-        use_v2_model_runner=False,
-        model_runner=SimpleNamespace(execute_model=run_model),
+        use_v2_model_runner=True,
+        model_runner=SimpleNamespace(
+            execute_model=run_model, is_pooling_model=True, pool=pool
+        ),
         annotate_profile=lambda scheduler_output: nullcontext(),
         _pp_send_work=[previous_tensor_send],
     )
@@ -217,7 +226,7 @@ def test_execute_model_waits_previous_pp_send_before_forward(
         total_num_scheduled_tokens=4, num_scheduled_tokens={"r0": 4}
     )
 
-    assert gpu_worker.Worker.execute_model(worker, scheduler_output) is None
+    assert gpu_worker.Worker.execute_model(worker, scheduler_output) is pooling_output
 
-    assert log == ["wait:prev-tensor", "forward", "isend"]
+    assert log == ["wait:prev-tensor", "forward", "isend", "pool"]
     assert worker._pp_send_work == [tensor_handle]

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -173,8 +173,7 @@ def test_execute_model_waits_previous_pp_send_before_forward(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Previous device handles are waited before the forward pass; the
-    metadata handle is left to the GroupCoordinator's reaper. Pooling
-    postprocessing runs after the next send has been enqueued."""
+    metadata handle is left to the GroupCoordinator's reaper."""
     import torch
 
     from vllm.sequence import IntermediateTensors
@@ -200,12 +199,6 @@ def test_execute_model_waits_previous_pp_send_before_forward(
         log.append("forward")
         return IntermediateTensors({"hidden_states": torch.zeros(1)})
 
-    pooling_output = object()
-
-    def pool():
-        log.append("pool")
-        return pooling_output
-
     worker = SimpleNamespace(
         vllm_config=SimpleNamespace(
             compilation_config=SimpleNamespace(
@@ -215,10 +208,8 @@ def test_execute_model_waits_previous_pp_send_before_forward(
                 pipeline_parallel_size=2, distributed_executor_backend="mp"
             ),
         ),
-        use_v2_model_runner=True,
-        model_runner=SimpleNamespace(
-            execute_model=run_model, is_pooling_model=True, pool=pool
-        ),
+        use_v2_model_runner=False,
+        model_runner=SimpleNamespace(execute_model=run_model),
         annotate_profile=lambda scheduler_output: nullcontext(),
         _pp_send_work=[previous_tensor_send],
     )
@@ -226,7 +217,7 @@ def test_execute_model_waits_previous_pp_send_before_forward(
         total_num_scheduled_tokens=4, num_scheduled_tokens={"r0": 4}
     )
 
-    assert gpu_worker.Worker.execute_model(worker, scheduler_output) is pooling_output
+    assert gpu_worker.Worker.execute_model(worker, scheduler_output) is None
 
-    assert log == ["wait:prev-tensor", "forward", "isend", "pool"]
+    assert log == ["wait:prev-tensor", "forward", "isend"]
     assert worker._pp_send_work == [tensor_handle]

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1211,6 +1211,8 @@ class Worker(WorkerBase):
         )
         self._pp_send_work = handles[1:]
 
+        if self.use_v2_model_runner and self.model_runner.is_pooling_model:
+            return self.model_runner.pool()  # type: ignore
         return None
 
     def take_draft_token_ids(self) -> DraftTokenIds | None:


### PR DESCRIPTION
## Purpose

Fix incorrect pooling outputs when Model Runner V2 uses pipeline parallelism and a request spans multiple scheduler steps. `Worker.execute_model()` previously called `pool()` only when the model forward returned `None`; non-final PP ranks instead return `IntermediateTensors`, so their pooling post-step never advanced `num_computed_tokens`. Later chunks consequently used stale request state. This change runs that post-step after enqueueing the intermediate-tensor send, retaining the non-blocking PP ordering while keeping all PP ranks synchronized.

## Reproducer

Run the following on `main` and on this branch, comparing the PP=2 result with a TP=1 or MRV1 reference:

```bash
CUDA_VISIBLE_DEVICES=0,1 VLLM_USE_V2_MODEL_RUNNER=1 \
.venv/bin/python - <<'PY'
from vllm import LLM

prompts = [
    "A",
    "A short sentence for embedding.",
    "Mixed-length pooling request " * 9,
    "A substantially longer pooling request " * 31,
    "tail",
]

llm = LLM(
    model="Qwen/Qwen3-Embedding-0.6B",
    runner="pooling",
    dtype="bfloat16",
    enforce_eager=True,
    max_model_len=512,
    max_num_batched_tokens=64,
    max_num_seqs=5,
    pipeline_parallel_size=2,
    distributed_executor_backend="mp",
)
outputs = llm.embed(prompts, use_tqdm=False)
print([len(output.prompt_token_ids) for output in outputs])
PY
```

## Output on main

```text
LAST main: {'max_abs': 0.1187209039926529, 'mean_abs': 0.004106242549953976, 'min_cosine': 0.6527300999190045}
ALL main (157-token request): {'max_abs': 0.2411421537399292, 'mean_abs': 0.012687100413670264, 'min_cosine': 0.2586870973477517}
```

## Output on this branch

```text
LAST branch: {'max_abs': 0.0, 'mean_abs': 0.0, 'min_cosine': 1.0}
ALL branch (157-token request): {'max_abs': 0.0, 'mean_abs': 0.0, 'min_cosine': 0.9999999999999998}
```

The ALL comparison uses the same model with `PoolerConfig(task="token_embed")`. Output shapes, float32 dtype, and prompt-token ordering also match exactly. 

## Test Plan

```bash
CUDA_VISIBLE_DEVICES=1 .venv/bin/python -m pytest \
  tests/v1/worker/test_gpu_worker.py -q
# 8 passed in 3.97s

CUDA_VISIBLE_DEVICES=1 VLLM_USE_V2_MODEL_RUNNER=1 \
  .venv/bin/python -m pytest \
  tests/v1/e2e/general/test_pooling_chunked_prefill.py -q
# 2 passed in 34.85s

```

Additional parity coverage compared MRV1 and MRV2 with PP=2, mixed prompt lengths, chunked scheduling, LAST pooling, and ALL/token-embedding pooling. 

## AI assistance disclosure

OpenAI GPT-5.6 assisted with drafting the code.