### PR TITLE
[ROCm][Bugfix] Initialize Ray NIXL agents for sharded RDT

### DIFF
--- a/tests/distributed/test_sharded_rdt_producer.py
+++ b/tests/distributed/test_sharded_rdt_producer.py
@@ -24,6 +24,8 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeout
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -31,6 +33,7 @@ import torch
 import vllm.distributed.weight_transfer.sharded_rdt_trainer as trainer_mod
 from vllm.distributed.weight_transfer.sharded_rdt_common import (
     buffer_alloc_bytes,
+    initialize_ray_nixl,
 )
 from vllm.distributed.weight_transfer.sharded_rdt_trainer import (
     DEFAULT_GATHER_LOOKAHEAD,
@@ -43,6 +46,77 @@ from vllm.distributed.weight_transfer.sharded_rdt_trainer import (
 GI_A, GI_B = 0, 1
 GROUP_A = ("model.layers.0.w", "model.layers.0.b")
 GROUP_B = ("model.layers.1.w",)
+
+
+@pytest.fixture
+def ray_nixl_transport(monkeypatch):
+    import ray
+    from ray.experimental.rdt import util
+    from ray.experimental.rdt.nixl_tensor_transport import NixlTensorTransport
+
+    from vllm.distributed import nixl_utils
+    from vllm.platforms import current_platform
+
+    transport = NixlTensorTransport()
+    agent = Mock(return_value=object())
+    config = Mock(return_value=object())
+    monkeypatch.setattr(util, "transport_managers", {"NIXL": transport})
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: True)
+    monkeypatch.setattr(
+        ray,
+        "get_runtime_context",
+        lambda: SimpleNamespace(get_actor_id=lambda: "rdt-actor"),
+    )
+    # Bypass lazy imports so these tests need neither NIXL nor a GPU.
+    monkeypatch.setitem(nixl_utils.__dict__, "NixlWrapper", agent)
+    monkeypatch.setitem(nixl_utils.__dict__, "nixl_agent_config", config)
+    return transport, agent, config
+
+
+@pytest.mark.parametrize("existing_agent", [False, True])
+def test_ray_reuses_rocm_nixl_agent(ray_nixl_transport, existing_agent):
+    """Ray's real accessor must reuse ROCm NIXL without importing CUDA NIXL."""
+    transport, agent, config = ray_nixl_transport
+    expected = object() if existing_agent else agent.return_value
+    if existing_agent:
+        transport._nixl_agent = expected
+
+    initialize_ray_nixl()
+    assert transport.get_nixl_agent() is expected
+    initialize_ray_nixl()
+    assert transport.get_nixl_agent() is expected
+    if existing_agent:
+        agent.assert_not_called()
+        config.assert_not_called()
+    else:
+        config.assert_called_once_with(backends=["UCX"])
+        agent.assert_called_once_with("rdt-actor", config.return_value)
+
+
+def test_ray_nixl_initialization_leaves_non_rocm_unchanged(
+    monkeypatch, ray_nixl_transport
+):
+    from vllm.platforms import current_platform
+
+    transport, agent, config = ray_nixl_transport
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: False)
+    initialize_ray_nixl()
+    assert transport._nixl_agent is None
+    agent.assert_not_called()
+    config.assert_not_called()
+
+
+def test_ray_nixl_initialization_reports_missing_rocm_package(
+    monkeypatch, ray_nixl_transport
+):
+    from vllm.distributed import nixl_utils
+
+    transport, agent, _ = ray_nixl_transport
+    monkeypatch.setitem(nixl_utils.__dict__, "NixlWrapper", None)
+    with pytest.raises(ImportError, match="nixl_rocm"):
+        initialize_ray_nixl()
+    assert transport._nixl_agent is None
+    agent.assert_not_called()
 
 
 @pytest.fixture

