### PR TITLE
[ROCm] Fuse RMSNorm into MXFP8 activation quant on CDNA4

### DIFF
--- a/tests/compile/passes/test_aiter_rms_mxfp8_quant_fusion.py
+++ b/tests/compile/passes/test_aiter_rms_mxfp8_quant_fusion.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for the MXFP8 patterns registered by
+``RocmAiterRMSNormQuantFusionPass``.
+
+The MXFP8 linear path (``_mxfp8_dot_scaled_linear``) quantizes its activation
+in a separate launch immediately before the ``tl.dot_scaled`` GEMM. AITER's
+fused RMSNorm can emit the same (FP8 E4M3, per-32 E8M0 scale) pair itself, so
+these patterns fold the quant into the norm:
+
+* ``AiterRMSNormMxfp8QuantPattern`` -- ``rms_norm -> mxfp8_quantize``
+* ``AiterFusedAddRMSNormMxfp8QuantPattern`` -- the residual-add shape, which is
+  the one that dominates the DeepSeek-V4.1 decode step
+* ``AiterFusedAddRMSNormMxfp8QuantViewPattern`` -- view-tolerant sibling, for
+  the 2D flatten that ``Mxfp8LinearKernel.apply_weights`` inserts
+
+Requires CDNA4 (gfx950) for native ``dot_scaled`` MX support, and an aiter
+build containing https://github.com/ROCm/aiter/pull/5480 -- without it,
+``add_rmsnorm_quant`` aborts for a group size of 32 at hidden sizes in
+(4096, 6144].
+"""
+
+import pytest
+import torch
+
+import vllm.config
+from tests.compile.backend import TestBackend
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
+from vllm.compilation.passes.utility.post_cleanup import PostCleanupPass
+from vllm.config import (
+    CompilationConfig,
+    CompilationMode,
+    ModelConfig,
+    PassConfig,
+    VllmConfig,
+)
+from vllm.platforms import current_platform
+
+EPS = 1e-5
+# DeepSeek-V4.1-Flash's hidden size, and the reason the aiter fix is needed:
+# it lands in the (4096, 6144] dispatch band.
+HIDDEN_SIZE = 5120
+
+
+class _RMSNormMxfp8Model(torch.nn.Module):
+    """``rms_norm -> mxfp8_quantize``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(HIDDEN_SIZE, dtype=torch.bfloat16))
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # keep the graph input off a matched pattern node
+        x = torch.relu(x)
+        rms = torch.ops.vllm_ir.rms_norm(x, self.weight, EPS)
+        return torch.ops.vllm.mxfp8_quantize.default(rms, False, 0)
+
+
+class _FusedAddRMSNormMxfp8Model(torch.nn.Module):
+    """``fused_add_rms_norm -> mxfp8_quantize``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(HIDDEN_SIZE, dtype=torch.bfloat16))
+
+    def forward(
+        self, x: torch.Tensor, residual: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        x = torch.relu(x)
+        rms, residual_out = torch.ops.vllm_ir.fused_add_rms_norm(
+            x, residual, self.weight, EPS
+        )
+        q, s = torch.ops.vllm.mxfp8_quantize.default(rms, False, 0)
+        return q, residual_out, s
+
+
+class _FusedAddRMSNormMxfp8ViewModel(_FusedAddRMSNormMxfp8Model):
+    """The graph the MXFP8 linear actually produces.
+
+    ``RocmDotScaledMxfp8LinearKernel.apply_weights`` flattens to 2D
+    (``x.reshape(-1, x.shape[-1])``) before quantizing. Hidden states are
+    already 2D, so that reshape is a no-op at runtime, but with a dynamic token
+    dimension it is not provably one and survives into the graph the fusion
+    pass sees.
+    """
+
+    def forward(
+        self, x: torch.Tensor, residual: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        x = torch.relu(x)
+        rms, residual_out = torch.ops.vllm_ir.fused_add_rms_norm(
+            x, residual, self.weight, EPS
+        )
+        rms_2d = rms.reshape(-1, rms.shape[-1])
+        q, s = torch.ops.vllm.mxfp8_quantize.default(rms_2d, False, 0)
+        return q, residual_out, s
+
+
+@pytest.mark.skipif(
+    not current_platform.is_rocm() or not current_platform.supports_mx(),
+    reason="fused MXFP8 norm quant requires CDNA4 (gfx95x)",
+)
+@pytest.mark.parametrize(
+    "model_cls, n_inputs, expect_op",
+    [
+        (_RMSNormMxfp8Model, 1, "get_rmsnorm_mxfp8_quant_op"),
+        (_FusedAddRMSNormMxfp8Model, 2, "get_rmsnorm_with_add_mxfp8_quant_op"),
+        (_FusedAddRMSNormMxfp8ViewModel, 2, "get_rmsnorm_with_add_mxfp8_quant_op"),
+    ],
+    ids=["rms_norm", "fused_add_rms_norm", "fused_add_rms_norm_view"],
+)
+def test_aiter_rms_mxfp8_quant_fusion(
+    model_cls: type[torch.nn.Module],
+    n_inputs: int,
+    expect_op: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The norm + MXFP8 quant pair must collapse into one AITER op, and the
+    fused result must agree with the unfused pair."""
+    torch._dynamo.reset()
+
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(dtype=torch.bfloat16),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            custom_ops=["+rms_norm"],
+            pass_config=PassConfig(
+                fuse_norm_quant=True,
+                eliminate_noops=True,
+            ),
+        ),
+    )
+
+    with vllm.config.set_current_vllm_config(vllm_config), monkeypatch.context() as m:
+        from vllm.compilation.passes.fusion.rocm_aiter_fusion import (
+            RocmAiterRMSNormQuantFusionPass,
+        )
+
+        torch.set_default_device("cuda")
+        torch.set_default_dtype(torch.bfloat16)
+        torch.manual_seed(0)
+
+        m.setenv("VLLM_ROCM_USE_AITER", "1")
+        rocm_aiter_ops.refresh_env_variables()
+
+        fusion_pass = RocmAiterRMSNormQuantFusionPass(vllm_config)
+        backend = TestBackend(
+            NoOpEliminationPass(vllm_config),
+            fusion_pass,
+            PostCleanupPass(vllm_config),
+        )
+        model = model_cls()
+
+        args = [torch.randn(8, HIDDEN_SIZE) * 0.5 for _ in range(n_inputs)]
+        torch._dynamo.mark_dynamic(args[0], 0)
+
+        # both norms write their residual in place, so each call needs its own
+        outputs_unfused = model(*[a.clone() for a in args])
+        outputs_fused = torch.compile(model, backend=backend)(
+            *[a.clone() for a in args]
+        )
+
+        assert fusion_pass.matched_count == 1, (
+            f"Expected {model_cls.__name__} to fuse into the AITER MXFP8 norm "
+            f"op (matched_count == 1), got {fusion_pass.matched_count}"
+        )
+        backend.check_after_ops([getattr(rocm_aiter_ops, expect_op)()])
+        # the standalone quant launch must be gone, not merely reduced
+        backend.check_before_ops([torch.ops.vllm.mxfp8_quantize.default])
+
+        # AITER and vLLM break ties differently when rounding a block amax to
+        # its E8M0 scale, so a few blocks out of a thousand land one power of
+        # two apart and no elementwise tolerance holds. What has to be true is
+        # that the fused kernel is no less faithful than the quant it replaces,
+        # so compare both against an fp32 reference of the same math.
+        ref = torch.relu(args[0]).float()
+        if n_inputs == 2:
+            ref = ref + args[1].float()
+        ref = (
+            ref
+            * torch.rsqrt(ref.pow(2).mean(-1, keepdim=True) + EPS)
+            * model.weight.float()
+        )
+
+        def rel_l1(q: torch.Tensor, s: torch.Tensor) -> float:
+            scales = torch.exp2(s.float() - 127.0)[:, :, None]
+            deq = (q.float().view(q.shape[0], -1, 32) * scales).view(q.shape)
+            return ((deq - ref).abs().sum() / ref.abs().sum()).item()
+
+        err_fused = rel_l1(outputs_fused[0], outputs_fused[-1])
+        err_unfused = rel_l1(outputs_unfused[0], outputs_unfused[-1])
+
+        # E4M3 with a shared per-32 exponent lands near 2%; the absolute bound
+        # keeps a degenerate output (e.g. all-zero scales) from passing the
+        # relative check below.
+        assert err_fused < 0.05, f"fused MXFP8 error too large: {err_fused}"
+        assert err_fused <= err_unfused * 1.05, (
+            f"fused MXFP8 quant is less accurate than the unfused pair: "
+            f"{err_fused} vs {err_unfused}"
+        )
+
+        if n_inputs == 2:
+            torch.testing.assert_close(outputs_fused[1], outputs_unfused[1])

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -11,6 +11,11 @@ from torch._ops import OpOverload
 
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    MXFP8_BLOCK_SIZE,
+    MXFP8_SCALE_DTYPE,
+    MXFP8_VALUE_DTYPE,
+)
 from vllm.platforms import current_platform
 from vllm.utils.import_utils import PlaceholderModule
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -1245,6 +1250,84 @@ def _rocm_aiter_rmsnorm_fp8_group_quant_fake(
     )
 
 
