### PR TITLE
[Perf] Parallelize mHC pre-norm JIT warmup

### DIFF
--- a/vllm/model_executor/kernels/mhc/warmup.py
+++ b/vllm/model_executor/kernels/mhc/warmup.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from typing import Any
 
@@ -60,6 +61,21 @@ class MHCPreNormKernel(VllmJitKernel["MHCPreNormKernel.CompileKey"]):
             self._compiled_cache[compile_key] = self.kernel.compile(
                 **asdict(compile_key)
             )
+
+    def compile_many(self, compile_keys: Iterable[CompileKey]) -> None:
+        missing = list(
+            dict.fromkeys(
+                key for key in compile_keys if key not in self._compiled_cache
+            )
+        )
+        if len(missing) < 2:
+            return super().compile_many(missing)
+
+        # TileLang elaborates serially before compiling independent TIR modules.
+        compiled = self.kernel.par_compile(
+            [asdict(key) for key in missing], num_workers=min(4, len(missing))
+        )
+        self._compiled_cache.update(zip(missing, compiled, strict=True))
 
     def __call__(self, *tensors, **fields):
         compile_key = self.dispatch(

--- a/vllm/model_executor/warmup/jit_warmup.py
+++ b/vllm/model_executor/warmup/jit_warmup.py
@@ -963,14 +963,18 @@ class VllmJitKernel(Generic[CompileKeyT], ABC):
         """Compile one warmup key."""
         raise NotImplementedError
 
+    def compile_many(self, compile_keys: Iterable[CompileKeyT]) -> None:
+        """Compile a batch of warmup keys, allowing backend-specific scheduling."""
+        for compile_key in compile_keys:
+            self.compile(compile_key)
+
     def register_warmup(self, *args: Any, **kwargs: Any) -> None:
         """Register this kernel with the active runner's warmup registry."""
         JitWarmupRegistry.register(self, *args, **kwargs)
 
     def warmup(self, *args: Any, **kwargs: Any) -> None:
         """Compile this kernel's warmup keys."""
-        for compile_key in self.get_warmup_keys(*args, **kwargs):
-            self.compile(compile_key)
+        self.compile_many(self.get_warmup_keys(*args, **kwargs))
 
 
 def _same_value(left: Any, right: Any) -> bool:
@@ -1111,5 +1115,4 @@ class JitWarmupRegistry:
                     f"{kernel.__class__.__name__} ({len(compile_keys)} keys)",
                     refresh=False,
                 )
-                for compile_key in compile_keys:
-                    kernel.compile(compile_key)
+                kernel.compile_many(compile_keys)


### PR DESCRIPTION
## Purpose

Compile independent mHC pre-norm warmup variants concurrently. Add a `compile_many()` hook to `VllmJitKernel`, retain sequential compilation by default, and use TileLang's `par_compile()` for missing `MHCPreNormKernel` variants with at most four compiler workers per process. Cached variants are retained and duplicate keys are removed. TileLang elaborates the modules serially before compiling them in parallel.

The existing open PRs #51802 and #49707 address mHC warmup coverage. This change preserves the existing registered keys and runtime dispatch, and changes how those keys are compiled. Searches for parallel JIT compilation and `par_compile` found no open PR implementing the same change. This PR is independent of the dummy-initialization change in #56682.

## Test Plan

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 VLLM_USE_RUST_FRONTEND=0 .venv/bin/python -m pytest tests/model_executor/test_jit_warmup.py tests/kernels/test_mhc_jit_warmup.py -q
.venv/bin/pre-commit run --files vllm/model_executor/warmup/jit_warmup.py vllm/model_executor/kernels/mhc/warmup.py
```

Also exercised the existing `test_deepseek_v41_mhc_pre_delayed` reference and CUDA graph replay assertions after batch warmup, for broadcast, identity, and carried pre-mix (33 tokens, fused normalization, DeepGEMM enabled, 20 Sinkhorn iterations).

## Test Result

60 existing warmup tests passed in 18.86 seconds. All three GPU reference/CUDA graph replay cases passed on GB200 after batch warmup. Applicable pre-commit hooks and `git diff --check` passed. No test additions are included.

On GB200, nine cold-cache DSV4.1 pre-norm variants (hidden size 5120, hc_mult 4, three input/pre-mix configurations and split counts 1/4/16) compiled in:

| Compilation | Wall time |
|---|---:|
| Sequential | 95.03s |
| Four compiler workers | 43.39s |

This is a 2.19x speedup for the isolated compilation stage. These are single-run measurements excluding imports/key enumeration, with separate empty TileLang caches; host-side engine initialization was concurrent, so they are exploratory measurements rather than a controlled end-to-end startup comparison. Generated CUDA source sets matched between the two runs.

A later TP4 real-weight DSV4.1 startup and greedy completion succeeded with this change. Its registry mHC phase had five variants already compiled by profiling and compiled the remaining four in parallel in approximately 14 seconds. No model-quality benchmark was run; this changes compilation scheduling, not kernel math. Full-engine startup speedup is not claimed.

AI assistance was used for diagnosis, implementation, and validation.
