### PR TITLE
[CI] Select the supported DCP backend for PCP eval

### DIFF
--- a/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP1-PCP4-DCP4-EP.yaml
+++ b/tests/evals/gsm8k/configs/GLM-5.2-NVFP4-TP1-PCP4-DCP4-EP.yaml
@@ -11,6 +11,7 @@ server_args: >-
   --moe-backend flashinfer_cutlass
   --prefill-context-parallel-size 4
   --decode-context-parallel-size 4
+  --dcp-comm-backend ag_rs
   --enable-expert-parallel
   --kv-cache-dtype fp8
 env:


### PR DESCRIPTION
## Summary

The new GLM-5.2 PCP+DCP evaluation config added by PR #56157 requests DCP4 but leaves `dcp_comm_backend` at its default `a2a`. The same PR added an explicit runtime requirement that MRV2 PCP+DCP use `ag_rs`, so nightly main #88612 deterministically rejected all four workers during startup.

Set the config's `--dcp-comm-backend ag_rs` explicitly.

Evidence:

- https://buildkite.com/vllm/ci/builds/88612#01a0995b-7d98-4db4-8647-8bcabd2a7ab1
- Failure: `NotImplementedError: MRV2 PCP + DCP requires dcp_comm_backend='ag_rs'; got 'a2a'.`
- PR #56157 build #88566 did not select the exact optional B200 LM Eval PCP job.

## Validation

- YAML + shell-argument parse asserted `--dcp-comm-backend ag_rs` — passed
- Applicable pre-commit hooks — passed
- `git diff --check` — passed

No B200 is available locally. Exact validation should target the new `GLM-5.2-NVFP4-TP1-PCP4-DCP4-EP` config. The aggregate lane also contains the pre-existing TP2/PCP2 memory-headroom failure owned by PR #55879; this one-line fix intentionally does not modify that sibling config.

## AI assistance

AI-assisted. This draft requires maintainer review before promotion.
