### PR TITLE
[Bugfix] Avoid repeated dummy initialization and random CPU Engram fills

### DIFF
--- a/vllm/model_executor/model_loader/dummy_loader.py
+++ b/vllm/model_executor/model_loader/dummy_loader.py
@@ -14,7 +14,6 @@ from vllm.model_executor.model_loader.reload.meta import materialize_layer
 from vllm.model_executor.model_loader.reload.types import LayerReloadingInfo
 from vllm.model_executor.model_loader.reload.utils import get_layer_tensors
 from vllm.model_executor.model_loader.weight_utils import (
-    initialize_dummy_weights,
     initialize_single_dummy_weight,
 )
 
@@ -41,7 +40,12 @@ class DummyModelLoader(BaseModelLoader):
             else:
                 # NOTE(woosuk): For accurate performance evaluation, we assign
                 # random values to the weights.
-                initialize_dummy_weights(layer, model_config)
+                # Initialize only local tensors: state_dict() would recursively
+                # initialize descendants that model.modules() also visits.
+                # Exclude nonpersistent buffers, matching state_dict().
+                for name, tensor in get_layer_tensors(layer).items():
+                    if name not in layer._non_persistent_buffers_set:
+                        initialize_single_dummy_weight(tensor)
 
     def _process_online_quant_layer(
         self,

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1341,6 +1341,10 @@ def initialize_single_dummy_weight(
     if param.device.type == "meta":
         return  # deferred to finalize_layerwise_processing (e.g. online quant)
 
+    if (dummy_weight_value := getattr(param, "dummy_weight_value", None)) is not None:
+        param.fill_(dummy_weight_value)
+        return
+
     if not torch.is_floating_point(param):
         if current_platform.is_rocm():
             # On ROCm, integer params (e.g. GPTQ qweight/qzeros) are left

--- a/vllm/models/deepseek_v4_1/common/engram.py
+++ b/vllm/models/deepseek_v4_1/common/engram.py
@@ -687,6 +687,10 @@ class ParallelEngramEmbedding(nn.Module):
                 },
             )
         if cpu_offload:
+            # Constant dummy values avoid randomizing huge CPU lookup tables.
+            set_weight_attrs(self.weight, {"dummy_weight_value": 1.0})
+            # The ue8m0 encoding of scale 1.0 is exponent byte 127.
+            set_weight_attrs(self.weight_scale_inv, {"dummy_weight_value": 127})
             logger.info(
                 "Engram table offloaded to pinned host memory: %d rows x %d, "
                 "%.2f GiB per rank",


### PR DESCRIPTION
## Purpose

Avoid repeatedly initializing descendant weights under `--load-format dummy`. The loader already walks `model.modules()`, so each iteration now initializes only local parameters and persistent buffers. This matches default PyTorch state selection without recursively revisiting descendants and preserves parameter attributes used for dummy initialization.

CPU-offloaded DeepSeek V4.1 Engram tables request constant dummy weights of 1.0 and UE8M0 scale byte 127 (scale 1.0). Their lookup access pattern does not require randomly generated table contents. Checkpoint loading is unchanged; online quantization retains its existing materialize/initialize/process path.

Duplicate checks found #54958, which addresses full-size FP8 temporary allocations and OOM. This PR addresses recursive duplicate initialization and CPU Engram constant initialization; it contains no generic FP8 allocation or chunking changes. No open PR addressing the same changes was found in the dummy initialization/loading searches.

## Test Plan

Run the existing checkpoint-sharding, nonpersistent alias-buffer, and online-processing tests:

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 VLLM_USE_RUST_FRONTEND=0 .venv/bin/python -m pytest tests/model_executor/model_loader/test_reload.py tests/kernels/test_engram.py -k 'online_processing_waits_for_late_registered_bias or head_shards_reconstruct_checkpoint or layerwise_reload_skips_non_persistent_parameter_alias_buffers' -q
```

Pre-commit was run on all three changed source files.

## Test Result

10 existing tests passed (101 deselected) in 5.26 seconds on the isolated PR branch. Applicable pre-commit hooks and git diff --check passed.

A standalone differential audit found exact old/new initialized values for nested and tied weights and persistent buffers. Tied parameter identities and nonpersistent alias buffers were retained; nonpersistent scratch buffers were unchanged and None tensors skipped. Tied parameters can still be visited under multiple owners: the change removes ancestor-level repetition, not all storage aliasing.

Development measurement on four GB200 GPUs with dummy weights and FlashInfer autotuning disabled: model loading completed in 19.66–19.80 seconds per worker; health returned HTTP 200 after 514.145 seconds and a 16-token smoke request succeeded. The previous run remained in dummy initialization at its 600-second cutoff. The development run also included separate mHC JIT and generic FP8 temporary changes, so its end-to-end time is not an isolated benchmark of this PR. No real-checkpoint accuracy evaluation was run.

AI assistance was used for diagnosis, implementation, and validation.
