### PR TITLE
[Bugfix] Skip Triton autotune inspection without Triton

### DIFF
--- a/tests/model_executor/test_jit_warmup_triton_launcher.py
+++ b/tests/model_executor/test_jit_warmup_triton_launcher.py
@@ -206,6 +206,26 @@ def test_triton_kernel_decorator_returns_launcher(
         launch(first, 1, 7, stale_constexpr=True)
 
 
+def test_triton_kernel_decorator_without_triton(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(jit_warmup_triton_helper, "HAS_TRITON", False)
+    monkeypatch.setattr(jit_warmup_triton_helper, "triton", object())
+    kernel = _FakeTritonKernel()
+
+    def warmup_inputs() -> dict[str, Any]:
+        return dict(first="warmup", second=1)
+
+    @triton_kernel_dispatcher_with_warmup(kernel=kernel, warmup_inputs=warmup_inputs)
+    def launch(first: str, second: int) -> LaunchSpec:
+        return (2,), dict(CONST=7)
+
+    launch("runtime", 2)
+    assert kernel.runtime_calls == [
+        ((2,), (), {"first": "runtime", "second": 2, "CONST": 7})
+    ]
+
+
 def test_triton_kernel_decorator_exhausts_large_ranges_before_deduplication(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/vllm/model_executor/warmup/jit_warmup_triton_helper.py
+++ b/vllm/model_executor/warmup/jit_warmup_triton_helper.py
@@ -15,7 +15,7 @@ from vllm.model_executor.warmup.jit_warmup import (
     get_function_source_node,
 )
 from vllm.platforms import current_platform
-from vllm.triton_utils import triton
+from vllm.triton_utils import HAS_TRITON, triton
 
 CompileKeyT = TypeVar("CompileKeyT")
 P = ParamSpec("P")
@@ -428,6 +428,8 @@ class _AutomaticTritonJitKernel(VllmTritonJitKernel[TritonCompileKey]):
 
 
 def _is_autotuned(kernel: Any) -> bool:
+    if not HAS_TRITON:
+        return False
     Autotuner = triton.runtime.autotuner.Autotuner
 
     while kernel is not None:


### PR DESCRIPTION
## Summary

Nightly main build #88612 exposed deterministic import failures in Arm CPU test shards 2 and 3. The CPU image correctly disables Triton and installs `TritonPlaceholder`, but importing `vllm.v1.spec_decode.utils` constructs a warmup dispatcher whose autotune check unconditionally dereferences `triton.runtime`.

This change returns `False` before Triton autotune inspection when `HAS_TRITON` is false. Runtime dispatch behavior is unchanged, and a regression test replaces the Triton object with a runtime-less placeholder before constructing and invoking the dispatcher.

Evidence:

- https://buildkite.com/vllm/ci/builds/88612#01a0995b-7d09-414a-9448-99777c1de60e
- https://buildkite.com/vllm/ci/builds/88612#01a0995b-7d0a-44d9-831b-87282c91863a

Both fail at `jit_warmup_triton_helper.py:_is_autotuned` with `AttributeError: module 'triton' has no attribute 'runtime'`. PR #56323 introduced the decorator, but its PR build #88574 did not select either Arm CPU shard.

## Validation

- `pytest -q tests/model_executor/test_jit_warmup_triton_launcher.py -k without_triton` — 1 passed
- CPU/no-active-Triton import smoke: `import vllm.v1.spec_decode.utils` — passed
- Applicable pre-commit hooks, including ruff and mypy — passed
- `git diff --check` — passed

The full launcher unit file includes CUDA/Triton-specific cases unavailable in the local CPU-only environment. Exact Arm CPU CI remains required.

## AI assistance

AI-assisted. This draft requires maintainer review before promotion.
