### PR TITLE
[Security] Validate cache_salt length and charset before engine hashing

### DIFF
--- a/rust/src/text/src/error.rs
+++ b/rust/src/text/src/error.rs
@@ -46,6 +46,8 @@ pub enum Error {
     TruncateUnsupportedWithMultimodal,
     #[error("invalid repetition detection params: {message}")]
     InvalidRepetitionDetection { message: String },
+    #[error("{message}")]
+    InvalidCacheSalt { message: &'static str },
     #[error("text request stream `{request_id}` closed before terminal output")]
     StreamClosedBeforeTerminalOutput { request_id: String },
     #[error(transparent)]
@@ -72,6 +74,7 @@ impl Error {
             | Self::InvalidTruncatePromptTokens { .. }
             | Self::TruncateUnsupportedWithMultimodal
             | Self::InvalidRepetitionDetection { .. }
+            | Self::InvalidCacheSalt { .. }
             // An empty tokenized prompt detected later, at request prepare
             // time, surfaces through the transparent Llm wrapper.
             | Self::Llm(LlmError::EmptyPromptTokenIds { .. })

--- a/rust/src/text/src/lower.rs
+++ b/rust/src/text/src/lower.rs
@@ -41,6 +41,7 @@ pub fn lower_text_request(
 ) -> Result<PreparedTextRequest> {
     let prompt_len = prompt_token_ids.len() as u32;
     validate_prompt_token_ids(&prompt_token_ids, &sampling_limits)?;
+    validate_cache_salt(request.cache_salt.as_deref())?;
 
     let generate_request = GenerateRequest {
         request_id: request.request_id.clone(),
@@ -298,6 +299,31 @@ pub fn resolve_max_tokens(
 
     let request_max_tokens = user_max_tokens.or(default_max_tokens);
     Ok(request_max_tokens.map_or(model_max_tokens, |n| n.min(model_max_tokens)))
+}
+
+const MAX_CACHE_SALT_CHARS: usize = 128;
+const CACHE_SALT_EMPTY_MESSAGE: &str =
+    "Parameter 'cache_salt' must be a non-empty string if provided.";
+const CACHE_SALT_INVALID_MESSAGE: &str = "Parameter 'cache_salt' must be at most 128 characters and must \
+     not contain '@', '/', '\\\\', or NUL.";
+
+/// Mirror Python `validate_cache_salt`: at most 128 characters, and no
+/// `@`, `/`, `\`, or NUL. `None` (omitted salt) is allowed.
+fn validate_cache_salt(cache_salt: Option<&str>) -> Result<()> {
+    let Some(salt) = cache_salt else {
+        return Ok(());
+    };
+    if salt.is_empty() {
+        return Err(Error::InvalidCacheSalt {
+            message: CACHE_SALT_EMPTY_MESSAGE,
+        });
+    }
+    if salt.chars().count() > MAX_CACHE_SALT_CHARS || salt.contains(['@', '/', '\\', '\0']) {
+        return Err(Error::InvalidCacheSalt {
+            message: CACHE_SALT_INVALID_MESSAGE,
+        });
+    }
+    Ok(())
 }
 
 fn merge_unique_token_ids(
@@ -1329,6 +1355,60 @@ mod tests {
         .unwrap();
 
         assert_eq!(prepared.generate_request.arrival_time, None);
+    }
+
+    fn lower_with_cache_salt(cache_salt: Option<String>) -> Result<PreparedTextRequest> {
+        let request = TextRequest {
+            cache_salt,
+            ..sample_request()
+        };
+        lower_text_request(
+            request,
+            vec![1, 2, 3],
+            sample_sampling_hints(),
+            sample_sampling_limits(),
+            &stub_tokenizer(),
+        )
+    }
+
+    #[test]
+    fn lower_text_request_accepts_omitted_and_valid_cache_salt() {
+        let omitted = lower_with_cache_salt(None).unwrap();
+        assert_eq!(omitted.generate_request.cache_salt, None);
+
+        let expected = "a".repeat(128);
+        let valid = lower_with_cache_salt(Some(expected.clone())).unwrap();
+        assert_eq!(
+            valid.generate_request.cache_salt.as_deref(),
+            Some(expected.as_str())
+        );
+    }
+
+    #[test]
+    fn lower_text_request_rejects_empty_cache_salt() {
+        let err = lower_with_cache_salt(Some(String::new())).unwrap_err();
+        assert!(err.is_request_validation_error());
+        assert!(err.to_string().contains("non-empty string"));
+    }
+
+    #[test]
+    fn lower_text_request_rejects_oversized_cache_salt() {
+        let err = lower_with_cache_salt(Some("B".repeat(129))).unwrap_err();
+        assert!(err.is_request_validation_error());
+        assert!(err.to_string().contains("at most 128 characters"));
+        assert!(lower_with_cache_salt(Some("B".repeat(1024 * 1024))).is_err());
+    }
+
+    #[test]
+    fn lower_text_request_rejects_forbidden_cache_salt_characters() {
+        for salt in ["tenant@victim", "../../etc/passwd", r"..\..\secret", "a\0b"] {
+            let err = lower_with_cache_salt(Some(salt.to_string())).unwrap_err();
+            assert!(err.is_request_validation_error(), "{salt:?}");
+            assert!(
+                err.to_string().contains("must not contain"),
+                "{salt:?}: {err}"
+            );
+        }
     }
 
     #[test]

--- a/tests/v1/test_request.py
+++ b/tests/v1/test_request.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
+
 from vllm import SamplingParams
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.request import Request, RequestStatus
@@ -40,3 +42,51 @@ def test_request_copies_session_id_from_engine_core_request():
     request = Request.from_engine_core_request(engine_request, block_hasher=None)
 
     assert request.session_id == "session-1"
+
+
+def _engine_request_with_salt(cache_salt: str | None) -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id="request-1",
+        prompt_token_ids=[1, 2, 3],
+        mm_features=None,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        arrival_time=0.0,
+        lora_request=None,
+        cache_salt=cache_salt,
+        data_parallel_rank=None,
+    )
+
+
+def test_request_accepts_omitted_and_valid_cache_salt():
+    omitted = Request.from_engine_core_request(
+        _engine_request_with_salt(None), block_hasher=None
+    )
+    assert omitted.cache_salt is None
+
+    valid = Request.from_engine_core_request(
+        _engine_request_with_salt("a" * 128), block_hasher=None
+    )
+    assert valid.cache_salt == "a" * 128
+
+
+def test_request_rejects_empty_cache_salt():
+    with pytest.raises(ValueError, match="non-empty string"):
+        Request.from_engine_core_request(
+            _engine_request_with_salt(""), block_hasher=None
+        )
+
+
+def test_request_rejects_oversized_cache_salt():
+    with pytest.raises(ValueError, match="at most 128 characters"):
+        Request.from_engine_core_request(
+            _engine_request_with_salt("B" * 129), block_hasher=None
+        )
+
+
+@pytest.mark.parametrize("cache_salt", ["tenant@victim", "../../x", r"..\x", "a\0b"])
+def test_request_rejects_forbidden_cache_salt_characters(cache_salt: str):
+    with pytest.raises(ValueError, match="must not contain"):
+        Request.from_engine_core_request(
+            _engine_request_with_salt(cache_salt), block_hasher=None
+        )

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -24,6 +24,27 @@ from vllm.v1.metrics.stats import PrefillStats, RequestSpecDecodeMetrics
 from vllm.v1.structured_output.request import StructuredOutputRequest
 from vllm.v1.utils import ConstantList
 
+_CACHE_SALT_FORBIDDEN_CHARS = frozenset("@/\\\x00")
+_MAX_CACHE_SALT_LENGTH = 128
+
+
+def _validate_cache_salt(cache_salt: str | None) -> str | None:
+    """Reject empty, oversized, or separator-bearing cache salts."""
+    if cache_salt is None:
+        return None
+    if (
+        not isinstance(cache_salt, str)
+        or not cache_salt
+        or len(cache_salt) > _MAX_CACHE_SALT_LENGTH
+        or any(char in _CACHE_SALT_FORBIDDEN_CHARS for char in cache_salt)
+    ):
+        raise ValueError(
+            "cache_salt must be a non-empty string of at most 128 "
+            "characters and must not contain '@', '/', '\\\\', or NUL."
+        )
+    return cache_salt
+
+
 if TYPE_CHECKING:
     from vllm.lora.request import LoRARequest
     from vllm.v1.core.kv_cache_utils import BlockHash
@@ -180,7 +201,7 @@ class Request:
 
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
-        self.cache_salt: str | None = cache_salt
+        self.cache_salt: str | None = _validate_cache_salt(cache_salt)
 
         # Multi-modal related
         self.mm_features = mm_features or []


### PR DESCRIPTION
## Summary
The Python serving layer already rejects `cache_salt` values longer than 128 characters or containing `@`, `/`, `\`, or NUL. The Rust frontend only required a non-empty string on some routes and forwarded the rest unchanged into EngineCore, where the salt is hashed on the scheduler thread. This change applies the same length and charset checks when lowering a Rust text request, and repeats them when constructing an engine `Request` so other frontends cannot skip the bound.

## Changes
- `rust/src/text/src/lower.rs`: reject empty, oversized, and separator-bearing `cache_salt` before building the engine request.
- `rust/src/text/src/error.rs`: map that failure to a request-validation error (HTTP 400 / gRPC invalid argument).
- `vllm/v1/request.py`: apply the same checks at engine admission.

## Codepath coverage
- Rust `/v1/chat/completions`, `/v1/completions`, `/v1/generate`, gRPC Generate/GenerateStream, and render-then-generate all go through `lower_text_request`.
- Python OpenAI/pooling/scale-out protocols already call `validate_cache_salt`; engine admission now covers ZMQ/custom frontends and Anthropic (charset was previously only bounded by `max_length=1024`).
- `/invocations` uses the Python serving stack and remains covered by the existing protocol validators plus engine admission.

## Duplicate-work check
Searched open and merged PRs for `cache_salt`, `validate_cache_salt`, and Rust frontend salt validation. Merged #51444 and #54353 add the Python-side checks only. Merged #53218 rejects empty Rust `cache_salt` but not length or charset. Open #56199 is pooling empty-string on Python. No open PR closes this sink.

## Tests
- `lower_text_request_accepts_omitted_and_valid_cache_salt`
- `lower_text_request_rejects_empty_cache_salt`
- `lower_text_request_rejects_oversized_cache_salt`
- `lower_text_request_rejects_forbidden_cache_salt_characters`
- `test_request_accepts_omitted_and_valid_cache_salt`
- `test_request_rejects_empty_cache_salt`
- `test_request_rejects_oversized_cache_salt`
- `test_request_rejects_forbidden_cache_salt_characters`

Commands:
- `cargo test -p vllm-text --lib -- lower` — 39 passed
- `.venv/bin/python -m pytest tests/v1/test_request.py -v` — 9 passed
- `pre-commit run` on staged files — passed

## AI assistance
This PR was developed with AI assistance.

Made with [Cursor](https://cursor.com)