### PR TITLE
[CI] Fix NIXL transfer-rank geometry fixture

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
+++ b/tests/v1/kv_connector/unit/test_nixl_desc_geometry.py
@@ -156,6 +156,8 @@ def test_overlaid_transfer_groups_share_region_geometry():
     worker = object.__new__(NixlConnectorWorker)
     worker.tp_rank = 0
     worker.world_size = 1
+    worker.transfer_tp_rank = 0
+    worker.transfer_tp_size = 1
     worker.block_size = 4
     worker.engine_id = "local-engine"
     worker.use_mla = True


### PR DESCRIPTION
## Summary

- initialize the transfer TP rank and size in the manually constructed NIXL worker fixture
- keep the geometry test aligned with the worker state added by the PCP/DCP transfer-rank change

## Duplicate-work check

This is not duplicating an existing PR. Searches for the exact failing test, NIXL geometry fixture fixes, and NIXL transfer-rank fixes found no open PR addressing this failure.

## Tests

- `.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_desc_geometry.py::test_overlaid_transfer_groups_share_region_geometry -q -x` — 1 passed
- `.venv/bin/pre-commit run --files tests/v1/kv_connector/unit/test_nixl_desc_geometry.py` — passed
- Full geometry suite on the original failing revision with the same patch — 209 passed

## Model evaluation

Not applicable; this only updates a unit-test fixture.

## AI assistance

AI assistance was used to bisect the failure, prepare the fixture update, and run verification. The human submitter must review and understand every changed line before marking this ready for review.