--- a/vllm/distributed/weight_transfer/sharded_rdt_common.py
+++ b/vllm/distributed/weight_transfer/sharded_rdt_common.py
@@ -9,7 +9,7 @@ group index means for any ``WeightSource``, not just this transport.
 """
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import torch
 
@@ -75,6 +75,36 @@ def check_ray_rdt_version() -> None:
             f"set_target_for_ref) needs at least 2.55. Found {current}. "
             f"Run `pip install -U 'ray>={required}'`."
         )
+
+
+def initialize_ray_nixl() -> None:
+    """Initialize Ray's process-local NIXL agent with the ROCm package."""
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_rocm():
+        return
+
+    import ray
+    from ray.experimental.rdt.nixl_tensor_transport import NixlTensorTransport
+    from ray.experimental.rdt.util import get_tensor_transport_manager
+
+    transport = cast(NixlTensorTransport, get_tensor_transport_manager("NIXL"))
+    if transport._nixl_agent is not None:
+        return
+
+    from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
+
+    if NixlWrapper is None or nixl_agent_config is None:
+        raise ImportError("Sharded RDT on ROCm requires the nixl_rocm package")
+
+    actor_id = ray.get_runtime_context().get_actor_id()
+    if actor_id is None:
+        import uuid
+
+        actor_id = f"RAY-DRIVER-{uuid.uuid4()}"
+    # Ray imports nixl._api when creating its agent. Populate the same cache
+    # with the ROCm implementation before any registration or transfer.
+    transport._nixl_agent = NixlWrapper(actor_id, nixl_agent_config(backends=["UCX"]))
 
 
 def assign_producer_indices(

--- a/vllm/distributed/weight_transfer/sharded_rdt_engine.py
+++ b/vllm/distributed/weight_transfer/sharded_rdt_engine.py
@@ -66,6 +66,7 @@ from vllm.distributed.weight_transfer.sharded_rdt_common import (
     RdtRouter,
     buffer_alloc_bytes,
     check_ray_rdt_version,
+    initialize_ray_nixl,
 )
 from vllm.distributed.weight_transfer.sharded_rdt_fake import (
     BakeSink,
@@ -590,6 +591,7 @@ class ShardedRDTWeightTransferEngine(
             return
         from ray.experimental import register_nixl_memory
 
+        initialize_ray_nixl()
         # (a) consumer receive buffers — one per ring slot, at the largest chunk.
         max_pack = max(c.pack_bytes for c in plan.chunks)
         alloc = buffer_alloc_bytes(max_pack, self._buffer_presize)

--- a/vllm/distributed/weight_transfer/sharded_rdt_trainer.py
+++ b/vllm/distributed/weight_transfer/sharded_rdt_trainer.py
@@ -47,6 +47,7 @@ from vllm.distributed.weight_transfer.sharded_rdt_common import (
     ALLOWED_OPS,
     buffer_alloc_bytes,
     check_ray_rdt_version,
+    initialize_ray_nixl,
 )
 from vllm.logger import init_logger
 
@@ -338,6 +339,7 @@ class _RDTProducerServer:
 
         self._nixl_warmup_buf = torch.zeros(1 << 20, dtype=torch.uint8, device="cuda")
         with self._reg_lock:
+            initialize_ray_nixl()
             register_nixl_memory(self._nixl_warmup_buf)
 
     # ---------------- engine-facing (per sync) ----------------


### PR DESCRIPTION
- Add a shared ROCm initializer that creates Ray's process-local NIXL agent through vLLM's existing `nixl_rocm` loader and populates Ray's cached agent.
- Call the initializer in both the producer actor and inference worker before NIXL memory registration, keeping transport compatibility in the sharded RDT implementation.
- Reuse an existing agent, leave non-ROCm initialization unchanged, and report a clear error when the ROCm NIXL package is unavailable.

[PR #50922](https://github.com/vllm-project/vllm/pull/50922) extends AMD CI coverage and exposed a failure in the final sharded RDT example in [Buildkite build 88592](https://buildkite.com/vllm/ci/builds/88592/list?jid=01a098e8-e816-48fd-b7dd-c7a96e7ad377&tab=output), on both the initial attempt and its retry. Ray 2.56.1 creates its NIXL agent by importing `nixl._api`, while the ROCm installation provides `nixl_rocm._api`. The evidence points to a transport integration gap exposed by the added coverage, rather than a regression in the tiny DeepSeek model.

OpenAI Codex assisted with implementation, validation, and this PR description.