+def _rocm_aiter_rmsnorm_mxfp8_quant_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    variance_epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    import aiter as rocm_aiter
+
+    M, N = x.shape
+    out = torch.empty((M, N), dtype=MXFP8_VALUE_DTYPE, device=x.device)
+    # A 1-byte scale is what routes aiter's dispatch to the E8M0 block-scale
+    # path; a float32 scale would be interpreted as per-token instead.
+    scale = torch.empty(
+        (M, N // MXFP8_BLOCK_SIZE), dtype=MXFP8_SCALE_DTYPE, device=x.device
+    )
+    rocm_aiter.rmsnorm_quant(
+        out, x, scale, weight, variance_epsilon, MXFP8_BLOCK_SIZE, False
+    )
+    return out, scale
+
+
+def _rocm_aiter_rmsnorm_mxfp8_quant_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    variance_epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    M, N = x.shape
+    return (
+        torch.empty((M, N), dtype=MXFP8_VALUE_DTYPE, device=x.device),
+        torch.empty(
+            (M, N // MXFP8_BLOCK_SIZE), dtype=MXFP8_SCALE_DTYPE, device=x.device
+        ),
+    )
+
+
+def _rocm_aiter_rmsnorm_with_add_mxfp8_quant_impl(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    variance_epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    import aiter as rocm_aiter
+
+    M, N = x.shape
+    out = torch.empty((M, N), dtype=MXFP8_VALUE_DTYPE, device=x.device)
+    scale = torch.empty(
+        (M, N // MXFP8_BLOCK_SIZE), dtype=MXFP8_SCALE_DTYPE, device=x.device
+    )
+    residual_out = torch.empty_like(residual)
+    rocm_aiter.add_rmsnorm_quant(
+        out,
+        x,
+        residual,
+        residual_out,
+        scale,
+        weight,
+        variance_epsilon,
+        MXFP8_BLOCK_SIZE,
+        False,
+    )
+    return out, residual_out, scale
+
+
+def _rocm_aiter_rmsnorm_with_add_mxfp8_quant_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    variance_epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    M, N = x.shape
+    return (
+        torch.empty((M, N), dtype=MXFP8_VALUE_DTYPE, device=x.device),
+        torch.empty_like(residual),
+        torch.empty(
+            (M, N // MXFP8_BLOCK_SIZE), dtype=MXFP8_SCALE_DTYPE, device=x.device
+        ),
+    )
+
+
 def _rocm_aiter_fused_rms_gated_fp8_group_quant_impl(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -1896,6 +1979,17 @@ class rocm_aiter_ops:
 
     @classmethod
     @if_aiter_supported
+    def is_mxfp8_norm_fusion_enabled(cls) -> bool:
+        """Whether the norm can emit MXFP8 directly for the MX GEMM to consume.
+
+        Needs CDNA4, where ``tl.dot_scaled`` takes the E8M0 block scales
+        natively; on other archs the MXFP8 linear falls through to the BF16
+        emulation path and never emits a quant op to fuse with.
+        """
+        return cls._AITER_ENABLED and current_platform.supports_mx()
+
+    @classmethod
+    @if_aiter_supported
     def is_linear_fp8_enabled(cls) -> bool:
         return cls.is_linear_enabled()
 
@@ -2282,6 +2376,20 @@ class rocm_aiter_ops:
             )
 
             direct_register_custom_op(
+                op_name="rocm_aiter_rmsnorm_mxfp8_quant",
+                op_func=_rocm_aiter_rmsnorm_mxfp8_quant_impl,
+                fake_impl=_rocm_aiter_rmsnorm_mxfp8_quant_fake,
+                dispatch_key=current_platform.dispatch_key,
+            )
+
+            direct_register_custom_op(
+                op_name="rocm_aiter_rmsnorm_with_add_mxfp8_quant",
+                op_func=_rocm_aiter_rmsnorm_with_add_mxfp8_quant_impl,
+                fake_impl=_rocm_aiter_rmsnorm_with_add_mxfp8_quant_fake,
+                dispatch_key=current_platform.dispatch_key,
+            )
+
+            direct_register_custom_op(
                 op_name="rocm_aiter_fused_rms_gated_fp8_group_quant",
                 op_func=_rocm_aiter_fused_rms_gated_fp8_group_quant_impl,
                 fake_impl=_rocm_aiter_fused_rms_gated_fp8_group_quant_fake,
@@ -2409,6 +2517,16 @@ class rocm_aiter_ops:
     @staticmethod
     def get_rmsnorm_group_fused_quant_op() -> OpOverload:
         return torch.ops.vllm.rocm_aiter_rmsnorm_fp8_group_quant.default
+
+    @staticmethod
+    def get_rmsnorm_mxfp8_quant_op() -> OpOverload:
+        """Return the fused RMSNorm + MXFP8 (block-32 E8M0) quant custom op."""
+        return torch.ops.vllm.rocm_aiter_rmsnorm_mxfp8_quant.default
+
+    @staticmethod
+    def get_rmsnorm_with_add_mxfp8_quant_op() -> OpOverload:
+        """Fused residual-add RMSNorm + MXFP8 (block-32 E8M0) quant custom op."""
+        return torch.ops.vllm.rocm_aiter_rmsnorm_with_add_mxfp8_quant.default
 
     @staticmethod
     def get_fused_rms_gated_fp8_group_quant_op() -> OpOverload:

--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -11,6 +11,7 @@ from torch._inductor.pattern_matcher import PatternMatcherPass
 
 import vllm.ir.ops
 import vllm.model_executor.layers.quantization.utils.fp8_utils  # noqa: F401
+import vllm.model_executor.layers.quantization.utils.mxfp8_utils  # noqa: F401
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.logger import init_logger
@@ -543,6 +544,104 @@ class AiterRMSNormGatedFp8GroupQuantPattern(AiterRMSNormQuantPattern):
         )
 
 
+class AiterRMSNormMxfp8QuantPattern:
+    """Fuse ``rms_norm`` + MXFP8 activation quant into one AITER kernel.
+
+    The MXFP8 linear path quantizes its activation in a separate launch right
+    before the ``tl.dot_scaled`` GEMM (``_mxfp8_dot_scaled_linear``), and the
+    trace shows that pair adjacent every time it appears. AITER's fused norm
+    can emit the same (FP8 E4M3, per-32 E8M0 scale) pair directly, so the
+    standalone quant launch is removable rather than merely cheap.
+
+    Unlike the FP8 siblings above there is no ``MatcherQuantFP8`` to reuse:
+    MXFP8 quant is a single custom op, so the pattern calls it directly.
+    """
+
+    FUSED_OP = rocm_aiter_ops.get_rmsnorm_mxfp8_quant_op()
+    QUANT_OP = torch.ops.vllm.mxfp8_quantize.default
+
+    def __init__(self, epsilon: float) -> None:
+        self.epsilon = epsilon
+        self.device = torch.device("cuda")
+
+    def empty(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        return torch.empty(*args, dtype=torch.bfloat16, device=self.device, **kwargs)
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            result_rms = torch.ops.vllm_ir.rms_norm(input, weight, self.epsilon)
+            result, scale = self.QUANT_OP(result_rms, False, 0)
+            return result, scale
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            at = self.FUSED_OP(
+                x=input,
+                weight=weight,
+                variance_epsilon=self.epsilon,
+            )
+            return at[0], at[1]
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            # hidden dim must be a multiple of the 32-element MX block
+            [self.empty(5, 64), self.empty(64)],
+            pm.fwd_only,
+            pm_pass,
+        )
+
+
+class AiterFusedAddRMSNormMxfp8QuantPattern(AiterRMSNormMxfp8QuantPattern):
+    """Residual-add sibling of :class:`AiterRMSNormMxfp8QuantPattern`.
+
+    This is the shape that actually dominates the DeepSeek-V4.1 decode step:
+    ``aiter::add_rmsnorm_quant_kernel`` immediately precedes the MXFP8 quant
+    for the majority of its occurrences.
+    """
+
+    FUSED_OP = rocm_aiter_ops.get_rmsnorm_with_add_mxfp8_quant_op()
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            residual: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            result_rms, residual_out = torch.ops.vllm_ir.fused_add_rms_norm(
+                input, residual, weight, self.epsilon
+            )
+            result, scale = self.QUANT_OP(result_rms, False, 0)
+            return result, residual_out, scale
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            residual: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            at = self.FUSED_OP(
+                x=input,
+                residual=residual,
+                weight=weight,
+                variance_epsilon=self.epsilon,
+            )
+            # result, residual, scale
+            return at[0], at[1], at[2]
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            [self.empty(5, 64), self.empty(64), self.empty(5, 64)],
+            pm.fwd_only,
+            pm_pass,
+        )
+
+
 class RocmAiterRMSNormQuantFusionPass(VllmPatternMatcherPass):
     """
     This pass fuses aiter rms_norm & vllm/aiter quant custom ops
@@ -613,6 +712,14 @@ class RocmAiterRMSNormQuantFusionPass(VllmPatternMatcherPass):
                 epsilon, FP8_DTYPE, GroupShape(1, 128), match_aiter_quant_op
             ).register(self.patterns)
 
+            # Fuse (fused_add_)rms_norm + MXFP8 activation quant, so the MX
+            # GEMM consumes the norm's block scales instead of re-quantizing.
+            # Register the fused-add variant before the plain one, for the
+            # same reason as the FP8 patterns above.
+            if rocm_aiter_ops.is_mxfp8_norm_fusion_enabled():
+                AiterFusedAddRMSNormMxfp8QuantPattern(epsilon).register(self.patterns)
+                AiterRMSNormMxfp8QuantPattern(epsilon).register(self.patterns)
+
             # When quant_fp8 custom ops are disabled, both AITER and native
             # quant matchers trace through QuantFP8's native implementation.
             # Registering both variants would create duplicate Inductor
@@ -676,6 +783,8 @@ class RocmAiterRMSNormQuantFusionPass(VllmPatternMatcherPass):
             DoubleAiterRMSFp8GroupQuantPattern,
             DoubleAiterRMSFp8GroupQuantViewPattern,
             AiterRMSNormGatedFp8GroupQuantPattern,
+            AiterRMSNormMxfp8QuantPattern,
+            AiterFusedAddRMSNormMxfp8QuantPattern,
         ]
         return self.hash_source(self, *fusion_patterns)
 


### PR DESCRIPTION
## Purpose

DeepSeek-V4.1-Flash quantizes every dense-linear activation to MXFP8 in a standalone kernel launch immediately before the `tl.dot_scaled` GEMM. Profiling a decode step on MI355X (gfx950) shows **187–198 of these quant/GEMM pairs per step, adjacent 100% of the time**, and the producer feeding the quant is almost always AITER's `add_rmsnorm`.

AITER's `add_rmsnorm_quant` / `rmsnorm_quant` already emit exactly the `(FP8 E4M3 value, per-32 E8M0 uint8 scale)` pair that `dot_scaled` consumes. So the quant launch can be **deleted outright** rather than merely made cheaper — no new kernel, no redundant work.

This PR adds the two custom ops plus the `torch.compile` patterns that rewrite

```
(fused_add_)rms_norm -> mxfp8_quantize
```

into the single fused AITER kernel.

## Why not fuse into the GEMM prologue

The obvious alternative — quantize in-register in the GEMM prologue — was implemented and measured first, and **rejected**: it came in at **0.28–0.89x** versus baseline. Triton's lowering of the reshape+reduce on gfx950 adds ~26 µs to a 12 µs GEMM in order to save a 4.4 µs launch. Producer-side fusion avoids that entirely because the norm already has the values resident.

## Results

Measured on the norm+quant pair at hidden 5120, amortizing over 64 copies per graph replay to get above the ~11 µs graph-dispatch floor:

| | latency | speedup |
|---|---|---|
| `add_rmsnorm` + separate MXFP8 quant | baseline | 1.00x |
| `add_rmsnorm_quant` (fused) | 2.2–4.1 µs saved per occurrence | **1.49–1.77x** |

At ~190 occurrences per decode step this is ~1% of step time.

## Dependency

**Requires https://github.com/ROCm/aiter/pull/5480** (merged). Without it, `add_rmsnorm_quant` aborts with `group_size not support: 32` for hidden sizes in `(4096, 6144]`, because those map to `thread_data_size=24` and `32 % 24 != 0` — and 5120 is exactly this model's hidden size. That PR extends the dispatch to route non-multiples of 24 in that band to the `(512,16)`/`(1024,8)` configs, mirroring logic the `n <= 8192` branch already had.

Gating is capability-based (`is_mxfp8_norm_fusion_enabled()` = aiter enabled + `supports_mx()`), with no new env var, since this is strictly a win wherever it applies. On non-CDNA4 the MXFP8 linear falls through to BF16 emulation and never emits a quant op to fuse with, so the patterns are not registered there.

## Test Plan

`tests/compile/passes/test_aiter_rms_mxfp8_quant_fusion.py` covers three graph shapes:

- `rms_norm -> mxfp8_quantize`
- `fused_add_rms_norm -> mxfp8_quantize` (the shape that dominates the decode step)
- the same with the 2D flatten that `RocmDotScaledMxfp8LinearKernel.apply_weights` inserts

Each asserts the pass matched exactly once, that the fused op is present after the pass, and that `mxfp8_quantize` is **fully** eliminated (`check_before_ops`).

On numerics: AITER and vLLM break ties differently when rounding a block amax to its E8M0 scale, so a few blocks per thousand land one power of two apart and no elementwise tolerance holds. The test instead asserts the fused kernel is **no less faithful** than the quant it replaces, comparing both against an fp32 reference of the same math (fused 0.0224 vs unfused 0.0225 relative L1; fused is marginally better). The residual output is bit-exact.

## Test Result

```
tests/compile/passes/test_aiter_rms_mxfp8_quant_fusion.py ... 3 passed
tests/compile/passes/test_double_aiter_rms_quant_fusion.py .. 3 passed, 2 skipped
```

Also verified on the real graph — vLLM's own `RMSNorm` module plus the actual `_mxfp8_dot_scaled_linear`, compiled through the full `PostGradPassManager` rather than the fusion pass alone:

```
mxfp8_quantize   before=1 after=0
fused norm+quant before=0 after=1
GEMM output rel_l1 fused vs unfused: 0.01702
residual bitexact: True
```

Context: this is item 7.2 of RFC #56506.
