### PR TITLE
[Perf] Flatten mergeable multi-branch allOf for xgrammar structured output

### DIFF
--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -56,6 +56,35 @@ def unsupported_object_schemas():
 
 
 @pytest.fixture
+def unsupported_allof_schemas():
+    return [
+        {
+            "$defs": {
+                "Base": {
+                    "type": "object",
+                    "properties": {"x": {"type": "integer", "minimum": 10}},
+                    "required": ["x"],
+                }
+            },
+            "allOf": [
+                {"$ref": "#/$defs/Base"},
+                {
+                    "type": "object",
+                    "properties": {"y": {"type": "string"}},
+                    "required": ["y"],
+                },
+            ],
+        },
+        {
+            "allOf": [
+                {"type": "string", "minLength": 1},
+                {"type": "string", "maxLength": 5},
+            ],
+        },
+    ]
+
+
+@pytest.fixture
 def supported_schema():
     return {
         "type": "object",
@@ -96,6 +125,7 @@ def supported_schema():
         "unsupported_number_schemas",
         "unsupported_array_schemas",
         "unsupported_object_schemas",
+        "unsupported_allof_schemas",
     ],
 )
 def test_unsupported_json_features_by_type(schema_type, request):
@@ -110,3 +140,18 @@ def test_supported_json_features(supported_schema):
     assert not has_xgrammar_unsupported_json_features(supported_schema), (
         "Schema should be supported"
     )
+
+
+def test_supported_single_branch_allof():
+    # A single-branch `allOf` is enforced correctly by xgrammar and must not
+    # be flagged as unsupported.
+    schema = {
+        "allOf": [
+            {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}},
+                "required": ["x"],
+            },
+        ],
+    }
+    assert not has_xgrammar_unsupported_json_features(schema)

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -282,6 +282,13 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
         ):
             return True
 
+        # xgrammar enforces `allOf` only when it has a single branch. For
+        # multiple branches it silently compiles to an "accept anything" rule,
+        # dropping every constraint without surfacing an error.
+        allof = obj.get("allOf")
+        if isinstance(allof, list) and len(allof) > 1:
+            return True
+
         # Recursively check all nested objects and arrays
         for value in obj.values():
             if isinstance(value, dict):


### PR DESCRIPTION
## Summary

#56557 makes the `auto` structured-output backend fall back to `guidance` for any JSON schema with more than one `allOf` branch, because xgrammar compiles a multi-branch `allOf` to an accept-anything rule and silently drops the constraints.

That fallback is wider than it needs to be. Pydantic and OpenAPI emit multi-branch `allOf` for plain model inheritance, for example `allOf: [{"$ref": "#/$defs/Base"}, {...}]`, so a common schema shape would move to the slower backend even though nothing in it conflicts.

This flattens a multi-branch `allOf` into a single object schema when the merge is lossless, and leaves the schema alone when it is not. In the second case the #56557 check still fires and `auto` still falls back, so the correctness fix is unchanged and only the fast path is widened.

**What gets merged**

- Each branch is resolved first: an inline object, or a local `$ref` into `$defs` / `definitions`. Refs are only resolved where they appear as an `allOf` branch; a bare `{"$ref": ...}` node is never inlined. Ref chains are followed and a cycle is rejected.
- Merged content: union of `properties`, with a property that appears in more than one branch merged recursively when every occurrence is itself an object schema; union of `required`; `$defs` / `definitions` preserved, because unresolved refs elsewhere may still point at them.
- Annotations (`title`, `description`, and similar) are carried through and do not constrain the accepted language. This matters because Pydantic puts `title` on the `$ref` target.

**When it declines to merge, so `auto` falls back to `guidance` as before**

- a branch that is not an object: `{"type": "string"}` branches, unions such as `["object", "null"]`, and any non-object `type`,
- two branches that constrain the same property incompatibly, for example `{"type": "string"}` against `{"type": "string", "maxLength": 5}`,
- any keyword whose merge is not provably lossless: `additionalProperties`, `patternProperties`, `propertyNames`, `minProperties`, `maxProperties`, `enum`, `anyOf`, `oneOf`, `not`, and so on,
- a `$ref` cycle that would have to be inlined.

Being conservative here is deliberate: anything the merge cannot handle returns `None` and keeps the fallback.

**Where the rewrite happens**

In `validate_xgrammar_grammar`, before the `has_xgrammar_unsupported_json_features` check. That is the code path that decides between xgrammar and guidance, and the schema carried to the engine is the one held in the sampling params, so the flattened schema is written back there. This follows the existing behaviour in the same function, where `choice` is converted into a `grammar`.

A `$ref` cycle reached through an `allOf` branch cannot be inlined, so it is treated as unmergeable and returns `None` rather than recursing.

## Depends on

#56557, stacked underneath this branch: the check it adds is what handles the non-mergeable case. Review the last commit only, the first commit in the diff is #56557.

## Why this is not a duplicate

Searched open PRs for #56556 and for `allOf` in structured output. #50933 resolves `$ref`/`$defs` in tool schemas and #53729 parses tool properties from combinators; both are in entrypoint tool parsing, not structured-output backend selection. No open PR flattens `allOf` for xgrammar.

## Testing

```
$ .venv/bin/python -m pytest tests/v1/structured_output/ tests/test_sampling_params.py -q
105 passed, 16 warnings in 76.33s

$ uvx ruff==0.14.0 check vllm/v1/structured_output/backend_xgrammar.py tests/v1/structured_output/test_utils.py tests/v1/structured_output/test_validation.py
All checks passed!

$ uvx ruff==0.14.0 format --check vllm/v1/structured_output/backend_xgrammar.py tests/v1/structured_output/test_utils.py tests/v1/structured_output/test_validation.py
3 files already formatted
```

New tests: `tests/v1/structured_output/test_utils.py` covers `$ref` inheritance, inline branches, a nested `allOf` inside `properties`, non-object branches, a conflicting property, `additionalProperties`, single-branch passthrough, that the input is not mutated, a ref cycle, and two sibling branches sharing one `$ref`. `tests/v1/structured_output/test_validation.py` asserts that `auto` stays on xgrammar for the inheritance schema and that the engine-facing schema no longer contains `allOf`.

Checked directly against the xgrammar compiler, on the inheritance schema with `{"breed": 5}` as the document (violates `required` and the declared type):

- unflattened, xgrammar accepts it and prints `Warning: Support for allOf with multiple options is still ongoing`, which is the silent constraint drop from #56556,
- flattened, xgrammar rejects it, and the schema is no longer flagged by `has_xgrammar_unsupported_json_features`.

## AI assistance

The code and tests in this PR were written with AI assistance (Grok, xAI), as required by AGENTS.md. I have reviewed every changed line, run the tests above, and can defend the change end to end.
