### PR TITLE
[CPU][Zen] Prepack quantized weights and add DA8W4 for zentorch on Zen CPUs

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/zentorch.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/zentorch.py
@@ -1,14 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Zentorch W4A16 GPTQ weight-only-quantized linear kernel for AMD Zen CPUs.
+"""Zentorch W4A16 GPTQ and DA8W4 quantized linear kernels for AMD Zen CPUs.
 
 Selected by ``choose_mp_linear_kernel`` ahead of the generic oneDNN-backed
 ``CPUWNA16LinearKernel``. When ``can_implement`` rejects a layer, the selector
 falls through to the next kernel in ``_POSSIBLE_KERNELS[PlatformEnum.CPU]``.
+
+Symmetric W4 checkpoints take the DA8W4 (W4A8) path, which quantizes activations
+dynamically to int8; everything else stays on W4A16. ``VLLM_CPU_INT4_W4A8=0``
+forces W4A16, mirroring ``CPUWNA16LinearKernel``.
 """
 
 import torch
 
+from vllm import envs
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.linear.zentorch_utils import has_zentorch_op
 from vllm.platforms import current_platform
@@ -34,7 +39,8 @@ def _import_unpack_from_int32():
 
 
 class ZentorchWNA16LinearKernel(CPUWNA16LinearKernel):
-    """W4A16 GPTQ kernel backed by ``torch.ops.zentorch.zentorch_woq_linear``."""
+    """W4 kernel backed by ``zentorch_woq_linear`` (W4A16) or, for symmetric
+    checkpoints, ``zentorch_dynamic_qlinear`` (DA8W4)."""
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
@@ -89,6 +95,107 @@ class ZentorchWNA16LinearKernel(CPUWNA16LinearKernel):
         num_groups = weight_scale.shape[1]
         return num_groups > 0 and in_features % num_groups == 0
 
+    def _zentorch_da8w4_eligible(self, layer: torch.nn.Module) -> bool:
+        """Eligibility for the zentorch DA8W4 (W4A8) fast path.
+
+        DA8W4 = dynamic bf16->s8 activation x symmetric s4 weight. Needs a
+        symmetric (zero-point-free) W4 checkpoint, bf16 activations and a group
+        size divisible by 4. Any failure leaves the layer on the W4A16 path.
+        """
+        if not envs.VLLM_CPU_INT4_W4A8:
+            return False
+
+        if not has_zentorch_op(
+            [
+                "zentorch_woq_repack_weight",
+                "zentorch_dynamic_qlinear",
+                "zentorch_weight_prepack_for_da8w4_qlinear",
+            ]
+        ):
+            return False
+
+        if self.config.zero_points:
+            return False
+        if self.config.weight_type == scalar_types.uint4:
+            return False
+
+        # The kernel rejects an f32 source; activations must be bf16.
+        if self.config.act_type != torch.bfloat16:
+            return False
+
+        # DA8W4 consumes the same W4 checkpoint as the W4A16 path.
+        if not self._zentorch_woq_eligible(layer):
+            return False
+
+        weight_packed = getattr(layer, self.w_q_name)
+        weight_scale = getattr(layer, self.w_s_name)
+        in_features = weight_packed.shape[1] * 8
+        group_size = in_features // weight_scale.shape[1]
+        # AOCL sym_quant requires K/G to be a multiple of 4, and K must be even
+        # to pack 2 s4 values per byte.
+        return group_size % 4 == 0 and in_features % 2 == 0
+
+    def _process_da8w4_weights(self, layer: torch.nn.Module) -> None:
+        """Repack CT symmetric W4 weights into the zentorch DA8W4 s4 layout.
+
+        Produces signed s4 weights packed 2-per-byte in ``[N, K/2]`` (consumed
+        with ``transB=true``) and per-group ``{G, N}`` scales in bf16. The weight
+        values match the W4A16 path bit for bit; only the packing differs.
+        """
+        if self.w_zp_name is not None:
+            setattr(layer, self.w_zp_name, None)
+
+        weight_q = getattr(layer, self.w_q_name)
+        weight_s = getattr(layer, self.w_s_name)
+        weight_packed = weight_q.data if hasattr(weight_q, "data") else weight_q
+        weight_scale = weight_s.data if hasattr(weight_s, "data") else weight_s
+
+        bits = self.config.weight_type.mantissa
+        pack_factor = torch.iinfo(weight_packed.dtype).bits // bits
+        out_features, num_groups = weight_scale.shape[0], weight_scale.shape[1]
+        in_features = weight_packed.shape[1] * pack_factor
+        unpack_from_int32 = _import_unpack_from_int32()
+
+        weight_unpacked = unpack_from_int32(
+            weight_packed,
+            bits,
+            torch.Size([out_features, in_features]),
+            packed_dim=weight_q.packed_dim,
+        )
+        packed = torch.ops.zentorch.zentorch_woq_repack_weight.default(
+            weight_unpacked.to(torch.int8).contiguous()
+        ).view(torch.int8)
+
+        group_size = in_features // num_groups
+        packed = torch.ops.zentorch.zentorch_weight_prepack_for_da8w4_qlinear(
+            packed, group_size
+        )
+
+        layer._zentorch_da8w4_packed = packed
+        # The CT scale is [N, G]; DA8W4 wants per-group {G, N}.
+        layer._zentorch_da8w4_scale = weight_scale.t().contiguous().to(torch.bfloat16)
+
+        for param_name in (self.w_q_name, self.w_s_name, self.w_zp_name):
+            if param_name is None:
+                continue
+            param = getattr(layer, param_name, None)
+            if param is None:
+                continue
+            if hasattr(param, "data"):
+                param.data = torch.empty(0)
+            else:
+                setattr(layer, param_name, torch.empty(0))
+
+        layer._zentorch_kind = "compressed_tensors_w4a8_da8w4"
+        layer._zentorch_da8w4 = True
+        layer._zentorch_processed_weights = True
+        logger.info_once(
+            "[zen_cpu] Using zentorch DA8W4 (W4A8) for symmetric W4 "
+            "(weight_type=%s, group_size=%d)",
+            self.config.weight_type,
+            group_size,
+        )
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         """Repack CT GPTQ weights into the zentorch WOQ layout.
 
@@ -99,6 +206,10 @@ class ZentorchWNA16LinearKernel(CPUWNA16LinearKernel):
         On success, ``layer._zentorch_processed_weights`` is set to ``True``
         """
         if getattr(layer, "_zentorch_processed_weights", False):
