### PR TITLE
[Feature][DSv4.1] Add eager MRV2 decode context parallelism

### DIFF
--- a/docs/serving/context_parallel_deployment.md
+++ b/docs/serving/context_parallel_deployment.md
@@ -46,7 +46,7 @@ Decode context parallel is supported in vLLM, for both MLA and GQA models. Some 
 
 DeepSeek V4.1 supports an initial eager DCP path with Model Runner V2 and the NVIDIA FlashMLA backend. DCP shards the shared main KV and index caches by logical record; sliding-window caches and compression state remain replicated. This path uses explicit communication and makes no serving-speedup guarantee.
 
-The supported configuration uses DCP size 2 or 4, interleave size 1, text-only input, and disabled prefix caching. CUDA graphs, PCP, pipeline parallelism, DBO, speculative decoding, and other attention backends are not supported by this path.
+The supported configuration uses DCP size 2 or 4, interleave size 1, FP8 indexer caches, text-only input, and disabled prefix caching. CUDA graphs, PCP, pipeline parallelism, DBO, speculative decoding, and other attention backends are not supported by this path.
 
 For example, the following configuration uses four GPUs and a fixed cache budget per GPU:
 
@@ -57,7 +57,7 @@ VLLM_USE_V2_MODEL_RUNNER=1 vllm serve deepseek-ai/DeepSeek-V4.1-Flash \
     --language-model-only \
     --enforce-eager \
     --no-enable-prefix-caching \
-    --attention-config '{"backend":"FLASHMLA_SPARSE_DSV41"}' \
+    --attention-config '{"backend":"FLASHMLA_SPARSE_DSV41","indexer_kv_dtype":"fp8"}' \
     --cp-kv-cache-interleave-size 1 \
     --max-model-len 32768 \
     --max-num-batched-tokens 1024 \

--- a/docs/serving/context_parallel_deployment.md
+++ b/docs/serving/context_parallel_deployment.md
@@ -42,6 +42,31 @@ In short, for decode context parallel, try to increase `-tp` size until you get 
 
 Decode context parallel is supported in vLLM, for both MLA and GQA models. Some attention backends also support the combination of decode context parallel and MTP (multi-token prediction) to further accelerate the decoding phase.
 
