### PR TITLE
Enable Kimi K3 shared expert sharding with DeepEP v2

### DIFF
--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -301,6 +301,27 @@ def test_shard_sequence_parallel_mlp_gating(
     )
 
 
+@pytest.mark.parametrize(
+    ("moe_backend", "all2all_backend", "expected"),
+    [
+        ("deep_gemm_mega_moe", "naive", True),
+        ("auto", "deepep_v2", True),
+        ("auto", "deepep_low_latency", False),
+    ],
+)
+def test_shared_expert_sharding_backend_gate(
+    moe_backend: str,
+    all2all_backend: str,
+    expected: bool,
+):
+    vllm_config = SimpleNamespace(
+        kernel_config=SimpleNamespace(moe_backend=moe_backend),
+        parallel_config=SimpleNamespace(all2all_backend=all2all_backend),
+    )
+
+    assert kimi_model.can_shard_sequence_parallel_shared_expert(vllm_config) is expected
+
+
 def test_sharded_sequence_parallel_mlp_matches_replicated(default_vllm_config):
     """Sharded SP MLP must reproduce the replicated result for every token.
 

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -155,6 +155,20 @@ def shard_sequence_parallel_mlp(
     )
 
 
+def can_shard_sequence_parallel_shared_expert(vllm_config: VllmConfig) -> bool:
+    """Whether the active MoE backend preserves the SP shared-expert contract.
+
+    MegaMoE invokes the shared expert directly. DeepEP v2 invokes it through
+    ``MoERunner``, but its EP combine returns the routed output in the local
+    sequence-sharded layout, so the shared expert can use the same
+    all-gather/partial-GEMM/reduce-scatter implementation.
+    """
+    return (
+        vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
+        or vllm_config.parallel_config.all2all_backend == "deepep_v2"
+    )
+
+
 def maybe_init_gemm_rs_ar(vllm_config: VllmConfig, use_sequence_parallel: bool) -> bool:
     # Both feature flags may be enabled; the worker's static SP topology binds
     # its singleton to exactly one mode.
@@ -632,10 +646,12 @@ class KimiMoE(nn.Module):
                 quant_config=quant_config,
                 reduce_results=False,
                 use_sequence_parallel=use_sequence_parallel,
-                # Only the MegaMoE path calls the shared experts directly; the
-                # FusedMoE path below hands them to the runner, which fuses
-                # their reduction and assumes the replicated layout.
-                can_shard_sequence_parallel=self.use_mega_moe,
+                # MegaMoE calls the shared expert directly. DeepEP v2 hands it
+                # to MoERunner, but preserves the local SP output layout needed
+                # by the sharded shared-expert path.
+                can_shard_sequence_parallel=can_shard_sequence_parallel_shared_expert(
+                    vllm_config
+                ),
                 run_gemm_rs_ar=run_gemm_rs_ar,
                 prefix=f"{prefix}.shared_experts",
                 activation_situ_beta=activation_situ_beta,


### PR DESCRIPTION
Signed-off-by: Elvir Crncevic <elvircrn@gmail.com>

## Purpose

Enable Kimi K3 shared experts sharing with DeepEP V2, previously only enabled for MegaMoE.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

