### PR TITLE
[Bugfix][Core] Profile and validate kv_cache_memory_bytes instead of skipping the profile

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -8,8 +8,9 @@ import time
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from datetime import timedelta
+from functools import partial
 from types import NoneType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import regex as re
@@ -521,6 +522,164 @@ class Worker(WorkerBase):
         with set_current_vllm_config(self.vllm_config):
             self.model_runner.reload_weights(*args, **kwargs)
 
+    def _profile_attention_for_pinned_kv(self) -> None:
+        """Extend the profile with attention, for a pinned KV size only.
+
+        ``profile_run`` forwards with ``skip_attn=True``: there is no KV cache
+        yet, so the attention kernels never run and neither their activations
+        nor the device memory their first launch takes reach the profile. Under
+        ``gpu_memory_utilization`` that is harmless -- what the profile missed
+        lands in the slice the utilization fraction left unallocated. A pinned
+        ``kv_cache_memory_bytes`` has no such slice, so the same bytes are
+        spent twice and the rank OOMs in the middle of a request.
+
+        Build the same minimal KV cache the CUDA graph profiling uses and run a
+        ladder of batch widths through it, so the surrounding
+        ``memory_profiling`` block sees the attention path. The ladder is not
+        redundant with its widest rung: the caching allocator keeps whole
+        segments per size class, so a served mix of widths costs more than the
+        widest one alone.
+
+        Best effort -- a backend that cannot serve a dummy attention forward
+        leaves the estimate where it was, which is no worse than skipping this
+        entirely.
+        """
+        max_tokens = self.model_runner.max_num_tokens
+        # Widest first, so a backend that refuses the narrow shapes still
+        # contributes the rung that dominates the peak.
+        widths = sorted(
+            {max(1, max_tokens * n // 8) for n in range(1, 9)} | {1}, reverse=True
+        )
+        runner = cast(Any, self.model_runner)
+        build_kv_cache: Callable[[], None]
+        teardown: Callable[[], None]
+        if self.use_v2_model_runner:
+            from vllm.v1.worker.gpu.cudagraph_utils import (
+                _init_minimal_kv_cache_for_profiling,
+                _teardown_profiling_state,
+            )
+
+            build_kv_cache = partial(_init_minimal_kv_cache_for_profiling, runner)
+            teardown = partial(_teardown_profiling_state, runner)
+        else:
+            build_kv_cache = runner._init_minimal_kv_cache_for_profiling
+            teardown = runner._cleanup_profiling_kv_cache
+
+        try:
+            with set_current_vllm_config(self.vllm_config):
+                build_kv_cache()
+        except Exception:
+            logger.warning(
+                "Could not build a profiling KV cache to forward attention "
+                "against, so the profile keeps excluding the attention path. "
+                "The pinned kv_cache_memory_bytes is checked against an "
+                "estimate that is known to be low; leave headroom for it.",
+                exc_info=True,
+            )
+            return
+
+        # Serving rebuilds the allocator pool from scratch: the profiling run's
+        # segments are released before the KV cache is allocated, and what the
+        # pool then has to re-reserve for the same shapes is what this measures.
+        # Against the warm pool profile_run leaves, it would report none of it.
+        gc.collect()
+        torch.accelerator.empty_cache()
+        reserved_before = torch.accelerator.memory_reserved(self.device)
+        allocated_before = torch.accelerator.memory_allocated(self.device)
+        torch.accelerator.reset_peak_memory_stats(self.device)
+        try:
+            for num_tokens in widths:
+                try:
+                    runner._dummy_run(num_tokens, is_profile=True)
+                except Exception:
+                    logger.warning(
+                        "Attention profiling forward at %d tokens failed; "
+                        "continuing with the other widths.",
+                        num_tokens,
+                        exc_info=True,
+                    )
+            # What the allocator had to hold, not just what was live at once.
+            # ``memory_profiling`` accounts for the live peak alone, which is
+            # the right call where the utilization slice absorbs the difference.
+            self._pinned_allocator_overhead_bytes = max(
+                0,
+                (torch.accelerator.max_memory_reserved(self.device) - reserved_before)
+                - (
+                    torch.accelerator.max_memory_allocated(self.device)
+                    - allocated_before
+                ),
+            )
+        finally:
+            teardown()
+
+    def _apply_pinned_kv_cache_memory(
+        self,
+        kv_cache_memory_bytes: int,
+        profile_result: Any,
+        cudagraph_memory_estimate_applied: int,
+    ) -> int:
+        """Check a pinned KV size against the profile and report it."""
+        allocator_overhead = getattr(self, "_pinned_allocator_overhead_bytes", 0)
+        # Manual control deliberately ignores gpu_memory_utilization, so the
+        # budget is the whole free device, not the utilization slice.
+        fits_kv_cache_memory_bytes = (
+            self.init_snapshot.free_memory
+            - profile_result.non_kv_cache_memory
+            - cudagraph_memory_estimate_applied
+            - allocator_overhead
+        )
+        if kv_cache_memory_bytes > fits_kv_cache_memory_bytes:
+            # Refuse rather than quietly serve a smaller cache: a pinned size is
+            # an explicit capacity decision, and halving it behind the
+            # operator's back hides the one number this option exists to
+            # control. Starting anyway is worse -- the bytes are spent either
+            # way, and the rank OOMs once traffic reaches the peak just
+            # measured.
+            raise ValueError(
+                f"kv_cache_memory_bytes={kv_cache_memory_bytes} "
+                f"({format_gib(kv_cache_memory_bytes)} GiB) does not fit on "
+                f"this rank. Of {format_gib(self.init_snapshot.free_memory)} "
+                f"GiB free at startup the model needs "
+                f"{format_gib(profile_result.non_kv_cache_memory)} GiB for "
+                f"weights, workspaces and its activation peak"
+                + (
+                    f", {format_gib(cudagraph_memory_estimate_applied)} GiB for "
+                    f"CUDA graphs"
+                    if cudagraph_memory_estimate_applied
+                    else ""
+                )
+                + (
+                    f" and {format_gib(allocator_overhead)} GiB the caching "
+                    f"allocator holds beyond that peak"
+                    if allocator_overhead
+                    else ""
+                )
+                + f", leaving {format_gib(fits_kv_cache_memory_bytes)} GiB. Set "
+                f"--kv-cache-memory-bytes={int(fits_kv_cache_memory_bytes)} or "
+                f"lower, or give this rank more room (fewer layers on it, a "
+                f"smaller max_num_batched_tokens or max_model_len). That figure "
+                f"is an upper bound, not a safe setting: the profile runs "
+                f"against a minimal KV cache, so peaks that scale with context "
+                f"length are not in it. Leave headroom below it."
+            )
+
+        self.available_kv_cache_memory_bytes = kv_cache_memory_bytes
+        logger.info(
+            "Initial free memory %s GiB, reserved %s GiB for KV Cache as "
+            "specified by kv_cache_memory_bytes config (profiled non-KV usage "
+            "%s GiB, %s GiB left unused). This does not respect the "
+            "gpu_memory_utilization config.",
+            format_gib(self.init_snapshot.free_memory),
+            format_gib(kv_cache_memory_bytes),
+            format_gib(profile_result.non_kv_cache_memory),
+            format_gib(fits_kv_cache_memory_bytes - kv_cache_memory_bytes),
+        )
+        return reserve_mm_ipc_gpu_memory(
+            kv_cache_memory_bytes,
+            self.model_config.multimodal_config,
+            getattr(self.parallel_config, "_api_process_count", 1),
+        )
+
     @torch.inference_mode()
     def determine_available_memory(self) -> int:
         """Profiles the peak memory usage of the model to determine how much
@@ -536,29 +695,14 @@ class Worker(WorkerBase):
         """
         maybe_apply_startup_plan(self)
 
-        if kv_cache_memory_bytes := self.cache_config.kv_cache_memory_bytes:
-            # still need a profile run which compiles the model for
-            # max_num_batched_tokens
-            self.model_runner.profile_run()
-
-            msg = (
-                f"Initial free memory {format_gib(self.init_snapshot.free_memory)} "
-                f"GiB, reserved {format_gib(kv_cache_memory_bytes)} GiB memory for "
-                "KV Cache as specified by kv_cache_memory_bytes config and "
-                "skipped memory profiling. This does not respect the "
-                "gpu_memory_utilization config. Only use kv_cache_memory_bytes "
-                "config when you want manual control of KV cache memory "
-                "size. If OOM'ed, check the difference of initial free "
-                "memory between the current run and the previous run "
-                "where kv_cache_memory_bytes is suggested and update it "
-                "correspondingly."
-            )
-            logger.info(msg)
-            return reserve_mm_ipc_gpu_memory(
-                kv_cache_memory_bytes,
-                self.model_config.multimodal_config,
-                getattr(self.parallel_config, "_api_process_count", 1),
-            )
+        # Pinning the KV size decides how much memory the cache takes, not how
+        # much the rest of the model needs: weights, workspaces and the
+        # activation peak are still there, and the profiling run below is what
+        # measures them. So it runs either way and kv_cache_memory_bytes is
+        # checked against the result, rather than trusted blind -- skipping the
+        # profile left the operator with no number to size the pin against, and
+        # a pin that does not fit surfaces much later as an OOM mid-request.
+        kv_cache_memory_bytes = self.cache_config.kv_cache_memory_bytes
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
@@ -567,6 +711,8 @@ class Worker(WorkerBase):
             weights_memory=int(self.model_runner.model_memory_usage),
         ) as profile_result:
             self.model_runner.profile_run()
+            if kv_cache_memory_bytes:
+                self._profile_attention_for_pinned_kv()
 
         # Profile CUDA graph memory if graphs will be captured.
         # ROCm is included: #44825 moved the profiler to
@@ -620,6 +766,13 @@ class Worker(WorkerBase):
             - profile_result.non_kv_cache_memory
             - cudagraph_memory_estimate_applied
         )
