### PR TITLE
fix(bench): use half-open intervals for peak concurrency

### DIFF
--- a/tests/benchmarks/test_serve_metrics.py
+++ b/tests/benchmarks/test_serve_metrics.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only regression tests for ``bench serve`` metric aggregation."""
+
+from vllm.benchmarks.lib.endpoint_request_func import RequestFuncOutput
+from vllm.benchmarks.serve import calculate_metrics
+
+
+def _successful_output(start_time: float, latency: float) -> RequestFuncOutput:
+    return RequestFuncOutput(
+        success=True,
+        start_time=start_time,
+        latency=latency,
+        output_tokens=1,
+        prompt_len=1,
+    )
+
+
+def _peak_concurrency(outputs: list[RequestFuncOutput]) -> int:
+    metrics, _ = calculate_metrics(
+        input_requests=[],
+        outputs=outputs,
+        dur_s=2.0,
+        tokenizer=None,
+        selected_percentiles=[],
+        goodput_config_dict={},
+    )
+    return metrics.max_concurrent_requests
+
+
+def test_calculate_metrics_does_not_count_adjacent_requests_as_concurrent() -> None:
+    outputs = [
+        _successful_output(start_time=0.0, latency=1.0),
+        _successful_output(start_time=1.0, latency=1.0),
+    ]
+
+    assert _peak_concurrency(outputs) == 1
+
+
+def test_calculate_metrics_counts_overlapping_requests_as_concurrent() -> None:
+    outputs = [
+        _successful_output(start_time=0.0, latency=1.5),
+        _successful_output(start_time=1.0, latency=1.0),
+    ]
+
+    assert _peak_concurrency(outputs) == 2

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -697,13 +697,14 @@ def calculate_metrics(
                 if 0 <= second_bucket < duration_seconds:
                     tokens_per_second[second_bucket] += 1
 
-            # Track concurrent requests for each second this request was active
+            # Use half-open intervals so a request ending at a bucket boundary
+            # does not overlap with one starting at that same boundary.
             request_start_second = int(output.start_time - min_start_time)
             request_end_second = int(
-                (output.start_time + output.latency) - min_start_time
+                np.ceil(output.start_time + output.latency - min_start_time)
             )
 
-            for second in range(request_start_second, request_end_second + 1):
+            for second in range(request_start_second, request_end_second):
                 concurrent_requests_per_second[second] += 1
 
         # Find the maximum tokens per second and corresponding


### PR DESCRIPTION
## Purpose

Fixes #56653.

Fix the `vllm bench serve` peak-concurrency bucket calculation reported in #56653.

`calculate_metrics()` currently increments an inclusive integer-second range. If one request ends exactly on a second boundary and another starts at that same boundary, non-overlapping requests can be counted in the same bucket. This change uses half-open per-second occupancy (`[start, end)`), so boundary-touching requests are not counted as concurrent while genuine overlap remains counted.

This is scoped separately from #37666, which concerns output-throughput inconsistency rather than peak-concurrency aggregation.

## Test plan

- [ ] `uv venv --python 3.12`
- [ ] `uv pip install -r requirements/test/cuda.in`
- [ ] `.venv/bin/python -m pytest tests/benchmarks/test_serve_metrics.py -v`
- [x] `git diff --check`
- [ ] Repository formatting and lint checks in a supported vLLM environment

The unit tests cover:
- adjacent `[0, 1)` and `[1, 2)` requests -> peak `1`
- overlapping `[0, 1.5)` and `[1, 2)` requests -> peak `2`

## Test result

`git diff --check` passed. The full pytest suite is pending in a supported vLLM development environment; the current Windows checkout is intentionally sparse and does not contain the complete test dependencies. No live model or Ray service was changed.

No model evaluation is required; this is a benchmark metric-only change.

## AI assistance disclosure

The candidate was prepared with AI assistance. The author reviewed the changed lines, source semantics, tests, and validation boundary before submission.