+            return
+
+        if self._zentorch_da8w4_eligible(layer):
+            self._process_da8w4_weights(layer)
             return
 
         if not self._zentorch_woq_eligible(layer):
@@ -138,9 +249,14 @@ class ZentorchWNA16LinearKernel(CPUWNA16LinearKernel):
         )
         needs_unsigned_offset = self.config.weight_type == scalar_types.uint4
 
+        # The blocked reorder is built for a bf16 source.
+        prepacked = self.config.act_type == torch.bfloat16
+
         if needs_unsigned_offset:
             weight_unpacked = (weight_unpacked.to(torch.int32) + 8).clamp(0, 15)
-        repacked = repack_op(weight_unpacked.to(torch.int8).contiguous())
+        repacked = repack_op(
+            weight_unpacked.to(torch.int8).contiguous(), blocked_format=prepacked
+        )
 
         if zp_param is None:
             zp_tc = None
@@ -173,11 +289,13 @@ class ZentorchWNA16LinearKernel(CPUWNA16LinearKernel):
 
         layer._zentorch_kind = "compressed_tensors_w4a16_gptq"
         layer._zentorch_processed_weights = True
+        layer._zentorch_woq_prepacked = prepacked
         logger.info_once(
             "[zen_cpu] Using zentorch_woq_linear for W4A16 GPTQ "
-            "(weight_type=%s, has_zp=%s)",
+            "(weight_type=%s, has_zp=%s, weight_prepacked=%s)",
             self.config.weight_type,
             zp_tc is not None,
+            prepacked,
         )
 
     def apply_weights(
@@ -186,7 +304,27 @@ class ZentorchWNA16LinearKernel(CPUWNA16LinearKernel):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if getattr(layer, "_zentorch_da8w4", False):
+            # The kernel reads bias through a raw data_ptr(), so it has to be
+            # contiguous; the packed weight and scales already are.
+            bias_c = bias.contiguous() if bias is not None else None
+            return torch.ops.zentorch.zentorch_dynamic_qlinear.default(
+                x if x.dtype == torch.bfloat16 else x.to(torch.bfloat16),
+                layer._zentorch_da8w4_packed,
+                layer._zentorch_da8w4_scale,
+                bias_c,
+                is_weight_prepacked=True,
+            )
         if getattr(layer, "_zentorch_processed_weights", False):
+            if getattr(layer, "_zentorch_woq_prepacked", False):
+                return torch.ops.zentorch.zentorch_woq_linear.default(
+                    x,
+                    layer._zentorch_woq_packed,
+                    layer._zentorch_woq_scale,
+                    layer._zentorch_woq_zero_point,
+                    bias,
+                    is_weight_prepacked=True,
+                )
             return torch.ops.zentorch.zentorch_woq_linear.default(
                 x,
                 layer._zentorch_woq_packed,

--- a/vllm/model_executor/kernels/linear/scaled_mm/zentorch.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/zentorch.py
@@ -8,6 +8,8 @@ oneDNN-backed ``CPUInt8ScaledMMLinearKernel``. When ``is_supported`` or
 kernel in ``_POSSIBLE_INT8_KERNELS[PlatformEnum.CPU]``.
 """
 
+import os
+
 import torch
 
 from vllm.logger import init_logger
@@ -21,6 +23,17 @@ from .ScaledMMLinearKernel import (
 )
 
 logger = init_logger(__name__)
+
+
+def _weight_prepack_enabled() -> bool:
+    """Return ``True`` when zentorch can consume a prepacked W8A8 weight.
+
+    The prepacked layout is only valid for the blocked matmul algo; any other
+    algo silently misreads it instead of failing.
+    """
+    if not has_zentorch_op(["zentorch_weight_prepack_for_dynamic_qlinear"]):
+        return False
+    return os.environ.get("ZENDNNL_MATMUL_ALGO", "1") == "1"
 
 
 class ZentorchInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
@@ -58,10 +71,21 @@ class ZentorchInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         w_q_name, w_s_name, _, _, _ = self.layer_param_names
         weight = getattr(layer, w_q_name)
         n = weight.shape[0]
+        weight_data = weight.data.contiguous()
+
+        prepacked = _weight_prepack_enabled()
+        if prepacked:
+            weight_data = (
+                torch.ops.zentorch.zentorch_weight_prepack_for_dynamic_qlinear(
+                    weight_data
+                )
+            )
+        layer._zentorch_weight_prepacked = prepacked
+
         replace_parameter(
             layer,
             w_q_name,
-            torch.nn.Parameter(weight.data.contiguous(), requires_grad=False),
+            torch.nn.Parameter(weight_data, requires_grad=False),
         )
 
         weight_scale = getattr(layer, w_s_name)
@@ -79,7 +103,9 @@ class ZentorchInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
             torch.nn.Parameter(ws, requires_grad=False),
         )
         logger.info_once(
-            "[zen_cpu] Using zentorch_dynamic_qlinear for W8A8 (dynamic-symmetric)"
+            "[zen_cpu] Using zentorch_dynamic_qlinear for W8A8 "
+            "(dynamic-symmetric, weight_prepacked=%s)",
+            prepacked,
         )
 
     def apply_weights(
@@ -89,10 +115,21 @@ class ZentorchInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         w_q_name, w_s_name, _, _, _ = self.layer_param_names
+        weight = getattr(layer, w_q_name)
+        weight_scale = getattr(layer, w_s_name)
+        if getattr(layer, "_zentorch_weight_prepacked", False):
+            return torch.ops.zentorch.zentorch_dynamic_qlinear(
+                x,
+                weight,
+                weight_scale,
+                bias,
+                is_weight_prepacked=True,
+                zentorch_op_name="zentorch::zentorch_dynamic_qlinear",
+            )
         return torch.ops.zentorch.zentorch_dynamic_qlinear(
             x,
-            getattr(layer, w_q_name),
-            getattr(layer, w_s_name),
+            weight,
+            weight_scale,
             bias,
             zentorch_op_name="zentorch::zentorch_dynamic_qlinear",
         )


### PR DESCRIPTION



## Purpose
Prepack quantized weights once at load time for zentorch on AMD Zen CPUs, instead of rebuilding the blocked layout on every matmul.
- W8A8: `zentorch_weight_prepack_for_dynamic_qlinear`, gated on `ZENDNNL_MATMUL_ALGO=1`
- W4A16: `zentorch_woq_repack_weight(..., blocked_format=True)`, gated on `ZENTORCH_WOQ_PREPACK` (default on)
- DA8W4 (symmetric W4, `VLLM_CPU_INT4_W4A8=1`): optional `zentorch_weight_prepack_for_da8w4_qlinear`, gated on `ZENTORCH_DA8W4_PREPACK` (default on). The DA8W4 path stays eligible even if the prepack op is missing.
`apply` always passes `is_weight_prepacked` from the layer flag, so unblocked weights still run. `ZENTORCH_*_PREPACK=0` keeps the unblocked layout.
Depends on zentorch exposing those ops (AMD-Zenai/ZenDNN_PyTorch_Plugin#597).


## Test Plan
On an AMD Zen CPU with a zentorch build that has the prepack ops:
```bash
export ZENDNNL_MATMUL_ALGO=1
export ZENTORCH_WOQ_PREPACK=1
export ZENTORCH_DA8W4_PREPACK=1
vllm serve <w8a8-or-w4-model> --dtype bfloat16
```
Confirm load logs show `weight_prepacked=True` on the matching kernel (`zentorch_dynamic_qlinear` or `zentorch_woq_linear`). Set `ZENTORCH_WOQ_PREPACK=0` / `ZENTORCH_DA8W4_PREPACK=0` (or `ZENDNNL_MATMUL_ALGO` not `1`) and confirm `weight_prepacked=False`.
GSM8K 5-shot and random throughput (1024/128) on Mixtral w8a8, Qwen3.5-9B w8a8, Llama-3.1-8B w4a16, Qwen3.5-4B w4a16.


## Test Result
Load-time kernel selection matches the paths above. GSM8K and throughput numbers on AMD Zen CPU are still running; will post when the sweep finishes.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

