### PR TITLE
[CI][Test] Mock CPU backend block sizes in kv_connector unit conftest

### DIFF
--- a/tests/v1/kv_connector/unit/conftest.py
+++ b/tests/v1/kv_connector/unit/conftest.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from vllm.platforms import current_platform
+
+
+@pytest.fixture(autouse=True)
+def _mock_cpu_backend_block_sizes(monkeypatch):
+    """Mock the CPU attention backend's kernel block-size declaration.
+
+    Connector unit tests exercise transfer logic, never the attention
+    kernel, and hard-code block_size=16. On CPU-only machines
+    `CPUAttentionBackend` declares `MultipleOf(32)` (#54042), so every
+    worker construction would fail in `select_common_block_size` before
+    reaching the code under test.
+    """
+    if not current_platform.is_cpu():
+        return
+    from vllm.v1.attention.backend import MultipleOf
+    from vllm.v1.attention.backends.cpu_attn import CPUAttentionBackend
+
+    monkeypatch.setattr(
+        CPUAttentionBackend,
+        "get_supported_kernel_block_sizes",
+        staticmethod(lambda: [MultipleOf(16)]),
+    )


### PR DESCRIPTION
## Purpose

Fixes #56668.

Since #54042 declared `MultipleOf(32)` for `CPUAttentionBackend`, 81 tests
under `tests/v1/kv_connector/unit/` (GPU lane, not `cpu_test`-marked) fail on
CPU-only machines with `ValueError: No common block size for 16.`.

Add a directory-level `conftest.py` that, on CPU platforms only, monkeypatches
the CPU backend's kernel block-size declaration back to `MultipleOf(16)`. The
connector unit tests consume that declaration but never execute the attention
kernel, so the constraint has no bearing on the code under test. No-op on
other platforms; production code unchanged. Alternatives are measured in the
issue.

Not a duplicate: open block-size PRs (#48313, #49845, #48499) change
`Platform.update_block_size_for_backend()` and predate #54042.

## Test Plan

CPU-only macOS (Apple Silicon), `main` @ `0cf266a469`, 1556 tests collected.
`HF_HUB_OFFLINE=1` keeps the tokenizer/config lookups on the local cache;
without it, back-to-back full runs can hit HF 429 rate limits in
`test_nixl_desc_geometry`, which is unrelated to this change.

```bash
# before: conftest.py stashed away
HF_HUB_OFFLINE=1 .venv/bin/python -m pytest tests/v1/kv_connector/unit -q -rf -p no:cacheprovider 2>&1 | tee before.log | tail -1
grep -c '^E .*No common block size for 16' before.log

# after: conftest.py in place
HF_HUB_OFFLINE=1 .venv/bin/python -m pytest tests/v1/kv_connector/unit -q -rf -p no:cacheprovider 2>&1 | tee after.log | tail -1
grep -c '^E .*No common block size for 16' after.log

# new failures introduced by the change (expected: none)
comm -13 <(grep '^FAILED' before.log | sed 's/^FAILED //; s/ - .*//' | sort) \
         <(grep '^FAILED' after.log  | sed 's/^FAILED //; s/ - .*//' | sort)
```

## Test Result

| | failed | passed | `No common block size` |
|---|---|---|---|
| before | 91 | 1438 | 81 |
| after | 10 | 1519 | 0 |

- All 10 remaining failures are pre-existing on `main` and unrelated to
  block size (`test_hf3fs_connector` ×4, `test_multi_connector` ×1,
  `test_nixl_connector::test_abort_timeout_on_prefiller` ×2,
  `test_nixl_connector_hma::test_fewer_blocks_with_hma` ×1,
  `test_offloading_connector` ×2). All 10 also fail in `before`.
- No test that passed before fails after.
- GPU lane: the fixture is a no-op when `current_platform.is_cpu()` is false;
  CI will confirm.

---

AI assistance (Claude Code) was used for investigation and drafting; I have
reviewed every line and run all commands above myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTDRbyaiww3yRXs4jwLgQa
