### PR TITLE
[Perf] Avoid redundant conversions in FP8 dummy initialization

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1380,10 +1380,9 @@ def initialize_single_dummy_weight(
     generator.manual_seed(seed)
     if torch.finfo(param.data.dtype).bits < 16:
         # uniform_ doesn't support < 16-bit datatypes (FP8)
-        dtype = param.data.dtype
-        tmp_param = param.data.to(torch.float16)
-        tmp_param = tmp_param.uniform_(low, high, generator=generator).to(dtype)
-        param.data.copy_(tmp_param)
+        tmp_param = torch.empty_like(param, dtype=torch.float16)
+        tmp_param.uniform_(low, high, generator=generator)
+        param.copy_(tmp_param)
     else:
         param.uniform_(low, high, generator=generator)
 


### PR DESCRIPTION
## Purpose

Avoid redundant conversions when initializing FP8 dummy weights. Allocate the FP16 scratch tensor with `empty_like`, fill it, and let `param.copy_` convert directly into the destination. This avoids reading old parameter values that are immediately overwritten and removes the intermediate FP8 allocation/copy.

For a 128 Mi-element FP8 tensor on one GB200, median GPU time over 10 iterations decreased from 0.665 ms to 0.301 ms; peak scratch allocation decreased from 384 MiB to 256 MiB. These are isolated initialization measurements, not end-to-end startup timings.

## Related work

Follow-up to merged #56682, which omitted this optimization. Checked open dummy-initialization/FP8 PRs and #54712. Related #54958 bounds scratch memory by chunking large tensors but retains the redundant conversions; this change addresses unnecessary memory traffic and the cast-back allocation, and does not implement chunking or claim to fix that OOM issue.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 VLLM_USE_RUST_FRONTEND=0 .venv/bin/python -m pytest tests/model_executor/test_weight_utils.py -q`: **32 passed**.
- `.venv/bin/python /tmp/fp8-dummy-init-pr/check.py`: exact old/new output parity in **24 cases**, covering CPU/CUDA, FP8 E4M3/E5M2, contiguous/transposed/strided tensors, and two seeds; also measured the timing and scratch allocation above.
- `.venv/bin/pre-commit run --files vllm/model_executor/model_loader/weight_utils.py`: passed.
- No new tests added. Real-weight loading/inference is unaffected; no model-quality evaluation was needed for this dummy-only change.

AI assistance: OpenAI Codex assisted with implementation, validation, and this PR description.