+## DeepSeek V4.1
+
+DeepSeek V4.1 supports an initial eager DCP path with Model Runner V2 and the NVIDIA FlashMLA backend. DCP shards the shared main KV and index caches by logical record; sliding-window caches and compression state remain replicated. This path uses explicit communication and makes no serving-speedup guarantee.
+
+The supported configuration uses DCP size 2 or 4, interleave size 1, text-only input, and disabled prefix caching. CUDA graphs, PCP, pipeline parallelism, DBO, speculative decoding, and other attention backends are not supported by this path.
+
+For example, the following configuration uses four GPUs and a fixed cache budget per GPU:
+
+```bash
+VLLM_USE_V2_MODEL_RUNNER=1 vllm serve deepseek-ai/DeepSeek-V4.1-Flash \
+    --tensor-parallel-size 4 \
+    --decode-context-parallel-size 2 \
+    --language-model-only \
+    --enforce-eager \
+    --no-enable-prefix-caching \
+    --attention-config '{"backend":"FLASHMLA_SPARSE_DSV41"}' \
+    --cp-kv-cache-interleave-size 1 \
+    --max-model-len 32768 \
+    --max-num-batched-tokens 1024 \
+    --max-num-seqs 4 \
+    --kv-cache-memory-bytes 536870912
+```
+
+Increase the cache budget according to the available device memory and required concurrency. The fixed budget above is the bounded validation configuration, not a general capacity recommendation.
+
 ## Technical Discussions
 
 The main discussions happen in the `#sig-context-parallel` channel of [vLLM Slack](https://slack.vllm.ai/).

--- a/tests/distributed/test_dsv41_dcp_candidate_blocks.py
+++ b/tests/distributed/test_dsv41_dcp_candidate_blocks.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from tests.utils import get_open_port
+
+
+def _all_gather_cat(value: torch.Tensor, dim: int) -> torch.Tensor:
+    gathered = [torch.empty_like(value) for _ in range(dist.get_world_size())]
+    dist.all_gather(gathered, value)
+    return torch.cat(gathered, dim=dim)
+
+
+def _candidate_worker(rank: int, world: int, port: int) -> None:
+    from vllm.model_executor.kernels.attention.dsa.candidate_blocks import (
+        select_candidate_blocks,
+        select_dcp_candidate_blocks,
+    )
+
+    torch.accelerator.set_device_index(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world,
+    )
+    try:
+        device = torch.device("cuda", rank)
+        allocated = [3, 19, 25, 43]
+        visible_values = [0, 2, 17, 41]
+        visible = torch.tensor(visible_values, dtype=torch.int32, device=device)
+        local_allocated = [(length + world - 1 - rank) // world for length in allocated]
+        starts_values = [0]
+        for length in local_allocated[:-1]:
+            starts_values.append(starts_values[-1] + length)
+        starts = torch.tensor(
+            starts_values,
+            dtype=torch.int32,
+            device=device,
+        )
+        local_visible_values = [
+            (length + world - 1 - rank) // world for length in visible_values
+        ]
+        local_visible = torch.tensor(
+            local_visible_values,
+            dtype=torch.int32,
+            device=device,
+        )
+        ends = starts + local_visible
+        rows = len(allocated)
+        local_logits = torch.full(
+            (rows, sum(local_allocated)), -torch.inf, device=device
+        )
+        dense_logits = torch.full((rows, max(allocated)), -torch.inf, device=device)
+        topk_blocks = 4
+        block_size = 8
+
+        for replay in range(2):
+            for row, global_len in enumerate(visible_values):
+                global_ids = torch.arange(global_len, device=device)
+                values = (global_ids * 17 + row * 13 + replay).float()
+                if replay and row == 2:
+                    values[5] = float("nan")
+                dense_logits[row].fill_(-torch.inf)
+                dense_logits[row, :global_len] = values
+                owned = global_ids % world == rank
+                local_logits[row].fill_(-torch.inf)
+                start = starts_values[row]
+                local_logits[row, start : start + local_visible_values[row]] = values[
+                    owned
+                ]
+
+            actual = torch.empty((rows, topk_blocks), dtype=torch.int32, device=device)
+            select_dcp_candidate_blocks(
+                local_logits,
+                starts,
+                ends,
+                visible,
+                topk_blocks,
+                block_size,
+                actual,
+                rank,
+                world,
+                _all_gather_cat,
+                chunk_blocks=2,
+            )
+            expected = torch.empty_like(actual)
+            select_candidate_blocks(
+                dense_logits,
+                None,
+                visible,
+                topk_blocks,
+                block_size,
+                expected,
+            )
+            torch.testing.assert_close(
+                actual.sort(dim=1).values,
+                expected.sort(dim=1).values,
+                rtol=0,
+                atol=0,
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    not torch.accelerator.is_available() or torch.accelerator.device_count() < 4,
+    reason="four CUDA devices required",
+)
+@pytest.mark.parametrize("world", [2, 4])
+def test_dsv41_dcp_candidate_blocks_match_dense_reference(world: int) -> None:
+    os.environ.setdefault("NCCL_CUMEM_ENABLE", "0")
+    mp.spawn(_candidate_worker, args=(world, get_open_port()), nprocs=world, join=True)

--- a/tests/model_executor/layers/test_dsv41_dcp_attention.py
+++ b/tests/model_executor/layers/test_dsv41_dcp_attention.py
@@ -124,3 +124,71 @@ def test_merge_normalizes_empty_native_lse_and_applies_sink_once(monkeypatch, ra
     expected = (scores - den[:, None]).exp() @ values
     expected = torch.stack([expected[rank * 2 : rank * 2 + 2], torch.zeros(2, 3)])
     torch.testing.assert_close(result, expected)
+
+
+@pytest.mark.skipif(not torch.accelerator.is_available(), reason="accelerator required")
+def test_dummy_attention_profiles_dcp_temporary_memory(monkeypatch):
+    """Automatic KV sizing must observe the FP32 DCP merge, not a zero-only stub."""
+    from types import SimpleNamespace
+
+    from vllm.models.deepseek_v4_1.nvidia import flashmla
+
+    class Group:
+        world_size = 2
+        rank_in_group = 0
+
+        def all_gather(self, tensor, dim):
+            return torch.cat([tensor, tensor], dim=dim)
+
+        def all_reduce(self, tensor):
+            return tensor.clone()
+
+    monkeypatch.setattr(dcp, "get_dcp_group", lambda: Group())
+    monkeypatch.setattr(
+        flashmla, "get_forward_context", lambda: SimpleNamespace(attn_metadata=None)
+    )
+    monkeypatch.setattr(
+        flashmla,
+        "current_workspace_manager",
+        lambda: SimpleNamespace(
+            get_simultaneous=lambda *args: (
+                torch.empty(1, 1, 512, device="cuda", dtype=torch.bfloat16),
+            )
+        ),
+    )
+
+    def native_stub(q, kv, indices, sm_scale, attn_sink, out):
+        return (
+            out,
+            torch.zeros(q.shape[:2], device=q.device),
+            torch.full(q.shape[:2], torch.inf, device=q.device),
+        )
+
+    monkeypatch.setattr(flashmla, "flash_mla_sparse_fwd", native_stub)
+    q = torch.zeros(128, 64, 512, dtype=torch.bfloat16, device="cuda")
+    output = torch.empty_like(q)
+    layer = SimpleNamespace(
+        compress_ratio=1,
+        max_model_len=32,
+        window_size=128,
+        max_num_batched_tokens=128,
+        topk_indices_buffer=torch.empty(128, 512, dtype=torch.int32, device="cuda"),
+        max_image_tokens=0,
+        PREFILL_CHUNK_SIZE=4,
+        dcp_world_size=2,
+        n_local_heads=2,
+        scale=512**-0.5,
+        attn_sink=torch.zeros(64, device="cuda"),
+    )
+    torch.accelerator.synchronize()
+    torch.accelerator.reset_peak_memory_stats()
+    before = torch.accelerator.memory_stats()["allocated_bytes.all.current"]
+    flashmla.DeepseekV4FlashMLAAttention.forward_mqa(
+        layer, q, q, torch.empty(0, device="cuda"), output
+    )
+    torch.accelerator.synchronize()
+    peak = torch.accelerator.memory_stats()["allocated_bytes.all.peak"]
+    # Two full FP32 buffers are a lower bound on live merge scratch. The old
+    # profiling path allocated neither and left the KV budget too large.
+    assert peak - before >= 2 * output.numel() * 4
+    assert torch.count_nonzero(output) == 0

--- a/tests/model_executor/layers/test_dsv41_dcp_attention.py
+++ b/tests/model_executor/layers/test_dsv41_dcp_attention.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4_1.nvidia import dcp
+
+
+@pytest.mark.parametrize("rank", [0, 1, 2])
+def test_owner_filter_compacts_valid_suffix_without_changing_input(rank):
+    ids = torch.tensor([[2, 4, -1, 9, 8, 3], [-1, -1, -1, -1, -1, -1]])
+    before = ids.clone()
+    local, counts = dcp.localize_topk(ids, rank, 3)
+    expected = [x // 3 for x in ids[0].tolist() if x >= 0 and x % 3 == rank]
+    assert local[0].tolist() == expected + [-1] * (6 - len(expected))
+    assert local[1].tolist() == [-1] * 6
+    assert counts.tolist() == [len(expected), 0]
+    assert torch.equal(ids, before)
+
+
+@pytest.mark.parametrize("rank", [0, 1])
+@pytest.mark.parametrize("ratio", [1, 2])
+def test_prefill_offsets_keep_requests_planes_and_causal_bounds_separate(rank, ratio):
+    ids = torch.tensor([[0, 1, 2, -1, 4, 5]] * 4, dtype=torch.int32)
+    pos = torch.tensor([5, 6, 20, 21])
+    req = torch.tensor([0, 0, 1, 1])
+    lens = torch.tensor([7, 22])
+    gather = torch.tensor([7, 8])
+    result, counts = dcp.prefill_indices(
+        ids,
+        pos,
+        req,
+        lens,
+        gather,
+        rank=rank,
+        world_size=2,
+        ratio=ratio,
+        window=4,
+        request_stride=64,
+        swa_offset=32,
+    )
+    assert result.shape == (4, 128)
+    for row in range(4):
+        r, p = int(req[row]), int(pos[row])
+        expected = [
+            r * 64 + c // 2
+            for c in ids[row].tolist()
+            if 0 <= c < (p + 1) // ratio and c % 2 == rank
+        ]
+        if rank == 0:
+            expected += [
+                r * 64 + 32 + t - int(lens[r] - gather[r])
+                for t in range(max(0, p - 3), p + 1)
+            ]
+        actual = result[row][result[row] >= 0].tolist()
+        assert actual == expected
+        assert int(counts[row]) == len(expected)
+        assert all(r * 64 <= x < (r + 1) * 64 for x in actual)
+
+
+def test_query_exchange_excludes_local_padding(monkeypatch):
+    class Group:
+        def all_gather(self, tensor, dim):
+            assert tensor.shape == (2, 2, 8) and dim == 1
+            return torch.cat([tensor, tensor * 2], dim=1)
+
+    monkeypatch.setattr(dcp, "get_dcp_group", lambda: Group())
+    q = torch.full((2, 64, 8), 99.0)
+    q[:, :2] = 1.0
+    result = dcp.gather_query(q, 2)
+    assert result.shape == (2, 64, 8)
+    assert torch.all(result[:, :2] == 1)
+    assert torch.all(result[:, 2:4] == 2)
+    assert torch.count_nonzero(result[:, 4:]) == 0
+
+
+@pytest.mark.parametrize("rank", [0, 1])
+def test_merge_normalizes_empty_native_lse_and_applies_sink_once(monkeypatch, rank):
+    torch.manual_seed(41)
+    scores = torch.randn(4, 5)
+    values = torch.randn(5, 3)
+    sink = torch.tensor([-torch.inf, torch.inf, 1.0, -1.0])
+    parts, lses = [], []
+    for owner in range(2):
+        local_scores = scores[:, owner::2]
+        part = local_scores.softmax(-1) @ values[owner::2]
+        parts.append(torch.stack([part, torch.full_like(part, torch.nan)]))
+        lses.append(
+            torch.stack([local_scores.logsumexp(-1), torch.full((4,), torch.inf)])
+        )
+    masked_lses = [x.clone() for x in lses]
+    for x in masked_lses:
+        x[1] = -torch.inf
+    total = torch.stack(masked_lses).logsumexp(0)
+    weighted = [
+        torch.stack(
+            [parts[i][0] * (lses[i][0] - total[0]).exp()[:, None], torch.zeros(4, 3)]
+        )
+        for i in range(2)
+    ]
+
+    class Group:
+        world_size = 2
+        rank_in_group = rank
+
+        def all_gather(self, tensor, dim):
+            torch.testing.assert_close(tensor, masked_lses[rank])
+            return torch.cat(masked_lses, dim=0)
+
+        def all_reduce(self, tensor):
+            torch.testing.assert_close(tensor, weighted[rank])
+            return weighted[0] + weighted[1]
+
+    monkeypatch.setattr(dcp, "get_dcp_group", lambda: Group())
+    result = dcp.merge_partial_output(
+        parts[rank],
+        lses[rank],
+        torch.tensor([3 - rank, 0]),
+        2,
+        sink[rank * 2 : rank * 2 + 2],
+    )
+    den = torch.logaddexp(scores.logsumexp(-1), sink)
+    expected = (scores - den[:, None]).exp() @ values
+    expected = torch.stack([expected[rank * 2 : rank * 2 + 2], torch.zeros(2, 3)])
+    torch.testing.assert_close(result, expected)

--- a/tests/model_executor/layers/test_mla_short_prefill_indexer.py
+++ b/tests/model_executor/layers/test_mla_short_prefill_indexer.py
@@ -315,6 +315,91 @@ def test_select_candidate_blocks_tolerates_empty_rows():
     assert (out[0] >= 0).all() and (out[2, :2] >= 0).all()
 
 
+def test_merge_dcp_block_scores_propagates_nan_and_pins_newest():
+    """Global block selection merges owner maxima without duplicating blocks."""
+    from vllm.model_executor.kernels.attention.dsa.candidate_blocks import (
+        merge_dcp_block_score_shards,
+    )
+
+    shard_scores = torch.tensor(
+        [
+            [[1.0, 8.0, 2.0], [4.0, 3.0, -torch.inf]],
+            [[7.0, 5.0, 6.0], [2.0, 9.0, -torch.inf]],
+        ]
+    )
+    nan_flags = torch.zeros_like(shard_scores, dtype=torch.uint8)
+    nan_flags[1, 0, 2] = 1
+    scores, ids = merge_dcp_block_score_shards(
+        shard_scores,
+        nan_flags,
+        torch.tensor([16, 9]),
+        block_start=0,
+        topk_blocks=2,
+        block_size=8,
+    )
+
+    assert set(ids[0].tolist()) == {1, 2}
+    assert torch.isnan(scores[0, ids[0] == 2]).all()
+    assert set(ids[1].tolist()) == {0, 1}
+    assert torch.isposinf(scores[1, ids[1] == 1]).all()
+
+
+def test_merge_dcp_block_scores_keeps_topk_across_bounded_chunks():
+    """Chunking preserves global IDs and drops unavailable padded blocks."""
+    from vllm.model_executor.kernels.attention.dsa.candidate_blocks import (
+        merge_dcp_block_score_shards,
+    )
+
+    first_scores, first_ids = merge_dcp_block_score_shards(
+        torch.tensor([[[1.0, 4.0]], [[3.0, 2.0]]]),
+        torch.zeros(2, 1, 2, dtype=torch.uint8),
+        torch.tensor([25]),
+        block_start=0,
+        topk_blocks=2,
+        block_size=8,
+    )
+    scores, ids = merge_dcp_block_score_shards(
+        torch.tensor([[[9.0, -torch.inf]], [[8.0, -torch.inf]]]),
+        torch.zeros(2, 1, 2, dtype=torch.uint8),
+        torch.tensor([25]),
+        block_start=2,
+        topk_blocks=2,
+        block_size=8,
+        prior_scores=first_scores,
+        prior_ids=first_ids,
+    )
+
+    assert set(ids[0].tolist()) == {2, 3}
+    assert torch.isposinf(scores[0, ids[0] == 3]).all()
+
+
+def test_merge_dcp_block_scores_uses_lower_global_id_for_cross_chunk_ties():
+    from vllm.model_executor.kernels.attention.dsa.candidate_blocks import (
+        merge_dcp_block_score_shards,
+    )
+
+    first_scores, first_ids = merge_dcp_block_score_shards(
+        torch.tensor([[[7.0, 7.0]]]),
+        torch.zeros(1, 1, 2, dtype=torch.uint8),
+        torch.tensor([80]),
+        block_start=2,
+        topk_blocks=2,
+        block_size=8,
+    )
+    _, ids = merge_dcp_block_score_shards(
+        torch.tensor([[[7.0, 7.0]]]),
+        torch.zeros(1, 1, 2, dtype=torch.uint8),
+        torch.tensor([80]),
+        block_start=6,
+        topk_blocks=2,
+        block_size=8,
+        prior_scores=first_scores,
+        prior_ids=first_ids,
+    )
+
+    assert ids.tolist() == [[2, 3]]
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.parametrize(
     "width,block_size,k,decode",
@@ -400,3 +485,35 @@ def test_candidate_kernels_preserve_packed_bounds_and_padding(
         keep = valid & (block >= 0) & ((cols - ks[:, None]) // block_size == block)
         reference = torch.where(keep, 3.0, -torch.inf)
         torch.testing.assert_close(logits, reference, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("world", [2, 4])
+def test_dcp_candidate_mask_maps_local_records_to_global_blocks(world):
+    """G=1 DCP masking consumes shared global block IDs on every owner."""
+    from vllm.model_executor.kernels.attention.dsa.candidate_blocks import (
+        apply_candidate_mask,
+    )
+
+    block_size = 8
+    global_len = 41
+    candidate_ids = torch.tensor([[1, 4]], dtype=torch.int32, device="cuda")
+    for rank in range(world):
+        local_len = (global_len + world - 1 - rank) // world
+        logits = torch.arange(local_len, dtype=torch.float32, device="cuda")[None]
+        original = logits.clone()
+        ends = torch.tensor([local_len], dtype=torch.int32, device="cuda")
+        apply_candidate_mask(
+            logits,
+            None,
+            ends,
+            candidate_ids,
+            block_size,
+            dcp_rank=rank,
+            dcp_world_size=world,
+            global_max_len=global_len,
+        )
+        global_records = torch.arange(local_len, device="cuda") * world + rank
+        keep = (global_records // block_size == 1) | (global_records // block_size == 4)
+        expected = original.masked_fill(~keep[None], -torch.inf)
+        torch.testing.assert_close(logits, expected, rtol=0, atol=0)

--- a/tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
+++ b/tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py
@@ -14,12 +14,15 @@ from vllm.models.deepseek_v4_1.sparse_mla import (
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.mla.compressor_utils import (
     CompressedSlotMappingKernel,
+    get_compressed_record_owner_and_local,
+    get_compressed_slot_mapping,
 )
 from vllm.v1.attention.backends.mla.indexer import (
     BuildPrefillChunkMetadataKernel,
     DeepseekV4IndexerBackend,
     DeepseekV32IndexerMetadataBuilder,
     DeepseekV41IndexerBackend,
+    build_prefill_chunk_metadata,
 )
 from vllm.v1.attention.backends.mla.sparse_utils import (
     ConvertReqIndexToGlobalIndexKernel,
@@ -96,6 +99,83 @@ def test_compressed_slot_mapping_warmup_includes_index_kpool():
 
     keys = CompressedSlotMappingKernel().get_warmup_keys(config)
     assert {(key.compress_ratio, key.block_size) for key in keys} == {(32, 2)}
+
+
+@pytest.mark.parametrize("compress_ratio", [1, 2])
+@pytest.mark.parametrize("dcp_world_size", [2, 4])
+def test_v41_compressed_records_use_record_space_ownership(
+    compress_ratio: int, dcp_world_size: int
+):
+    records_per_rank = 4
+    num_records = records_per_rank * dcp_world_size
+    owned: list[list[int]] = [[] for _ in range(dcp_world_size)]
+
+    for position in range(num_records * compress_ratio):
+        mapping = get_compressed_record_owner_and_local(
+            position, compress_ratio, dcp_world_size
+        )
+        if (position + 1) % compress_ratio:
+            assert mapping is None
+            continue
+        assert mapping is not None
+        owner, local_record = mapping
+        global_record = position // compress_ratio
+        assert owner == global_record % dcp_world_size
+        assert local_record == global_record // dcp_world_size
+        owned[owner].append(local_record)
+
+    assert owned == [list(range(records_per_rank))] * dcp_world_size
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("dcp_rank", [0, 1])
+def test_v41_compressed_slot_mapping_uses_record_owner(dcp_rank: int):
+    device = torch.device("cuda")
+    actual = get_compressed_slot_mapping(
+        num_tokens=8,
+        query_start_loc=torch.tensor([0, 8], dtype=torch.int32, device=device),
+        seq_lens=torch.tensor([8], dtype=torch.int32, device=device),
+        block_table=torch.tensor([[5]], dtype=torch.int32, device=device),
+        block_size=4,
+        compress_ratio=2,
+        dcp_rank=dcp_rank,
+        dcp_world_size=2,
+    )
+    expected = torch.full((8,), -1, dtype=torch.int64, device=device)
+    expected[1 + 2 * dcp_rank :: 4] = torch.tensor(
+        [20, 21], dtype=torch.int64, device=device
+    )
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize(
+    ("dcp_rank", "expected_ends"),
+    [(0, [1, 2, 2, 2]), (1, [1, 1, 1, 2])],
+)
+def test_v41_prefill_bounds_and_token_rows_are_owner_packed(
+    dcp_rank: int, expected_ends: list[int]
+):
+    device = torch.device("cuda")
+    metadata = build_prefill_chunk_metadata(
+        0,
+        1,
+        query_start_loc=torch.tensor([0, 4], dtype=torch.int32, device=device),
+        query_start_loc_cpu=torch.tensor([0, 4], dtype=torch.int32),
+        uncompressed_seq_lens=torch.tensor([8], dtype=torch.int32, device=device),
+        compressed_seq_lens=torch.tensor([4], dtype=torch.int32, device=device),
+        compressed_seq_lens_cpu=torch.tensor([4], dtype=torch.int32),
+        block_table=torch.tensor([[5]], dtype=torch.int32, device=device),
+        compress_ratio=2,
+        dcp_rank=dcp_rank,
+        dcp_world_size=2,
+    )
+    assert metadata is not None
+    assert metadata.local_cu_seq_lens is not None
+    assert metadata.local_cu_seq_lens.tolist() == [0, 2]
+    assert metadata.cu_seqlen_ks.tolist() == [0, 0, 0, 0]
+    assert metadata.cu_seqlen_ke.tolist() == expected_ends
+    assert metadata.token_to_seq[:2].tolist() == [0, 0]
 
 
 def test_index_conversion_warmup_uses_physical_block_stride():

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -58,6 +58,7 @@ from vllm.v1.kv_cache_interface import (
     HiddenStateCacheSpec,
     KpoolTailSpec,
     KVCacheConfig,
+    KVCacheDCPPlacement,
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheSpecKind,
@@ -1341,6 +1342,47 @@ def test_dcp_world_size_for_kv_cache_spec_shards_full_attention_only():
     assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(uniform_mla, dcp) == dcp
     assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(mamba, dcp) == 1
     assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(full, 1) == 1
+
+
+def test_explicit_dcp_cache_placement_controls_accounting_and_grouping():
+    dcp = 4
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=1024),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp),
+        max_in_flight_tokens=256,
+    )
+    common = dict(block_size=16, num_kv_heads=1, head_size=8, dtype=torch.float32)
+    sharded = MLAAttentionSpec(
+        **common, dcp_kv_cache_placement=KVCacheDCPPlacement.SHARDED
+    )
+    replicated = MLAAttentionSpec(
+        **common, dcp_kv_cache_placement=KVCacheDCPPlacement.REPLICATED
+    )
+
+    assert sharded.max_num_blocks_per_req(vllm_config, 1024) == 16
+    assert replicated.max_num_blocks_per_req(vllm_config, 1024) == 64
+    assert sharded.max_memory_usage_bytes(vllm_config) * dcp == (
+        replicated.max_memory_usage_bytes(vllm_config)
+    )
+    assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(sharded, dcp) == dcp
+    assert kv_cache_utils.dcp_world_size_for_kv_cache_spec(replicated, dcp) == 1
+    assert not UniformTypeKVCacheSpecs.is_uniform_type(
+        {"sharded": sharded, "replicated": replicated}
+    )
+
+    replicated_swa = SlidingWindowMLASpec(
+        **common,
+        sliding_window=128,
+        dcp_kv_cache_placement=KVCacheDCPPlacement.REPLICATED,
+    )
+    expected_blocks = replicated_swa.max_admission_blocks_per_request(
+        vllm_config.max_in_flight_tokens,
+        vllm_config.model_config.max_model_len,
+    )
+    assert replicated_swa.max_num_blocks_per_req(vllm_config, 1024) == 64
+    assert replicated_swa.max_memory_usage_bytes(vllm_config) == (
+        expected_blocks * replicated_swa.page_size_bytes
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -212,6 +212,42 @@ def test_dcp_slot_mapping_with_smaller_kernel_blocks(cp_rank: int):
     assert torch.equal(actual, expected)
 
 
+@pytest.mark.parametrize("cp_rank", [0, 1])
+def test_dcp_slot_mapping_supports_mixed_group_placement(cp_rank: int):
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[4, 4],
+        max_num_reqs=1,
+        max_num_batched_tokens=8,
+        max_num_blocks_per_group=[1, 2],
+        device=device,
+        kernel_block_sizes=[4, 4],
+        cp_size=2,
+        cp_rank=cp_rank,
+        cp_interleave=1,
+        dcp_sharded=[True, False],
+    )
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([5], [7, 8]),
+        overwrite=True,
+    )
+    block_tables.apply_staged_writes()
+
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 8], dtype=torch.int32, device=device)
+    positions = torch.arange(8, dtype=torch.int64, device=device)
+    actual = block_tables.compute_slot_mappings(
+        idx_mapping, query_start_loc, positions, num_tokens_padded=8
+    )
+
+    sharded = torch.full((8,), -1, dtype=torch.int64, device=device)
+    sharded[cp_rank::2] = torch.arange(20, 24, dtype=torch.int64, device=device)
+    replicated = torch.arange(28, 36, dtype=torch.int64, device=device)
+    assert torch.equal(actual[0], sharded)
+    assert torch.equal(actual[1], replicated)
+
+
 def test_v1_block_table_move_row_clears_vacated_row():
     """condense() moves the last row into a freed slot; the vacated row must
     not keep stale block ids. Padded dummy-run batches dereference stale rows

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -108,6 +108,7 @@ def test_qsa_circular_group_uses_custom_slot_mapping(monkeypatch):
 
     assert captured["max_num_blocks_per_group"] == [1, 1]
     assert captured["slot_mapping_enabled"] == [False, True]
+    assert captured["dcp_sharded"] == [True, True]
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/kernels/attention/dsa/candidate_blocks.py
+++ b/vllm/model_executor/kernels/attention/dsa/candidate_blocks.py
@@ -1,14 +1,69 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Callable
+
 import torch
 
 from vllm.triton_utils import tl, triton
+
+DCP_BLOCK_SCORE_WORKSPACE_BYTES = 64 * 1024 * 1024
 
 
 @triton.jit
 def _max_with_nan(a, b):
     return tl.maximum(a, b, propagate_nan=tl.PropagateNan.ALL)
+
+
+@triton.jit(do_not_specialize=["width", "block_start", "block_count"])
+def _dcp_block_scores_kernel(
+    logits,
+    starts,
+    ends,
+    scores,
+    nan_flags,
+    stride_row,
+    stride_col,
+    stride_start,
+    stride_end,
+    width,
+    block_start,
+    block_count,
+    DCP_RANK: tl.constexpr,
+    DCP_WORLD_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    HAS_STARTS: tl.constexpr,
+    ROW_REPEAT: tl.constexpr,
+    TILE: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    blocks = block_start + tl.program_id(1) * TILE + tl.arange(0, TILE)
+    offsets = tl.arange(0, triton.next_power_of_2(BLOCK_SIZE))
+    global_records = blocks[:, None] * BLOCK_SIZE + offsets[None, :]
+    owned = (global_records % DCP_WORLD_SIZE) == DCP_RANK
+    local_records = global_records // DCP_WORLD_SIZE
+    start = tl.load(starts + row // ROW_REPEAT * stride_start) if HAS_STARTS else 0
+    end = tl.load(ends + row // ROW_REPEAT * stride_end)
+    cols = start + local_records
+    valid = (
+        (blocks[:, None] < block_start + block_count)
+        & (offsets[None, :] < BLOCK_SIZE)
+        & owned
+        & (cols < end)
+        & (cols < width)
+    )
+    values = tl.load(
+        logits + row * stride_row + cols * stride_col,
+        valid,
+        other=-float("inf"),
+    )
+    has_nan = tl.max(tl.where(valid & (values != values), 1, 0), axis=1)
+    values = tl.where(values != values, -float("inf"), values)
+    reduced = tl.max(values, axis=1)
+    out_blocks = blocks - block_start
+    store_mask = blocks < block_start + block_count
+    tl.store(scores + row * block_count + out_blocks, reduced, store_mask)
+    tl.store(nan_flags + row * block_count + out_blocks, has_nan, store_mask)
 
 
 @triton.jit(do_not_specialize=["width", "nblocks"])
@@ -87,6 +142,7 @@ def _candidate_flags_kernel(
     K: tl.constexpr,
     HAS_STARTS: tl.constexpr,
     ROW_REPEAT: tl.constexpr,
+    DCP_WORLD_SIZE: tl.constexpr,
 ):
     row = tl.program_id(0).to(tl.int64)
     offsets = tl.arange(0, 1024)
@@ -98,8 +154,11 @@ def _candidate_flags_kernel(
     block = tl.load(
         candidates + row * stride_row + cols * stride_col, cols < K, other=-1
     ).to(tl.int64)
-    # Preserve the packed-column clamp for candidates beyond the logits width.
-    block = tl.where(start + block * BLOCK_SIZE >= width, nblocks, block)
+    if DCP_WORLD_SIZE == 1:
+        # Preserve the packed-column clamp for candidates beyond the logits width.
+        block = tl.where(start + block * BLOCK_SIZE >= width, nblocks, block)
+    else:
+        block = tl.where(block >= nblocks, nblocks, block)
     tl.debug_barrier()
     tl.store(flags + row * (nblocks + 1) + block, 1, (cols < K) & (block >= 0))
 
@@ -119,6 +178,8 @@ def _mask_candidates_kernel(
     BLOCK_SIZE: tl.constexpr,
     HAS_STARTS: tl.constexpr,
     ROW_REPEAT: tl.constexpr,
+    DCP_RANK: tl.constexpr,
+    DCP_WORLD_SIZE: tl.constexpr,
     TILE: tl.constexpr,
 ):
     row = tl.program_id(0).to(tl.int64)
@@ -126,10 +187,16 @@ def _mask_candidates_kernel(
     start = tl.load(starts + row // ROW_REPEAT * stride_start) if HAS_STARTS else 0
     end = tl.load(ends + row // ROW_REPEAT * stride_end)
     valid = (cols >= start) & (cols < end) & (cols < width)
-    block = (cols - start) // BLOCK_SIZE
+    record = cols - start
+    if DCP_WORLD_SIZE > 1:
+        record = record * DCP_WORLD_SIZE + DCP_RANK
+    block = record // BLOCK_SIZE
     keep = tl.load(flags + row * (nblocks + 1) + block, valid, other=0)
-    edge = tl.load(flags + row * (nblocks + 1) + nblocks)
-    keep = (keep != 0) | ((cols == width - 1) & (edge != 0))
+    if DCP_WORLD_SIZE == 1:
+        edge = tl.load(flags + row * (nblocks + 1) + nblocks)
+        keep = (keep != 0) | ((cols == width - 1) & (edge != 0))
+    else:
+        keep = keep != 0
     tl.store(
         logits + row * stride_row + cols * stride_col,
         -float("inf"),
@@ -188,6 +255,124 @@ def select_candidate_blocks(
     )
 
 
+def merge_dcp_block_score_shards(
+    score_shards: torch.Tensor,
+    nan_shards: torch.Tensor,
+    global_row_lens: torch.Tensor,
+    block_start: int,
+    topk_blocks: int,
+    block_size: int,
+    prior_scores: torch.Tensor | None = None,
+    prior_ids: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Merge one global-block chunk and retain the best candidates so far."""
+    assert score_shards.ndim == 3 and nan_shards.shape == score_shards.shape
+    scores = score_shards.amax(dim=0)
+    scores.masked_fill_(nan_shards.amax(dim=0).bool(), float("nan"))
+    rows, block_count = scores.shape
+    ids = torch.arange(
+        block_start,
+        block_start + block_count,
+        device=scores.device,
+        dtype=torch.int64,
+    ).expand(rows, -1)
+    newest = torch.div(global_row_lens - 1, block_size, rounding_mode="floor")
+    scores.masked_fill_(
+        (global_row_lens > 0)[:, None] & (ids == newest[:, None]), float("inf")
+    )
+    if prior_scores is not None:
+        assert prior_ids is not None
+        scores = torch.cat((prior_scores, scores), dim=1)
+        ids = torch.cat((prior_ids, ids), dim=1)
+    keep = min(topk_blocks, scores.shape[1])
+    order = torch.argsort(scores, dim=1, descending=True, stable=True)[:, :keep]
+    kept_scores = scores.gather(1, order)
+    kept_ids = ids.gather(1, order)
+    return kept_scores, kept_ids
+
+
+def select_dcp_candidate_blocks(
+    logits: torch.Tensor,
+    row_ks: torch.Tensor | None,
+    row_ke: torch.Tensor,
+    global_row_lens: torch.Tensor,
+    topk_blocks: int,
+    block_size: int,
+    out: torch.Tensor,
+    dcp_rank: int,
+    dcp_world_size: int,
+    gather: Callable[..., torch.Tensor],
+    row_repeat: int = 1,
+    chunk_blocks: int = 4096,
+) -> None:
+    """Select global blocks from record-striped DCP logits with bounded scratch."""
+    assert logits.is_cuda
+    assert dcp_world_size in (2, 4)
+    assert topk_blocks > 0 and block_size > 0 and chunk_blocks > 0
+    rows, width = logits.shape
+    if not rows:
+        return
+    bytes_per_block = rows * (dcp_world_size + 1) * 5
+    chunk_blocks = min(
+        chunk_blocks,
+        max(1, DCP_BLOCK_SCORE_WORKSPACE_BYTES // bytes_per_block),
+    )
+    max_global_len = int(global_row_lens.max().item()) if rows else 0
+    total_blocks = triton.cdiv(max_global_len, block_size)
+    if total_blocks == 0:
+        out.fill_(-1)
+        return
+    running_scores = None
+    running_ids = None
+    for block_start in range(0, total_blocks, chunk_blocks):
+        block_count = min(chunk_blocks, total_blocks - block_start)
+        scores = logits.new_empty((rows, block_count))
+        nan_flags = torch.empty(
+            (rows, block_count), dtype=torch.uint8, device=logits.device
+        )
+        _dcp_block_scores_kernel[(rows, triton.cdiv(block_count, 128))](
+            logits,
+            row_ks,
+            row_ke,
+            scores,
+            nan_flags,
+            *logits.stride(),
+            row_ks.stride(0) if row_ks is not None else 0,
+            row_ke.stride(0),
+            width,
+            block_start,
+            block_count,
+            dcp_rank,
+            dcp_world_size,
+            block_size,
+            row_ks is not None,
+            row_repeat,
+            128,
+        )
+        gathered_scores = gather(scores, dim=0).reshape(
+            dcp_world_size, rows, block_count
+        )
+        gathered_nans = gather(nan_flags, dim=0).reshape(
+            dcp_world_size, rows, block_count
+        )
+        running_scores, running_ids = merge_dcp_block_score_shards(
+            gathered_scores,
+            gathered_nans,
+            global_row_lens,
+            block_start,
+            topk_blocks,
+            block_size,
+            running_scores,
+            running_ids,
+        )
+    assert running_scores is not None and running_ids is not None
+    out.fill_(-1)
+    valid = running_scores > -float("inf")
+    out[:, : running_ids.shape[1]].copy_(
+        torch.where(valid, running_ids, -1).to(out.dtype)
+    )
+
+
 def apply_candidate_mask(
     logits: torch.Tensor,
     row_ks: torch.Tensor | None,
@@ -195,13 +380,21 @@ def apply_candidate_mask(
     candidate_blocks: torch.Tensor,
     block_size: int,
     row_repeat: int = 1,
+    dcp_rank: int = 0,
+    dcp_world_size: int = 1,
+    global_max_len: int | None = None,
 ) -> None:
     """Mask packed logits outside causal bounds and request-local candidates."""
     assert logits.is_cuda
     rows, width = logits.shape
     if not rows or not width:
         return
-    nblocks = triton.cdiv(width, block_size)
+    if dcp_world_size > 1:
+        assert dcp_world_size in (2, 4)
+        assert global_max_len is not None
+        nblocks = triton.cdiv(global_max_len, block_size)
+    else:
+        nblocks = triton.cdiv(width, block_size)
     flags = torch.empty((rows, nblocks + 1), device=logits.device, dtype=torch.uint8)
     start_stride = row_ks.stride(0) if row_ks is not None else 0
     _candidate_flags_kernel[(rows,)](
@@ -216,6 +409,7 @@ def apply_candidate_mask(
         candidate_blocks.shape[1],
         row_ks is not None,
         row_repeat,
+        dcp_world_size,
     )
     _mask_candidates_kernel[(rows, triton.cdiv(width, 1024))](
         logits,
@@ -230,5 +424,7 @@ def apply_candidate_mask(
         block_size,
         row_ks is not None,
         row_repeat,
+        dcp_rank,
+        dcp_world_size,
         1024,
     )

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -19,6 +19,9 @@ from vllm.model_executor.kernels.attention.dsa.candidate_blocks import (
 from vllm.model_executor.kernels.attention.dsa.candidate_blocks import (
     select_candidate_blocks as _select_candidate_blocks,
 )
+from vllm.model_executor.kernels.attention.dsa.candidate_blocks import (
+    select_dcp_candidate_blocks as _select_dcp_candidate_blocks,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     get_fp8_min_max,
 )
@@ -333,12 +336,17 @@ def sparse_attn_indexer(
     k_cache_prefix = _resolve_layer_name(k_cache_prefix)
 
     if candidate_blocks is not None:
-        # Candidate blocks are request-local; the DCP-sharded logits layout
-        # would need per-rank translation that is not implemented.
-        assert dcp_world_size == 1, (
-            "v4.1 two-level candidate filtering is not supported with DCP."
-        )
         assert candidate_block_size > 0
+        if dcp_world_size > 1 and (
+            not current_platform.is_cuda()
+            or dcp_world_size not in (2, 4)
+            or cp_kv_cache_interleave_size != 1
+            or use_pcp
+        ):
+            raise RuntimeError(
+                "V4.1 DCP candidate filtering requires NVIDIA CUDA, DCP2/4, "
+                "record interleave 1, and PCP1."
+            )
 
     # assert isinstance(attn_metadata, dict)
     if not isinstance(attn_metadata, dict):
@@ -526,8 +534,7 @@ def sparse_attn_indexer(
                         cu_seqlen_ke,
                         clean_logits=False,
                     )
-                num_rows = logits.shape[0]
-                if candidate_blocks is not None:
+                if candidate_blocks is not None and dcp_world_size == 1:
                     # Two-level selection (v4.1): the candidate source
                     # publishes its top blocks; later indexers mask their
                     # scores to them. Both before the row top-k.
@@ -551,6 +558,38 @@ def sparse_attn_indexer(
                             chunk_candidates,
                             candidate_block_size,
                         )
+
+            num_rows = logits.shape[0]
+            if candidate_blocks is not None and dcp_world_size > 1:
+                chunk_candidates = candidate_blocks[chunk.token_start : chunk.token_end]
+                local_lens = (cu_seqlen_ke - cu_seqlen_ks).reshape(-1, 1)
+                global_lens = get_dcp_group().all_gather(local_lens, dim=1).sum(dim=1)
+                if candidate_write:
+                    _select_dcp_candidate_blocks(
+                        logits,
+                        cu_seqlen_ks,
+                        cu_seqlen_ke,
+                        global_lens,
+                        chunk_candidates.shape[1],
+                        candidate_block_size,
+                        chunk_candidates,
+                        dcp_rank,
+                        dcp_world_size,
+                        get_dcp_group().all_gather,
+                    )
+                else:
+                    _apply_candidate_mask(
+                        logits,
+                        cu_seqlen_ks,
+                        cu_seqlen_ke,
+                        chunk_candidates,
+                        candidate_block_size,
+                        dcp_rank=dcp_rank,
+                        dcp_world_size=dcp_world_size,
+                        global_max_len=int(global_lens.max().item()),
+                    )
+
+            if chunk.local_total_seq_lens > 0:
                 ops.top_k_per_row_prefill(
                     logits,
                     cu_seqlen_ks,
@@ -667,16 +706,49 @@ def sparse_attn_indexer(
             vis = vis[:num_rows]
             decode_candidates = candidate_blocks[:num_rows]
             if candidate_write:
-                _select_candidate_blocks(
-                    logits,
-                    None,
-                    vis,
-                    decode_candidates.shape[1],
-                    candidate_block_size,
-                    decode_candidates,
-                    row_repeat,
-                )
+                if dcp_world_size > 1:
+                    if next_n != 1 or decode_metadata.requires_padding:
+                        raise RuntimeError(
+                            "V4.1 DCP candidate filtering does not support "
+                            "speculative or padded decode."
+                        )
+                    assert decode_metadata.global_seq_lens is not None
+                    global_lens = decode_metadata.global_seq_lens[:num_rows].reshape(-1)
+                    _select_dcp_candidate_blocks(
+                        logits,
+                        None,
+                        vis,
+                        global_lens,
+                        decode_candidates.shape[1],
+                        candidate_block_size,
+                        decode_candidates,
+                        dcp_rank,
+                        dcp_world_size,
+                        get_dcp_group().all_gather,
+                        row_repeat,
+                    )
+                else:
+                    _select_candidate_blocks(
+                        logits,
+                        None,
+                        vis,
+                        decode_candidates.shape[1],
+                        candidate_block_size,
+                        decode_candidates,
+                        row_repeat,
+                    )
             else:
+                global_max_len = None
+                if dcp_world_size > 1:
+                    if next_n != 1 or decode_metadata.requires_padding:
+                        raise RuntimeError(
+                            "V4.1 DCP candidate filtering does not support "
+                            "speculative or padded decode."
+                        )
+                    assert decode_metadata.global_seq_lens is not None
+                    global_max_len = int(
+                        decode_metadata.global_seq_lens[:num_rows].max().item()
+                    )
                 _apply_candidate_mask(
                     logits,
                     None,
@@ -684,6 +756,9 @@ def sparse_attn_indexer(
                     decode_candidates,
                     candidate_block_size,
                     row_repeat,
+                    dcp_rank,
+                    dcp_world_size,
+                    global_max_len,
                 )
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 

--- a/vllm/models/deepseek_v4_1/attention.py
+++ b/vllm/models/deepseek_v4_1/attention.py
@@ -64,6 +64,7 @@ from vllm.v1.attention.backends.mla.indexer import (
 )
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
 from vllm.v1.kv_cache_interface import (
+    KVCacheDCPPlacement,
     KVCacheSpec,
     MLAAttentionSpec,
     get_kv_quant_mode,
@@ -220,6 +221,40 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         tp_size = get_tensor_model_parallel_world_size()
         layer_id = extract_layer_index(prefix)
         self.layer_id = layer_id
+
+        if vllm_config.parallel_config.decode_context_parallel_size > 1:
+            parallel = vllm_config.parallel_config
+            unsupported = []
+            if parallel.decode_context_parallel_size not in (2, 4):
+                unsupported.append("DCP sizes other than two or four")
+            if cache_config is not None and cache_config.enable_prefix_caching:
+                unsupported.append("prefix caching")
+            if not vllm_config.use_v2_model_runner:
+                unsupported.append("MRV1")
+            if not vllm_config.model_config.enforce_eager:
+                unsupported.append("CUDA graphs")
+            if parallel.prefill_context_parallel_size > 1:
+                unsupported.append("PCP")
+            if parallel.pipeline_parallel_size > 1:
+                unsupported.append("pipeline parallelism")
+            if parallel.enable_dbo:
+                unsupported.append("DBO")
+            if vllm_config.speculative_config is not None:
+                unsupported.append("speculative decoding")
+            if parallel.cp_kv_cache_interleave_size != 1:
+                unsupported.append("record interleave other than one")
+            if self.backend_cls.get_name() != "FLASHMLA_SPARSE_DSV41":
+                unsupported.append("attention backends other than FlashMLA")
+            if (
+                getattr(config, "vision_n_layers", 0) > 0
+                and vllm_config.model_config.multimodal_config is not None
+                and not vllm_config.model_config.multimodal_config.language_model_only
+            ):
+                unsupported.append("vision")
+            if unsupported:
+                raise NotImplementedError(
+                    "DeepSeek V4.1 DCP does not support " + ", ".join(unsupported)
+                )
 
         self.prefix = prefix  # Alias for compatibility with compressor
         self.hidden_size = config.hidden_size
@@ -454,6 +489,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             cache_config=cache_config,
             backend_cls=self.swa_backend_cls,
             block_size=32,
+            dcp_kv_cache_placement=KVCacheDCPPlacement.REPLICATED,
         )
 
         # The attention layer itself was already registered with the
@@ -944,6 +980,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             head_size=self.head_dim,
             dtype=torch.uint8 if uses_fp8_ds_mla_layout else self.kv_cache_torch_dtype,
             tokens_per_state=self.compress_ratio,
+            dcp_kv_cache_placement=KVCacheDCPPlacement.SHARDED,
             cache_dtype_str=self.kv_cache_dtype,
             alignment=576 if uses_fp8_ds_mla_layout else 512,
             model_version="deepseek_v4",
@@ -998,6 +1035,7 @@ class DeepseekV4IndexerCache(torch.nn.Module, AttentionLayerBase):
             head_size=self.head_dim,
             dtype=self.dtype,
             tokens_per_state=self.compress_ratio,
+            dcp_kv_cache_placement=KVCacheDCPPlacement.SHARDED,
             # 576B for FlashMLA packing; 512B for FlashInfer sparse (#44577).
             alignment=576 if uses_fp8_ds_mla_layout else 512,
         )

--- a/vllm/models/deepseek_v4_1/attention.py
+++ b/vllm/models/deepseek_v4_1/attention.py
@@ -225,6 +225,8 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         if vllm_config.parallel_config.decode_context_parallel_size > 1:
             parallel = vllm_config.parallel_config
             unsupported = []
+            if dsa_indexer_uses_fp4(vllm_config):
+                unsupported.append("MXFP4 indexer cache")
             if parallel.decode_context_parallel_size not in (2, 4):
                 unsupported.append("DCP sizes other than two or four")
             if cache_config is not None and cache_config.enable_prefix_caching:

--- a/vllm/models/deepseek_v4_1/compressor.py
+++ b/vllm/models/deepseek_v4_1/compressor.py
@@ -25,7 +25,11 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-from vllm.v1.kv_cache_interface import CircularBufferSpec, KVCacheSpec
+from vllm.v1.kv_cache_interface import (
+    CircularBufferSpec,
+    KVCacheDCPPlacement,
+    KVCacheSpec,
+)
 
 
 class CompressorBackend(AttentionBackend):
@@ -160,6 +164,7 @@ class CompressorStateCache(torch.nn.Module, AttentionLayerBase):
             head_size=self.state_dim,
             head_size_v=0,
             dtype=self.dtype,
+            dcp_kv_cache_placement=KVCacheDCPPlacement.REPLICATED,
         )
 
     def forward(self): ...

--- a/vllm/models/deepseek_v4_1/nvidia/dcp.py
+++ b/vllm/models/deepseek_v4_1/nvidia/dcp.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Explicit-communication helpers for DeepSeek V4.1 DCP attention."""
+
+import torch
+
+from vllm.distributed import get_dcp_group
+
+
+def localize_topk(
+    indices: torch.Tensor, rank: int, world_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Keep this owner's record IDs, compacting holes before paged lookup."""
+    valid = (indices >= 0) & (indices % world_size == rank)
+    width = indices.shape[-1]
+    positions = torch.arange(width, device=indices.device)
+    order = torch.where(valid, positions, width).argsort(dim=-1)
+    local = torch.where(valid, indices // world_size, -1)
+    return local.gather(-1, order), valid.sum(dim=-1, dtype=torch.int32)
+
+
+def gather_query(q: torch.Tensor, local_heads: int) -> torch.Tensor:
+    """Gather real TP heads, then restore the native kernel's head padding."""
+    gathered = get_dcp_group().all_gather(q[:, :local_heads].contiguous(), dim=1)
+    heads = gathered.shape[1]
+    padded = 64 if heads <= 64 else 128
+    if heads > padded:
+        raise ValueError(f"DeepSeek V4.1 DCP requires at most 128 heads, got {heads}")
+    return torch.nn.functional.pad(gathered, (0, 0, 0, padded - heads))
+
+
+def merge_partial_output(
+    output: torch.Tensor,
+    lse: torch.Tensor,
+    valid_counts: torch.Tensor,
+    local_heads: int,
+    sink: torch.Tensor,
+) -> torch.Tensor:
+    """Merge unsunk partials and apply the sink once on the query-head owner.
+
+    FlashMLA returns +inf LSE for empty rows and excludes the sink from LSE.
+    Metadata counts, rather than the LSE sentinel, identify empty partitions.
+    """
+    group = get_dcp_group()
+    valid = valid_counts[:, None] > 0
+    lse = torch.where(valid, lse, -torch.inf)
+    partial = torch.where(valid[..., None], output.float(), 0.0)
+    all_lse = group.all_gather(lse.contiguous(), dim=0).view(
+        group.world_size, *lse.shape
+    )
+    total_lse = torch.logsumexp(all_lse, dim=0)
+    weight = torch.exp(torch.where(valid, lse - total_lse, -torch.inf))
+    merged = group.all_reduce((partial * weight[..., None]).contiguous())
+    first = group.rank_in_group * local_heads
+    local_lse = total_lse[:, first : first + local_heads]
+    denominator = torch.logaddexp(local_lse, sink[None, :local_heads])
+    factor = torch.where(
+        torch.isneginf(local_lse), 0.0, torch.exp(local_lse - denominator)
+    )
+    return merged[:, first : first + local_heads] * factor[..., None]
+
+
+def prefill_indices(
+    topk: torch.Tensor,
+    positions: torch.Tensor,
+    request_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    *,
+    rank: int,
+    world_size: int,
+    ratio: int,
+    window: int,
+    request_stride: int,
+    swa_offset: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Index gathered owner-local records and one copy of the replicated SWA.
+
+    Requests occupy separate rows of the gathered buffer. Preserve -1 sentinels
+    before adding each request's base, including for requests after the first.
+    """
+    requests = request_indices.long()
+    valid = (topk >= 0) & (topk % world_size == rank)
+    valid &= topk < ((positions[:, None] + 1) // ratio)
+    base = requests[:, None] * request_stride
+    main = torch.where(valid, base + topk // world_size, -1)
+    offsets = torch.arange(window, device=topk.device)
+    first = (positions - window + 1).clamp_min(0)
+    swa_positions = first[:, None] + offsets
+    swa_valid = (swa_positions <= positions[:, None]) & (rank == 0)
+    gather_start = seq_lens[requests] - gather_lens[requests]
+    swa = torch.where(
+        swa_valid, base + swa_offset + swa_positions - gather_start[:, None], -1
+    )
+    indices = torch.cat((main, swa), dim=-1).to(torch.int32)
+    padded = ((indices.shape[1] + 127) // 128) * 128
+    indices = torch.nn.functional.pad(indices, (0, padded - indices.shape[1]), value=-1)
+    return indices, (indices >= 0).sum(dim=-1, dtype=torch.int32)

--- a/vllm/models/deepseek_v4_1/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4_1/nvidia/flashmla.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, ClassVar, cast
 
 import torch
 
+from vllm.distributed import get_dcp_group
 from vllm.forward_context import get_forward_context
 from vllm.models.deepseek_v4.nvidia.ops.o_proj import (
     compute_fp8_einsum_recipe,
@@ -16,6 +17,12 @@ from vllm.models.deepseek_v4_1.common.ops import (
     compute_global_topk_indices_and_lens,
     dequantize_and_gather_k_cache,
 )
+from vllm.models.deepseek_v4_1.nvidia.dcp import (
+    gather_query,
+    localize_topk,
+    merge_partial_output,
+    prefill_indices,
+)
 from vllm.models.deepseek_v4_1.sparse_mla import (
     DeepseekV4FlashMLABackend,
     DeepseekV4FlashMLAMetadata,
@@ -25,6 +32,7 @@ from vllm.utils.math_utils import round_up
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWABackend
 from vllm.v1.attention.ops.flashmla import (
+    FlashMLASchedMeta,
     flash_mla_sparse_fwd,
     flash_mla_with_kvcache,
 )
@@ -54,6 +62,8 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.dcp_world_size = get_dcp_group().world_size
+        self.dcp_rank = get_dcp_group().rank_in_group
         self._einsum_recipe, self._tma_aligned_scales = compute_fp8_einsum_recipe(
             self._o_proj_block_size
         )
@@ -198,8 +208,13 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
             assert self.topk_indices_buffer is not None
             block_size = attn_metadata.block_size // self.compress_ratio
             is_valid = swa_metadata.is_valid_token[:num_decode_tokens]
+            record_indices = self.topk_indices_buffer[:num_decode_tokens]
+            if self.dcp_world_size > 1:
+                record_indices, _ = localize_topk(
+                    record_indices, self.dcp_rank, self.dcp_world_size
+                )
             global_indices, topk_lens = compute_global_topk_indices_and_lens(
-                self.topk_indices_buffer[:num_decode_tokens],
+                record_indices,
                 swa_metadata.token_to_req_indices,
                 attn_metadata.block_table[:num_decodes],
                 block_size,
@@ -209,6 +224,12 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
 
         swa_indices = swa_metadata.decode_swa_indices
         swa_lens = swa_metadata.decode_swa_lens
+        use_dcp = self.dcp_world_size > 1 and not swa_only
+        if use_dcp:
+            q = gather_query(q, self.n_local_heads)
+            if self.dcp_rank != 0:
+                swa_indices = torch.full_like(swa_indices, -1)
+                swa_lens = torch.zeros_like(swa_lens)
 
         # We treat queries in the same seq as different queries
         # and later we only attend by generated indices.
@@ -240,7 +261,10 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
             "allocate one for this layer type."
         )
 
-        out, _ = flash_mla_with_kvcache(
+        if use_dcp:
+            # Owner-local counts can differ between index-source epochs.
+            tile_metadata = FlashMLASchedMeta()
+        out, lse = flash_mla_with_kvcache(
             q=q,
             k_cache=swa_cache,
             block_table=None,
@@ -251,12 +275,23 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
             indices=swa_indices,
             topk_length=swa_lens,
             softmax_scale=self.scale,
-            attn_sink=self.attn_sink,
+            attn_sink=None if use_dcp else self.attn_sink,
             extra_k_cache=kv_cache if not swa_only else None,
             extra_indices_in_kvcache=topk_indices,
             extra_topk_length=topk_lens,
             out=output.unsqueeze(1),
         )
+        if use_dcp:
+            assert topk_lens is not None
+            merged = merge_partial_output(
+                out.squeeze(1),
+                lse.squeeze(-1),
+                swa_lens + topk_lens,
+                self.n_local_heads,
+                self.attn_sink,
+            )
+            output.zero_()
+            output[:, : self.n_local_heads].copy_(merged)
 
     def _forward_prefill(
         self,
@@ -269,6 +304,9 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
         swa_metadata: "DeepseekSparseSWAMetadata",
     ) -> None:
         swa_only = self.compress_ratio == 0
+        use_dcp = self.dcp_world_size > 1 and not swa_only
+        if use_dcp:
+            q = gather_query(q, self.n_local_heads)
 
         num_prefill_tokens = swa_metadata.num_prefill_tokens
         num_decodes = swa_metadata.num_decodes
@@ -315,10 +353,15 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                 # Gather compressed KV
                 assert attn_metadata is not None
                 block_table = attn_metadata.block_table[num_decodes:]
+                compressed_lens = seq_lens[chunk_start:chunk_end] // self.compress_ratio
+                if use_dcp:
+                    compressed_lens = (
+                        compressed_lens + self.dcp_world_size - 1 - self.dcp_rank
+                    ) // self.dcp_world_size
                 dequantize_and_gather_k_cache(
                     kv[:chunk_size],
                     compressed_k_cache,
-                    seq_lens=seq_lens[chunk_start:chunk_end] // self.compress_ratio,
+                    seq_lens=compressed_lens,
                     gather_lens=None,
                     block_table=block_table[chunk_start:chunk_end],
                     block_size=attn_metadata.block_size // self.compress_ratio,
@@ -347,41 +390,70 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
             combined_indices_out = combined_indices_out[: query_end - query_start]
             combined_lens_out = combined_lens_out[: query_end - query_start]
 
-            combined_indices, combined_lens = combine_topk_swa_indices(
-                topk_indices[query_start:query_end],
-                query_start_loc[
-                    num_decodes + chunk_start : num_decodes + chunk_end + 1
-                ],
-                seq_lens[chunk_start:chunk_end],
-                gather_lens[chunk_start:chunk_end],
-                self.window_size,
-                self.compress_ratio,
-                top_k,
-                chunk_M,
-                chunk_N,
-                out=(combined_indices_out, combined_lens_out),
-                left_visible=(
-                    swa_metadata.prefill_left_visible[
-                        num_decode_tokens + query_start : num_decode_tokens + query_end
-                    ]
-                    if swa_metadata.prefill_left_visible is not None
-                    else None
-                ),
-                right_visible=(
-                    swa_metadata.prefill_right_visible[
-                        num_decode_tokens + query_start : num_decode_tokens + query_end
-                    ]
-                    if swa_metadata.prefill_right_visible is not None
-                    else None
-                ),
-                max_image_tokens=self.max_image_tokens,
+            token_slice = slice(
+                num_decode_tokens + query_start, num_decode_tokens + query_end
             )
-            flash_mla_sparse_fwd(
+            valid_counts = None
+            if use_dcp:
+                assert attn_metadata is not None
+                request_indices = attn_metadata.req_id_per_token[
+                    num_decode_tokens + query_start : num_decode_tokens + query_end
+                ] - (num_decodes + chunk_start)
+                combined_indices, valid_counts = prefill_indices(
+                    topk_indices[query_start:query_end],
+                    positions[query_start:query_end],
+                    request_indices,
+                    seq_lens[chunk_start:chunk_end],
+                    gather_lens[chunk_start:chunk_end],
+                    rank=self.dcp_rank,
+                    world_size=self.dcp_world_size,
+                    ratio=self.compress_ratio,
+                    window=self.window_size,
+                    request_stride=chunk_M,
+                    swa_offset=chunk_N,
+                )
+                # Ownership filtering leaves holes; scan the complete padded row.
+                combined_lens = None
+            else:
+                combined_indices, combined_lens = combine_topk_swa_indices(
+                    topk_indices[query_start:query_end],
+                    query_start_loc[
+                        num_decodes + chunk_start : num_decodes + chunk_end + 1
+                    ],
+                    seq_lens[chunk_start:chunk_end],
+                    gather_lens[chunk_start:chunk_end],
+                    self.window_size,
+                    self.compress_ratio,
+                    top_k,
+                    chunk_M,
+                    chunk_N,
+                    out=(combined_indices_out, combined_lens_out),
+                    left_visible=(
+                        swa_metadata.prefill_left_visible[token_slice]
+                        if swa_metadata.prefill_left_visible is not None
+                        else None
+                    ),
+                    right_visible=(
+                        swa_metadata.prefill_right_visible[token_slice]
+                        if swa_metadata.prefill_right_visible is not None
+                        else None
+                    ),
+                    max_image_tokens=self.max_image_tokens,
+                )
+            result, _, lse = flash_mla_sparse_fwd(
                 q=q[query_start:query_end],
                 kv=kv.view(-1, 1, q.shape[-1]),
                 indices=combined_indices.unsqueeze(1),
                 sm_scale=self.scale,
-                attn_sink=self.attn_sink,
+                attn_sink=None if use_dcp else self.attn_sink,
                 topk_length=combined_lens,
                 out=output[query_start:query_end],
             )
+            if use_dcp:
+                assert valid_counts is not None
+                merged = merge_partial_output(
+                    result, lse, valid_counts, self.n_local_heads, self.attn_sink
+                )
+                target = output[query_start:query_end]
+                target.zero_()
+                target[:, : self.n_local_heads].copy_(merged)

--- a/vllm/models/deepseek_v4_1/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4_1/nvidia/flashmla.py
@@ -132,12 +132,41 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
             combined_topk = round_up(
                 top_k + self.window_size + self.max_image_tokens, 128
             )
-            current_workspace_manager().get_simultaneous(
+            workspace = current_workspace_manager().get_simultaneous(
                 ((self.PREFILL_CHUNK_SIZE, M, q.shape[-1]), torch.bfloat16),
                 ((self.max_num_batched_tokens, combined_topk), torch.int32),
                 ((self.max_num_batched_tokens,), torch.int32),
             )
             output.zero_()
+            if self.dcp_world_size > 1 and not swa_only:
+                # Profile the real exchange/merge scratch and lazy communicator
+                # allocations before the automatic KV budget is selected.
+                gathered_q = gather_query(q, self.n_local_heads)
+                profile_topk = round_up(top_k + self.window_size, 128)
+                indices = torch.full(
+                    (q.shape[0], 1, profile_topk),
+                    -1,
+                    dtype=torch.int32,
+                    device=q.device,
+                )
+                valid_counts = torch.zeros(
+                    gathered_q.shape[0], dtype=torch.int32, device=q.device
+                )
+                _, max_logits, lse = flash_mla_sparse_fwd(
+                    q=gathered_q,
+                    kv=workspace[0].view(-1, 1, q.shape[-1]),
+                    indices=indices,
+                    sm_scale=self.scale,
+                    attn_sink=None,
+                    out=output,
+                )
+                # Keep native outputs and indices live through the merge, as in
+                # prefill. Empty rows avoid reading the dummy KV workspace.
+                merge_partial_output(
+                    output, lse, valid_counts, self.n_local_heads, self.attn_sink
+                )
+                del max_logits
+                output.zero_()
             return
 
         assert isinstance(attn_metadata, dict)

--- a/vllm/models/deepseek_v4_1/sparse_mla.py
+++ b/vllm/models/deepseek_v4_1/sparse_mla.py
@@ -9,6 +9,7 @@ import torch
 
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
+from vllm.distributed.parallel_state import get_dcp_group
 from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backend import (
@@ -26,6 +27,7 @@ from vllm.v1.attention.backends.mla.sparse_swa import (
     _LAYER_TYPE_SWAONLY,
     DeepseekSparseSWAMetadataBuilder,
 )
+from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 # v4.1 per-layer compress ratios: 0 = pure sliding window, 1 = full-length
@@ -139,6 +141,11 @@ class DeepseekV4FlashMLAMetadata(AttentionMetadata):
     req_id_per_token: torch.Tensor
     block_size: int
     topk_tokens: int
+    global_seq_lens: torch.Tensor | None = None
+    local_seq_lens: torch.Tensor | None = None
+    record_block_size: int = 0
+    dcp_rank: int = 0
+    dcp_world_size: int = 1
 
 
 class DeepseekV4SparseMLAMetadataBuilder(
@@ -159,6 +166,14 @@ class DeepseekV4SparseMLAMetadataBuilder(
         # supports_spec_as_decode=True) as decodes; longer queries go to prefill.
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
         self.topk_tokens = self.model_config.hf_config.index_topk
+        parallel_config = vllm_config.parallel_config
+        self.dcp_world_size = parallel_config.decode_context_parallel_size
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        self.dcp_interleave = parallel_config.cp_kv_cache_interleave_size
+        if self.dcp_world_size > 1 and self.dcp_interleave != 1:
+            raise NotImplementedError(
+                "DeepSeek V4.1 compressed DCP requires cp_kv_cache_interleave_size=1."
+            )
 
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         self.req_id_per_token_buffer = torch.empty(
@@ -201,7 +216,18 @@ class DeepseekV4SparseMLAMetadataBuilder(
                 int(self.kv_cache_spec.num_states),
                 self.compress_ratio,
                 out=self.compressed_slot_mapping_buffer,
+                dcp_rank=self.dcp_rank,
+                dcp_world_size=self.dcp_world_size,
+                dcp_interleave=self.dcp_interleave,
             )
+
+        global_seq_lens = cm.seq_lens // self.compress_ratio
+        local_seq_lens = get_dcp_local_seq_lens(
+            global_seq_lens,
+            self.dcp_world_size,
+            self.dcp_rank,
+            self.dcp_interleave,
+        )
 
         return DeepseekV4FlashMLAMetadata(
             num_reqs=cm.num_reqs,
@@ -211,9 +237,14 @@ class DeepseekV4SparseMLAMetadataBuilder(
             query_start_loc=cm.query_start_loc,
             slot_mapping=slot_mapping,
             block_table=cm.block_table_tensor,
+            global_seq_lens=global_seq_lens,
+            local_seq_lens=local_seq_lens,
             req_id_per_token=req_id_per_token,
             block_size=self.kv_cache_spec.block_size,
+            record_block_size=int(self.kv_cache_spec.num_states),
             topk_tokens=self.topk_tokens,
+            dcp_rank=self.dcp_rank,
+            dcp_world_size=self.dcp_world_size,
         )
 
 

--- a/vllm/v1/attention/backends/mla/compressor_utils.py
+++ b/vllm/v1/attention/backends/mla/compressor_utils.py
@@ -38,6 +38,9 @@ class CompressedSlotMappingKernel(
         compress_ratio: int
         triton_block_size: int
         block_size: int
+        dcp_rank: int
+        dcp_world_size: int
+        dcp_interleave: int
 
     @staticmethod
     @triton.jit(do_not_specialize=["block_table_stride"])
@@ -52,6 +55,9 @@ class CompressedSlotMappingKernel(
         block_table_ptr,
         block_table_stride,
         block_size,
+        DCP_RANK: tl.constexpr,
+        DCP_WORLD_SIZE: tl.constexpr,
+        DCP_INTERLEAVE: tl.constexpr,
         COMPRESS_RATIO: tl.constexpr,
         PAD_ID: tl.constexpr,
         TRITON_BLOCK_SIZE: tl.constexpr,
@@ -71,7 +77,12 @@ class CompressedSlotMappingKernel(
 
             pos = start_pos + i + tl.arange(0, TRITON_BLOCK_SIZE)
             is_valid = (pos + 1) % COMPRESS_RATIO == 0
-            pos_after_compress = pos // COMPRESS_RATIO
+            global_record = pos // COMPRESS_RATIO
+            owner = (global_record // DCP_INTERLEAVE) % DCP_WORLD_SIZE
+            group_round = global_record // (DCP_INTERLEAVE * DCP_WORLD_SIZE)
+            group_offset = global_record % DCP_INTERLEAVE
+            pos_after_compress = group_round * DCP_INTERLEAVE + group_offset
+            is_valid &= owner == DCP_RANK
 
             block_ids = pos_after_compress // block_size
             block_numbers = tl.load(
@@ -89,11 +100,17 @@ class CompressedSlotMappingKernel(
         *,
         compress_ratio: int,
         block_size: int,
+        dcp_rank: int = 0,
+        dcp_world_size: int = 1,
+        dcp_interleave: int = 1,
     ) -> CompileKey:
         return self.CompileKey(
             compress_ratio=compress_ratio,
             triton_block_size=self.TRITON_BLOCK_SIZE,
             block_size=triton_scalar_specialization_rep(block_size),
+            dcp_rank=triton_scalar_specialization_rep(dcp_rank),
+            dcp_world_size=triton_scalar_specialization_rep(dcp_world_size),
+            dcp_interleave=triton_scalar_specialization_rep(dcp_interleave),
         )
 
     def get_warmup_keys(self, vllm_config: Any) -> list[CompileKey]:
@@ -107,12 +124,19 @@ class CompressedSlotMappingKernel(
         )
         if not compress_ratios:
             return []
+        parallel_config = getattr(vllm_config, "parallel_config", None)
+        dcp_world_size = getattr(parallel_config, "decode_context_parallel_size", 1)
+        dcp_rank = 0
+        dcp_interleave = getattr(parallel_config, "cp_kv_cache_interleave_size", 1)
         return self._trace_dispatch(self.dispatch)(
             zip_inputs(
                 *(
                     dict(
                         compress_ratio=ratio,
                         block_size=vllm_config.cache_config.block_size // ratio,
+                        dcp_rank=dcp_rank,
+                        dcp_world_size=dcp_world_size,
+                        dcp_interleave=dcp_interleave,
                     )
                     for ratio in compress_ratios
                 )
@@ -128,6 +152,9 @@ class CompressedSlotMappingKernel(
             block_table=int32_ptr,
             block_size=compile_key.block_size,
             compress_ratio=compile_key.compress_ratio,
+            dcp_rank=compile_key.dcp_rank,
+            dcp_world_size=compile_key.dcp_world_size,
+            dcp_interleave=compile_key.dcp_interleave,
         )
 
     @kernel_launcher
@@ -139,9 +166,15 @@ class CompressedSlotMappingKernel(
         block_table: torch.Tensor,
         block_size: int,
         compress_ratio: int,
+        dcp_rank: int = 0,
+        dcp_world_size: int = 1,
+        dcp_interleave: int = 1,
     ) -> LaunchSpec:
         return (block_table.shape[0],), dict(
             block_table_stride=block_table.stride(0),
+            DCP_RANK=dcp_rank,
+            DCP_WORLD_SIZE=dcp_world_size,
+            DCP_INTERLEAVE=dcp_interleave,
             COMPRESS_RATIO=compress_ratio,
             PAD_ID=-1,
             TRITON_BLOCK_SIZE=self.TRITON_BLOCK_SIZE,
@@ -156,6 +189,9 @@ def get_compressed_slot_mapping(
     block_size: int,
     compress_ratio: int,
     out: torch.Tensor | None = None,
+    dcp_rank: int = 0,
+    dcp_world_size: int = 1,
+    dcp_interleave: int = 1,
 ) -> torch.Tensor:
     if out is not None:
         # Guard: for padded / invalid sequences.
@@ -176,8 +212,29 @@ def get_compressed_slot_mapping(
         block_table,
         block_size,
         compress_ratio,
+        dcp_rank,
+        dcp_world_size,
+        dcp_interleave,
     )
     return slot_mapping
+
+
+def get_compressed_record_owner_and_local(
+    position: int,
+    compress_ratio: int,
+    dcp_world_size: int,
+    dcp_interleave: int = 1,
+) -> tuple[int, int] | None:
+    """Return the owner and owner-local record for an emitted raw position."""
+    if (position + 1) % compress_ratio != 0:
+        return None
+    record = position // compress_ratio
+    owner = (record // dcp_interleave) % dcp_world_size
+    local = (
+        record // (dcp_interleave * dcp_world_size) * dcp_interleave
+        + record % dcp_interleave
+    )
+    return owner, local
 
 
 _COMPRESSED_SLOT_MAPPING_KERNEL = CompressedSlotMappingKernel()

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -39,6 +39,7 @@ from vllm.v1.attention.backends.utils import (
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    KVCacheDCPPlacement,
     KVCacheLayout,
     KVCacheSpec,
     MLAAttentionSpec,
@@ -262,8 +263,7 @@ class DeepseekV41IndexerBackend(DeepseekV4IndexerBackend):
 @dataclass
 class DeepseekV32IndexerPrefillChunkMetadata:
     block_table: torch.Tensor
-    # Under DCP (dcp_world_size > 1) these hold this rank's local row bounds;
-    # otherwise they hold the global bounds.
+    # Owner-packed compressed-record row bounds.
     cu_seqlen_ks: torch.Tensor
     cu_seqlen_ke: torch.Tensor
     cu_seq_lens: torch.Tensor
@@ -365,11 +365,21 @@ class BuildPrefillChunkMetadataKernel(
                 mask=mask,
             )
 
-        # Compute token_to_seq
-        for i in range(0, compressed_seq_len, BLOCK_SIZE):
+        local_compressed_seq_len = compressed_seq_len
+        if DCP_WORLD > 1:
+            base = compressed_seq_len // DCP_INTERLEAVE // DCP_WORLD * DCP_INTERLEAVE
+            remainder = compressed_seq_len - base * DCP_WORLD
+            remainder = tl.minimum(
+                tl.maximum(remainder - DCP_RANK * DCP_INTERLEAVE, 0),
+                DCP_INTERLEAVE,
+            )
+            local_compressed_seq_len = base + remainder
+
+        # token_to_seq follows the same owner-packed layout as gathered K.
+        for i in range(0, local_compressed_seq_len, BLOCK_SIZE):
             offset = i + tl.arange(0, BLOCK_SIZE)
-            mask = offset < compressed_seq_len
-            tl.store(token_to_seq_ptr + seq_start + offset, batch_idx, mask=mask)
+            mask = offset < local_compressed_seq_len
+            tl.store(token_to_seq_ptr + row_start + offset, batch_idx, mask=mask)
 
     def dispatch(  # type: ignore[override]
         self,
@@ -491,6 +501,7 @@ class DeepSeekV32IndexerDecodeMetadata:
     decode_lens: torch.Tensor
     requires_padding: bool
     schedule_metadata: torch.Tensor
+    # Global compressed-record visible lengths, before DCP localization.
     global_seq_lens: torch.Tensor | None = None
     per_req_decode_lens: torch.Tensor | None = None
     decode_is_uniform: bool = True
@@ -773,7 +784,16 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # are whisper block pooling and never reach MLA).
             assert isinstance(self.kv_cache_spec.tokens_per_state, int)
             self.compress_ratio = self.kv_cache_spec.tokens_per_state
-        if self.dcp_world_size > 1 and self.compress_ratio > 1:
+        supports_compressed_dcp = (
+            isinstance(self.kv_cache_spec, MLAAttentionSpec)
+            and self.kv_cache_spec.dcp_kv_cache_placement == KVCacheDCPPlacement.SHARDED
+            and self.compress_ratio in (1, 2)
+        )
+        if (
+            self.dcp_world_size > 1
+            and self.compress_ratio > 1
+            and not supports_compressed_dcp
+        ):
             raise NotImplementedError(
                 "DCP is not supported with sparse indexer KV compression "
                 f"(compress_ratio={self.compress_ratio})."
@@ -1088,6 +1108,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 self.kv_cache_spec.num_states,
                 self.compress_ratio,
                 out=self.compressed_slot_mapping_buffer,
+                dcp_rank=self.dcp_rank,
+                dcp_world_size=self.dcp_world_size,
+                dcp_interleave=self.cp_kv_cache_interleave_size,
             )
             if self.pcp_world_size > 1:
                 compressed_slot_mapping = get_pcp_group().all_gather(
@@ -1254,16 +1277,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # batches. Keep its address stable across varlen graph replays.
             seq_lens_is_buffer_view = not use_native or next_n > 1
 
-            # DCP: localize the now-expanded per-token global bounds to this
-            # rank's owned KV. Done here (after expansion) so each token's global
-            # causal length is localized individually; see the comment above.
-            if dcp_local_seq_lens is not None:
-                seq_lens = self._dcp_localize_decode_seq_lens(
-                    seq_lens, num_decodes, seq_lens_is_buffer_view
-                )
-
-            # For DeepseekV4 (compress_ratio > 1), the indexer KV cache stores
-            # compressed tokens. Convert uncompressed seq_lens to compressed.
+            # Convert raw visible lengths to record space before DCP ownership.
             if self.compress_ratio > 1:
                 if seq_lens_is_buffer_view:
                     seq_lens //= self.compress_ratio
@@ -1274,6 +1288,22 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     )
                     self.expanded_seq_lens_buffer[num_decodes:num_decode_tokens] = 0
                     seq_lens = self.expanded_seq_lens_buffer[:num_decode_tokens]
+
+                if global_seq_lens_for_decode is not None:
+                    global_shape = global_seq_lens_for_decode.shape
+                    global_numel = global_seq_lens_for_decode.numel()
+                    global_record_seq_lens = self.global_decode_seq_lens_buffer[
+                        :global_numel
+                    ].view(global_shape)
+                    global_record_seq_lens.copy_(global_seq_lens_for_decode)
+                    global_record_seq_lens //= self.compress_ratio
+                    global_seq_lens_for_decode = global_record_seq_lens
+
+            # Localize emitted records, not their source raw-token positions.
+            if dcp_local_seq_lens is not None:
+                seq_lens = self._dcp_localize_decode_seq_lens(
+                    seq_lens, num_decodes, seq_lens_is_buffer_view
+                )
 
             # Non-MTP: deep_gemm paged MQA logits requires 2D context_lens
             # (csrc/apis/attention.hpp). Unsqueeze to (B, 1) so downstream
@@ -1343,8 +1373,6 @@ def build_prefill_chunk_metadata(
 
     num_reqs = end_idx - start_idx
     device = block_table.device
-    token_to_seq = torch.empty(total_seq_lens, dtype=torch.int32, device=device)
-
     cu_seq_lens = torch.empty(num_reqs + 1, dtype=torch.int32, device=device)
     # Assigning to slice avoids cpu sync.
     cu_seq_lens[:1] = 0
@@ -1368,6 +1396,10 @@ def build_prefill_chunk_metadata(
         torch.cumsum(this_rank_counts, dim=0, out=local_cu_seq_lens[1:])
         local_total_seq_lens = int(local_cu_seq_lens[-1].item())
         max_local_total_seq_lens = int(local_seq_lens.sum(dim=0).max().item())
+
+    token_to_seq = torch.empty(
+        max_local_total_seq_lens, dtype=torch.int32, device=device
+    )
 
     query_start_loc = (
         query_start_loc[start_idx : end_idx + 1] - query_start_loc[start_idx]

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -33,6 +33,7 @@ from vllm.v1.attention.backends.mla.compressor_utils import (
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
 from vllm.v1.attention.ops.flashmla import FlashMLASchedMeta, get_mla_metadata
 from vllm.v1.kv_cache_interface import (
+    KVCacheDCPPlacement,
     KVCacheSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
@@ -79,6 +80,7 @@ class DeepseekV4SWACache(torch.nn.Module, AttentionLayerBase):
         cache_config: CacheConfig,
         backend_cls: "type[AttentionBackend] | None" = None,
         block_size: int = 64,
+        dcp_kv_cache_placement: KVCacheDCPPlacement | None = None,
     ):
         super().__init__()
         self.backend_cls = backend_cls or DeepseekSparseSWABackend
@@ -87,6 +89,7 @@ class DeepseekV4SWACache(torch.nn.Module, AttentionLayerBase):
         self.window_size = window_size
         self.prefix = prefix
         self.cache_config = cache_config
+        self.dcp_kv_cache_placement = dcp_kv_cache_placement
         self.dtype = dtype
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
@@ -121,6 +124,7 @@ class DeepseekV4SWACache(torch.nn.Module, AttentionLayerBase):
             alignment=576 if uses_fp8_ds_mla_layout else 512,
             model_version="deepseek_v4",
             kv_quant_mode=get_kv_quant_mode(self.cache_config.cache_dtype),
+            dcp_kv_cache_placement=self.dcp_kv_cache_placement,
         )
 
     def forward(self): ...

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -20,11 +20,14 @@ from vllm.v1.core.single_type_kv_cache_manager import (
     get_manager_for_kv_cache_spec,
 )
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
+    KVCacheDCPPlacement,
     KVCacheSpec,
     MambaSpec,
     SlidingWindowSpec,
+    iter_layer_specs,
 )
 from vllm.v1.request import Request
 
@@ -649,15 +652,25 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         )
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
         if dcp_world_size > 1:
-            # DCP shards full-attention KV across ranks and replicates Mamba
-            # state; other spec types (e.g. sliding window) have no DCP-aware
-            # handling yet, so reject them explicitly.
             for g in kv_cache_config.kv_cache_groups:
-                assert isinstance(g.kv_cache_spec, (FullAttentionSpec, MambaSpec)), (
-                    "DCP with hybrid KV cache layouts only supports "
-                    "full-attention and Mamba groups, got: "
-                    f"{type(g.kv_cache_spec).__name__}."
-                )
+                for spec in iter_layer_specs(g.kv_cache_spec):
+                    supported = (
+                        isinstance(spec, MambaSpec)
+                        or (
+                            isinstance(spec, FullAttentionSpec)
+                            and spec.is_dcp_kv_cache_sharded
+                        )
+                        or (
+                            isinstance(spec, AttentionSpec)
+                            and spec.dcp_kv_cache_placement
+                            == KVCacheDCPPlacement.REPLICATED
+                        )
+                    )
+                    assert supported, (
+                        "DCP hybrid KV cache groups require sharded full attention "
+                        "or explicitly replicated attention state, got: "
+                        f"{type(spec).__name__}."
+                    )
         # Fine-grained hash hits require Mamba "align" and compatible cache
         # managers in every group. TP needs hashing finer than the Mamba block;
         # DCP accepts equality because it scales the effective full-attention

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -654,7 +654,8 @@ def resolve_dcp_kv_block_size(spec: KVCacheSpec, dcp_world_size: int) -> int:
     """Return the token span of a cache block under DCP."""
     layer_specs = iter_layer_specs(spec)
     if len(layer_specs) > 0 and all(
-        isinstance(layer_spec, AttentionSpec) for layer_spec in layer_specs
+        isinstance(layer_spec, AttentionSpec) and layer_spec.is_dcp_kv_cache_sharded
+        for layer_spec in layer_specs
     ):
         return spec.block_size * dcp_world_size
     return spec.block_size
@@ -691,10 +692,16 @@ def dcp_world_size_for_kv_cache_spec(spec: KVCacheSpec, dcp_world_size: int) -> 
     """
     if dcp_world_size <= 1:
         return 1
-    inner = spec
-    if isinstance(spec, UniformTypeKVCacheSpecs):
-        inner = next(iter(spec.kv_cache_specs.values()))
-    if isinstance(inner, FullAttentionSpec):
+    layer_specs = iter_layer_specs(spec)
+    placements = {
+        layer_spec.is_dcp_kv_cache_sharded
+        for layer_spec in layer_specs
+        if isinstance(layer_spec, AttentionSpec)
+    }
+    assert len(placements) <= 1, (
+        "All layers in a KV cache group must use the same DCP placement."
+    )
+    if placements == {True}:
         return dcp_world_size
     return 1
 
@@ -722,7 +729,11 @@ def resolve_kv_cache_block_sizes(
     groups = kv_cache_config.kv_cache_groups
 
     if len(groups) <= 1:
-        bs = cache_config.block_size * dcp
+        bs = (
+            resolve_dcp_kv_block_size(groups[0].kv_cache_spec, dcp)
+            if groups
+            else cache_config.block_size * dcp
+        )
         return bs, bs
 
     group_block_sizes = [

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -147,6 +147,13 @@ class KVCacheSpecKind(str, Enum):
     UNKNOWN = "unknown"
 
 
+class KVCacheDCPPlacement(str, Enum):
+    """How a cache group's states are placed across DCP ranks."""
+
+    SHARDED = "sharded"
+    REPLICATED = "replicated"
+
+
 @dataclass(frozen=True)
 class KVCacheSpec:
     """
@@ -401,6 +408,8 @@ class AttentionSpec(KVCacheSpec):
     """Tokens covered by one stored state. Ints > 1 compress multiple tokens
     into one state (DSv4 sparse MLA); fractions < 1 store multiple states per
     token (Whisper block pooling: ``Fraction(1, block_pool_size)``)."""
+    dcp_kv_cache_placement: KVCacheDCPPlacement | None = None
+    """Explicit per-group DCP placement. None preserves legacy inference."""
 
     def __post_init__(self):
         if self.head_size_v is None:
@@ -437,9 +446,20 @@ class AttentionSpec(KVCacheSpec):
         """
         return self.unpadded_page_size_bytes
 
+    @property
+    def is_dcp_kv_cache_sharded(self) -> bool:
+        placement = self.dcp_kv_cache_placement
+        if placement is not None:
+            return placement == KVCacheDCPPlacement.SHARDED
+        return isinstance(self, FullAttentionSpec)
+
     def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
         parallel_config = vllm_config.parallel_config
-        kv_shard_count = parallel_config.decode_context_parallel_size
+        kv_shard_count = (
+            parallel_config.decode_context_parallel_size
+            if self.is_dcp_kv_cache_sharded
+            else 1
+        )
         return cdiv(max_len, self.block_size * kv_shard_count)
 
 
@@ -472,7 +492,7 @@ class FullAttentionSpec(AttentionSpec):
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_model_len = vllm_config.model_config.max_model_len
         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
-        if dcp_world_size > 1:
+        if dcp_world_size > 1 and self.is_dcp_kv_cache_sharded:
             max_model_len = cdiv(max_model_len, dcp_world_size)
         return cdiv(max_model_len, self.block_size) * self.page_size_bytes
 
@@ -520,6 +540,7 @@ class FullAttentionSpec(AttentionSpec):
             num_head_slots=specs[0].num_head_slots,
             state_content_bytes=specs[0].state_content_bytes,
             tokens_per_state=specs[0].tokens_per_state,
+            dcp_kv_cache_placement=specs[0].dcp_kv_cache_placement,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
             # If any layer in the group is non-causal, treat the group as
@@ -599,6 +620,7 @@ class MLAAttentionSpec(FullAttentionSpec):
             state_content_bytes=specs[0].state_content_bytes,
             cache_dtype_str=cache_dtype_str_set.pop(),
             tokens_per_state=tokens_per_state_set.pop(),
+            dcp_kv_cache_placement=specs[0].dcp_kv_cache_placement,
             model_version=model_version_set.pop(),
             storage_block_size=storage_block_size_set.pop(),
             non_causal_multi_token_decode=any(
@@ -656,6 +678,7 @@ class RSWASpec(FullAttentionSpec):
             num_head_slots=base.num_head_slots,
             state_content_bytes=base.state_content_bytes,
             tokens_per_state=base.tokens_per_state,
+            dcp_kv_cache_placement=base.dcp_kv_cache_placement,
             sliding_window=base.sliding_window,
             attention_chunk_size=base.attention_chunk_size,
             non_causal=base.non_causal,
@@ -742,9 +765,10 @@ class SlidingWindowSpec(AttentionSpec):
         return cdiv(num_tokens, self.block_size) + 1
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
-        assert vllm_config.parallel_config.decode_context_parallel_size == 1, (
-            "DCP not support sliding window."
-        )
+        dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
+        assert dcp_world_size == 1 or (
+            self.dcp_kv_cache_placement == KVCacheDCPPlacement.REPLICATED
+        ), "DCP sliding-window cache requires explicit replicated placement."
         max_blocks = self.max_admission_blocks_per_request(
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             max_model_len=vllm_config.model_config.max_model_len,
@@ -846,6 +870,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             extra_retained_tokens=extra_retained_set.pop(),
             cache_dtype_str=cache_dtype_str_set.pop(),
             tokens_per_state=tokens_per_state_set.pop(),
+            dcp_kv_cache_placement=specs[0].dcp_kv_cache_placement,
             model_version=model_version_set.pop(),
         )
 
@@ -1050,6 +1075,8 @@ class SinkFullAttentionSpec(FullAttentionSpec):
             page_size_padded=specs[0].page_size_padded,
             num_head_slots=specs[0].num_head_slots,
             state_content_bytes=specs[0].state_content_bytes,
+            tokens_per_state=specs[0].tokens_per_state,
+            dcp_kv_cache_placement=specs[0].dcp_kv_cache_placement,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
             non_causal=any(spec.non_causal for spec in specs),
@@ -1127,6 +1154,12 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
             # Different block sizes, not uniform.
             return False
         first_spec = next(iter(kv_cache_specs.values()))
+        if isinstance(first_spec, AttentionSpec) and any(
+            not isinstance(spec, AttentionSpec)
+            or spec.is_dcp_kv_cache_sharded != first_spec.is_dcp_kv_cache_sharded
+            for spec in kv_cache_specs.values()
+        ):
+            return False
         return first_spec.is_uniform_with_collection(kv_cache_specs)
 
     @classmethod

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -27,6 +27,7 @@ class BlockTables:
         cp_rank: int = 0,
         cp_interleave: int = 1,
         slot_mapping_enabled: list[bool] | None = None,
+        dcp_sharded: list[bool] | None = None,
     ):
         self.block_sizes = block_sizes
         self.kernel_block_sizes = kernel_block_sizes
@@ -44,6 +45,10 @@ class BlockTables:
             slot_mapping_enabled = [True] * self.num_kv_cache_groups
         assert len(slot_mapping_enabled) == self.num_kv_cache_groups
         self._slot_mapping_enabled = slot_mapping_enabled
+        if dcp_sharded is None:
+            dcp_sharded = [cp_size > 1] * self.num_kv_cache_groups
+        assert len(dcp_sharded) == self.num_kv_cache_groups
+        self._dcp_sharded = dcp_sharded
 
         self.blocks_per_kv_block = [
             bs // kbs for bs, kbs in zip(block_sizes, kernel_block_sizes)
@@ -107,6 +112,9 @@ class BlockTables:
         )
         self.slot_mapping_enabled = torch.tensor(
             self._slot_mapping_enabled, dtype=torch.bool, device=self.device
+        )
+        self.dcp_sharded = torch.tensor(
+            self._dcp_sharded, dtype=torch.bool, device=self.device
         )
         self.input_block_table_ptrs = self._make_ptr_tensor(self.input_block_tables)
 
@@ -211,6 +219,7 @@ class BlockTables:
             self.block_sizes_tensor,
             self.kernel_block_sizes_tensor,
             self.slot_mapping_enabled,
+            self.dcp_sharded,
             slot_mappings,
             slot_mappings.stride(0),
             self.cp_rank,
@@ -284,6 +293,7 @@ def _compute_slot_mappings_kernel(
     block_sizes,  # [num_kv_cache_groups]
     kernel_block_sizes,  # [num_kv_cache_groups]
     slot_mapping_enabled,  # [num_kv_cache_groups]
+    dcp_sharded,  # [num_kv_cache_groups]
     slot_mappings_ptr,  # [num_kv_cache_groups, max_num_tokens]
     slot_mappings_stride,
     cp_rank,
@@ -313,6 +323,7 @@ def _compute_slot_mappings_kernel(
     kv_block_size = tl.load(block_sizes + group_id)
     kernel_block_size = tl.load(kernel_block_sizes + group_id)
     mapping_enabled = tl.load(slot_mapping_enabled + group_id)
+    group_is_sharded = tl.load(dcp_sharded + group_id)
 
     req_state_idx = tl.load(idx_mapping + batch_idx)
     start_idx = tl.load(query_start_loc + batch_idx)
@@ -330,11 +341,13 @@ def _compute_slot_mappings_kernel(
             virtual_block_size = kv_block_size * CP_SIZE
             virtual_block_indices = positions // virtual_block_size
             virtual_block_offsets = positions % virtual_block_size
-            is_local = virtual_block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
+            is_owner = virtual_block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
             rounds = virtual_block_offsets // (CP_INTERLEAVE * CP_SIZE)
             remainder = virtual_block_offsets % CP_INTERLEAVE
-            local_offsets = rounds * CP_INTERLEAVE + remainder
-            local_positions = virtual_block_indices * kv_block_size + local_offsets
+            sharded_offsets = rounds * CP_INTERLEAVE + remainder
+            sharded_positions = virtual_block_indices * kv_block_size + sharded_offsets
+            is_local = (~group_is_sharded) | is_owner
+            local_positions = tl.where(group_is_sharded, sharded_positions, positions)
 
         block_indices = tl.where(
             mapping_enabled, local_positions // kernel_block_size, 0

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -872,7 +872,9 @@ def _extrapolate_full_graph_memory(mem_samples: list[int], total_graphs: int) ->
     return first_capture + (total_graphs - 1) * per_graph
 
 
-def _init_minimal_kv_cache_for_profiling(runner: "GPUModelRunner") -> None:
+def _init_minimal_kv_cache_for_profiling(
+    runner: "GPUModelRunner", min_blocks: int | None = None
+) -> None:
     """Allocate the smallest KV cache that still lets every graph be captured."""
     from vllm.v1.core.kv_cache_utils import (
         get_kv_cache_config_from_groups,
@@ -882,10 +884,14 @@ def _init_minimal_kv_cache_for_profiling(runner: "GPUModelRunner") -> None:
     kv_cache_spec = runner.get_kv_cache_spec()
     kv_cache_groups = get_kv_cache_groups(runner.vllm_config, kv_cache_spec)
     # At least one block per sequence is required to capture the graphs.
-    min_blocks = (
-        min(runner.max_num_reqs, runner.compilation_config.max_cudagraph_capture_size)
-        or 1
-    )
+    if min_blocks is None:
+        min_blocks = (
+            min(
+                runner.max_num_reqs,
+                runner.compilation_config.max_cudagraph_capture_size,
+            )
+            or 1
+        )
     saved_override = runner.cache_config.num_gpu_blocks_override
     runner.cache_config.num_gpu_blocks_override = min_blocks
     try:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -69,6 +69,7 @@ from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     CircularBufferSpec,
     KVCacheConfig,
+    KVCacheDCPPlacement,
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -584,11 +585,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         block_sizes = []
         max_num_blocks_per_group = []
         slot_mapping_enabled = []
+        dcp_sharded = []
         for kv_cache_group in kv_cache_config.kv_cache_groups:
             spec = kv_cache_group.kv_cache_spec
             block_sizes.append(spec.block_size)
             layer_spec = (
                 spec.first_spec if isinstance(spec, UniformTypeKVCacheSpecs) else spec
+            )
+            dcp_sharded.append(
+                getattr(layer_spec, "dcp_kv_cache_placement", None)
+                != KVCacheDCPPlacement.REPLICATED
             )
             slot_mapping_enabled.append(not isinstance(layer_spec, CircularBufferSpec))
             # Let each cache type account for CP. Attention KV is DCP-sharded,
@@ -650,6 +656,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             device=self.device,
             kernel_block_sizes=self.kernel_block_sizes,
             slot_mapping_enabled=slot_mapping_enabled,
+            dcp_sharded=dcp_sharded,
             cp_size=self.dcp_size,
             cp_rank=self.dcp_rank,
             cp_interleave=self.cp_interleave,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -31,7 +31,7 @@ import torch.nn as nn
 import vllm.envs as envs
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphStat
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.parallel_state import (
     get_dcp_group,
@@ -105,6 +105,8 @@ from vllm.v1.worker.gpu.cp_utils import maybe_prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     ModelCudaGraphManager,
+    _init_minimal_kv_cache_for_profiling,
+    _teardown_profiling_state,
     has_compiled_submodule,
     make_cudagraph_stats,
 )
@@ -917,6 +919,36 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
     @torch.inference_mode()
     def profile_run(self) -> None:
+        # Mixed DCP layouts retain sizeable per-group metadata. Initialize it
+        # before measuring activation peaks, then discard the temporary cache.
+        profile_metadata = (
+            self.dcp_size > 1
+            and self.cache_config.kv_cache_memory_bytes is None
+            and any(
+                getattr(spec, "dcp_kv_cache_placement", None)
+                == KVCacheDCPPlacement.REPLICATED
+                for spec in self.get_kv_cache_spec().values()
+            )
+        )
+        try:
+            if profile_metadata:
+                with set_current_vllm_config(self.vllm_config):
+                    _init_minimal_kv_cache_for_profiling(self, min_blocks=1)
+                # Small batches may initialize a different communicator/GEMM
+                # workspace. Keep it resident while measuring the largest batch.
+                _, sample_hidden_states = self._dummy_run(
+                    1, skip_attn=True, is_profile=True
+                )
+                if self.is_last_pp_rank and self.pooling_runner is None:
+                    assert sample_hidden_states is not None
+                    self._dummy_sampler_run(sample_hidden_states)
+                del sample_hidden_states
+            self._profile_run()
+        finally:
+            if profile_metadata:
+                _teardown_profiling_state(self)
+
+    def _profile_run(self) -> None:
         if self.supports_mm_inputs and self.is_first_pp_rank:
             mm_config = self.model_config.multimodal_config
             if mm_config is not None and not mm_config.skip_mm_profiling:


### PR DESCRIPTION
## Summary

DeepSeek V4.1 currently rejects DCP for its compressed indexer and sliding-window cache layout. Add an initial MRV2 eager FlashMLA path that shards the shared main/index caches by logical record while retaining replicated sliding-window and compressor state.

```text
ASIS
TP replicas: full C1/C2 source caches + SWA/state
DCP > 1 -> unsupported cache/indexer layout
```

```text
PR
C1/C2 records -> unique DCP owner, shared across consuming layers
SWA/state    -> replicated; SWA counted once in attention
global TopK  -> owner partials -> merged heads -> sink once
```

Per-group placement has backward-compatible defaults. Compression precedes record ownership; main and index caches agree on the mapping. Candidate source 20 exchanges global block scores separately from its unmasked token TopK, and later indexers filter in global record coordinates. Attention compacts owner-local decode indices and merges unsunk output/LSE with explicit empty-partition handling before applying the sink once.

The initial scope is NVIDIA FlashMLA, MRV2 eager, DCP2/4, interleave 1, FP8 indexer caches, text-only input, no prefix caching, PCP1/PP1, no DBO or speculative decoding. Unsupported combinations fail at startup. Deployment instructions are included.

This is an explicit-communication correctness baseline; no serving-speedup or measured-capacity claim is made. It is separate from V4.0 DCP PR #44573, whose ratio-4/128 compressor does not match V4.1's ratio-1/2 shared-source topology. Refreshed V4.1 DCP searches found no equivalent open implementation. Existing peer-memory optimizations are follow-ups, not dependencies.

## Validation

- TP4 GB200, MRV2 eager, native binaries matching upstream eed1f3d and source-pinned CuTeDSL 4.7.1. Automatic cache sizing at utilization 0.55, maxbatch 8192, maxseq 4, maxlen 32768.
- Four fixed-answer stress requests pass in DCP1/2/4, including 23,023/23,024-token retrieval. Pinned five-shot 32-question GSM8K: 31/32 control, 31/32 DCP2, 32/32 DCP4; no truncations or newly incorrect answers. This is bounded no-regression evidence, not bitwise parity or an accuracy-improvement claim.
- Profiles native attention, exchange and merge scratch, mixed-layout metadata, and small-batch lazy workspaces before selecting the automatic KV budget. DCP2/4 stay 151/148 MiB below their profiled budgets on this stress workload. The unchanged upstream DCP1 path underprofiles by 448 MiB. Higher concurrency and serving performance remain unqualified.
- Post-merge attention and runner-profiling tests: 24 passed. Final focused suite: 187 passed; one existing V4 case requires gated Llama metadata (HTTP 401). The same assertions pass with an accessible OPT config fixture; both results are retained. Applicable Ruff, format, mypy and commit hooks passed.
- Earlier fixed 512 MiB-budget smoke, 23K retrieval, 32-question evaluation and kernel/placement checks are retained with their distinct runtime and workload.

```bash
.venv/bin/python -m pytest -q tests/model_executor/layers/test_mla_short_prefill_indexer.py tests/model_executor/layers/test_dsv41_dcp_attention.py tests/distributed/test_dsv41_dcp_candidate_blocks.py tests/v1/core/test_kv_cache_utils.py tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py tests/v1/worker/test_gpu_model_runner_v2.py tests/v1/worker/test_gpu_block_table.py tests/v1/attention/test_indexer_deepseek_v4_slot_mapping.py -k "not test_indexer_builder_deepseek_v4_compressed_slot_mapping_uses_num_states"
# From the workspace with the recorded runtime overlay and GPU lease:
vllm-dcp/.venv/bin/python artifacts/dcp/runtime_qualification.py --dcp 2 --output artifacts/dcp/runtime-471/final-dcp2-auto.json
```

AI assistance was used for implementation, testing and investigation. The submitting human confirmed review of every changed line and a relevant test rerun.

[Validation report, raw results, drivers and checksums](https://github.com/foraxe/vllm/tree/2ee0d437f3008f929a66e4d13564ddc90d158470/evidence/dsv41-dcp-eager). Feature candidate 936c40f; base eed1f3d.

Current main has advanced to 9f03b51 with overlapping sparse-indexer changes. This draft retains the reviewed and validated head; rebasing the two conflicting indexer files and revalidating the integration remain pending.