+
+        if kv_cache_memory_bytes:
+            return self._apply_pinned_kv_cache_memory(
+                kv_cache_memory_bytes,
+                profile_result,
+                cudagraph_memory_estimate_applied,
+            )
 
         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
         logger.debug(


### PR DESCRIPTION
## Purpose

`--kv-cache-memory-bytes` never checked the size it was handed. The branch returned before `memory_profiling` ran, logged "skipped memory profiling", and passed the number straight through. Nothing compared it against what the model needs for itself, so a size that is too large starts fine, serves short requests, and then OOMs in the middle of one once traffic reaches the activation peak.

The same measurement gap exists under `gpu_memory_utilization`, but it stays hidden there: the KV size is derived from a budget that is only a fraction of the device, so whatever the profile missed lands in the part the utilization fraction left unallocated. A pinned size has no such slack — the operator sized it to use what was free — so the pinned cache and the unprofiled activation peak compete for the same free memory.

There is a second half to it. Even when the profile does run, it forwards with `skip_attn=True`, because there is no KV cache yet to attend against. The attention activations, and the device memory those kernels take the first time they launch, are simply not in the figure. Harmless where slack absorbs it; not harmless when the cache was pinned to that figure.

## What this changes

Run the profile for a pinned size too, and check the value against the result. If it does not fit, fail at startup and report the largest size admitted by this profile. Refusing rather than quietly capping is deliberate: a pinned size is an explicit capacity decision, and silently reducing it hides the one number this option exists to control. Starting anyway is worse — the bytes are spent either way, and the failure just moves to a request.

When a size is pinned, extend the profile with attention: build the same minimal KV cache the CUDA graph profiling already uses, run a short ladder of batch widths through it, then tear it down. The ladder is not redundant with its widest rung, since the caching allocator keeps whole segments per size class and a served mix of widths costs more than the widest one alone. Then account for what the allocator holds beyond the live peak — `memory_profiling` measures `allocated_bytes.all.peak`, which is the right call where slack absorbs the difference and the wrong one where there is none.

All of it sits inside the pinned branch; the `gpu_memory_utilization` path is untouched.

## What it deliberately does not do

The reported figure is an upper bound, not a safe setting, and the error message says so. The profile forwards against a *minimal* KV cache, so peaks that scale with context length are still outside it. For the serve described below, the unmargined bound was 3.53 GiB. A pinned size at that bound still OOMed under four concurrent requests, while 3.07 GiB completed the workload without failure. I did not measure where the real boundary between those two is, so no margin is applied here — the number is what the profile can account for, and the operator is told to leave room under it.

A percentage margin was the first thing I tried, and I dropped it. The shortfall scales with the model's activation footprint rather than with the cache, so a fraction of the cache size wastes memory wherever the cache is large; and a fraction fitted to a single measurement is not evidence, it just reproduces that measurement.

## Test Plan

Two-rank pipeline-parallel serve with an unbalanced layer split and the KV cache pinned. The rank carrying the larger share is the one that runs out. Workload: text prompts from 1.6k to 259k tokens, images from 360 to 14k tokens, and mixed batches at concurrency 3 and 4.

## Test Result

Profiled non-KV usage on that rank, against an observed non-KV peak of 59.24 GiB under the same workload:

| profile | non-KV |
| --- | --- |
| before this change (figure from a later probe, since nothing was measured) | 57.52 GiB |
| with attention in the profile | 58.28 GiB |
| with allocator overhead as well | 59.11 GiB |

A pinned 4.1 GiB that used to start and OOM later is now refused at startup:

```
ValueError: kv_cache_memory_bytes=4400000000 (4.1 GiB) does not fit on this rank. Of 62.93 GiB free at startup the model needs 59.11 GiB for weights, persistent workspaces and its activation peak, 0.21 GiB for CUDA graphs and 0.08 GiB the caching allocator holds beyond that peak, leaving 3.53 GiB. Set --kv-cache-memory-bytes=3785959936 or lower, or give this rank more room (fewer layers on it, a smaller max_num_batched_tokens or max_model_len). That figure is an upper bound, not a safe setting: the profile runs against a minimal KV cache, so peaks that scale with context length are not in it. Leave headroom below it.
```

At a pinned size below the bound the same serve finishes the whole workload with no failures, including a 258,953-token prompt and four concurrent image requests.

`ruff check` and `ruff format` pass. The `mypy` hook reports five errors in this file; all five are present on the unmodified file at the same base and none are on the added lines.

All results above come from local runs on one two-GPU host.
